### PR TITLE
A number of C3 updates, including Army Options for all lists

### DIFF
--- a/Algoryn.cat
+++ b/Algoryn.cat
@@ -1,4781 +1,8290 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="4868-1e60-4bba-a4b2" revision="3" gameSystemId="c339-677a-60db-4060" gameSystemRevision="0" battleScribeVersion="1.15" name="Algoryn" authorName="Michael Ovsenik" authorContact="FB" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
-  <entries>
-    <entry id="b73b-6140-e2ca-f0c1" name="AI Assault Command Squad" points="69.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="b36d-f9f6-80eb-6f8a" name="AI Assault Commander" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="ee93-85a8-a748-3858" name="Leader Level" defaultEntryId="13a7-6cb8-6b4e-1067" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="13a7-6cb8-6b4e-1067" name="Leader Two" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="129d-7b43-801a-0589" targetId="7850-89e7-bab8-86e9" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="7be4-5a80-2f33-ce29" name="Leader Three" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="8609-a47e-3460-8e88" targetId="05bb-4d34-70cd-25d2" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-            <entryGroup id="de4b-186e-6c61-b8c8" name="Ranged Weapon" defaultEntryId="b6b5-3cea-3fa2-850b" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="b6b5-3cea-3fa2-850b" targetId="b08e-548a-fda7-0a4e" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="e6fb-c60a-b21f-bd96" profileTypeId="f9a2-eeae-3284-75fd" name="AI Assault Commander" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="18c1-4764-7d08-708d" name="Ag" value="5"/>
-                <characteristic characteristicId="e39c-d7a4-86a8-d23d" name="Acc" value="5"/>
-                <characteristic characteristicId="0790-bfd5-1273-fe12" name="Str" value="5"/>
-                <characteristic characteristicId="5b77-3595-2819-675c" name="Res" value="6 (7)"/>
-                <characteristic characteristicId="c0d8-f6fd-a474-1385" name="Init" value="7"/>
-                <characteristic characteristicId="135d-efc3-5039-b6e6" name="Co" value="9"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="5923-8349-07a9-9c2e" targetId="5c9b-1bde-ee01-04a4" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="04eb-c412-1c75-748c" targetId="7bc9-5e98-2914-5abd" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="e315-7c8e-c397-f04f" targetId="8de3-1e72-72ef-e7a3" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="1c7d-3ba7-b033-2246" targetId="6b54-c223-3c4a-5de7" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="4581-2e23-0a04-b8cc" name="AI Assault Trooper" points="25.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="7dd7-204e-3f42-653d" profileTypeId="f9a2-eeae-3284-75fd" name="AI Assault Trooper" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="18c1-4764-7d08-708d" name="Ag" value="5"/>
-                <characteristic characteristicId="e39c-d7a4-86a8-d23d" name="Acc" value="5"/>
-                <characteristic characteristicId="0790-bfd5-1273-fe12" name="Str" value="5"/>
-                <characteristic characteristicId="5b77-3595-2819-675c" name="Res" value="6 (7)"/>
-                <characteristic characteristicId="c0d8-f6fd-a474-1385" name="Init" value="7"/>
-                <characteristic characteristicId="135d-efc3-5039-b6e6" name="Co" value="8"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="8620-6d9e-b094-c795" name="Close Combat Weapon" defaultEntryId="47f0-ec05-82ba-dabf" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="47f0-ec05-82ba-dabf" targetId="72ba-15e7-dbf7-816c" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="2c02-cbb9-e589-21a8" name="Ranged Weapon" defaultEntryId="3366-c793-e3b7-e8d1" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="3366-c793-e3b7-e8d1" targetId="b018-6101-d2e3-b4ea" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="3542-e211-b704-3388" name="Limited Choice" hidden="false" book="">
-          <modifiers/>
-        </rule>
-        <rule id="ab69-5653-55c0-16cf" name="Infantry Command Unit" hidden="false" book="">
-          <modifiers/>
-        </rule>
-      </rules>
+<catalogue id="4868-1e60-4bba-a4b2" name="Algoryn" revision="4" battleScribeVersion="2.00" authorName="Michael Ovsenik" authorContact="FB" gameSystemId="c339-677a-60db-4060" gameSystemRevision="0" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <profiles/>
+  <rules/>
+  <infoLinks/>
+  <costTypes/>
+  <profileTypes/>
+  <forceEntries/>
+  <selectionEntries>
+    <selectionEntry id="b73b-6140-e2ca-f0c1" name="AI Assault Command Squad" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
       <profiles/>
-      <links>
-        <link id="b6c9-b77c-8db6-960c" targetId="7ac3-5fd7-f7a8-3a01" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="b73b-6140-e2ca-f0c1" incrementChildId="4581-2e23-0a04-b8cc" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="b73b-6140-e2ca-f0c1" incrementChildId="b36d-f9f6-80eb-6f8a" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="9320-7fb3-d40b-9284" targetId="502c-9855-7269-eaa2" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="20.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="5895-7a8e-8c94-2b8c" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="dd12-396f-dbfc-e1cf" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="f223-6e88-8981-51d2" targetId="3af1-7df9-4f90-c12c" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="5cda-2300-7dae-8090" name="AI Assault Squad" points="32.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="060b-a9a7-c641-af07" name="AI Assault Leader" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="7bf3-7f8c-bb36-8056" name="Leader Level" defaultEntryId="8bb2-13f1-ebb2-0d18" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="1fb7-4557-878e-29b0" name="Leader Two" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="7124-cd7f-e6ae-bab4" targetId="7850-89e7-bab8-86e9" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="8bb2-13f1-ebb2-0d18" name="Leader One" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="8222-a0b4-a917-311b" targetId="05bb-4d34-70cd-25d2" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-            <entryGroup id="f6c4-adbe-a27d-129a" name="Ranged Weapon" defaultEntryId="f607-640a-427e-f60b" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="f607-640a-427e-f60b" targetId="b08e-548a-fda7-0a4e" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="12c1-cfee-5af0-aab1" profileTypeId="1650-77b3-10d1-6406" name="AI Assault Leader" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="6 (7)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="1b94-84e5-38b3-52e1" targetId="5c9b-1bde-ee01-04a4" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="1ef4-89e2-2882-8cf9" targetId="7bc9-5e98-2914-5abd" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="26dc-46a0-f598-e869" name="AI Assault Trooper" points="22.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="7" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="d6e9-1827-8091-a2dc" profileTypeId="1650-77b3-10d1-6406" name="AI Assault Trooper" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="6 (7)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="07d2-b644-beb6-a202" name="Close Combat Weapon" defaultEntryId="8180-7329-3c28-309c" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="8180-7329-3c28-309c" targetId="72ba-15e7-dbf7-816c" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="ba41-be49-a2d8-0b1b" name="Ranged Weapon" defaultEntryId="fa33-be90-9a74-eca3" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="fa33-be90-9a74-eca3" targetId="790a-6841-6372-870b" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
       <rules>
-        <rule id="0587-e7a6-cccd-a152" name="Infantry Unit" hidden="false" book="">
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links>
-        <link id="85ac-b191-0b0d-b952" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="3142-6999-6b67-9a7a" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="764c-a373-c9f4-1395" targetId="1b16-412b-662a-5467" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="15.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="13aa-e20e-c8eb-40a4" targetId="3af1-7df9-4f90-c12c" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="04d7-b8fa-d20d-5a98" name="AI Avenger Attack Skimmer" points="118.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="c30a-e7b6-bb84-7bb5" name="AI Avenger Skimmer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="c647-b28b-df13-6d30" name="Weapon" defaultEntryId="4c83-fe4e-babc-141c" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="4c83-fe4e-babc-141c" targetId="a00c-0542-f2a5-8124" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="a15c-d3b9-b787-53f8" targetId="ac1e-a740-57b7-cc64" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="c647-b28b-df13-6d30" incrementChildId="a15c-d3b9-b787-53f8" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="bab1-4391-32c8-71c1" profileTypeId="1650-77b3-10d1-6406" name="AI Avenger Skimmer" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="11"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-              </characteristics>
-              <modifiers>
-                <modifier type="increment" field="f214-abe8-c922-c51b" value="1" repeat="true" numRepeats="1" incrementParentId="04d7-b8fa-d20d-5a98" incrementChildId="d788-9457-e43f-3692" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-        <entry id="d788-9457-e43f-3692" name="HL Booster (adds +1 res)" points="24.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
+        <rule id="3542-e211-b704-3388" name="Limited Choice" book="" hidden="false">
           <profiles/>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+        <rule id="ab69-5653-55c0-16cf" name="Infantry Command Unit" book="" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks/>
       <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="b36d-f9f6-80eb-6f8a" name="AI Assault Commander" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="e6fb-c60a-b21f-bd96" name="AI Assault Commander" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="5"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="6 (7)"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="7"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="9"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="5923-8349-07a9-9c2e" hidden="false" targetId="5c9b-1bde-ee01-04a4" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="04eb-c412-1c75-748c" hidden="false" targetId="7bc9-5e98-2914-5abd" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="ee93-85a8-a748-3858" name="Leader Level" hidden="false" collective="false" defaultSelectionEntryId="13a7-6cb8-6b4e-1067">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="13a7-6cb8-6b4e-1067" name="Leader Two" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="129d-7b43-801a-0589" hidden="false" targetId="7850-89e7-bab8-86e9" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="7be4-5a80-2f33-ce29" name="Leader Three" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="8609-a47e-3460-8e88" hidden="false" targetId="05bb-4d34-70cd-25d2" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="de4b-186e-6c61-b8c8" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="b6b5-3cea-3fa2-850b">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="b6b5-3cea-3fa2-850b" hidden="false" targetId="b08e-548a-fda7-0a4e" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="e315-7c8e-c397-f04f" hidden="false" targetId="8de3-1e72-72ef-e7a3" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="1c7d-3ba7-b033-2246" hidden="false" targetId="6b54-c223-3c4a-5de7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4581-2e23-0a04-b8cc" name="AI Assault Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="7dd7-204e-3f42-653d" name="AI Assault Trooper" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="5"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="6 (7)"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="7"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="8"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="25.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="8620-6d9e-b094-c795" name="Close Combat Weapon" hidden="false" collective="false" defaultSelectionEntryId="47f0-ec05-82ba-dabf">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="47f0-ec05-82ba-dabf" hidden="false" targetId="72ba-15e7-dbf7-816c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="2c02-cbb9-e589-21a8" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="3366-c793-e3b7-e8d1">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="3366-c793-e3b7-e8d1" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="b6c9-b77c-8db6-960c" hidden="false" targetId="7ac3-5fd7-f7a8-3a01" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="b73b-6140-e2ca-f0c1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4581-2e23-0a04-b8cc" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="b73b-6140-e2ca-f0c1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b36d-f9f6-80eb-6f8a" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="9320-7fb3-d40b-9284" hidden="false" targetId="502c-9855-7269-eaa2" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="20.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="5895-7a8e-8c94-2b8c" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="dd12-396f-dbfc-e1cf" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="f223-6e88-8981-51d2" hidden="false" targetId="3af1-7df9-4f90-c12c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="69.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5cda-2300-7dae-8090" name="AI Assault Squad" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="0587-e7a6-cccd-a152" name="Infantry Unit" book="" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="060b-a9a7-c641-af07" name="AI Assault Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="12c1-cfee-5af0-aab1" name="AI Assault Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (7)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="1b94-84e5-38b3-52e1" hidden="false" targetId="5c9b-1bde-ee01-04a4" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="1ef4-89e2-2882-8cf9" hidden="false" targetId="7bc9-5e98-2914-5abd" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="7bf3-7f8c-bb36-8056" name="Leader Level" hidden="false" collective="false" defaultSelectionEntryId="8bb2-13f1-ebb2-0d18">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="1fb7-4557-878e-29b0" name="Leader Two" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="7124-cd7f-e6ae-bab4" hidden="false" targetId="7850-89e7-bab8-86e9" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="8bb2-13f1-ebb2-0d18" name="Leader One" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="8222-a0b4-a917-311b" hidden="false" targetId="05bb-4d34-70cd-25d2" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="f6c4-adbe-a27d-129a" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="f607-640a-427e-f60b">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="f607-640a-427e-f60b" hidden="false" targetId="b08e-548a-fda7-0a4e" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="26dc-46a0-f598-e869" name="AI Assault Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="d6e9-1827-8091-a2dc" name="AI Assault Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (7)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="22.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="07d2-b644-beb6-a202" name="Close Combat Weapon" hidden="false" collective="false" defaultSelectionEntryId="8180-7329-3c28-309c">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="8180-7329-3c28-309c" hidden="false" targetId="72ba-15e7-dbf7-816c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="ba41-be49-a2d8-0b1b" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="fa33-be90-9a74-eca3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="fa33-be90-9a74-eca3" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="85ac-b191-0b0d-b952" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="3142-6999-6b67-9a7a" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="764c-a373-c9f4-1395" hidden="false" targetId="1b16-412b-662a-5467" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="15.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="13aa-e20e-c8eb-40a4" hidden="false" targetId="3af1-7df9-4f90-c12c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="32.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="04d7-b8fa-d20d-5a98" name="AI Avenger Attack Skimmer" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
       <rules>
         <rule id="3282-4fa8-4571-f511" name="Vehicle Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="77a4-a25f-8f3d-ddd5" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="fad5-611a-6a4f-5232" targetId="d571-d584-85fc-9110" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="20.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="b3ea-1e90-ad90-ee02" targetId="5565-ce10-1c78-1ee7" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="48a7-1194-3630-6d90" targetId="a221-d53c-b4bd-b52c" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="8e96-907a-4420-b86b" name="AI Bastion Heavy Combat Skimmer" points="378.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="632e-ffdc-3914-61fd" name="Heavy Combat Skimmer" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="838e-15d8-5642-5e1d" name="Weapon 2" defaultEntryId="c5f6-8957-d653-74bc" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="3185-11b1-845c-6d8c" targetId="cf3a-e6a9-bdc0-e0ae" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="30.0" repeat="false" numRepeats="1" incrementParentId="838e-15d8-5642-5e1d" incrementChildId="3185-11b1-845c-6d8c" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-                <link id="a832-43c3-1367-a986" targetId="ac1e-a740-57b7-cc64" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="838e-15d8-5642-5e1d" incrementChildId="a832-43c3-1367-a986" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-                <link id="c5f6-8957-d653-74bc" targetId="a00c-0542-f2a5-8124" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="904b-239e-b811-6062" name="Weapon 1" defaultEntryId="6195-3bcc-f9b1-0807" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="6195-3bcc-f9b1-0807" targetId="5149-5183-64d5-feaf" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
+      <infoLinks>
+        <infoLink id="b3ea-1e90-ad90-ee02" hidden="false" targetId="5565-ce10-1c78-1ee7" type="rule">
+          <profiles/>
           <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="48a7-1194-3630-6d90" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="c30a-e7b6-bb84-7bb5" name="AI Avenger Skimmer" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles>
-            <profile id="15cb-1690-7486-ff16" profileTypeId="1650-77b3-10d1-6406" name="Heavy Combat Skimmer" hidden="false" book="BtGoA" page="177">
+            <profile id="bab1-4391-32c8-71c1" name="AI Avenger Skimmer" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="f214-abe8-c922-c51b" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="04d7-b8fa-d20d-5a98" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d788-9457-e43f-3692" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
               <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="15"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="11"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
               </characteristics>
-              <modifiers/>
             </profile>
           </profiles>
-          <links/>
-        </entry>
-        <entry id="e7bb-38cd-60f1-d00a" name="Self-repair" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
           <rules/>
-          <profiles/>
-          <links>
-            <link id="ea04-a869-16aa-e442" targetId="3377-9408-33bb-6a02" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="b7cf-d031-b4af-a0fb" name="Spotter Drone" defaultEntryId="ed14-1b82-dde1-a5fb" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="ed14-1b82-dde1-a5fb" targetId="f3aa-148a-0460-c7e5" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="c647-b28b-df13-6d30" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="4c83-fe4e-babc-141c">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="4c83-fe4e-babc-141c" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="a15c-d3b9-b787-53f8" hidden="false" targetId="ac1e-a740-57b7-cc64" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="10.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d788-9457-e43f-3692" name="HL Booster (adds +1 res)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="24.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="77a4-a25f-8f3d-ddd5" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="fad5-611a-6a4f-5232" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="20.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="118.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8e96-907a-4420-b86b" name="AI Bastion Heavy Combat Skimmer" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
       <rules>
         <rule id="fd56-a7ac-05bb-f09d" name="Vehicle Unit" hidden="false">
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links>
-        <link id="f8b8-ceab-912d-3aeb" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="2a3c-922a-bfb5-01f5" targetId="d571-d584-85fc-9110" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="20.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="c33c-1c39-2527-ed08" targetId="8151-2e24-94ee-0477" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="a501-c7f3-fa66-a68e" targetId="a221-d53c-b4bd-b52c" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="e053-eb8f-4496-b11b" targetId="b145-19b3-baae-ff39" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="1bdc-3be1-9f95-d580" targetId="b145-19b3-baae-ff39" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="e12d-a3e2-9bcf-6c07" targetId="d571-d584-85fc-9110" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="20.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="fbc9-aa13-ad9a-0d47" targetId="7c88-64d4-50ad-2313" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="1405-a43b-534b-ab05" name="AI Command Squad" points="64.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="172">
-      <entries>
-        <entry id="9d5a-e373-e211-b23f" name="AI Commander" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="630f-9d3c-aa03-5c21" name="Leader Level" defaultEntryId="a337-bb3b-7f63-a07d" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="a337-bb3b-7f63-a07d" name="Leader Two" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="6ac6-af14-69ac-df2e" targetId="7850-89e7-bab8-86e9" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="d566-c736-730d-469f" name="Leader Three" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="b069-cf74-6fac-ccf1" targetId="05bb-4d34-70cd-25d2" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-            <entryGroup id="52a6-3ce8-252c-c409" name="Ranged Weapon" defaultEntryId="6ed7-4c98-cab0-baca" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="6ed7-4c98-cab0-baca" targetId="b08e-548a-fda7-0a4e" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="39d5-3220-e21e-4db1" profileTypeId="f9a2-eeae-3284-75fd" name="AI Commander" hidden="false" book="BtGoA" page="172">
-              <characteristics>
-                <characteristic characteristicId="18c1-4764-7d08-708d" name="Ag" value="5"/>
-                <characteristic characteristicId="e39c-d7a4-86a8-d23d" name="Acc" value="5"/>
-                <characteristic characteristicId="0790-bfd5-1273-fe12" name="Str" value="5"/>
-                <characteristic characteristicId="5b77-3595-2819-675c" name="Res" value="6 (7)"/>
-                <characteristic characteristicId="c0d8-f6fd-a474-1385" name="Init" value="7"/>
-                <characteristic characteristicId="135d-efc3-5039-b6e6" name="Co" value="9"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="8602-3bc3-a97f-da4e" targetId="5c9b-1bde-ee01-04a4" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="3252-b423-64d9-9d6b" targetId="7bc9-5e98-2914-5abd" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="cf1c-44f1-6657-cd52" targetId="8de3-1e72-72ef-e7a3" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="1fd5-10fc-1961-7c0e" targetId="6b54-c223-3c4a-5de7" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="6f86-347f-273f-84ca" name="AI Trooper" points="20.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="c89a-7590-da72-6fef" profileTypeId="f9a2-eeae-3284-75fd" name="AI Trooper" hidden="false" book="BtGoA" page="172">
-              <characteristics>
-                <characteristic characteristicId="18c1-4764-7d08-708d" name="Ag" value="5"/>
-                <characteristic characteristicId="e39c-d7a4-86a8-d23d" name="Acc" value="5"/>
-                <characteristic characteristicId="0790-bfd5-1273-fe12" name="Str" value="5"/>
-                <characteristic characteristicId="5b77-3595-2819-675c" name="Res" value="6 (7)"/>
-                <characteristic characteristicId="c0d8-f6fd-a474-1385" name="Init" value="7"/>
-                <characteristic characteristicId="135d-efc3-5039-b6e6" name="Co" value="8"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="6a2d-6157-812a-f7fb" name="Ranged Weapon" defaultEntryId="65c3-8209-8f2a-270d" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="65c3-8209-8f2a-270d" targetId="b018-6101-d2e3-b4ea" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="b2d5-107a-301c-db27" name="Limited Choice" hidden="false" book="">
-          <modifiers/>
-        </rule>
-        <rule id="05ad-d2b8-2f3f-67e1" name="Infantry Command Unit" hidden="false" book="">
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links>
-        <link id="5adb-71d8-e2d3-99fd" targetId="7ac3-5fd7-f7a8-3a01" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="1405-a43b-534b-ab05" incrementChildId="6f86-347f-273f-84ca" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="9d5a-e373-e211-b23f" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="32bd-d9c2-5ebd-a3d2" targetId="502c-9855-7269-eaa2" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="20.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="61bb-6fc6-c633-8420" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="6b0e-52a5-ac46-3630" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="9ee7-2ebf-4786-f817" targetId="3af1-7df9-4f90-c12c" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="2c84-d60c-787a-53bf" name="AI Command Squad - General Tar Es Janar" points="105.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="172">
-      <entries>
-        <entry id="9ba6-ad89-b106-ccdf" name="General Tar Es Janar" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="3e7b-f325-9d1c-8a70" name="Ranged Weapon" defaultEntryId="d809-f3a9-13a3-d6e8" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="d809-f3a9-13a3-d6e8" targetId="e6db-6ed3-1a26-ea56" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="e684-e721-4d5b-8160" profileTypeId="f9a2-eeae-3284-75fd" name="General Tar Es Janar" hidden="false" book="BtGoA" page="221">
-              <characteristics>
-                <characteristic characteristicId="18c1-4764-7d08-708d" name="Ag" value="5"/>
-                <characteristic characteristicId="e39c-d7a4-86a8-d23d" name="Acc" value="5"/>
-                <characteristic characteristicId="0790-bfd5-1273-fe12" name="Str" value="5"/>
-                <characteristic characteristicId="5b77-3595-2819-675c" name="Res" value="6 (7)"/>
-                <characteristic characteristicId="c0d8-f6fd-a474-1385" name="Init" value="8"/>
-                <characteristic characteristicId="135d-efc3-5039-b6e6" name="Co" value="10"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="a8b9-0454-3df1-671f" targetId="67fa-a913-bd09-5b13" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="5754-6af9-f502-5a10" targetId="9cab-babb-fd75-a302" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="f3ea-9f2c-c96a-7aa5" name="AI Trooper" points="20.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="5484-f1a2-ada9-fb48" profileTypeId="f9a2-eeae-3284-75fd" name="AI Trooper" hidden="false" book="BtGoA" page="172">
-              <characteristics>
-                <characteristic characteristicId="18c1-4764-7d08-708d" name="Ag" value="5"/>
-                <characteristic characteristicId="e39c-d7a4-86a8-d23d" name="Acc" value="5"/>
-                <characteristic characteristicId="0790-bfd5-1273-fe12" name="Str" value="5"/>
-                <characteristic characteristicId="5b77-3595-2819-675c" name="Res" value="6 (7)"/>
-                <characteristic characteristicId="c0d8-f6fd-a474-1385" name="Init" value="7"/>
-                <characteristic characteristicId="135d-efc3-5039-b6e6" name="Co" value="8"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="a5ce-7f12-9d34-2772" name="Ranged Weapon" defaultEntryId="8d72-d6d9-9cc7-15ef" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="8d72-d6d9-9cc7-15ef" targetId="b018-6101-d2e3-b4ea" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="6eaf-e8a3-9c82-8a79" name="Limited Choice" hidden="false" book="">
-          <modifiers/>
-        </rule>
-        <rule id="e3b0-fd02-8fe9-9236" name="Infantry Command Unit" hidden="false" book="">
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links>
-        <link id="e392-c338-4e8f-b800" targetId="7ac3-5fd7-f7a8-3a01" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="roster" incrementChildId="f3ea-9f2c-c96a-7aa5" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="9ba6-ad89-b106-ccdf" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="e8cc-b606-0691-7064" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="e0a0-b333-4df7-b100" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="cdfd-7d13-efd0-6540" name="AI Defiant Transport Skimmer" points="164.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="176">
-      <entries>
-        <entry id="ae68-51cd-72e4-7d16" name="Transport Skimmer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="15aa-6cbb-cf07-cc0d" name="Weapon" defaultEntryId="9f00-29c6-1215-a78c" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="9f00-29c6-1215-a78c" targetId="a00c-0542-f2a5-8124" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="52eb-0d0b-7f7a-ceb5" profileTypeId="1650-77b3-10d1-6406" name="AI Defiant Transport Skimmer" hidden="false" book="BtGoA" page="176">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="13"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-        <entry id="2cb5-9676-7408-1e67" name="Self Repair" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
           <profiles/>
-          <links>
-            <link id="828c-1127-983a-c4ea" targetId="3377-9408-33bb-6a02" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="c33c-1c39-2527-ed08" hidden="false" targetId="8151-2e24-94ee-0477" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="a501-c7f3-fa66-a68e" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="fbc9-aa13-ad9a-0d47" hidden="false" targetId="7c88-64d4-50ad-2313" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="632e-ffdc-3914-61fd" name="Heavy Combat Skimmer" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="15cb-1690-7486-ff16" name="Heavy Combat Skimmer" book="BtGoA" page="177" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="15"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="838e-15d8-5642-5e1d" name="Weapon 2" hidden="false" collective="false" defaultSelectionEntryId="c5f6-8957-d653-74bc">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="3185-11b1-845c-6d8c" hidden="false" targetId="cf3a-e6a9-bdc0-e0ae" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="30.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="a832-43c3-1367-a986" hidden="false" targetId="ac1e-a740-57b7-cc64" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="10.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="c5f6-8957-d653-74bc" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="904b-239e-b811-6062" name="Weapon 1" hidden="false" collective="false" defaultSelectionEntryId="6195-3bcc-f9b1-0807">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="6195-3bcc-f9b1-0807" hidden="false" targetId="5149-5183-64d5-feaf" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e7bb-38cd-60f1-d00a" name="Self-repair" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="ea04-a869-16aa-e442" hidden="false" targetId="3377-9408-33bb-6a02" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="b7cf-d031-b4af-a0fb" name="Spotter Drone" hidden="false" collective="false" defaultSelectionEntryId="ed14-1b82-dde1-a5fb">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="ed14-1b82-dde1-a5fb" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="f8b8-ceab-912d-3aeb" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="2a3c-922a-bfb5-01f5" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="20.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="e053-eb8f-4496-b11b" hidden="false" targetId="b145-19b3-baae-ff39" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="1bdc-3be1-9f95-d580" hidden="false" targetId="b145-19b3-baae-ff39" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="e12d-a3e2-9bcf-6c07" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="20.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="378.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1405-a43b-534b-ab05" name="AI Command Squad" book="BtGoA" page="172" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="b2d5-107a-301c-db27" name="Limited Choice" book="" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+        <rule id="05ad-d2b8-2f3f-67e1" name="Infantry Command Unit" book="" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="9d5a-e373-e211-b23f" name="AI Commander" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="39d5-3220-e21e-4db1" name="AI Commander" book="BtGoA" page="172" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="5"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="6 (7)"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="7"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="9"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="8602-3bc3-a97f-da4e" hidden="false" targetId="5c9b-1bde-ee01-04a4" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="3252-b423-64d9-9d6b" hidden="false" targetId="7bc9-5e98-2914-5abd" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="630f-9d3c-aa03-5c21" name="Leader Level" hidden="false" collective="false" defaultSelectionEntryId="a337-bb3b-7f63-a07d">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="a337-bb3b-7f63-a07d" name="Leader Two" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="6ac6-af14-69ac-df2e" hidden="false" targetId="7850-89e7-bab8-86e9" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="d566-c736-730d-469f" name="Leader Three" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="b069-cf74-6fac-ccf1" hidden="false" targetId="05bb-4d34-70cd-25d2" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="52a6-3ce8-252c-c409" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="6ed7-4c98-cab0-baca">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="6ed7-4c98-cab0-baca" hidden="false" targetId="b08e-548a-fda7-0a4e" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="cf1c-44f1-6657-cd52" hidden="false" targetId="8de3-1e72-72ef-e7a3" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="1fd5-10fc-1961-7c0e" hidden="false" targetId="6b54-c223-3c4a-5de7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6f86-347f-273f-84ca" name="AI Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="c89a-7590-da72-6fef" name="AI Trooper" book="BtGoA" page="172" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="5"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="6 (7)"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="7"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="8"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6a2d-6157-812a-f7fb" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="65c3-8209-8f2a-270d">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="65c3-8209-8f2a-270d" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="5adb-71d8-e2d3-99fd" hidden="false" targetId="7ac3-5fd7-f7a8-3a01" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="1405-a43b-534b-ab05" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6f86-347f-273f-84ca" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="32bd-d9c2-5ebd-a3d2" hidden="false" targetId="502c-9855-7269-eaa2" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="20.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="61bb-6fc6-c633-8420" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="6b0e-52a5-ac46-3630" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="9ee7-2ebf-4786-f817" hidden="false" targetId="3af1-7df9-4f90-c12c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="64.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2c84-d60c-787a-53bf" name="AI Command Squad - General Tar Es Janar" book="BtGoA" page="172" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="6eaf-e8a3-9c82-8a79" name="Limited Choice" book="" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+        <rule id="e3b0-fd02-8fe9-9236" name="Infantry Command Unit" book="" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="9ba6-ad89-b106-ccdf" name="General Tar Es Janar" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="e684-e721-4d5b-8160" name="General Tar Es Janar" book="BtGoA" page="221" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="5"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="6 (7)"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="8"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="10"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="3e7b-f325-9d1c-8a70" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="d809-f3a9-13a3-d6e8">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="d809-f3a9-13a3-d6e8" hidden="false" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="a8b9-0454-3df1-671f" hidden="false" targetId="67fa-a913-bd09-5b13" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="5754-6af9-f502-5a10" hidden="false" targetId="9cab-babb-fd75-a302" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f3ea-9f2c-c96a-7aa5" name="AI Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="5484-f1a2-ada9-fb48" name="AI Trooper" book="BtGoA" page="172" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="5"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="6 (7)"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="7"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="8"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="a5ce-7f12-9d34-2772" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="8d72-d6d9-9cc7-15ef">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="8d72-d6d9-9cc7-15ef" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="e392-c338-4e8f-b800" hidden="false" targetId="7ac3-5fd7-f7a8-3a01" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f3ea-9f2c-c96a-7aa5" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="e8cc-b606-0691-7064" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="e0a0-b333-4df7-b100" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="105.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cdfd-7d13-efd0-6540" name="AI Defiant Transport Skimmer" book="BtGoA" page="176" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
       <rules>
         <rule id="5dd0-14ba-f6df-3805" name="Vehicle Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="646a-6f39-6651-8108" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="b8ef-dcef-9393-5153" targetId="d571-d584-85fc-9110" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="4f72-dd3a-c2e4-f2f6" targetId="5565-ce10-1c78-1ee7" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="da13-89f6-1936-7777" targetId="a221-d53c-b4bd-b52c" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="7260-678e-004e-ec18" targetId="ab37-33d8-41f3-7532" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="d092-6db8-5232-419b" targetId="b145-19b3-baae-ff39" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="23b4-74fe-41bf-570c" targetId="b145-19b3-baae-ff39" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="c921-cfbe-51c6-44f8" name="AI Heavy Support Team" points="45.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="176">
-      <entries>
-        <entry id="eba4-0d79-41b8-1568" name="AI Trooper Crew" points="14.0" categoryId="(No Category)" type="model" minSelections="3" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="4760-495f-6534-ada3" name="Weapon" defaultEntryId="be3f-4e32-9b54-3fff" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="0636-a911-f505-3eb8" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-                <link id="be3f-4e32-9b54-3fff" targetId="8690-3ab7-9fef-06ee" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="e68a-5d99-1837-00bf" targetId="790a-6841-6372-870b" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+      <infoLinks>
+        <infoLink id="4f72-dd3a-c2e4-f2f6" hidden="false" targetId="5565-ce10-1c78-1ee7" type="rule">
           <profiles/>
-          <links>
-            <link id="a84d-a071-f48f-33ab" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="9044-f681-7df2-2217" name="Promote one crew member to Leader" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
           <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="da13-89f6-1936-7777" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
           <profiles/>
-          <links>
-            <link id="2f85-136a-da3c-3dc1" targetId="e441-c3a6-7d61-2c63" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="c5a0-5915-45d9-3ebc" name="Weapon" defaultEntryId="a41c-198c-6e6b-9630" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="c9f2-2169-2f1e-3e18" targetId="9733-7039-e306-26b5" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="c5a0-5915-45d9-3ebc" incrementChildId="c9f2-2169-2f1e-3e18" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="cdf4-eed0-f3d7-f3ce" targetId="b9f1-a313-3e59-57ab" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="a41c-198c-6e6b-9630" targetId="cea7-8511-2208-1b1f" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="1dd0-b0d7-ca04-2982" targetId="5149-5183-64d5-feaf" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="a4b4-7d9b-c27e-715b" targetId="af24-45f9-4669-bf98" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="25.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="46ac-8536-740b-1631" name="Spotter Drone" defaultEntryId="dae2-19d0-0b13-21d4" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+        </infoLink>
+        <infoLink id="7260-678e-004e-ec18" hidden="false" targetId="ab37-33d8-41f3-7532" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="dae2-19d0-0b13-21d4" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules>
-        <rule id="75c1-4b49-0793-db9e" name="Weapon Team Unit" hidden="false">
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="ae68-51cd-72e4-7d16" name="Transport Skimmer" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="52eb-0d0b-7f7a-ceb5" name="AI Defiant Transport Skimmer" book="BtGoA" page="176" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="13"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </rule>
-      </rules>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="15aa-6cbb-cf07-cc0d" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="9f00-29c6-1215-a78c">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="9f00-29c6-1215-a78c" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2cb5-9676-7408-1e67" name="Self Repair" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="828c-1127-983a-c4ea" hidden="false" targetId="3377-9408-33bb-6a02" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="646a-6f39-6651-8108" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="b8ef-dcef-9393-5153" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="d092-6db8-5232-419b" hidden="false" targetId="b145-19b3-baae-ff39" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="23b4-74fe-41bf-570c" hidden="false" targetId="b145-19b3-baae-ff39" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="164.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c921-cfbe-51c6-44f8" name="AI Heavy Support Team" book="BtGoA" page="176" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
       <profiles>
-        <profile id="7202-783f-fe86-4d0a" profileTypeId="1650-77b3-10d1-6406" name="AI Trooper Crew" hidden="false" book="BtGoA" page="176">
-          <characteristics>
-            <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-            <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-            <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-            <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="6 (7)"/>
-            <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-            <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-          </characteristics>
+        <profile id="7202-783f-fe86-4d0a" name="AI Trooper Crew" book="BtGoA" page="176" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+            <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+            <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+            <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (7)"/>
+            <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+            <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+            <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="d0c6-69c7-03f7-6e2c" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="e2a2-f0ce-1b55-1a05" targetId="a221-d53c-b4bd-b52c" linkType="rule">
+      <rules>
+        <rule id="75c1-4b49-0793-db9e" name="Weapon Team Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="df0b-acc2-2121-e8af" targetId="a846-6829-3398-bac1" linkType="rule">
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="e2a2-f0ce-1b55-1a05" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="cca7-6248-d4d1-89fb" targetId="d571-d584-85fc-9110" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="20.0" repeat="false" numRepeats="1" incrementParentId="c921-cfbe-51c6-44f8" incrementChildId="cca7-6248-d4d1-89fb" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-      </links>
-    </entry>
-    <entry id="40ad-08b6-fa6a-0171" name="AI Infiltration Squad" points="47.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="174">
-      <entries>
-        <entry id="c3fa-7787-a4d1-50f8" name="AI Infiltration Leader" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="189f-239f-cc54-f496" name="Leader Level" defaultEntryId="6d3e-ba32-c035-533f" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="6d3e-ba32-c035-533f" name="Leader One" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="3c69-4c06-1da1-77d4" targetId="e441-c3a6-7d61-2c63" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="6cd8-052e-b9da-e94e" name="Leader Two" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="f2ac-6316-75a8-0504" targetId="7850-89e7-bab8-86e9" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
+        </infoLink>
+        <infoLink id="df0b-acc2-2121-e8af" hidden="false" targetId="a846-6829-3398-bac1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="eba4-0d79-41b8-1568" name="AI Trooper Crew" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="4760-495f-6534-ada3" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="be3f-4e32-9b54-3fff">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <links/>
-            </entryGroup>
-            <entryGroup id="f5ed-8cd5-154e-1987" name="Ranged Weapon 1" defaultEntryId="5c28-c516-b9ce-5802" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="5c28-c516-b9ce-5802" targetId="8690-3ab7-9fef-06ee" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="a317-28d4-96e1-cd44" targetId="790a-6841-6372-870b" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="0636-a911-f505-3eb8" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers>
-                    <modifier type="increment" field="points" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                    <modifier type="increment" field="points" value="3.0">
+                      <repeats/>
                       <conditions/>
                       <conditionGroups/>
                     </modifier>
                   </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="5601-2930-b7cc-3680" name="Ranged Weapon 2" defaultEntryId="a4e2-f9bc-7f43-1bec" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="a4e2-f9bc-7f43-1bec" targetId="b08e-548a-fda7-0a4e" linkType="entry">
+                  <constraints/>
+                </entryLink>
+                <entryLink id="be3f-4e32-9b54-3fff" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="fd6a-ddcd-7bd1-baf2" profileTypeId="1650-77b3-10d1-6406" name="AI Infiltration Leader" hidden="false" book="BtGoA" page="174">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="6 (7)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-              </characteristics>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="e68a-5d99-1837-00bf" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="3.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="a84d-a071-f48f-33ab" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="db1e-2f71-fc74-8619" targetId="6b54-c223-3c4a-5de7" linkType="entry">
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="14.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9044-f681-7df2-2217" name="Promote one crew member to Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="2f85-136a-da3c-3dc1" hidden="false" targetId="e441-c3a6-7d61-2c63" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c5a0-5915-45d9-3ebc" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="a41c-198c-6e6b-9630">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="c9f2-2169-2f1e-3e18" hidden="false" targetId="9733-7039-e306-26b5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="points" value="5.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-            <link id="dbcb-5feb-24da-acaf" targetId="8de3-1e72-72ef-e7a3" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="cdf4-eed0-f3d7-f3ce" hidden="false" targetId="b9f1-a313-3e59-57ab" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="points" value="5.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="97e8-d8ef-1bec-906d" name="AI Infiltration Trooper" points="18.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="7" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="a41c-198c-6e6b-9630" hidden="false" targetId="cea7-8511-2208-1b1f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="1dd0-b0d7-ca04-2982" hidden="false" targetId="5149-5183-64d5-feaf" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="a4b4-7d9b-c27e-715b" hidden="false" targetId="af24-45f9-4669-bf98" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="25.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="46ac-8536-740b-1631" name="Spotter Drone" hidden="false" collective="false" defaultSelectionEntryId="dae2-19d0-0b13-21d4">
+          <profiles/>
           <rules/>
-          <profiles>
-            <profile id="c30e-c14d-871a-7b22" profileTypeId="1650-77b3-10d1-6406" name="AI Infiltration Trooper" hidden="false" book="BtGoA" page="17">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="6 (7)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="6250-ec69-9b1a-177f" name="Spotter Drone" defaultEntryId="5e81-802d-021d-5a05" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="5e81-802d-021d-5a05" targetId="f3aa-148a-0460-c7e5" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="dae2-19d0-0b13-21d4" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="fff7-d85d-7713-194d" name="Ranged Weapon" defaultEntryId="1b32-6cc9-8dc9-64b3" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="1b32-6cc9-8dc9-64b3" targetId="790a-6841-6372-870b" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="d0c6-69c7-03f7-6e2c" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="cca7-6248-d4d1-89fb" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="20.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="45.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="40ad-08b6-fa6a-0171" name="AI Infiltration Squad" book="BtGoA" page="174" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
       <profiles/>
-      <links>
-        <link id="33fc-4af1-3af0-2309" targetId="7ac3-5fd7-f7a8-3a01" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="40ad-08b6-fa6a-0171" incrementChildId="97e8-d8ef-1bec-906d" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="40ad-08b6-fa6a-0171" incrementChildId="c3fa-7787-a4d1-50f8" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="6e03-f2a2-1a44-794d" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="7876-6071-860a-2b8f" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="478c-3cc9-275f-7eac" targetId="96c4-7a43-2a4c-d7d3" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="2e0c-d76f-3052-0617" targetId="1b16-412b-662a-5467" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="15.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="dc54-b931-3a06-f2b0" targetId="4933-25f0-2896-ac60" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="55f2-7f85-9f7a-d31c" targetId="db03-7794-daeb-fef6" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="3.0" repeat="true" numRepeats="1" incrementParentId="40ad-08b6-fa6a-0171" incrementChildId="c3fa-7787-a4d1-50f8" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="3.0" repeat="true" numRepeats="1" incrementParentId="40ad-08b6-fa6a-0171" incrementChildId="97e8-d8ef-1bec-906d" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="2f0f-7aeb-c2c2-ead0" targetId="3af1-7df9-4f90-c12c" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="969a-8139-9654-9cdf" name="AI Intruder Skimmer Command Squad" points="186.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="174">
-      <entries>
-        <entry id="d40e-0a4d-13fa-863b" name="AI Intruder Commander" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="e0b2-8c3a-7575-9736" name="Leader Level" defaultEntryId="b5bf-1e38-3cd6-1854" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="6aec-3a3c-0e12-62d2" name="Leader Three" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="1f66-c0d1-8d27-5711" targetId="05bb-4d34-70cd-25d2" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="b5bf-1e38-3cd6-1854" name="Leader Two" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="b6ec-8536-6683-19c2" targetId="7850-89e7-bab8-86e9" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="478c-3cc9-275f-7eac" hidden="false" targetId="96c4-7a43-2a4c-d7d3" type="rule">
+          <profiles/>
           <rules/>
-          <profiles>
-            <profile id="c399-5307-6ed8-f37e" profileTypeId="f9a2-eeae-3284-75fd" name="AI Intruder Commander" hidden="false" book="BtGoA" page="174">
-              <characteristics>
-                <characteristic characteristicId="18c1-4764-7d08-708d" name="Ag" value="5"/>
-                <characteristic characteristicId="e39c-d7a4-86a8-d23d" name="Acc" value="5"/>
-                <characteristic characteristicId="0790-bfd5-1273-fe12" name="Str" value="5"/>
-                <characteristic characteristicId="5b77-3595-2819-675c" name="Res" value="6 (8)"/>
-                <characteristic characteristicId="c0d8-f6fd-a474-1385" name="Init" value="7"/>
-                <characteristic characteristicId="135d-efc3-5039-b6e6" name="Co" value="9"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="0b4f-18e9-64d4-1bc8" targetId="5c9b-1bde-ee01-04a4" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="7780-1ba7-1b1c-b4c2" targetId="7bc9-5e98-2914-5abd" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="2c42-d94f-83c4-fb4f" name="AI Intruder Trooper" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <infoLinks/>
           <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="eebb-ce4e-05d2-168c" profileTypeId="f9a2-eeae-3284-75fd" name="AI Intruder Trooper" hidden="false" book="BtGoA" page="174">
-              <characteristics>
-                <characteristic characteristicId="18c1-4764-7d08-708d" name="Ag" value="5"/>
-                <characteristic characteristicId="e39c-d7a4-86a8-d23d" name="Acc" value="5"/>
-                <characteristic characteristicId="0790-bfd5-1273-fe12" name="Str" value="5"/>
-                <characteristic characteristicId="5b77-3595-2819-675c" name="Res" value="6 (8)"/>
-                <characteristic characteristicId="c0d8-f6fd-a474-1385" name="Init" value="7"/>
-                <characteristic characteristicId="135d-efc3-5039-b6e6" name="Co" value="8"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="6569-9429-8783-633d" name="Compactor Drone" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="7dc0-df51-06b7-f55f" targetId="babd-f951-933b-1254" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="ec3d-370a-88c3-460a" targetId="2144-e450-c8f2-af26" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="15.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="9809-38d3-a32e-66a6" targetId="666e-aa69-6e72-f168" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="25.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="c3fa-7787-a4d1-50f8" name="AI Infiltration Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="fd6a-ddcd-7bd1-baf2" name="AI Infiltration Leader" book="BtGoA" page="174" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (7)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="189f-239f-cc54-f496" name="Leader Level" hidden="false" collective="false" defaultSelectionEntryId="6d3e-ba32-c035-533f">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="6d3e-ba32-c035-533f" name="Leader One" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="3c69-4c06-1da1-77d4" hidden="false" targetId="e441-c3a6-7d61-2c63" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="6cd8-052e-b9da-e94e" name="Leader Two" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="f2ac-6316-75a8-0504" hidden="false" targetId="7850-89e7-bab8-86e9" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="f5ed-8cd5-154e-1987" name="Ranged Weapon 1" hidden="false" collective="false" defaultSelectionEntryId="5c28-c516-b9ce-5802">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="5c28-c516-b9ce-5802" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="a317-28d4-96e1-cd44" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="3.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="5601-2930-b7cc-3680" name="Ranged Weapon 2" hidden="false" collective="false" defaultSelectionEntryId="a4e2-f9bc-7f43-1bec">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="a4e2-f9bc-7f43-1bec" hidden="false" targetId="b08e-548a-fda7-0a4e" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="db1e-2f71-fc74-8619" hidden="false" targetId="6b54-c223-3c4a-5de7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="dbcb-5feb-24da-acaf" hidden="false" targetId="8de3-1e72-72ef-e7a3" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="97e8-d8ef-1bec-906d" name="AI Infiltration Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="c30e-c14d-871a-7b22" name="AI Infiltration Trooper" book="BtGoA" page="17" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (7)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="18.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6250-ec69-9b1a-177f" name="Spotter Drone" hidden="false" collective="false" defaultSelectionEntryId="5e81-802d-021d-5a05">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="5e81-802d-021d-5a05" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="fff7-d85d-7713-194d" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="1b32-6cc9-8dc9-64b3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="1b32-6cc9-8dc9-64b3" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="33fc-4af1-3af0-2309" hidden="false" targetId="7ac3-5fd7-f7a8-3a01" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="40ad-08b6-fa6a-0171" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97e8-d8ef-1bec-906d" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="40ad-08b6-fa6a-0171" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c3fa-7787-a4d1-50f8" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="6e03-f2a2-1a44-794d" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="7876-6071-860a-2b8f" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="2e0c-d76f-3052-0617" hidden="false" targetId="1b16-412b-662a-5467" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="15.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="dc54-b931-3a06-f2b0" hidden="false" targetId="4933-25f0-2896-ac60" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="55f2-7f85-9f7a-d31c" hidden="false" targetId="db03-7794-daeb-fef6" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="3.0">
+              <repeats>
+                <repeat field="selections" scope="40ad-08b6-fa6a-0171" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c3fa-7787-a4d1-50f8" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="3.0">
+              <repeats>
+                <repeat field="selections" scope="40ad-08b6-fa6a-0171" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97e8-d8ef-1bec-906d" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="2f0f-7aeb-c2c2-ead0" hidden="false" targetId="3af1-7df9-4f90-c12c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="47.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="969a-8139-9654-9cdf" name="AI Intruder Skimmer Command Squad" book="BtGoA" page="174" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
       <rules>
         <rule id="76be-d990-01b2-40b5" name="Mounted Command Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
         <rule id="801f-37d3-aeef-35ef" name="Limited Choice" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="56bf-6681-ddbb-0f61" targetId="b018-6101-d2e3-b4ea" linkType="entry">
+      <infoLinks>
+        <infoLink id="8ada-48df-990a-b1c6" hidden="false" targetId="b0ca-8e7d-d03f-f027" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="c483-cdc7-d858-3c42" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
+        </infoLink>
+        <infoLink id="0026-0fee-242b-f524" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="aa2a-68f4-e973-4cd9" targetId="573b-88bc-97d7-d890" linkType="entry">
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="d40e-0a4d-13fa-863b" name="AI Intruder Commander" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="c399-5307-6ed8-f37e" name="AI Intruder Commander" book="BtGoA" page="174" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="5"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="6 (8)"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="7"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="9"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="0b4f-18e9-64d4-1bc8" hidden="false" targetId="5c9b-1bde-ee01-04a4" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="7780-1ba7-1b1c-b4c2" hidden="false" targetId="7bc9-5e98-2914-5abd" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-        </link>
-        <link id="b590-78da-ab5f-0d08" targetId="d3a3-d3e0-1480-e349" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="e0b2-8c3a-7575-9736" name="Leader Level" hidden="false" collective="false" defaultSelectionEntryId="b5bf-1e38-3cd6-1854">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="6aec-3a3c-0e12-62d2" name="Leader Three" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="1f66-c0d1-8d27-5711" hidden="false" targetId="05bb-4d34-70cd-25d2" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="b5bf-1e38-3cd6-1854" name="Leader Two" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="b6ec-8536-6683-19c2" hidden="false" targetId="7850-89e7-bab8-86e9" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2c42-d94f-83c4-fb4f" name="AI Intruder Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="eebb-ce4e-05d2-168c" name="AI Intruder Trooper" book="BtGoA" page="174" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="5"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="6 (8)"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="7"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="8"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="8ada-48df-990a-b1c6" targetId="b0ca-8e7d-d03f-f027" linkType="rule">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6569-9429-8783-633d" name="Compactor Drone" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="0026-0fee-242b-f524" targetId="a221-d53c-b4bd-b52c" linkType="rule">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="7dc0-df51-06b7-f55f" hidden="false" targetId="babd-f951-933b-1254" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="ec3d-370a-88c3-460a" hidden="false" targetId="2144-e450-c8f2-af26" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="15.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="9809-38d3-a32e-66a6" hidden="false" targetId="666e-aa69-6e72-f168" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="25.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="56bf-6681-ddbb-0f61" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="42ca-1a8a-cce2-27fa" targetId="f3aa-148a-0460-c7e5" linkType="entry">
+          <constraints/>
+        </entryLink>
+        <entryLink id="c483-cdc7-d858-3c42" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="aa2a-68f4-e973-4cd9" hidden="false" targetId="573b-88bc-97d7-d890" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="b590-78da-ab5f-0d08" hidden="false" targetId="d3a3-d3e0-1480-e349" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="42ca-1a8a-cce2-27fa" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+            <modifier type="increment" field="points" value="10.0">
+              <repeats/>
               <conditions/>
               <conditionGroups/>
             </modifier>
           </modifiers>
-        </link>
-      </links>
-    </entry>
-    <entry id="a370-0f8b-0d94-4a92" name="AI Intruder Skimmer Squad" points="106.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="174">
-      <entries>
-        <entry id="878f-69c7-26a8-6ce6" name="AI Intruder Leader" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="ae93-a927-8e78-de03" name="Leader Level" defaultEntryId="2cc3-9451-546f-657e" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="2cc3-9451-546f-657e" name="Leader One" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="89a6-bbef-965b-3f5c" targetId="e441-c3a6-7d61-2c63" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="84f4-c3d5-1823-40f0" name="Leader Two" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="f55f-569b-afc4-bbf0" targetId="7850-89e7-bab8-86e9" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="8fa0-38f8-b4f7-0628" profileTypeId="1650-77b3-10d1-6406" name="AI Intruder Leader" hidden="false" book="BtGoA" page="174">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="6 (8)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-        <entry id="866e-82e8-762b-d9e4" name="AI Intruder Trooper" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="09b6-2b18-a5f2-e766" profileTypeId="1650-77b3-10d1-6406" name="AI Intruder Trooper" hidden="false" book="BtGoA" page="174">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="6 (8)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="0f92-fd86-3f9e-e9fe" name="Compactor Drone" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="557a-84b3-18bd-cc77" targetId="babd-f951-933b-1254" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="9a43-cccb-c740-8ebe" targetId="2144-e450-c8f2-af26" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="15.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="62bc-0d96-f9ef-d438" targetId="666e-aa69-6e72-f168" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="25.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="186.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a370-0f8b-0d94-4a92" name="AI Intruder Skimmer Squad" book="BtGoA" page="174" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
       <rules>
         <rule id="d6d7-1279-f75c-631d" name="Mounted Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="c2e3-b061-d782-a118" targetId="b0ca-8e7d-d03f-f027" linkType="rule">
+      <infoLinks>
+        <infoLink id="c2e3-b061-d782-a118" hidden="false" targetId="b0ca-8e7d-d03f-f027" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="3995-9f22-61e1-b9b9" targetId="a221-d53c-b4bd-b52c" linkType="rule">
+        </infoLink>
+        <infoLink id="3995-9f22-61e1-b9b9" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="aa34-e573-72bb-e9cc" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="878f-69c7-26a8-6ce6" name="AI Intruder Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="8fa0-38f8-b4f7-0628" name="AI Intruder Leader" book="BtGoA" page="174" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (8)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="b225-a9df-6064-269c" targetId="573b-88bc-97d7-d890" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="ae93-a927-8e78-de03" name="Leader Level" hidden="false" collective="false" defaultSelectionEntryId="2cc3-9451-546f-657e">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="2cc3-9451-546f-657e" name="Leader One" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="89a6-bbef-965b-3f5c" hidden="false" targetId="e441-c3a6-7d61-2c63" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="84f4-c3d5-1823-40f0" name="Leader Two" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="f55f-569b-afc4-bbf0" hidden="false" targetId="7850-89e7-bab8-86e9" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="866e-82e8-762b-d9e4" name="AI Intruder Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="09b6-2b18-a5f2-e766" name="AI Intruder Trooper" book="BtGoA" page="174" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (8)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="8dbf-1e54-2cf4-54d1" targetId="d3a3-d3e0-1480-e349" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0f92-fd86-3f9e-e9fe" name="Compactor Drone" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="8207-ff16-0131-7167" targetId="790a-6841-6372-870b" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="557a-84b3-18bd-cc77" hidden="false" targetId="babd-f951-933b-1254" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="9a43-cccb-c740-8ebe" hidden="false" targetId="2144-e450-c8f2-af26" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="15.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="62bc-0d96-f9ef-d438" hidden="false" targetId="666e-aa69-6e72-f168" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="25.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="aa34-e573-72bb-e9cc" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="42b1-9365-4a16-cdee" targetId="f3aa-148a-0460-c7e5" linkType="entry">
+          <constraints/>
+        </entryLink>
+        <entryLink id="b225-a9df-6064-269c" hidden="false" targetId="573b-88bc-97d7-d890" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="8dbf-1e54-2cf4-54d1" hidden="false" targetId="d3a3-d3e0-1480-e349" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="8207-ff16-0131-7167" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="42b1-9365-4a16-cdee" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+            <modifier type="increment" field="points" value="10.0">
+              <repeats/>
               <conditions/>
               <conditionGroups/>
             </modifier>
           </modifiers>
-        </link>
-      </links>
-    </entry>
-    <entry id="0686-8100-d42b-6954" name="AI Liberator Combat Skimmer - X01 Hi-Mag" points="184.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="177">
-      <entries>
-        <entry id="7b1b-0acb-dc91-c73c" name="Combat Skimmer" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="47c3-c21c-89a3-b7aa" name="Weapon 1" defaultEntryId="1986-3dd7-bc70-4c75" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="e124-c6c8-c9a6-aba5" targetId="6a2b-50c5-9a33-b756" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="5.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-                <link id="1986-3dd7-bc70-4c75" targetId="a00c-0542-f2a5-8124" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="e38e-9547-9de7-4d25" targetId="ac1e-a740-57b7-cc64" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="8f5d-6287-181b-080e" name="Weapon 2" defaultEntryId="c220-bfa1-44ba-606d" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="c220-bfa1-44ba-606d" targetId="a00c-0542-f2a5-8124" linkType="entry">
-                  <modifiers>
-                    <modifier type="set" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="5e4d-1347-d97b-2c1c" profileTypeId="1650-77b3-10d1-6406" name="Combat Skimmer" hidden="false" book="BtGoA" page="177">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="13"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-        <entry id="f530-4134-9321-4225" name="Self-repair" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="d0d1-b167-3160-1832" targetId="3377-9408-33bb-6a02" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="ce8a-8159-acb9-92ce" name="Spotter Drone" defaultEntryId="e4fc-24b0-5c48-8684" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="e4fc-24b0-5c48-8684" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="106.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0686-8100-d42b-6954" name="AI Liberator Combat Skimmer - X01 Hi-Mag" book="BtGoA" page="177" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
       <rules>
         <rule id="62b4-e4e2-6e8f-f278" name="Vehicle Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="b74d-1f52-721b-b36a" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="d94f-ac4d-8c56-887f" targetId="d571-d584-85fc-9110" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="20.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="59ef-0e7f-1772-9e70" targetId="5565-ce10-1c78-1ee7" linkType="rule">
+      <infoLinks>
+        <infoLink id="59ef-0e7f-1772-9e70" hidden="false" targetId="5565-ce10-1c78-1ee7" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="7286-f996-cc44-fec2" targetId="a221-d53c-b4bd-b52c" linkType="rule">
+        </infoLink>
+        <infoLink id="7286-f996-cc44-fec2" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="a84e-3d94-c89b-60aa" targetId="b145-19b3-baae-ff39" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="6838-8300-be85-24bc" targetId="b145-19b3-baae-ff39" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="782f-3ac2-6327-f7e6" targetId="d571-d584-85fc-9110" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="20.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-      </links>
-    </entry>
-    <entry id="cf98-8e3e-b9d5-f49a" name="AI Liberator Combat Skimmer - X06 Plasma Destroyer" points="244.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="177">
-      <entries>
-        <entry id="56de-38d4-1aca-461a" name="Combat Skimmer" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="f07c-b712-2b7c-c102" name="Weapon 1" defaultEntryId="c603-2a8c-dd35-9edc" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="7b1b-0acb-dc91-c73c" name="Combat Skimmer" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="5e4d-1347-d97b-2c1c" name="Combat Skimmer" book="BtGoA" page="177" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <links>
-                <link id="71e8-3334-6c11-96c8" targetId="c2bf-0272-30c6-dd20" linkType="entry">
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="13"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="47c3-c21c-89a3-b7aa" name="Weapon 1" hidden="false" collective="false" defaultSelectionEntryId="1986-3dd7-bc70-4c75">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="e124-c6c8-c9a6-aba5" hidden="false" targetId="6a2b-50c5-9a33-b756" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers>
-                    <modifier type="increment" field="points" value="5.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                    <modifier type="increment" field="points" value="5.0">
+                      <repeats/>
                       <conditions/>
                       <conditionGroups/>
                     </modifier>
                   </modifiers>
-                </link>
-                <link id="c603-2a8c-dd35-9edc" targetId="cf3a-e6a9-bdc0-e0ae" linkType="entry">
+                  <constraints/>
+                </entryLink>
+                <entryLink id="1986-3dd7-bc70-4c75" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="7238-1278-7cd9-35b9" name="Weapon 2" defaultEntryId="c713-86f2-8e3c-d472" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="e38e-9547-9de7-4d25" hidden="false" targetId="ac1e-a740-57b7-cc64" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="10.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="8f5d-6287-181b-080e" name="Weapon 2" hidden="false" collective="false" defaultSelectionEntryId="c220-bfa1-44ba-606d">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <links>
-                <link id="c713-86f2-8e3c-d472" targetId="cf3a-e6a9-bdc0-e0ae" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="a1fc-039b-f26f-d312" profileTypeId="1650-77b3-10d1-6406" name="Combat Skimmer" hidden="false" book="BtGoA" page="177">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="13"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-        <entry id="4b89-b0c3-6567-01ea" name="Self-repair" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="c220-bfa1-44ba-606d" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="minSelections" value="1.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f530-4134-9321-4225" name="Self-repair" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles/>
-          <links>
-            <link id="7100-9b0a-a8e8-4e34" targetId="3377-9408-33bb-6a02" linkType="rule">
+          <rules/>
+          <infoLinks>
+            <infoLink id="d0d1-b167-3160-1832" hidden="false" targetId="3377-9408-33bb-6a02" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="4df1-eb5e-8db2-db61" name="Spotter Drone" defaultEntryId="83e9-0151-9a15-88c1" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-          <links>
-            <link id="83e9-0151-9a15-88c1" targetId="f3aa-148a-0460-c7e5" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ce8a-8159-acb9-92ce" name="Spotter Drone" hidden="false" collective="false" defaultSelectionEntryId="e4fc-24b0-5c48-8684">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="e4fc-24b0-5c48-8684" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="b74d-1f52-721b-b36a" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="d94f-ac4d-8c56-887f" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="20.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="a84e-3d94-c89b-60aa" hidden="false" targetId="b145-19b3-baae-ff39" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="6838-8300-be85-24bc" hidden="false" targetId="b145-19b3-baae-ff39" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="782f-3ac2-6327-f7e6" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="20.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="184.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cf98-8e3e-b9d5-f49a" name="AI Liberator Combat Skimmer - X06 Plasma Destroyer" book="BtGoA" page="177" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
       <rules>
         <rule id="5ff2-21b6-d9eb-8179" name="Vehicle Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="e7c0-191b-b438-9587" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="d5c0-573b-2c9d-b181" targetId="d571-d584-85fc-9110" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="20.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="cb8f-8375-aa9f-ae21" targetId="5565-ce10-1c78-1ee7" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="8f7c-f29c-bcb9-2ad0" targetId="a221-d53c-b4bd-b52c" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="cb78-c4c0-6bce-7852" targetId="b145-19b3-baae-ff39" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="63b5-c9c4-0a0a-4965" targetId="b145-19b3-baae-ff39" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="9234-aca6-0fcc-b015" targetId="d571-d584-85fc-9110" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="20.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-      </links>
-    </entry>
-    <entry id="17b0-20bb-f500-0569" name="AI Liberator Combat Skimmer - X10 Special" points="224.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="177">
-      <entries>
-        <entry id="6f63-5f0c-90ec-e2b3" name="Combat Skimmer" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="9e35-33d9-cae6-d346" name="Weapon 2" defaultEntryId="1fb7-e103-c0d9-9236" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="aa6b-9767-c637-e7fe" targetId="71c9-4382-01cf-c737" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="1fb7-e103-c0d9-9236" targetId="93db-3751-fdd4-08f9" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="c220-2f65-16f0-92b3" name="Weapon 1" defaultEntryId="5702-e83d-65f6-5c48" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="5702-e83d-65f6-5c48" targetId="a00c-0542-f2a5-8124" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
+      <infoLinks>
+        <infoLink id="cb8f-8375-aa9f-ae21" hidden="false" targetId="5565-ce10-1c78-1ee7" type="rule">
+          <profiles/>
           <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="8f7c-f29c-bcb9-2ad0" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="56de-38d4-1aca-461a" name="Combat Skimmer" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles>
-            <profile id="b3f1-d6e2-efa7-8d7d" profileTypeId="1650-77b3-10d1-6406" name="Combat Skimmer" hidden="false" book="BtGoA" page="177">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="13"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-              </characteristics>
+            <profile id="a1fc-039b-f26f-d312" name="Combat Skimmer" book="BtGoA" page="177" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="13"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
             </profile>
           </profiles>
-          <links/>
-        </entry>
-        <entry id="05c1-f431-5866-b555" name="Self-repair" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
           <rules/>
-          <profiles/>
-          <links>
-            <link id="f21d-ca8b-0cc0-a455" targetId="3377-9408-33bb-6a02" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="313b-f390-285f-40a6" name="Spotter Drone" defaultEntryId="d040-0f75-6159-a817" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="d040-0f75-6159-a817" targetId="f3aa-148a-0460-c7e5" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="f07c-b712-2b7c-c102" name="Weapon 1" hidden="false" collective="false" defaultSelectionEntryId="c603-2a8c-dd35-9edc">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="71e8-3334-6c11-96c8" hidden="false" targetId="c2bf-0272-30c6-dd20" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="5.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="c603-2a8c-dd35-9edc" hidden="false" targetId="cf3a-e6a9-bdc0-e0ae" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="7238-1278-7cd9-35b9" name="Weapon 2" hidden="false" collective="false" defaultSelectionEntryId="c713-86f2-8e3c-d472">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="c713-86f2-8e3c-d472" hidden="false" targetId="cf3a-e6a9-bdc0-e0ae" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4b89-b0c3-6567-01ea" name="Self-repair" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="7100-9b0a-a8e8-4e34" hidden="false" targetId="3377-9408-33bb-6a02" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="4df1-eb5e-8db2-db61" name="Spotter Drone" hidden="false" collective="false" defaultSelectionEntryId="83e9-0151-9a15-88c1">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="83e9-0151-9a15-88c1" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="e7c0-191b-b438-9587" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="d5c0-573b-2c9d-b181" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="20.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="cb78-c4c0-6bce-7852" hidden="false" targetId="b145-19b3-baae-ff39" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="63b5-c9c4-0a0a-4965" hidden="false" targetId="b145-19b3-baae-ff39" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="9234-aca6-0fcc-b015" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="20.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="244.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="17b0-20bb-f500-0569" name="AI Liberator Combat Skimmer - X10 Special" book="BtGoA" page="177" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
       <rules>
         <rule id="5885-c36a-df02-8929" name="Vehicle Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="d5cc-327b-cc1e-1b7c" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="2923-da64-562b-a9d3" targetId="d571-d584-85fc-9110" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="20.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="a585-1593-09ca-fa4f" targetId="5565-ce10-1c78-1ee7" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="4440-5c30-6a45-9157" targetId="a221-d53c-b4bd-b52c" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="1164-7112-54d8-3e3f" targetId="b145-19b3-baae-ff39" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="ed71-7a9d-bb0f-29a4" targetId="b145-19b3-baae-ff39" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="6264-308a-a95f-6374" targetId="d571-d584-85fc-9110" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="20.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-      </links>
-    </entry>
-    <entry id="7ad1-0ccb-ea7e-405e" name="AI Medic Team" points="0.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="178">
-      <entries>
-        <entry id="bc34-41d2-bb66-d916" name="Algoryn Medic" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="48dd-78d2-9329-d56a" name="Weapon" defaultEntryId="7d3f-fe8e-3299-77b5" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="9d2b-b5d7-170a-1dcf" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-                <link id="7d3f-fe8e-3299-77b5" targetId="8690-3ab7-9fef-06ee" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="c6a1-68fd-f47c-0fe6" targetId="790a-6841-6372-870b" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="a149-379a-67e9-44b9" profileTypeId="1650-77b3-10d1-6406" name="Algoryn Medic" hidden="false" book="BtGoA" page="178">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="6 (7)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="51b6-9c64-6a1e-ca04" targetId="137e-c2b6-65b7-ecc3" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="a112-61a7-be5e-8620" name="Spotter Drone" defaultEntryId="ac15-6ba2-59ae-15c0" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="ac15-6ba2-59ae-15c0" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="035c-588d-4b1e-482e" targetId="502c-9855-7269-eaa2" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="20.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-      </links>
-    </entry>
-    <entry id="500b-c1c5-a0da-aecc" name="AI Specialist Heavy Support Team" points="65.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="176">
-      <entries>
-        <entry id="6eab-104b-f771-03c2" name="AI Trooper Crew" points="14.0" categoryId="(No Category)" type="model" minSelections="3" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="df91-f3d2-baf0-d57b" name="Weapon" defaultEntryId="90f4-92b9-a73e-7a8e" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="df08-f4ae-9c52-fdfc" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-                <link id="90f4-92b9-a73e-7a8e" targetId="8690-3ab7-9fef-06ee" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="0242-1032-6f80-0baa" targetId="790a-6841-6372-870b" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="3d91-fd9c-e7ea-045e" profileTypeId="f9a2-eeae-3284-75fd" name="AI Trooper Crew" hidden="false" book="BtGoA" page="176">
-              <characteristics>
-                <characteristic characteristicId="18c1-4764-7d08-708d" name="Ag" value="5"/>
-                <characteristic characteristicId="e39c-d7a4-86a8-d23d" name="Acc" value="5"/>
-                <characteristic characteristicId="0790-bfd5-1273-fe12" name="Str" value="5"/>
-                <characteristic characteristicId="5b77-3595-2819-675c" name="Res" value="6 (7)"/>
-                <characteristic characteristicId="c0d8-f6fd-a474-1385" name="Init" value="7"/>
-                <characteristic characteristicId="135d-efc3-5039-b6e6" name="Co" value="8"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="d4b7-2639-1cdf-ae0e" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="0699-99a3-4367-379c" name="Promote one crew member to Leader" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
+      <infoLinks>
+        <infoLink id="a585-1593-09ca-fa4f" hidden="false" targetId="5565-ce10-1c78-1ee7" type="rule">
           <profiles/>
-          <links>
-            <link id="dea8-fdda-5e18-1abc" targetId="e441-c3a6-7d61-2c63" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="38b0-3566-c9c9-74c2" name="Weapon" defaultEntryId="271c-f9a4-c727-98ec" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="8562-8e48-301a-2b10" targetId="2cec-e1d7-c680-7ca0" linkType="entry">
+        </infoLink>
+        <infoLink id="4440-5c30-6a45-9157" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="6f63-5f0c-90ec-e2b3" name="Combat Skimmer" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="b3f1-d6e2-efa7-8d7d" name="Combat Skimmer" book="BtGoA" page="177" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="13"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="9e35-33d9-cae6-d346" name="Weapon 2" hidden="false" collective="false" defaultSelectionEntryId="1fb7-e103-c0d9-9236">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="aa6b-9767-c637-e7fe" hidden="false" targetId="71c9-4382-01cf-c737" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="1fb7-e103-c0d9-9236" hidden="false" targetId="93db-3751-fdd4-08f9" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="c220-2f65-16f0-92b3" name="Weapon 1" hidden="false" collective="false" defaultSelectionEntryId="5702-e83d-65f6-5c48">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="5702-e83d-65f6-5c48" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="05c1-f431-5866-b555" name="Self-repair" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="f21d-ca8b-0cc0-a455" hidden="false" targetId="3377-9408-33bb-6a02" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="313b-f390-285f-40a6" name="Spotter Drone" hidden="false" collective="false" defaultSelectionEntryId="d040-0f75-6159-a817">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="d040-0f75-6159-a817" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="d5cc-327b-cc1e-1b7c" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="2923-da64-562b-a9d3" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="20.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="1164-7112-54d8-3e3f" hidden="false" targetId="b145-19b3-baae-ff39" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="ed71-7a9d-bb0f-29a4" hidden="false" targetId="b145-19b3-baae-ff39" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="6264-308a-a95f-6374" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="20.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="224.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7ad1-0ccb-ea7e-405e" name="AI Medic Team" book="BtGoA" page="178" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="bc34-41d2-bb66-d916" name="Algoryn Medic" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="a149-379a-67e9-44b9" name="Algoryn Medic" book="BtGoA" page="178" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (7)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="51b6-9c64-6a1e-ca04" hidden="false" targetId="137e-c2b6-65b7-ecc3" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="48dd-78d2-9329-d56a" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="7d3f-fe8e-3299-77b5">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="9d2b-b5d7-170a-1dcf" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="3.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="7d3f-fe8e-3299-77b5" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="c6a1-68fd-f47c-0fe6" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="3.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="a112-61a7-be5e-8620" name="Spotter Drone" hidden="false" collective="false" defaultSelectionEntryId="ac15-6ba2-59ae-15c0">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="ac15-6ba2-59ae-15c0" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="points" value="15.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-            <link id="271c-f9a4-c727-98ec" targetId="67b6-d6f5-5ba3-e50d" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="e6ec-90fe-f9df-14d6" name="Spotter Drone" defaultEntryId="f7c2-a2e6-f678-9d8c" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="f7c2-a2e6-f678-9d8c" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="035c-588d-4b1e-482e" hidden="false" targetId="502c-9855-7269-eaa2" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="20.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="500b-c1c5-a0da-aecc" name="AI Specialist Heavy Support Team" book="BtGoA" page="176" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
       <rules>
         <rule id="9f81-a903-76b1-2432" name="Weapon Team Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
         <rule id="05e7-9036-3057-a796" name="Limited Choice" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="feab-a4b0-75c9-7c44" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="d6cc-47c5-c602-dd58" targetId="a221-d53c-b4bd-b52c" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="d7b2-c85c-0f0d-e5fb" targetId="7c88-64d4-50ad-2313" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="2a78-7bc5-b123-adcb" targetId="d571-d584-85fc-9110" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="20.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-      </links>
-    </entry>
-    <entry id="6d12-fb12-c8a4-6e92" name="AI Specialist Support Team" points="40.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="175">
-      <entries>
-        <entry id="fb98-1376-32bb-e1c9" name="AI Trooper Crew" points="14.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="9e08-6f41-23c9-b23e" name="Weapon" defaultEntryId="ac29-0bf1-4bb7-fd44" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="ac29-0bf1-4bb7-fd44" targetId="8690-3ab7-9fef-06ee" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="cafb-2d79-5445-7fbd" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-                <link id="a149-2c1a-0510-97e5" targetId="790a-6841-6372-870b" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
+      <infoLinks>
+        <infoLink id="d6cc-47c5-c602-dd58" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+          <profiles/>
           <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="d7b2-c85c-0f0d-e5fb" hidden="false" targetId="7c88-64d4-50ad-2313" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="6eab-104b-f771-03c2" name="AI Trooper Crew" book="" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles>
-            <profile id="2ece-5823-dbf7-60fe" profileTypeId="1650-77b3-10d1-6406" name="AI Trooper Crew" hidden="false" book="BtGoA" page="175">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="6 (7)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-              </characteristics>
+            <profile id="3d91-fd9c-e7ea-045e" name="AI Trooper Crew" book="BtGoA" page="176" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="5"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="6 (7)"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="7"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="8"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424"/>
+              </characteristics>
             </profile>
           </profiles>
-          <links>
-            <link id="52b5-70d9-3c1a-82d2" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="8fb3-51ec-113a-efb3" name="Promote one crew member to Leader" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="a6ea-6c72-b495-c935" name="Leader Level" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="53ad-d00a-2804-2864" name="Leader One" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="851e-d52c-6b45-e360" targetId="e441-c3a6-7d61-2c63" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
           <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="39c8-fdfb-8dea-b355" name="Weapon" defaultEntryId="280e-bb1b-83db-559d" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="510d-3509-91ea-5410" targetId="93db-3751-fdd4-08f9" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="3aee-e32a-a8dd-ee3c" targetId="c2bf-0272-30c6-dd20" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="280e-bb1b-83db-559d" targetId="cf3a-e6a9-bdc0-e0ae" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="df91-f3d2-baf0-d57b" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="90f4-92b9-a73e-7a8e">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="19ef-aa68-146b-c160" targetId="71c9-4382-01cf-c737" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="df08-f4ae-9c52-fdfc" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="3.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="90f4-92b9-a73e-7a8e" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="0242-1032-6f80-0baa" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="3.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="d4b7-2639-1cdf-ae0e" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="14.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0699-99a3-4367-379c" name="Promote one crew member to Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="dea8-fdda-5e18-1abc" hidden="false" targetId="e441-c3a6-7d61-2c63" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="38b0-3566-c9c9-74c2" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="271c-f9a4-c727-98ec">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="8562-8e48-301a-2b10" hidden="false" targetId="2cec-e1d7-c680-7ca0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="15.0">
+                  <repeats/>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="271c-f9a4-c727-98ec" hidden="false" targetId="67b6-d6f5-5ba3-e50d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e6ec-90fe-f9df-14d6" name="Spotter Drone" hidden="false" collective="false" defaultSelectionEntryId="f7c2-a2e6-f678-9d8c">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="f7c2-a2e6-f678-9d8c" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="feab-a4b0-75c9-7c44" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="2a78-7bc5-b123-adcb" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="20.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="65.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6d12-fb12-c8a4-6e92" name="AI Specialist Support Team" book="BtGoA" page="175" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
       <rules>
         <rule id="8c84-00e0-fedc-fd8b" name="Weapon Team Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="71a4-4336-f898-7048" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="a44f-4447-aff2-0dcd" name="AI Squad" points="0.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="173">
-      <entries>
-        <entry id="c61f-6de1-069d-821f" name="AI Leader" points="26.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="eeeb-14fc-3015-51fc" name="Leader Level" defaultEntryId="36ec-d26c-3022-b885" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="36ec-d26c-3022-b885" name="Leader One" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="93f8-4f41-c31d-0653" targetId="e441-c3a6-7d61-2c63" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="a094-8787-d876-c144" name="Leader Two" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="4cb6-9a0e-7326-22e3" targetId="7850-89e7-bab8-86e9" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-            <entryGroup id="614f-b64a-4c29-8d4f" name="Ranged Weapon 1" defaultEntryId="2bc1-4f6e-02ba-7d1c" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="ea0d-f127-d94d-dc3d" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-                <link id="2bc1-4f6e-02ba-7d1c" targetId="8690-3ab7-9fef-06ee" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="f673-3a81-fee5-e6ee" targetId="790a-6841-6372-870b" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="fb07-2f58-0224-c3c4" name="Ranged Weapon 2" defaultEntryId="4f39-d122-493b-a05f" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="4f39-d122-493b-a05f" targetId="b08e-548a-fda7-0a4e" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="a328-3542-e3c3-2ca9" profileTypeId="1650-77b3-10d1-6406" name="AI Leader" hidden="false" book="BtGoA" page="173">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="6 (7)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-        <entry id="d441-f08b-6ae0-3ce1" name="AI Trooper" points="17.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="7" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="c3fb-a74b-70a2-dc3c" profileTypeId="1650-77b3-10d1-6406" name="AI Trooper" hidden="false" book="BtGoA" page="173">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="6 (7)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-        <entry id="4ecc-3f7f-9999-5af9" name="SlingNet Ammo for X-sling / Micro-X Launchers" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="a44f-4447-aff2-0dcd" incrementChildId="c077-8ef3-73f4-f156" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="a44f-4447-aff2-0dcd" incrementChildId="7bac-8174-3f34-cc91" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="a44f-4447-aff2-0dcd" incrementChildId="4f39-d122-493b-a05f" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-        <entry id="7197-0bcf-a743-25bd" name="Overload Ammo for X-sling / Micro-X Launchers" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="a44f-4447-aff2-0dcd" incrementChildId="7bac-8174-3f34-cc91" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="a44f-4447-aff2-0dcd" incrementChildId="c077-8ef3-73f4-f156" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="a44f-4447-aff2-0dcd" incrementChildId="4f39-d122-493b-a05f" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="ca95-0934-b9b4-b948" name="One Special Weapon" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="6b69-fba3-4cfc-2523" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="21c1-860e-a5c0-590b" targetId="790a-6841-6372-870b" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="c077-8ef3-73f4-f156" targetId="1a9d-01a2-ee09-883c" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="b9b6-482e-88c8-9a56" name="Ranged Weapon" defaultEntryId="de3c-744f-11c6-d83f" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="de3c-744f-11c6-d83f" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="b3d3-d6e4-df8d-5379" name="Micro-X Launcher" defaultEntryId="7bac-8174-3f34-cc91" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="7bac-8174-3f34-cc91" targetId="1a9d-01a2-ee09-883c" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <infoLinks/>
       <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="4af6-1eac-39c6-7d91" targetId="7ac3-5fd7-f7a8-3a01" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="a44f-4447-aff2-0dcd" incrementChildId="d441-f08b-6ae0-3ce1" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="a44f-4447-aff2-0dcd" incrementChildId="c61f-6de1-069d-821f" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="0c7f-6883-5b9e-f555" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="13d3-407b-5520-a098" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="8ea5-97f9-9ffd-604f" targetId="3af1-7df9-4f90-c12c" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="0f2b-5fd2-86c3-563b" name="AI Support Team" points="10.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="175">
-      <entries>
-        <entry id="3b68-a4c9-03bb-dd68" name="AI Trooper Crew" points="14.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="09ce-fa1f-63c6-0dee" name="Weapon" defaultEntryId="e022-953c-7321-fa34" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="e022-953c-7321-fa34" targetId="8690-3ab7-9fef-06ee" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="c2ee-fcfd-3075-694e" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-                <link id="2552-caa3-aa9d-704b" targetId="790a-6841-6372-870b" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="fb98-1376-32bb-e1c9" name="AI Trooper Crew" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles>
-            <profile id="6c57-a89b-6cf0-a030" profileTypeId="1650-77b3-10d1-6406" name="AI Trooper Crew" hidden="false" book="BtGoA" page="175">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="6 (7)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-              </characteristics>
+            <profile id="2ece-5823-dbf7-60fe" name="AI Trooper Crew" book="BtGoA" page="175" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (7)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
             </profile>
           </profiles>
-          <links>
-            <link id="5647-de18-512c-9f6f" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="5baf-a32e-e0b0-f74a" name="Promote one crew member to Leader" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="0160-815b-453d-fb00" name="Leader One" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="276a-5c2d-6a39-a811" targetId="e441-c3a6-7d61-2c63" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
           <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="85a1-9aa5-986c-0134" name="Weapon" defaultEntryId="5764-6087-e7b6-4c73" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="7198-55af-d564-f2fd" targetId="6a2b-50c5-9a33-b756" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="9e08-6f41-23c9-b23e" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="ac29-0bf1-4bb7-fd44">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="ac29-0bf1-4bb7-fd44" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="cafb-2d79-5445-7fbd" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="3.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="a149-2c1a-0510-97e5" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="3.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="52b5-70d9-3c1a-82d2" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="14.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8fb3-51ec-113a-efb3" name="Promote one crew member to Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="a6ea-6c72-b495-c935" name="Leader Level" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="53ad-d00a-2804-2864" name="Leader One" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="851e-d52c-6b45-e360" hidden="false" targetId="e441-c3a6-7d61-2c63" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="39c8-fdfb-8dea-b355" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="280e-bb1b-83db-559d">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="510d-3509-91ea-5410" hidden="false" targetId="93db-3751-fdd4-08f9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-            <link id="4711-a1d0-8193-4ddf" targetId="eed0-b68f-b5fb-92c7" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="3aee-e32a-a8dd-ee3c" hidden="false" targetId="c2bf-0272-30c6-dd20" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="280e-bb1b-83db-559d" hidden="false" targetId="cf3a-e6a9-bdc0-e0ae" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="5764-6087-e7b6-4c73" targetId="a00c-0542-f2a5-8124" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+              <constraints/>
+            </entryLink>
+            <entryLink id="19ef-aa68-146b-c160" hidden="false" targetId="71c9-4382-01cf-c737" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="71a4-4336-f898-7048" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a44f-4447-aff2-0dcd" name="AI Squad" book="BtGoA" page="173" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="c61f-6de1-069d-821f" name="AI Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="a328-3542-e3c3-2ca9" name="AI Leader" book="BtGoA" page="173" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (7)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="eeeb-14fc-3015-51fc" name="Leader Level" hidden="false" collective="false" defaultSelectionEntryId="36ec-d26c-3022-b885">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="36ec-d26c-3022-b885" name="Leader One" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="93f8-4f41-c31d-0653" hidden="false" targetId="e441-c3a6-7d61-2c63" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="a094-8787-d876-c144" name="Leader Two" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="4cb6-9a0e-7326-22e3" hidden="false" targetId="7850-89e7-bab8-86e9" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="614f-b64a-4c29-8d4f" name="Ranged Weapon 1" hidden="false" collective="false" defaultSelectionEntryId="2bc1-4f6e-02ba-7d1c">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="ea0d-f127-d94d-dc3d" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="3.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="2bc1-4f6e-02ba-7d1c" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="f673-3a81-fee5-e6ee" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="3.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="fb07-2f58-0224-c3c4" name="Ranged Weapon 2" hidden="false" collective="false" defaultSelectionEntryId="4f39-d122-493b-a05f">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="4f39-d122-493b-a05f" hidden="false" targetId="b08e-548a-fda7-0a4e" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="26.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d441-f08b-6ae0-3ce1" name="AI Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="c3fb-a74b-70a2-dc3c" name="AI Trooper" book="BtGoA" page="173" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (7)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="17.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4ecc-3f7f-9999-5af9" name="SlingNet Ammo for X-sling / Micro-X Launchers" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="a44f-4447-aff2-0dcd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c077-8ef3-73f4-f156" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="a44f-4447-aff2-0dcd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7bac-8174-3f34-cc91" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="a44f-4447-aff2-0dcd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4f39-d122-493b-a05f" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7197-0bcf-a743-25bd" name="Overload Ammo for X-sling / Micro-X Launchers" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="a44f-4447-aff2-0dcd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7bac-8174-3f34-cc91" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="a44f-4447-aff2-0dcd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c077-8ef3-73f4-f156" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="a44f-4447-aff2-0dcd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4f39-d122-493b-a05f" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ca95-0934-b9b4-b948" name="One Special Weapon" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="6b69-fba3-4cfc-2523" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="21c1-860e-a5c0-590b" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="c077-8ef3-73f4-f156" hidden="false" targetId="1a9d-01a2-ee09-883c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="b9b6-482e-88c8-9a56" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="de3c-744f-11c6-d83f">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="de3c-744f-11c6-d83f" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="b3d3-d6e4-df8d-5379" name="Micro-X Launcher" hidden="false" collective="false" defaultSelectionEntryId="7bac-8174-3f34-cc91">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="7bac-8174-3f34-cc91" hidden="false" targetId="1a9d-01a2-ee09-883c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="4af6-1eac-39c6-7d91" hidden="false" targetId="7ac3-5fd7-f7a8-3a01" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="a44f-4447-aff2-0dcd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d441-f08b-6ae0-3ce1" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="a44f-4447-aff2-0dcd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c61f-6de1-069d-821f" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="0c7f-6883-5b9e-f555" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="13d3-407b-5520-a098" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="8ea5-97f9-9ffd-604f" hidden="false" targetId="3af1-7df9-4f90-c12c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0f2b-5fd2-86c3-563b" name="AI Support Team" book="BtGoA" page="175" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
       <rules>
         <rule id="a6d0-fc64-ad5d-674a" name="Weapon Team Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="216c-c44e-3347-b938" targetId="f3aa-148a-0460-c7e5" linkType="entry">
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="3b68-a4c9-03bb-dd68" name="AI Trooper Crew" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="6c57-a89b-6cf0-a030" name="AI Trooper Crew" book="BtGoA" page="175" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (7)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="09ce-fa1f-63c6-0dee" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="e022-953c-7321-fa34">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="e022-953c-7321-fa34" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="c2ee-fcfd-3075-694e" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="3.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="2552-caa3-aa9d-704b" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="3.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="5647-de18-512c-9f6f" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="14.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5baf-a32e-e0b0-f74a" name="Promote one crew member to Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="0160-815b-453d-fb00" name="Leader One" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="276a-5c2d-6a39-a811" hidden="false" targetId="e441-c3a6-7d61-2c63" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="85a1-9aa5-986c-0134" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="5764-6087-e7b6-4c73">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="7198-55af-d564-f2fd" hidden="false" targetId="6a2b-50c5-9a33-b756" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="4711-a1d0-8193-4ddf" hidden="false" targetId="eed0-b68f-b5fb-92c7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="5764-6087-e7b6-4c73" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="216c-c44e-3347-b938" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+            <modifier type="increment" field="points" value="10.0">
+              <repeats/>
               <conditions/>
               <conditionGroups/>
             </modifier>
           </modifiers>
-        </link>
-      </links>
-    </entry>
-    <entry id="5dcd-bab6-1f25-0e1c" name="Scout Probe Shard" points="0.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="178">
-      <entries>
-        <entry id="d71e-dea9-a547-4ad4" name="Scout Probe" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="4" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="4d1a-750f-a521-9748" profileTypeId="1650-77b3-10d1-6406" name="Scout Probe" hidden="false" book="BtGoA" page="178">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="-"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="-"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="-"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="-"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="513a-bdeb-bad5-0c83" targetId="00b8-b49c-4c61-2943" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5dcd-bab6-1f25-0e1c" name="Scout Probe Shard" book="BtGoA" page="178" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit">
+      <profiles/>
       <rules>
-        <rule id="c1cd-61c1-df04-7b1e" name="Probe Unit" hidden="false" book="">
+        <rule id="c1cd-61c1-df04-7b1e" name="Probe Unit" book="" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="aa6c-67b7-3d3b-2a61" name="Targeter Probe Shard" points="0.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="178">
-      <entries>
-        <entry id="31ff-3d6d-2a30-3b5a" name="Targeter Probe" points="5.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="d71e-dea9-a547-4ad4" name="Scout Probe" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles>
-            <profile id="5411-31d1-ef11-d835" profileTypeId="1650-77b3-10d1-6406" name="Targeter Probe" hidden="false" book="BtGoA" page="178">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="-"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="-"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="-"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="-"/>
-              </characteristics>
+            <profile id="4d1a-750f-a521-9748" name="Scout Probe" book="BtGoA" page="178" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
             </profile>
           </profiles>
-          <links>
-            <link id="58b0-e470-5c3a-0e30" targetId="00b8-b49c-4c61-2943" linkType="rule">
+          <rules/>
+          <infoLinks>
+            <infoLink id="513a-bdeb-bad5-0c83" hidden="false" targetId="00b8-b49c-4c61-2943" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="aa6c-67b7-3d3b-2a61" name="Targeter Probe Shard" book="BtGoA" page="178" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit">
+      <profiles/>
       <rules>
-        <rule id="8104-2eac-f495-21f9" name="Probe Unit" hidden="false" book="">
+        <rule id="8104-2eac-f495-21f9" name="Probe Unit" book="" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links/>
-    </entry>
-  </entries>
-  <rules/>
-  <links/>
-  <sharedEntries>
-    <entry id="e9dd-1dc6-3c92-4305" name="AG Chute" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="120">
-      <entries/>
-      <entryGroups/>
+      <infoLinks/>
       <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="54c4-0df3-268c-9fe1" targetId="7daf-414b-c030-7626" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="828e-3aa2-3dbf-f2cb" name="Auto-Workshop" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="120">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="2aa0-3909-ff3b-5bfe" targetId="b7c6-fc7c-d48b-aae4" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="d571-d584-85fc-9110" name="Batter Drone" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="11">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="af35-43cb-665c-f896" name="Booster Drone" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="111">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="afb1-18d4-57fc-1fd3" profileTypeId="1650-77b3-10d1-6406" name="Booster Drone" hidden="false" book="BtGoA" page="111">
-          <characteristics>
-            <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag"/>
-            <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc"/>
-            <characteristic characteristicId="8294-36f1-6431-2145" name="Str"/>
-            <characteristic characteristicId="f214-abe8-c922-c51b" name="Res"/>
-            <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init"/>
-            <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="be1b-5f25-85e3-4789" targetId="c3e6-4e9b-858c-80d3" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="4933-25f0-2896-ac60" name="Camo Drone" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="babd-f951-933b-1254" name="Compactor Drone" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="666e-aa69-6e72-f168" name="Compactor Drone with Mag Cannon" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="9c4f-f6de-c09c-eab2" targetId="6a2b-50c5-9a33-b756" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="2144-e450-c8f2-af26" name="Compactor Drone with Mag Light Support" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="d525-3a93-38f1-7e4e" targetId="a00c-0542-f2a5-8124" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="0299-39fc-32bd-8ac2" name="Compactor Drone with Plasma Cannon" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="e506-bd0d-b513-7050" targetId="c2bf-0272-30c6-dd20" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="af24-45f9-4669-bf98" name="Compression Bombard" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="84">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="f3f6-794b-82b3-a39a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Bombard" hidden="false" book="BtGoA" page="84">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-50"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="150"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="9/7/5"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Cycle, Heavy Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="d318-c320-5b7c-b089" targetId="7db4-2d14-3984-37d9" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="a2f7-528d-dd59-9d00" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="b53d-32d6-c4fc-cefc" targetId="cf7f-6f85-e64e-0363" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="71c9-4382-01cf-c737" name="Compression Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="78">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="b626-3a7f-ecf5-ea69" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Cannon" hidden="false" book="BtGoA" page="78">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="7/4/2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Cycle,  Light Support Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="a6f9-23ce-e99d-7c15" targetId="7db4-2d14-3984-37d9" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="3003-31fb-fb6c-3084" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="70d5-a230-ba57-ead0" targetId="cf7f-6f85-e64e-0363" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="059b-38f7-0313-5ae4" name="Compression Carbine" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="72">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="7915-046b-1179-7fab" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Carbine" hidden="false" book="BtGoA" page="72">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="5"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2/1/0"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Standard Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="e580-6389-7ec6-d445" targetId="7db4-2d14-3984-37d9" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="908d-0879-a0b5-3f4b" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="72ba-15e7-dbf7-816c" name="D-Spinner" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="66">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="bc08-23ff-215d-d442" profileTypeId="ecae-8ac8-2c13-0dd3" name="D-Spinner" hidden="false" book="BtGoA" page="66">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="Varies"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks, Variable Res/Strike, Grenade, Hand Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="bf1e-fb77-9e71-f9fe" targetId="2cbd-47c9-de87-ec2a" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="363c-73f0-41ad-dfb8" targetId="99fd-f354-1703-5941" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="91a4-fa2b-910b-b8f8" targetId="b466-7990-db34-55b1" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="ff6c-f8d8-94e6-57bc" name="Disruptor Bomber" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="77">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="c100-99b7-2ff6-24a0" profileTypeId="ecae-8ac8-2c13-0dd3" name="Disruptor Bomber" hidden="false" book="BtGoA" page="77">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="60"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="120"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D5, No Crew, Limited Ammo, No Cover, Disruptor,  Light Support Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="5bfd-e568-cff9-ff1b" targetId="c3bc-87fd-fa5d-5055" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="ada8-a0a5-d314-27a6" targetId="b050-496a-ed16-2b2a" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="c9a5-e124-997c-44ea" targetId="f502-611e-9704-97bb" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="b3e6-5aa3-ef1f-f7b1" targetId="5efa-64a9-bbc9-3dba" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="df53-3436-c62e-c73e" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="7fb2-1ffe-610d-7f33" targetId="6305-72fa-da02-235b" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="f771-f4b5-0047-de53" name="Disruptor Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="79">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="17db-4b84-9d1b-122d" profileTypeId="ecae-8ac8-2c13-0dd3" name="Disruptor Cannon" hidden="false" book="BtGoA" page="79">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D4, No Cover, Disruptor, Light Support Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="48bb-4c87-e0f2-08b4" targetId="ca96-58c9-9551-d4fe" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="3b06-bc9e-4002-8aeb" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="8e03-d6b4-1fab-5cd2" targetId="6305-72fa-da02-235b" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="396e-b157-b3bb-a5e7" name="Disruptor Discharger" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="86">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="de01-ba7b-11ee-55ca" profileTypeId="ecae-8ac8-2c13-0dd3" name="Disruptor Discharger" hidden="false" book="BtGoA" page="86">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="Point blank shooting only"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="Point blank shooting only"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="Point blank shooting only"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D4, No Cover, Disruptor, Grenade"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="e755-a7a2-1343-d27a" targetId="5d64-4bf5-e947-95d1" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="b2cb-0542-2c44-9f1b" targetId="ca96-58c9-9551-d4fe" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="049f-1e26-3f5d-a4f9" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="adad-ebe2-3953-6510" targetId="6305-72fa-da02-235b" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="2cec-e1d7-c680-7ca0" name="Fractal Bombard" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="83">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="279b-22b3-c3ff-1320" profileTypeId="ecae-8ac8-2c13-0dd3" name="Fractal Bombard" hidden="false" book="BtGoA" page="83">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="50"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="200"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3 + 2 Max 10"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock, Heavy Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="fe6a-32a9-1211-b766" targetId="d50c-3bbe-c62d-34c3" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="93db-3751-fdd4-08f9" name="Fractal Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="76">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="cb47-aad3-9a1b-1266" profileTypeId="ecae-8ac8-2c13-0dd3" name="Fractal Cannon" hidden="false" book="BtGoA" page="76">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2 + 1 Max 10"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock,  Light Support Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="b7b4-01fa-5f1f-ebee" targetId="d50c-3bbe-c62d-34c3" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="aac7-43b0-4a5c-05bb" name="Frag Borer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="77">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="5cb2-9abf-ed28-03ff" profileTypeId="ecae-8ac8-2c13-0dd3" name="Frag Borer" hidden="false" book="BtGoA" page="77">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="60"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3 + 1 Max 10"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock,  Light Support Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="eac9-8b04-b66c-5db6" targetId="d50c-3bbe-c62d-34c3" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="3975-3892-22f2-0c8e" name="Ghar Plasma Claw" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="66">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="57de-9415-94c2-a9cd" profileTypeId="ecae-8ac8-2c13-0dd3" name="Ghar Plasma Claw" hidden="false" book="BtGoA" page="66">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="D4"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Random SV,  Hand Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="7eb4-a0e1-1e61-3d82" targetId="b6e3-9cf0-1a9f-a941" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="f319-5d36-f853-9d45" name="Gouger Gun" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="74">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="5caa-0eb3-a2c8-d79c" profileTypeId="ecae-8ac8-2c13-0dd3" name="Gouger Gun" hidden="false" book="BtGoA" page="74">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Down, Inaccurate, Standard Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="6c43-9149-1b89-35e5" targetId="9444-e2a0-8048-5ce9" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="aa66-a1ad-73f1-8bd2" targetId="3b84-9d0e-a3c1-6c1f" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="b8d1-46be-c623-ad68" name="Gun Drone" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="4ada-f132-9605-ef1f" targetId="78dd-7840-1210-fb35" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="f9cf-568d-998b-c3ca" name="Heavy Disruptor Bomber" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="80">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="a9a7-e90e-e54a-e37c" profileTypeId="ecae-8ac8-2c13-0dd3" name="Heavy Disruptor Bomber" hidden="false" book="BtGoA" page="80">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="60"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="120"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH x2, Blast D10, Limited Ammo, No Cover, Disruptor, Heavy Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="baaa-0b37-7581-545a" targetId="aef6-6934-1dee-6fa0" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="ad5f-454c-b4ec-0b29" targetId="04d9-a48d-7b25-4dd3" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="3dc5-ce4c-aaf4-7bc4" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="1d69-8270-126c-b660" targetId="6305-72fa-da02-235b" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="564d-3561-f5e4-783d" name="Heavy Frag Borer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="83">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="4001-9da2-86d1-6b80" profileTypeId="ecae-8ac8-2c13-0dd3" name="Heavy Frag Borer" hidden="false" book="BtGoA" page="83">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="60"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="6 + 1 Max 10"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock, Heavy Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="174d-fb91-0ee1-de89" targetId="d50c-3bbe-c62d-34c3" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="5149-5183-64d5-feaf" name="Heavy Mag Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="81">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="49f7-05c7-8536-e088" profileTypeId="ecae-8ac8-2c13-0dd3" name="Heavy Mag Cannon" hidden="false" book="BtGoA" page="81">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="50"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="10"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="250"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="6"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Massive Damage, Heavy Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="2226-327b-9cef-5629" targetId="c863-510b-e239-be92" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="4fbe-feab-de05-5312" name="Heavy Tractor Maul" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="65">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="05cc-6d3b-93d8-0b0e" profileTypeId="ecae-8ac8-2c13-0dd3" name="Heavy Tractor Maul" hidden="false" book="BtGoA" page="65">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks, Hand Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="c401-a6db-93c9-69e0" targetId="2cbd-47c9-de87-ec2a" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="eff8-bb0e-1b1d-bbb2" name="HL armor" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="93">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="2a6f-a102-e7b6-54c7" targetId="b436-1f8a-5d3a-2d7d" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="573b-88bc-97d7-d890" name="HL Booster" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="121">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="45e9-26e8-e029-93d0" targetId="56ab-52fc-9557-2586" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="1b16-412b-662a-5467" name="Homer Drone" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="f99c-daab-b3d7-9c61" name="Implosion Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="85">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="50ac-e85f-6480-9e2e" profileTypeId="ecae-8ac8-2c13-0dd3" name="Implosion Grenades" hidden="false" book="BtGoA" page="85">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Hazardous H2H, Grenade"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="9868-0703-9743-d4b5" targetId="1c2c-6574-0a17-f90c" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="b357-a997-60e5-053e" name="IMTel Stave" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="67">
-      <entries>
-        <entry id="d6be-b9a8-1ea3-d1ee" name="IMTel Stave - Standard" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="31ff-3d6d-2a30-3b5a" name="Targeter Probe" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles>
-            <profile id="9cc5-5341-3598-a655" profileTypeId="ecae-8ac8-2c13-0dd3" name="IMTel Stave - Standard" hidden="false" book="BtGoA" page="67">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="3 Attacks, Hand Weapon"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="051e-0412-fe0f-16d2" targetId="61e2-3707-ade3-c9ad" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="da2f-6bd2-fb0e-5e5e" name="IMTel Stave - Nano Drone Boost" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="cf0b-c836-c681-d9c0" profileTypeId="ecae-8ac8-2c13-0dd3" name="IMTel Stave - Nano Drone Boost" hidden="false" book="BtGoA" page="67">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="6"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="3 Attacks, Blast D3, Exhausted, Hand Weapon"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="8918-00b1-258e-5005" targetId="61e2-3707-ade3-c9ad" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="a14f-0f5e-7b8f-63f5" targetId="1acd-39d3-94e7-48e1" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="e461-67a4-a88e-a136" targetId="4232-2801-36cf-704c" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="5346-a420-8994-c5ed" name="Interceptor Bike" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="100">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="c7d2-5723-e428-dd5a" name="Ranged Weapon" minSelections="3" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="fa7c-b456-730f-167f" targetId="47d9-8149-9744-9849" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="ec8f-9506-26e0-53ec" targetId="78dd-7840-1210-fb35" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="d3a3-d3e0-1480-e349" name="Intruder Skimmer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="9">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="e102-2c84-66f5-fba9" name="Ranged Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="ed95-b0bc-1c54-77ce" name="Twin Mag Repeaters" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
+            <profile id="5411-31d1-ef11-d835" name="Targeter Probe" book="BtGoA" page="178" hidden="false" profileTypeId="1650-77b3-10d1-6406">
               <profiles/>
-              <links/>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="3aa7-ded4-1810-f136" targetId="f31c-6e5c-19c0-ada7" linkType="entry">
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="02f3-3134-ae39-afed" name="Leader 2" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="135">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="0240-940c-2896-fe6d" targetId="7850-89e7-bab8-86e9" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="5a4c-2f5e-40a2-91d4" name="Leader 3" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="135">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="0722-f7c8-1f58-524e" targetId="05bb-4d34-70cd-25d2" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="222a-c399-636e-c285" name="Lectro Lance" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="66">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="1194-e016-79d8-8f37" profileTypeId="ecae-8ac8-2c13-0dd3" name="Lectro Lance" hidden="false" book="BtGoA" page="66">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Hand Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="10e4-842d-bb66-6204" name="Lectro Lash" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="65">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="0e1a-a803-d9c9-9f0a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Lectro Lash" hidden="false" book="BtGoA" page="65">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="3 Attacks, Hand Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="485e-5cd5-458a-5b01" targetId="61e2-3707-ade3-c9ad" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="3ad3-bfdd-6120-7c29" name="Lugger Gun" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="73">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="5c6f-c4ef-b4a1-32eb" profileTypeId="ecae-8ac8-2c13-0dd3" name="Lugger Gun" hidden="false" book="BtGoA" page="73">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2, Limited Ammo, Standard Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="a5ed-7915-9221-076b" targetId="0cb1-ea91-e5bc-4f75" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="cc2c-1225-57ca-f1ed" targetId="5efa-64a9-bbc9-3dba" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="6a2b-50c5-9a33-b756" name="Mag Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="75">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="295a-d623-e2d2-c684" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Cannon" hidden="false" book="BtGoA" page="75">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="5"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="5"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Massive Damage, Light Support Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="ba14-c26b-33c6-8283" targetId="c863-510b-e239-be92" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="84ac-0f31-c388-d0bd" name="Mag Gun" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="69">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="d809-b3af-7007-a7b3" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Gun" hidden="false" book="BtGoA" page="69">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="60"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="cea7-8511-2208-1b1f" name="Mag Heavy Support" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="81">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="c318-2375-d610-2950" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Heavy Support" hidden="false" book="BtGoA" page="81">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="5"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF5, Heavy Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="d752-3c59-1096-f66d" targetId="b0cb-c022-0531-4852" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="b5e9-5297-04d2-2bf8" name="Mag Lash" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="67">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="f404-2eda-272f-57cf" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Lash" hidden="false" book="BtGoA" page="67">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="a97e-ddef-2a97-6023" targetId="2cbd-47c9-de87-ec2a" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="a00c-0542-f2a5-8124" name="Mag Light Support" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="75">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="df5b-35ce-669c-6aee" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Light Support" hidden="false" book="BtGoA" page="75">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="50"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3, Light Support Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="1edc-0547-c0b3-df09" targetId="97d4-67cb-2671-ca29" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="9733-7039-e306-26b5" name="Mag Mortar" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="81">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="d461-69b8-c506-322a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Mortar" hidden="false" book="BtGoA" page="81">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH x2, Blast D10, No Cover, Heavy Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="f42c-7e9e-5b27-6658" targetId="aef6-6934-1dee-6fa0" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="bfd1-e214-1717-c121" targetId="04d9-a48d-7b25-4dd3" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="f78e-6fd2-fff5-58e2" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="3203-24a2-4083-bc0d" targetId="7849-7fc2-0006-8fbd" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="8690-3ab7-9fef-06ee" name="Mag Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="68">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="57f9-ac99-e46c-2757" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Pistol" hidden="false" book="BtGoA" page="68">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="30"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Hand Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="790a-6841-6372-870b" name="Mag Repeater" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="69">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="1c20-93a8-d402-9d61" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Repeater" hidden="false" book="BtGoA" page="69">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2, Standard Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="af4a-bed9-243c-993e" targetId="0cb1-ea91-e5bc-4f75" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="3ecf-d559-4559-c1bb" name="Mass Compactor" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="71">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="b468-06b2-1a5d-2ec0" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mass Compactor" hidden="false" book="BtGoA" page="71">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="30"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3/2/1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Standard Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="068c-0048-aa5f-9906" targetId="7db4-2d14-3984-37d9" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="af50-5808-cb3e-2ec9" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="502c-9855-7269-eaa2" name="Medi-Drone" points="0.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="113">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="1a9d-01a2-ee09-883c" name="Micro-X Launcher" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="71">
-      <entries>
-        <entry id="756b-b4d4-8824-056b" name="Micro X-Launcher - Overhead" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="b067-87fe-65b4-6bd8" profileTypeId="ecae-8ac8-2c13-0dd3" name="Micro X-Launcher Overhead" hidden="false" book="BtGoA" page="71">
               <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="5"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D4, No Cover, Standard Weapon"/>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
               </characteristics>
-              <modifiers/>
             </profile>
           </profiles>
-          <links>
-            <link id="29b1-77a8-eac1-dcb8" targetId="c3bc-87fd-fa5d-5055" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="5888-4d4d-b427-d1f3" targetId="ca96-58c9-9551-d4fe" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="de68-1314-0e93-bc44" targetId="a41d-d55e-6d97-049d" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="b484-5b5d-96fb-e628" name="Micro X-Launcher - Direct Fire" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
           <rules/>
-          <profiles>
-            <profile id="c0c1-ee5f-5c1f-77a0" profileTypeId="ecae-8ac8-2c13-0dd3" name="Micro X-Launcher - Direct Fire" hidden="false" book="BtGoA" page="71">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
-              </characteristics>
+          <infoLinks>
+            <infoLink id="58b0-e470-5c3a-0e30" hidden="false" targetId="00b8-b49c-4c61-2943" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <entryLinks>
+    <entryLink id="0714-acf5-311e-bcd9" name="Army Options" hidden="false" targetId="529a-3e2a-4bd5-5e5f" type="selectionEntry" categoryEntryId="50ba-cf77-3941-189c">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </entryLink>
+  </entryLinks>
+  <sharedSelectionEntries>
+    <selectionEntry id="e9dd-1dc6-3c92-4305" name="AG Chute" book="BtGoA" page="120" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="54c4-0df3-268c-9fe1" hidden="false" targetId="7daf-414b-c030-7626" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="828e-3aa2-3dbf-f2cb" name="Auto-Workshop" book="BtGoA" page="120" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="2aa0-3909-ff3b-5bfe" hidden="false" targetId="b7c6-fc7c-d48b-aae4" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d571-d584-85fc-9110" name="Batter Drone" book="BtGoA" page="11" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="af35-43cb-665c-f896" name="Booster Drone" book="BtGoA" page="111" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="afb1-18d4-57fc-1fd3" name="Booster Drone" book="BtGoA" page="111" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd"/>
+            <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d"/>
+            <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145"/>
+            <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b"/>
+            <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e"/>
+            <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20"/>
+            <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="be1b-5f25-85e3-4789" hidden="false" targetId="c3e6-4e9b-858c-80d3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4933-25f0-2896-ac60" name="Camo Drone" book="BtGoA" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="babd-f951-933b-1254" name="Compactor Drone" book="BtGoA" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="666e-aa69-6e72-f168" name="Compactor Drone with Mag Cannon" book="BtGoA" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="9c4f-f6de-c09c-eab2" hidden="false" targetId="6a2b-50c5-9a33-b756" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2144-e450-c8f2-af26" name="Compactor Drone with Mag Light Support" book="BtGoA" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="d525-3a93-38f1-7e4e" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0299-39fc-32bd-8ac2" name="Compactor Drone with Plasma Cannon" book="BtGoA" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="e506-bd0d-b513-7050" hidden="false" targetId="c2bf-0272-30c6-dd20" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="af24-45f9-4669-bf98" name="Compression Bombard" book="BtGoA" page="84" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="f3f6-794b-82b3-a39a" name="Compression Bombard" book="BtGoA" page="84" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-50"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="150"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="9/7/5"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Cycle, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d318-c320-5b7c-b089" hidden="false" targetId="7db4-2d14-3984-37d9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="a2f7-528d-dd59-9d00" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b53d-32d6-c4fc-cefc" hidden="false" targetId="cf7f-6f85-e64e-0363" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="71c9-4382-01cf-c737" name="Compression Cannon" book="BtGoA" page="78" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="b626-3a7f-ecf5-ea69" name="Compression Cannon" book="BtGoA" page="78" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="7/4/2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Cycle,  Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a6f9-23ce-e99d-7c15" hidden="false" targetId="7db4-2d14-3984-37d9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3003-31fb-fb6c-3084" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="70d5-a230-ba57-ead0" hidden="false" targetId="cf7f-6f85-e64e-0363" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="059b-38f7-0313-5ae4" name="Compression Carbine" book="BtGoA" page="72" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="7915-046b-1179-7fab" name="Compression Carbine" book="BtGoA" page="72" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="5"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2/1/0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="e580-6389-7ec6-d445" hidden="false" targetId="7db4-2d14-3984-37d9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="908d-0879-a0b5-3f4b" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="72ba-15e7-dbf7-816c" name="D-Spinner" book="BtGoA" page="66" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="bc08-23ff-215d-d442" name="D-Spinner" book="BtGoA" page="66" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="Varies"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks, Variable Res/Strike, Grenade, Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="bf1e-fb77-9e71-f9fe" hidden="false" targetId="2cbd-47c9-de87-ec2a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="363c-73f0-41ad-dfb8" hidden="false" targetId="99fd-f354-1703-5941" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="91a4-fa2b-910b-b8f8" hidden="false" targetId="b466-7990-db34-55b1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ff6c-f8d8-94e6-57bc" name="Disruptor Bomber" book="BtGoA" page="77" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="c100-99b7-2ff6-24a0" name="Disruptor Bomber" book="BtGoA" page="77" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D5, No Crew, Limited Ammo, No Cover, Disruptor,  Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="5bfd-e568-cff9-ff1b" hidden="false" targetId="c3bc-87fd-fa5d-5055" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ada8-a0a5-d314-27a6" hidden="false" targetId="b050-496a-ed16-2b2a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="c9a5-e124-997c-44ea" hidden="false" targetId="f502-611e-9704-97bb" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b3e6-5aa3-ef1f-f7b1" hidden="false" targetId="5efa-64a9-bbc9-3dba" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="df53-3436-c62e-c73e" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7fb2-1ffe-610d-7f33" hidden="false" targetId="6305-72fa-da02-235b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f771-f4b5-0047-de53" name="Disruptor Cannon" book="BtGoA" page="79" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="17db-4b84-9d1b-122d" name="Disruptor Cannon" book="BtGoA" page="79" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, No Cover, Disruptor, Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="48bb-4c87-e0f2-08b4" hidden="false" targetId="ca96-58c9-9551-d4fe" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3b06-bc9e-4002-8aeb" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="8e03-d6b4-1fab-5cd2" hidden="false" targetId="6305-72fa-da02-235b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="396e-b157-b3bb-a5e7" name="Disruptor Discharger" book="BtGoA" page="86" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="de01-ba7b-11ee-55ca" name="Disruptor Discharger" book="BtGoA" page="86" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="Point blank shooting only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="Point blank shooting only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="Point blank shooting only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, No Cover, Disruptor, Grenade"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="e755-a7a2-1343-d27a" hidden="false" targetId="5d64-4bf5-e947-95d1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b2cb-0542-2c44-9f1b" hidden="false" targetId="ca96-58c9-9551-d4fe" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="049f-1e26-3f5d-a4f9" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="adad-ebe2-3953-6510" hidden="false" targetId="6305-72fa-da02-235b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2cec-e1d7-c680-7ca0" name="Fractal Bombard" book="BtGoA" page="83" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="279b-22b3-c3ff-1320" name="Fractal Bombard" book="BtGoA" page="83" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="50"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="200"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3 + 2 Max 10"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="fe6a-32a9-1211-b766" hidden="false" targetId="d50c-3bbe-c62d-34c3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="93db-3751-fdd4-08f9" name="Fractal Cannon" book="BtGoA" page="76" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="cb47-aad3-9a1b-1266" name="Fractal Cannon" book="BtGoA" page="76" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2 + 1 Max 10"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock,  Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="b7b4-01fa-5f1f-ebee" hidden="false" targetId="d50c-3bbe-c62d-34c3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="aac7-43b0-4a5c-05bb" name="Frag Borer" book="BtGoA" page="77" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="5cb2-9abf-ed28-03ff" name="Frag Borer" book="BtGoA" page="77" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3 + 1 Max 10"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock,  Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="eac9-8b04-b66c-5db6" hidden="false" targetId="d50c-3bbe-c62d-34c3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3975-3892-22f2-0c8e" name="Ghar Plasma Claw" book="BtGoA" page="66" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="57de-9415-94c2-a9cd" name="Ghar Plasma Claw" book="BtGoA" page="66" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="D4"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Random SV,  Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="7eb4-a0e1-1e61-3d82" hidden="false" targetId="b6e3-9cf0-1a9f-a941" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f319-5d36-f853-9d45" name="Gouger Gun" book="BtGoA" page="74" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="5caa-0eb3-a2c8-d79c" name="Gouger Gun" book="BtGoA" page="74" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Down, Inaccurate, Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="6c43-9149-1b89-35e5" hidden="false" targetId="9444-e2a0-8048-5ce9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="aa66-a1ad-73f1-8bd2" hidden="false" targetId="3b84-9d0e-a3c1-6c1f" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b8d1-46be-c623-ad68" name="Gun Drone" book="BtGoA" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="4ada-f132-9605-ef1f" hidden="false" targetId="78dd-7840-1210-fb35" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f9cf-568d-998b-c3ca" name="Heavy Disruptor Bomber" book="BtGoA" page="80" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="a9a7-e90e-e54a-e37c" name="Heavy Disruptor Bomber" book="BtGoA" page="80" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH x2, Blast D10, Limited Ammo, No Cover, Disruptor, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="baaa-0b37-7581-545a" hidden="false" targetId="aef6-6934-1dee-6fa0" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ad5f-454c-b4ec-0b29" hidden="false" targetId="04d9-a48d-7b25-4dd3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3dc5-ce4c-aaf4-7bc4" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="1d69-8270-126c-b660" hidden="false" targetId="6305-72fa-da02-235b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="564d-3561-f5e4-783d" name="Heavy Frag Borer" book="BtGoA" page="83" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="4001-9da2-86d1-6b80" name="Heavy Frag Borer" book="BtGoA" page="83" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6 + 1 Max 10"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="174d-fb91-0ee1-de89" hidden="false" targetId="d50c-3bbe-c62d-34c3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5149-5183-64d5-feaf" name="Heavy Mag Cannon" book="BtGoA" page="81" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="49f7-05c7-8536-e088" name="Heavy Mag Cannon" book="BtGoA" page="81" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="50"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="10"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="250"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Massive Damage, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="2226-327b-9cef-5629" hidden="false" targetId="c863-510b-e239-be92" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4fbe-feab-de05-5312" name="Heavy Tractor Maul" book="BtGoA" page="65" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="05cc-6d3b-93d8-0b0e" name="Heavy Tractor Maul" book="BtGoA" page="65" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks, Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="c401-a6db-93c9-69e0" hidden="false" targetId="2cbd-47c9-de87-ec2a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eff8-bb0e-1b1d-bbb2" name="HL armor" book="BtGoA" page="93" hidden="false" collective="true" categoryEntryId="(No Category)" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="2a6f-a102-e7b6-54c7" hidden="false" targetId="b436-1f8a-5d3a-2d7d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="573b-88bc-97d7-d890" name="HL Booster" book="BtGoA" page="121" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="45e9-26e8-e029-93d0" hidden="false" targetId="56ab-52fc-9557-2586" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1b16-412b-662a-5467" name="Homer Drone" book="BtGoA" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f99c-daab-b3d7-9c61" name="Implosion Grenades" book="BtGoA" page="85" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="50ac-e85f-6480-9e2e" name="Implosion Grenades" book="BtGoA" page="85" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Hazardous H2H, Grenade"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="9868-0703-9743-d4b5" hidden="false" targetId="1c2c-6574-0a17-f90c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b357-a997-60e5-053e" name="IMTel Stave" book="BtGoA" page="67" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="d6be-b9a8-1ea3-d1ee" name="IMTel Stave - Standard" hidden="true" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="9cc5-5341-3598-a655" name="IMTel Stave - Standard" book="BtGoA" page="67" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="3 Attacks, Hand Weapon"/>
+              </characteristics>
             </profile>
           </profiles>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="051e-0412-fe0f-16d2" hidden="false" targetId="61e2-3707-ade3-c9ad" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="da2f-6bd2-fb0e-5e5e" name="IMTel Stave - Nano Drone Boost" hidden="true" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="cf0b-c836-c681-d9c0" name="IMTel Stave - Nano Drone Boost" book="BtGoA" page="67" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="3 Attacks, Blast D3, Exhausted, Hand Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="8918-00b1-258e-5005" hidden="false" targetId="61e2-3707-ade3-c9ad" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="a14f-0f5e-7b8f-63f5" hidden="false" targetId="1acd-39d3-94e7-48e1" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="e461-67a4-a88e-a136" hidden="false" targetId="4232-2801-36cf-704c" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5346-a420-8994-c5ed" name="Interceptor Bike" book="BtGoA" page="100" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="7849-7fc2-0006-8fbd" name="Munitions" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="cf32-46fd-cdce-80dd" name="Munitions" minSelections="0" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="2f9e-d8b5-f1a8-6e4c" name="Scrambler" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-              <entries/>
-              <entryGroups/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c7d2-5723-e428-dd5a" name="Ranged Weapon" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="fa7c-b456-730f-167f" hidden="false" targetId="47d9-8149-9744-9849" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="ec8f-9506-26e0-53ec" hidden="false" targetId="78dd-7840-1210-fb35" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d3a3-d3e0-1480-e349" name="Intruder Skimmer" book="BtGoA" page="9" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e102-2c84-66f5-fba9" name="Ranged Weapon" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="ed95-b0bc-1c54-77ce" name="Twin Mag Repeaters" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="3aa7-ded4-1810-f136" hidden="false" targetId="f31c-6e5c-19c0-ada7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="02f3-3134-ae39-afed" name="Leader 2" book="BtGoA" page="135" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0240-940c-2896-fe6d" hidden="false" targetId="7850-89e7-bab8-86e9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5a4c-2f5e-40a2-91d4" name="Leader 3" book="BtGoA" page="135" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0722-f7c8-1f58-524e" hidden="false" targetId="05bb-4d34-70cd-25d2" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="222a-c399-636e-c285" name="Lectro Lance" book="BtGoA" page="66" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="1194-e016-79d8-8f37" name="Lectro Lance" book="BtGoA" page="66" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="10e4-842d-bb66-6204" name="Lectro Lash" book="BtGoA" page="65" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="0e1a-a803-d9c9-9f0a" name="Lectro Lash" book="BtGoA" page="65" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="3 Attacks, Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="485e-5cd5-458a-5b01" hidden="false" targetId="61e2-3707-ade3-c9ad" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3ad3-bfdd-6120-7c29" name="Lugger Gun" book="BtGoA" page="73" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="5c6f-c4ef-b4a1-32eb" name="Lugger Gun" book="BtGoA" page="73" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Limited Ammo, Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a5ed-7915-9221-076b" hidden="false" targetId="0cb1-ea91-e5bc-4f75" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="cc2c-1225-57ca-f1ed" hidden="false" targetId="5efa-64a9-bbc9-3dba" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6a2b-50c5-9a33-b756" name="Mag Cannon" book="BtGoA" page="75" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="295a-d623-e2d2-c684" name="Mag Cannon" book="BtGoA" page="75" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="5"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="5"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Massive Damage, Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="ba14-c26b-33c6-8283" hidden="false" targetId="c863-510b-e239-be92" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="84ac-0f31-c388-d0bd" name="Mag Gun" book="BtGoA" page="69" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="d809-b3af-7007-a7b3" name="Mag Gun" book="BtGoA" page="69" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cea7-8511-2208-1b1f" name="Mag Heavy Support" book="BtGoA" page="81" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="c318-2375-d610-2950" name="Mag Heavy Support" book="BtGoA" page="81" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="5"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF5, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d752-3c59-1096-f66d" hidden="false" targetId="b0cb-c022-0531-4852" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b5e9-5297-04d2-2bf8" name="Mag Lash" book="BtGoA" page="67" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="f404-2eda-272f-57cf" name="Mag Lash" book="BtGoA" page="67" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a97e-ddef-2a97-6023" hidden="false" targetId="2cbd-47c9-de87-ec2a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a00c-0542-f2a5-8124" name="Mag Light Support" book="BtGoA" page="75" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="df5b-35ce-669c-6aee" name="Mag Light Support" book="BtGoA" page="75" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="50"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3, Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="1edc-0547-c0b3-df09" hidden="false" targetId="97d4-67cb-2671-ca29" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9733-7039-e306-26b5" name="Mag Mortar" book="BtGoA" page="81" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="d461-69b8-c506-322a" name="Mag Mortar" book="BtGoA" page="81" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH x2, Blast D10, No Cover, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="f42c-7e9e-5b27-6658" hidden="false" targetId="aef6-6934-1dee-6fa0" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="bfd1-e214-1717-c121" hidden="false" targetId="04d9-a48d-7b25-4dd3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f78e-6fd2-fff5-58e2" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="3203-24a2-4083-bc0d" hidden="false" targetId="7849-7fc2-0006-8fbd" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8690-3ab7-9fef-06ee" name="Mag Pistol" book="BtGoA" page="68" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="57f9-ac99-e46c-2757" name="Mag Pistol" book="BtGoA" page="68" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="790a-6841-6372-870b" name="Mag Repeater" book="BtGoA" page="69" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="1c20-93a8-d402-9d61" name="Mag Repeater" book="BtGoA" page="69" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="af4a-bed9-243c-993e" hidden="false" targetId="0cb1-ea91-e5bc-4f75" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3ecf-d559-4559-c1bb" name="Mass Compactor" book="BtGoA" page="71" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="b468-06b2-1a5d-2ec0" name="Mass Compactor" book="BtGoA" page="71" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3/2/1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="068c-0048-aa5f-9906" hidden="false" targetId="7db4-2d14-3984-37d9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="af50-5808-cb3e-2ec9" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="502c-9855-7269-eaa2" name="Medi-Drone" book="BtGoA" page="113" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1a9d-01a2-ee09-883c" name="Micro-X Launcher" book="BtGoA" page="71" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="756b-b4d4-8824-056b" name="Micro X-Launcher - Overhead" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="b067-87fe-65b4-6bd8" name="Micro X-Launcher Overhead" book="BtGoA" page="71" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="5"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D4, No Cover, Standard Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="29b1-77a8-eac1-dcb8" hidden="false" targetId="c3bc-87fd-fa5d-5055" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="5888-4d4d-b427-d1f3" hidden="false" targetId="ca96-58c9-9551-d4fe" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="de68-1314-0e93-bc44" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b484-5b5d-96fb-e628" name="Micro X-Launcher - Direct Fire" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="c0c1-ee5f-5c1f-77a0" name="Micro X-Launcher - Direct Fire" book="BtGoA" page="71" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7849-7fc2-0006-8fbd" name="Munitions" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="cf32-46fd-cdce-80dd" name="Munitions" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="2f9e-d8b5-f1a8-6e4c" name="Scrambler" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="c2fb-c9db-5e9c-dcfe" hidden="false" targetId="7a3b-74a5-3ced-dd88" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="9622-01bf-0303-e5f7" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
               <modifiers>
-                <modifier type="hide" field="maxSelections" value="0.0" repeat="true" numRepeats="1" incrementParentId="cf32-46fd-cdce-80dd" incrementChildId="057c-a217-e792-8ef7" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="hidden" value="true">
+                  <repeats>
+                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="47c5-9ed0-b50a-45b7" name="Arc" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links>
-                <link id="c2fb-c9db-5e9c-dcfe" targetId="7a3b-74a5-3ced-dd88" linkType="rule">
+              <rules/>
+              <infoLinks>
+                <infoLink id="1838-cbe5-7c85-395d" hidden="false" targetId="c1ba-c745-22a8-e2d7" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-                <link id="9622-01bf-0303-e5f7" targetId="b996-131f-b84a-4724" linkType="rule">
+                </infoLink>
+                <infoLink id="6568-0044-8497-b002" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="47c5-9ed0-b50a-45b7" name="Arc" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-              <entries/>
-              <entryGroups/>
+                </infoLink>
+              </infoLinks>
               <modifiers>
-                <modifier type="hide" field="maxSelections" value="0.0" repeat="true" numRepeats="1" incrementParentId="cf32-46fd-cdce-80dd" incrementChildId="057c-a217-e792-8ef7" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="hidden" value="true">
+                  <repeats>
+                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="876b-029d-8c49-cf28" name="Blur" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links>
-                <link id="1838-cbe5-7c85-395d" targetId="c1ba-c745-22a8-e2d7" linkType="rule">
+              <rules/>
+              <infoLinks>
+                <infoLink id="8a68-f508-7c9e-1ee4" hidden="false" targetId="117a-a2aa-4be7-dffe" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-                <link id="6568-0044-8497-b002" targetId="b996-131f-b84a-4724" linkType="rule">
+                </infoLink>
+                <infoLink id="1fe7-d90c-fd8b-2777" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="876b-029d-8c49-cf28" name="Blur" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-              <entries/>
-              <entryGroups/>
+                </infoLink>
+              </infoLinks>
               <modifiers>
-                <modifier type="hide" field="maxSelections" value="0.0" repeat="true" numRepeats="1" incrementParentId="cf32-46fd-cdce-80dd" incrementChildId="057c-a217-e792-8ef7" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="hidden" value="true">
+                  <repeats>
+                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2f18-3173-0eea-f19f" name="Scoot" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links>
-                <link id="8a68-f508-7c9e-1ee4" targetId="117a-a2aa-4be7-dffe" linkType="rule">
+              <rules/>
+              <infoLinks>
+                <infoLink id="a787-c45e-8df6-7cdb" hidden="false" targetId="28a0-7151-a0c5-9495" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-                <link id="1fe7-d90c-fd8b-2777" targetId="b996-131f-b84a-4724" linkType="rule">
+                </infoLink>
+                <infoLink id="4acd-4d6e-c5ce-c202" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="2f18-3173-0eea-f19f" name="Scoot" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-              <entries/>
-              <entryGroups/>
+                </infoLink>
+              </infoLinks>
               <modifiers>
-                <modifier type="hide" field="maxSelections" value="0.0" repeat="true" numRepeats="1" incrementParentId="cf32-46fd-cdce-80dd" incrementChildId="057c-a217-e792-8ef7" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="hidden" value="true">
+                  <repeats>
+                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="99d6-3f14-a1e9-779b" name="Net" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links>
-                <link id="a787-c45e-8df6-7cdb" targetId="28a0-7151-a0c5-9495" linkType="rule">
+              <rules/>
+              <infoLinks>
+                <infoLink id="c8d2-16b3-5523-a9b1" hidden="false" targetId="ac33-af99-2d76-c981" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-                <link id="4acd-4d6e-c5ce-c202" targetId="b996-131f-b84a-4724" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="99d6-3f14-a1e9-779b" name="Net" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-              <entries/>
-              <entryGroups/>
+                </infoLink>
+              </infoLinks>
               <modifiers>
-                <modifier type="hide" field="maxSelections" value="0.0" repeat="true" numRepeats="1" incrementParentId="cf32-46fd-cdce-80dd" incrementChildId="057c-a217-e792-8ef7" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="hidden" value="true">
+                  <repeats>
+                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e014-fd16-bd43-6ead" name="Grip" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links>
-                <link id="c8d2-16b3-5523-a9b1" targetId="ac33-af99-2d76-c981" linkType="rule">
+              <rules/>
+              <infoLinks>
+                <infoLink id="6ffa-8857-9b93-35b5" hidden="false" targetId="1045-95cb-5504-9050" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="e014-fd16-bd43-6ead" name="Grip" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-              <entries/>
-              <entryGroups/>
+                </infoLink>
+                <infoLink id="3eba-9eb4-bf44-4b04" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
               <modifiers>
-                <modifier type="hide" field="maxSelections" value="0.0" repeat="true" numRepeats="1" incrementParentId="cf32-46fd-cdce-80dd" incrementChildId="057c-a217-e792-8ef7" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="hidden" value="true">
+                  <repeats>
+                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="057c-a217-e792-8ef7" name="All" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links>
-                <link id="6ffa-8857-9b93-35b5" targetId="1045-95cb-5504-9050" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="3eba-9eb4-bf44-4b04" targetId="b996-131f-b84a-4724" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="057c-a217-e792-8ef7" name="All" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
               <rules/>
+              <infoLinks>
+                <infoLink id="7fae-ff88-b94e-934e" hidden="false" targetId="c1ba-c745-22a8-e2d7" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="49a1-2fba-ff8f-c1b0" hidden="false" targetId="117a-a2aa-4be7-dffe" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="7acb-0144-9a6a-9840" hidden="false" targetId="1045-95cb-5504-9050" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="878e-a6f2-d2ce-4e02" hidden="false" targetId="ac33-af99-2d76-c981" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="ed06-0ab3-bc83-05de" hidden="false" targetId="28a0-7151-a0c5-9495" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="03ee-325f-d6f1-fd20" hidden="false" targetId="7a3b-74a5-3ced-dd88" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="8d63-0835-da60-a624" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bf0f-913b-e028-8891" name="Nano Drone" book="BtGoA" page="113" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6b54-c223-3c4a-5de7" name="Overload Ammo" book="BtGoA" page="89" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="6edf-03c1-417f-13e8" hidden="false" targetId="3559-4b87-980d-f90d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eb94-d1e8-1084-71b3" name="Phase Armor" book="BtGoA" page="93" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="3da3-80ac-dc11-6809" hidden="false" targetId="b28d-571e-af69-4582" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5725-5e4d-d4f2-1dd0" name="Phase Rifle" book="BtGoA" page="72" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="d2b1-2482-5f97-a4e4" name="Phase Rifle" book="BtGoA" page="72" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="No Cover, RF D6 Fire Only, Concentrated Fire, Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0d4d-4f3f-c86d-9dbe" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b46e-26ca-aad6-e64b" hidden="false" targetId="1863-c041-6dc4-c62d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6fea-ec6b-df33-2abe" hidden="false" targetId="5fb8-4f09-d496-4ea9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a18f-8d16-f879-e590" name="Phaseshift Shield" book="BtGoA" page="122" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="67b6-d6f5-5ba3-e50d" name="Plasma Bombard" book="BtGoA" page="82" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="a5d1-11c5-eb13-f676" name="Plasma Bombard" book="BtGoA" page="82" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="200"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="7"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Plasma Fade, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="7388-9f57-6e2a-eadb" hidden="false" targetId="6b03-2ad4-34c1-7f73" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c2bf-0272-30c6-dd20" name="Plasma Cannon" book="BtGoA" page="76" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="dce6-92d7-7812-820a" name="Plasma Cannon" book="BtGoA" page="76" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="4"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Plasma Fade, Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="3c39-3d6d-7a5a-f2f5" hidden="false" targetId="6b03-2ad4-34c1-7f73" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b018-6101-d2e3-b4ea" name="Plasma Carbine" book="BtGoA" page="70" hidden="false" collective="true" categoryEntryId="(No Category)" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="6eee-a6a9-5856-1e5c" name="Plasma Carbine - Single Shot" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="7257-2eab-532a-574a" name="Plasma Carbine - Single Shot" book="BtGoA" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
               <profiles/>
-              <links>
-                <link id="7fae-ff88-b94e-934e" targetId="c1ba-c745-22a8-e2d7" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="49a1-2fba-ff8f-c1b0" targetId="117a-a2aa-4be7-dffe" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="7acb-0144-9a6a-9840" targetId="1045-95cb-5504-9050" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="878e-a6f2-d2ce-4e02" targetId="ac33-af99-2d76-c981" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="ed06-0ab3-bc83-05de" targetId="28a0-7151-a0c5-9495" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="03ee-325f-d6f1-fd20" targetId="7a3b-74a5-3ced-dd88" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="8d63-0835-da60-a624" targetId="b996-131f-b84a-4724" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="bf0f-913b-e028-8891" name="Nano Drone" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="113">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="6b54-c223-3c4a-5de7" name="Overload Ammo" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="89">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="6edf-03c1-417f-13e8" targetId="3559-4b87-980d-f90d" linkType="rule">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ee30-9dc9-222e-98ff" name="Plasma Carbine - Scatter" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="91b8-8208-7974-813c" name="Plasma Carbine - Scatter" book="BtGoA" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Standard Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="b68d-f1c4-f949-d02b" hidden="false" targetId="0cb1-ea91-e5bc-4f75" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="eb94-d1e8-1084-71b3" name="Phase Armor" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="93">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="3da3-80ac-dc11-6809" targetId="b28d-571e-af69-4582" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="5725-5e4d-d4f2-1dd0" name="Phase Rifle" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="72">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7ac3-5fd7-f7a8-3a01" name="Plasma Grenades" book="BtGoA" page="85" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="d2b1-2482-5f97-a4e4" profileTypeId="ecae-8ac8-2c13-0dd3" name="Phase Rifle" hidden="false" book="BtGoA" page="72">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="No Cover, RF D6 Fire Only, Concentrated Fire, Standard Weapon"/>
-          </characteristics>
+        <profile id="e2c1-97d0-4ba5-2d8f" name="Plasma Grenades" book="BtGoA" page="85" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Grenade"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="0d4d-4f3f-c86d-9dbe" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="b46e-26ca-aad6-e64b" targetId="1863-c041-6dc4-c62d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="6fea-ec6b-df33-2abe" targetId="5fb8-4f09-d496-4ea9" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="a18f-8d16-f879-e590" name="Phaseshift Shield" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="122">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="47d9-8149-9744-9849" name="Plasma Lance" book="BtGoA" page="70" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="67b6-d6f5-5ba3-e50d" name="Plasma Bombard" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="82">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="a5d1-11c5-eb13-f676" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Bombard" hidden="false" book="BtGoA" page="82">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="200"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="7"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Plasma Fade, Heavy Weapon"/>
-          </characteristics>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="b6e9-addd-c005-4547" name="Plasma Lance - Single Shot" book="BtGoA" page="70" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="3799-96cf-d949-da4e" name="Plasma Lance - Single Shot" book="BtGoA" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="80ed-e766-57b1-3d2a" name="Plasma Lance - Scatter" book="BtGoA" page="70" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="9ad5-3648-6628-2caa" name="Plasma Lance - Scatter" book="BtGoA" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Standard Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="3f8e-ffa3-e1eb-fde7" hidden="false" targetId="0cb1-ea91-e5bc-4f75" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4069-4420-c5b5-56af" name="Plasma Lance - Lance" book="BtGoA" page="70" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="f44f-9fdb-7e3c-bf9e" name="Plasma Lance - Lance" book="BtGoA" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="4"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Choose Target, Inaccurate, Standard Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="7213-775a-deac-dce8" hidden="false" targetId="fd72-d48c-e8af-4883" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="9752-310b-98a1-37af" hidden="false" targetId="3b84-9d0e-a3c1-6c1f" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cf3a-e6a9-bdc0-e0ae" name="Plasma Light Support" book="BtGoA" page="76" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="d429-b8cc-aca0-aac9" name="Plasma Light Support" book="BtGoA" page="76" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="4"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3, Light Support Weapon"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="7388-9f57-6e2a-eadb" targetId="6b03-2ad4-34c1-7f73" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="c2bf-0272-30c6-dd20" name="Plasma Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="76">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="dce6-92d7-7812-820a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Cannon" hidden="false" book="BtGoA" page="76">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="4"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="6"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Plasma Fade, Light Support Weapon"/>
-          </characteristics>
+      <infoLinks>
+        <infoLink id="9e8b-6ee9-56f0-aedf" hidden="false" targetId="97d4-67cb-2671-ca29" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e6db-6ed3-1a26-ea56" name="Plasma Pistol" book="BtGoA" page="68" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="6f3c-42a6-dd21-2d9d" name="Plasma Pistol" page="68" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Hand Weapon"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="3c39-3d6d-7a5a-f2f5" targetId="6b03-2ad4-34c1-7f73" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="b018-6101-d2e3-b4ea" name="Plasma Carbine" points="0.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="70">
-      <entries>
-        <entry id="6eee-a6a9-5856-1e5c" name="Plasma Carbine - Single Shot" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="7257-2eab-532a-574a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Carbine - Single Shot" hidden="false" book="BtGoA" page="70">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-        <entry id="ee30-9dc9-222e-98ff" name="Plasma Carbine - Scatter" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="91b8-8208-7974-813c" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Carbine - Scatter" hidden="false" book="BtGoA" page="70">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2, Standard Weapon"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="b68d-f1c4-f949-d02b" targetId="0cb1-ea91-e5bc-4f75" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9cdf-f068-bbde-2d0c" name="Reflex Armor" book="BtGoA" page="93" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="7ac3-5fd7-f7a8-3a01" name="Plasma Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="85">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="e2c1-97d0-4ba5-2d8f" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Grenades" hidden="false" book="BtGoA" page="85">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Grenade"/>
-          </characteristics>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="abe2-ce1e-271f-5a85" name="Scourer Cannon" book="BtGoA" page="73" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="ccbf-d756-25d7-40f4" name="Scourer Cannon - Dispersed" book="BtGoA" page="73" hidden="true" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="03b8-44da-840d-df59" name="Scourer Cannon - Dispersed" book="BtGoA" page="73" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3, Standard Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="6631-7298-fd9d-ce64" hidden="false" targetId="97d4-67cb-2671-ca29" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="713c-944f-32ee-fe55" name="Scourer Cannon - Concentrated" book="BtGoA" page="73" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="0f28-d6ef-0f10-6e8f" name="Scourer Cannon - Concentrated" book="BtGoA" page="73" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="40"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="4"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9a2e-529c-2e81-0d99" name="Scourer Cannon - Disruptor" book="BtGoA" page="73" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="1b2e-f75a-2b45-9cde" name="Scourer Cannon - Disruptor" book="BtGoA" page="73" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, No Cover, Disruptor, Standard Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="393a-a871-9061-745a" hidden="false" targetId="ca96-58c9-9551-d4fe" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="dee2-529a-c466-8b1e" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="1a7e-03a3-9055-86c1" hidden="false" targetId="6305-72fa-da02-235b" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b145-19b3-baae-ff39" name="Shield Drone" book="BtGoA" page="114" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8de3-1e72-72ef-e7a3" name="SlingNet Ammo" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="27d6-5dd8-337d-1005" hidden="false" targetId="5bd0-9ab2-0523-cbc8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="db03-7794-daeb-fef6" name="Solar Charges" book="BtGoA" page="85" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="457b-abde-ffd5-bb14" name="Solar Charges" book="BtGoA" page="85" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D3, Hazardhous H2H, Grenade"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links/>
-    </entry>
-    <entry id="47d9-8149-9744-9849" name="Plasma Lance" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="70">
-      <entries>
-        <entry id="b6e9-addd-c005-4547" name="Plasma Lance - Single Shot" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="70">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="7a23-290e-0678-0165" hidden="false" targetId="1acd-39d3-94e7-48e1" type="rule">
+          <profiles/>
           <rules/>
-          <profiles>
-            <profile id="3799-96cf-d949-da4e" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Single Shot" hidden="false" book="BtGoA" page="70">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-        <entry id="80ed-e766-57b1-3d2a" name="Plasma Lance - Scatter" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="70">
-          <entries/>
-          <entryGroups/>
+          <infoLinks/>
           <modifiers/>
+        </infoLink>
+        <infoLink id="7cdc-f9ef-85bc-947a" hidden="false" targetId="1c2c-6574-0a17-f90c" type="rule">
+          <profiles/>
           <rules/>
-          <profiles>
-            <profile id="9ad5-3648-6628-2caa" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Scatter" hidden="false" book="BtGoA" page="70">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2, Standard Weapon"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="3f8e-ffa3-e1eb-fde7" targetId="0cb1-ea91-e5bc-4f75" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="4069-4420-c5b5-56af" name="Plasma Lance - Lance" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="70">
-          <entries/>
-          <entryGroups/>
+          <infoLinks/>
           <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3878-9363-1705-9eda" name="Soma Graft" book="BtGoA" page="121" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="3d50-6009-476b-2dd3" hidden="false" targetId="1253-ef5b-67d4-3e18" type="rule">
+          <profiles/>
           <rules/>
-          <profiles>
-            <profile id="f44f-9fdb-7e3c-bf9e" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Lance" hidden="false" book="BtGoA" page="70">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="4"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Choose Target, Inaccurate, Standard Weapon"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="7213-775a-deac-dce8" targetId="fd72-d48c-e8af-4883" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="9752-310b-98a1-37af" targetId="3b84-9d0e-a3c1-6c1f" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f3aa-148a-0460-c7e5" name="Spotter Drone" book="BtGoA" page="114" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="cf3a-e6a9-bdc0-e0ae" name="Plasma Light Support" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="76">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="d429-b8cc-aca0-aac9" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Light Support" hidden="false" book="BtGoA" page="76">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="4"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3, Light Support Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="9e8b-6ee9-56f0-aedf" targetId="97d4-67cb-2671-ca29" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="e6db-6ed3-1a26-ea56" name="Plasma Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="68">
-      <entries/>
-      <entryGroups/>
+      <infoLinks/>
       <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="6f3c-42a6-dd21-2d9d" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Pistol" hidden="false" page="68">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="30"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Hand Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="9cdf-f068-bbde-2d0c" name="Reflex Armor" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="93">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9cab-babb-fd75-a302" name="Strategic Genius" book="GOA" page="221" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="abe2-ce1e-271f-5a85" name="Scourer Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="73">
-      <entries>
-        <entry id="ccbf-d756-25d7-40f4" name="Scourer Cannon - Dispersed" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true" book="BtGoA" page="73">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="03b8-44da-840d-df59" profileTypeId="ecae-8ac8-2c13-0dd3" name="Scourer Cannon - Dispersed" hidden="false" book="BtGoA" page="73">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3, Standard Weapon"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="6631-7298-fd9d-ce64" targetId="97d4-67cb-2671-ca29" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="713c-944f-32ee-fe55" name="Scourer Cannon - Concentrated" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="73">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="0f28-d6ef-0f10-6e8f" profileTypeId="ecae-8ac8-2c13-0dd3" name="Scourer Cannon - Concentrated" hidden="false" book="BtGoA" page="73">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="40"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="4"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-        <entry id="9a2e-529c-2e81-0d99" name="Scourer Cannon - Disruptor" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="73">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="1b2e-f75a-2b45-9cde" profileTypeId="ecae-8ac8-2c13-0dd3" name="Scourer Cannon - Disruptor" hidden="false" book="BtGoA" page="73">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D4, No Cover, Disruptor, Standard Weapon"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="393a-a871-9061-745a" targetId="ca96-58c9-9551-d4fe" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="dee2-529a-c466-8b1e" targetId="a41d-d55e-6d97-049d" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="1a7e-03a3-9055-86c1" targetId="6305-72fa-da02-235b" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="b145-19b3-baae-ff39" name="Shield Drone" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="114">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="8de3-1e72-72ef-e7a3" name="SlingNet Ammo" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="27d6-5dd8-337d-1005" targetId="5bd0-9ab2-0523-cbc8" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="db03-7794-daeb-fef6" name="Solar Charges" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="85">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="457b-abde-ffd5-bb14" profileTypeId="ecae-8ac8-2c13-0dd3" name="Solar Charges" hidden="false" book="BtGoA" page="85">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D3, Hazardhous H2H, Grenade"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="7a23-290e-0678-0165" targetId="1acd-39d3-94e7-48e1" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="7cdc-f9ef-85bc-947a" targetId="1c2c-6574-0a17-f90c" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="3878-9363-1705-9eda" name="Soma Graft" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="121">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="3d50-6009-476b-2dd3" targetId="1253-ef5b-67d4-3e18" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="f3aa-148a-0460-c7e5" name="Spotter Drone" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="114">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="9cab-babb-fd75-a302" name="Strategic Genius" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="GOA" page="221">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules>
-        <rule id="d728-35a5-0ebb-1929" name="Strategic Genius" hidden="false" book="GOA" page="221">
+        <rule id="d728-35a5-0ebb-1929" name="Strategic Genius" book="GOA" page="221" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
           <description>Strategic Genius.As a General of one of the Prosperate’s most famous armies, Tar Es Janar is expert at placing his forces where they are needed as quickly as possible. To represent this, in games where units must test their Command to deploy onto or move on to the table, they test as if they had the same stat value as Tar Es Janar – i.e. 10. Remember that rolls of a 10 will fail anyway, so even Ta Es Janar is not infallible.</description>
-          <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="6bfe-ff47-b61c-afd2" name="Sub-mounted X-Sling" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA">
-      <entries/>
-      <entryGroups/>
+      <infoLinks/>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6bfe-ff47-b61c-afd2" name="Sub-mounted X-Sling" book="BtGoA" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="a9af-f28d-4e65-6d1b" targetId="b08e-548a-fda7-0a4e" linkType="entry">
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="a9af-f28d-4e65-6d1b" hidden="false" targetId="b08e-548a-fda7-0a4e" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="fb8b-7402-c5a9-8644" name="Subverter Matrix" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="122">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fb8b-7402-c5a9-8644" name="Subverter Matrix" book="BtGoA" page="122" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="24bd-bd70-2f6b-0434" targetId="cd8d-624c-ed86-e310" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="02f1-fd15-ca9d-ad79" name="Tractor Maul" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="65">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="24bd-bd70-2f6b-0434" hidden="false" targetId="cd8d-624c-ed86-e310" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="02f1-fd15-ca9d-ad79" name="Tractor Maul" book="BtGoA" page="65" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="0f4d-9895-e878-29ea" profileTypeId="ecae-8ac8-2c13-0dd3" name="Tractor Maul" hidden="false" book="BtGoA" page="65">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks, Hand Weapon"/>
-          </characteristics>
+        <profile id="0f4d-9895-e878-29ea" name="Tractor Maul" book="BtGoA" page="65" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks, Hand Weapon"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="311e-56e1-d1bc-36a1" targetId="2cbd-47c9-de87-ec2a" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="ac1e-a740-57b7-cc64" name="Twin Mag Light Support" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="75">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="25d4-13e2-3977-4bd4" name="Mag Light Support" defaultEntryId="d17e-2eae-cc33-8d46" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="d17e-2eae-cc33-8d46" targetId="a00c-0542-f2a5-8124" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="c10e-6e9c-dabb-e6f1" name="Mag Light Support" defaultEntryId="b385-bf67-9722-e7f9" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="b385-bf67-9722-e7f9" targetId="a00c-0542-f2a5-8124" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
       <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="f31c-6e5c-19c0-ada7" name="Twin Mag Repeaters" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="69">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="4e5a-4594-d2da-527c" name="Mag Repeater" defaultEntryId="513b-6ec0-e655-02cd" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+      <infoLinks>
+        <infoLink id="311e-56e1-d1bc-36a1" hidden="false" targetId="2cbd-47c9-de87-ec2a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="513b-6ec0-e655-02cd" targetId="790a-6841-6372-870b" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="273a-5de1-c9e1-5310" name="Mag Repeater" defaultEntryId="6e82-7e87-0e72-610f" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="6e82-7e87-0e72-610f" targetId="790a-6841-6372-870b" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ac1e-a740-57b7-cc64" name="Twin Mag Light Support" book="BtGoA" page="75" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
       <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="78dd-7840-1210-fb35" name="Twin Plasma Carbines" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="3053-5f5d-f959-4765" name="Plasma Carbine" defaultEntryId="e69d-d58d-9506-291e" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="e69d-d58d-9506-291e" targetId="b018-6101-d2e3-b4ea" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="306b-df6b-34af-a65f" name="Plasma Carbine" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="50f5-f0eb-d9cb-a569" targetId="b018-6101-d2e3-b4ea" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <infoLinks/>
       <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="25d4-13e2-3977-4bd4" name="Mag Light Support" hidden="false" collective="false" defaultSelectionEntryId="d17e-2eae-cc33-8d46">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="d17e-2eae-cc33-8d46" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="c10e-6e9c-dabb-e6f1" name="Mag Light Support" hidden="false" collective="false" defaultSelectionEntryId="b385-bf67-9722-e7f9">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="b385-bf67-9722-e7f9" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f31c-6e5c-19c0-ada7" name="Twin Mag Repeaters" book="BtGoA" page="69" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
       <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="67fa-a913-bd09-5b13" name="Vertex Mace" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="GOA" page="221">
-      <entries/>
-      <entryGroups/>
+      <infoLinks/>
       <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="4e5a-4594-d2da-527c" name="Mag Repeater" hidden="false" collective="false" defaultSelectionEntryId="513b-6ec0-e655-02cd">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="513b-6ec0-e655-02cd" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="273a-5de1-c9e1-5310" name="Mag Repeater" hidden="false" collective="false" defaultSelectionEntryId="6e82-7e87-0e72-610f">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="6e82-7e87-0e72-610f" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="78dd-7840-1210-fb35" name="Twin Plasma Carbines" book="BtGoA" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="3053-5f5d-f959-4765" name="Plasma Carbine" hidden="false" collective="false" defaultSelectionEntryId="e69d-d58d-9506-291e">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="e69d-d58d-9506-291e" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="306b-df6b-34af-a65f" name="Plasma Carbine" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="50f5-f0eb-d9cb-a569" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="67fa-a913-bd09-5b13" name="Vertex Mace" book="GOA" page="221" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
       <rules>
-        <rule id="0313-f279-525f-da8c" name="Vertex Mace" hidden="false" book="GOA" page="221">
+        <rule id="0313-f279-525f-da8c" name="Vertex Mace" book="GOA" page="221" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
           <description>The vertex mace is both a symbol of oﬃce and a tool that gives its wielder the ability to intercept and direct nano‐coms and interface directly with the combat shards of units under his command. This enables the commander to extend his Command rule to any unit on the table that has a spotter drone regardless of range.</description>
-          <modifiers/>
         </rule>
       </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b9f1-a313-3e59-57ab" name="X-Howitzer" book="BtGoA" page="82" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="acf4-2a5f-e9a1-6d3c" name="X-Howitzer" book="BtGoA" page="82" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-50"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="250"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D10, No Cover, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="6f40-42de-4957-1df4" hidden="false" targetId="c3bc-87fd-fa5d-5055" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b631-2638-986b-4611" hidden="false" targetId="04d9-a48d-7b25-4dd3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7c8b-6880-8593-4b52" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="92e5-9a8f-2921-8280" hidden="false" targetId="7849-7fc2-0006-8fbd" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eed0-b68f-b5fb-92c7" name="X-Launcher" book="BtGoA" page="78" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="2489-100b-d116-96c6" name="X-Launcher" book="BtGoA" page="78" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D5, No Cover,  Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="cbba-ff32-112c-3173" hidden="false" targetId="c3bc-87fd-fa5d-5055" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="57ac-1f50-9d13-b33b" hidden="false" targetId="b050-496a-ed16-2b2a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="613e-43c3-a036-e997" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="7bb9-56de-ae51-c52b" hidden="false" targetId="7849-7fc2-0006-8fbd" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b08e-548a-fda7-0a4e" name="X-Sling" book="BtGoA" page="68" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="3cec-d2e0-b0ed-7856" name="X-Sling" book="BtGoA" page="68" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D3, Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="ff22-4293-45d6-b483" hidden="false" targetId="1acd-39d3-94e7-48e1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3af1-7df9-4f90-c12c" name="Synchronizer Drone" book="BFX" page="79" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="b9f1-a313-3e59-57ab" name="X-Howitzer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="82">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="acf4-2a5f-e9a1-6d3c" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Howitzer" hidden="false" book="BtGoA" page="82">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-50"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="250"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D10, No Cover, Heavy Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="6f40-42de-4957-1df4" targetId="c3bc-87fd-fa5d-5055" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="b631-2638-986b-4611" targetId="04d9-a48d-7b25-4dd3" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="7c8b-6880-8593-4b52" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="92e5-9a8f-2921-8280" targetId="7849-7fc2-0006-8fbd" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="eed0-b68f-b5fb-92c7" name="X-Launcher" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="78">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="2489-100b-d116-96c6" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Launcher" hidden="false" book="BtGoA" page="78">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="60"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="120"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D5, No Cover,  Light Support Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="cbba-ff32-112c-3173" targetId="c3bc-87fd-fa5d-5055" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="57ac-1f50-9d13-b33b" targetId="b050-496a-ed16-2b2a" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="613e-43c3-a036-e997" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="7bb9-56de-ae51-c52b" targetId="7849-7fc2-0006-8fbd" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="b08e-548a-fda7-0a4e" name="X-Sling" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="68">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="3cec-d2e0-b0ed-7856" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Sling" hidden="false" book="BtGoA" page="68">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D3, Hand Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="ff22-4293-45d6-b483" targetId="1acd-39d3-94e7-48e1" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="3af1-7df9-4f90-c12c" name="Synchronizer Drone" points="20.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BFX" page="79">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules>
-        <rule id="8a43-b875-0c02-cece" name="Synchoniser Drone" hidden="false" book="BfX" page="79">
+        <rule id="8a43-b875-0c02-cece" name="Synchoniser Drone" book="BfX" page="79" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
           <description>If a unit with a Synchoroniser Drone is given an order, and if it passes any order test required, then after the unit has carried out its acton the player can use the drone to try to synchonise the unit with another unit within 10&quot; of it. If sucessful draw one of his order dice from the dice bag and give this second unit an order in the usual way
 10&quot; synchonisation distance is measured AFTER the synchoronising unit resolving anything resulting from the action itself (including enemy reactions.
 If the drone dies then you may no longer sync.
 May NOT &apos;Chain&apos; syncronisers to make unit 1 sync to unit 2, who syncs to unit 3.
 May NOT be used in combination with the Command rule.
 The unit may perform any action that it normally would be able to pick.</description>
-          <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links/>
-    </entry>
-  </sharedEntries>
-  <sharedEntryGroups/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups/>
   <sharedRules>
-    <rule id="2cbd-47c9-de87-ec2a" name="2 Attacks" hidden="false" book="BtGoA" page="133">
+    <rule id="2cbd-47c9-de87-ec2a" name="2 Attacks" book="BtGoA" page="133" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Two attacks in close combat.</description>
-      <modifiers/>
     </rule>
-    <rule id="61e2-3707-ade3-c9ad" name="3 Attacks" hidden="false" book="BtGoA" page="133">
+    <rule id="61e2-3707-ade3-c9ad" name="3 Attacks" book="BtGoA" page="133" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Three attacks in close combat.</description>
-      <modifiers/>
     </rule>
-    <rule id="7daf-414b-c030-7626" name="AG Chute" hidden="false" book="BtGoA" page="120">
+    <rule id="7daf-414b-c030-7626" name="AG Chute" book="BtGoA" page="120" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May make 2M move and shoot when given advance order. +1 Ag. Treat difficult ground as suspensored vehicle. </description>
-      <modifiers/>
     </rule>
-    <rule id="c1ba-c745-22a8-e2d7" name="Arc" hidden="false" book="BtGoA" page="88">
+    <rule id="c1ba-c745-22a8-e2d7" name="Arc" book="BtGoA" page="88" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Creates 3&quot; sink area. Affects any shooter attemping to draw LOS and shoot through the arc. Roll a D10 if LOS goes through - 1-5 the shot is normal, 6-10 the shot automatically misses. Make test before rolling Acc to hit. 
 
 OH shots are affected if the target is within 3&quot; of the marker. </description>
-      <modifiers/>
     </rule>
-    <rule id="b7c6-fc7c-d48b-aae4" name="Auto-Workshop" hidden="false" book="BtGoA" page="121">
+    <rule id="b7c6-fc7c-d48b-aae4" name="Auto-Workshop" book="BtGoA" page="121" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Activated from any order to the unit. Affects every vehicle, weapon drone, weapon team, and machine mounted unit within 5&quot; of the unit, and itself. Roll D10 - on 1-5, nothing happens, 6-10 each unit removes a pin.</description>
-      <modifiers/>
     </rule>
-    <rule id="04d9-a48d-7b25-4dd3" name="Blast D10" hidden="false" book="BtGoA">
+    <rule id="04d9-a48d-7b25-4dd3" name="Blast D10" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Inflicts D10 hits on a successful shooting attack.</description>
-      <modifiers/>
     </rule>
-    <rule id="1acd-39d3-94e7-48e1" name="Blast D3" hidden="false" book="BtGoA">
+    <rule id="1acd-39d3-94e7-48e1" name="Blast D3" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Inflicts D3 hits on a successful shooting attack.</description>
-      <modifiers/>
     </rule>
-    <rule id="ca96-58c9-9551-d4fe" name="Blast D4" hidden="false" book="BtGoA">
+    <rule id="ca96-58c9-9551-d4fe" name="Blast D4" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Inflicts D4 hits on a successful shooting attack.</description>
-      <modifiers/>
     </rule>
-    <rule id="b050-496a-ed16-2b2a" name="Blast D5" hidden="false" book="BtGoA">
+    <rule id="b050-496a-ed16-2b2a" name="Blast D5" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Inflicts D5 hits on a successful shooting attack.</description>
-      <modifiers/>
     </rule>
-    <rule id="117a-a2aa-4be7-dffe" name="Blur" hidden="false" book="BtGoA" page="89">
+    <rule id="117a-a2aa-4be7-dffe" name="Blur" book="BtGoA" page="89" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Any unit within 3&quot; reduces Acc by D3 each time it shoots. If within two or more blur markers, roll a D3 for each and take highest.</description>
-      <modifiers/>
     </rule>
-    <rule id="c3e6-4e9b-858c-80d3" name="Booster Drone" hidden="false" book="BtGoA" page="92">
+    <rule id="c3e6-4e9b-858c-80d3" name="Booster Drone" book="BtGoA" page="92" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Infantry, Weapon Team, or Command unit gains +1 armor bonus from reflex, hyperlight, and phase armor. Cannot benefit units with HL boosters.</description>
-      <modifiers/>
     </rule>
-    <rule id="fd72-d48c-e8af-4883" name="Choose Target" hidden="false" book="BtGoA" page="70">
+    <rule id="fd72-d48c-e8af-4883" name="Choose Target" book="BtGoA" page="70" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May fire at a different target from the test of the unit. If more than one model has a weapon with Choose Target, all weapons with Choose Target must shoot at same target.</description>
-      <modifiers/>
     </rule>
-    <rule id="5c9b-1bde-ee01-04a4" name="Command" hidden="false" book="BtGoA" page="133">
+    <rule id="5c9b-1bde-ee01-04a4" name="Command" book="BtGoA" page="133" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Friendly units within 10&quot; can use this model&apos;s Co value for any Co based test instead of their own. Pins still affect this Co value.</description>
-      <modifiers/>
     </rule>
-    <rule id="7db4-2d14-3984-37d9" name="Compressor" hidden="false" book="BtGoA" page="71">
+    <rule id="7db4-2d14-3984-37d9" name="Compressor" book="BtGoA" page="71" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>SV value varies with range band.</description>
-      <modifiers/>
     </rule>
-    <rule id="5fb8-4f09-d496-4ea9" name="Concentrated Fire" hidden="false" book="BtGoA" page="72">
+    <rule id="5fb8-4f09-d496-4ea9" name="Concentrated Fire" book="BtGoA" page="72" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Any lucky hits can be allocated to the same model, do not have to be distributed evenly.</description>
-      <modifiers/>
     </rule>
-    <rule id="c34f-bbca-9bfc-6874" name="Crawler" hidden="false" book="BtGoA" page="133">
+    <rule id="c34f-bbca-9bfc-6874" name="Crawler" book="BtGoA" page="133" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Crawlers are restricted when moving over certain terrain types as described in the terrain section. They cross obstacles in the same manner as a heavy weapon team. They cannot cross at a run and must test to cross at advance rate. Crossing obstacles, p22</description>
-      <modifiers/>
     </rule>
-    <rule id="cf7f-6f85-e64e-0363" name="Cycle" hidden="false" book="BtGoA" page="78">
+    <rule id="cf7f-6f85-e64e-0363" name="Cycle" book="BtGoA" page="78" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>On the Acc roll of a 10 shot misses and weapon team goes down.</description>
-      <modifiers/>
     </rule>
-    <rule id="6305-72fa-da02-235b" name="Disruptor" hidden="false" book="BtGoA" page="79">
+    <rule id="6305-72fa-da02-235b" name="Disruptor" book="BtGoA" page="79" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>A target hit by a disruptor weapon gets no cover bonus to its Res roll against the hit.
 
 A non-Ghar target hit by a disruptor weapon takes 2 pins rather than the usual 1 pin. If the target has Res &gt; 10, it takes these pins even if the hit is successfully resisted. Ghar do not suffer these pins. 
@@ -4783,120 +8292,201 @@ A non-Ghar target hit by a disruptor weapon takes 2 pins rather than the usual 1
 Buddy drones can be allocated hits from this weapon by the shooter from any hits, not just lucky hits.
 
 If the target is a probe it only passes Res tests on a 1.</description>
-      <modifiers/>
     </rule>
-    <rule id="9444-e2a0-8048-5ce9" name="Down" hidden="false" book="BtGoA" page="74">
+    <rule id="9444-e2a0-8048-5ce9" name="Down" book="BtGoA" page="74" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Unit hit automatically goes down after shooting has been worked out whether casualties are caused or not. </description>
-      <modifiers/>
     </rule>
-    <rule id="4232-2801-36cf-704c" name="Exhausted" hidden="false" book="BtGoA" page="67">
+    <rule id="4232-2801-36cf-704c" name="Exhausted" book="BtGoA" page="67" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Rolls of 10 on Str or Acc to-hit rolls cannot be re-rolled and stave has become exhausted. Make a test at the turn end phase - 1-5 it is still exhausted, 6-10 it is replenished.</description>
-      <modifiers/>
     </rule>
-    <rule id="b0ca-8e7d-d03f-f027" name="Fast" hidden="false" book="BtGoA" page="133">
+    <rule id="b0ca-8e7d-d03f-f027" name="Fast" book="BtGoA" page="133" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Move at double pace - 10&quot; per advance, 20&quot; for run. Shots fired at fast targets with a run order must re-roll hits. 
 Fast units may break off of assault after point blank shooting has been conducted. They may move through the enemy during this move.</description>
-      <modifiers/>
     </rule>
-    <rule id="7bc9-5e98-2914-5abd" name="Follow" hidden="false" book="BtGoA" page="13">
+    <rule id="7bc9-5e98-2914-5abd" name="Follow" book="BtGoA" page="13" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>When a leader with follow gives his unit an order, any other friendly units within 5&quot; may make the same action as long as they have no pins and are otherwise able to make the action.</description>
-      <modifiers/>
     </rule>
-    <rule id="d50c-3bbe-c62d-34c3" name="Fractal Lock" hidden="false" book="BtGoA" page="83">
+    <rule id="d50c-3bbe-c62d-34c3" name="Fractal Lock" book="BtGoA" page="83" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>If the weapon hits, it locks on. If the target does not move and the unit receives a fire order it automatically hits. Each time it auto-hits the SV value goes up by 2.</description>
-      <modifiers/>
     </rule>
-    <rule id="b466-7990-db34-55b1" name="Grenade" hidden="false" book="BtGoA" page="85">
+    <rule id="b466-7990-db34-55b1" name="Grenade" book="BtGoA" page="85" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>In H2H counts as hand weapon +1 Str bonus. Grenade hits compound in H2H - if a model takes suffers two or more hits from grenades, add all SVs together and take one Res test.</description>
-      <modifiers/>
     </rule>
-    <rule id="1045-95cb-5504-9050" name="Grip" hidden="false" book="BtGoA" page="87">
+    <rule id="1045-95cb-5504-9050" name="Grip" book="BtGoA" page="87" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Unit beginning its move within 3&quot; must take and pass an Ag test. If failed it may not move, if passed it can move half rate, failed on a 10 it takes a pin and cannot move.
 
 If a unit moves within 3&quot; it must take the Ag test as above. </description>
-      <modifiers/>
     </rule>
-    <rule id="1c2c-6574-0a17-f90c" name="Hazardous H2H" hidden="false" book="BtGoA" page="85">
+    <rule id="1c2c-6574-0a17-f90c" name="Hazardous H2H" book="BtGoA" page="85" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Any H2H Str roll of 10 hits the user, not enemy.</description>
-      <modifiers/>
     </rule>
-    <rule id="a846-6829-3398-bac1" name="Heavy" hidden="false" book="BtGoA" page="134">
+    <rule id="a846-6829-3398-bac1" name="Heavy" book="BtGoA" page="134" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Movement restricted across obstacles per p22. Cannot cross obstacles at a run. Agility test required to cross at advance. When rolling resistance checks only fail on a 10, roll on damage chart p37.</description>
-      <modifiers/>
     </rule>
-    <rule id="3c64-6022-a5f1-9c04" name="Hero" hidden="false" book="BtGoA" page="134">
+    <rule id="3c64-6022-a5f1-9c04" name="Hero" book="BtGoA" page="134" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Friendly units within 10&quot; may use this model&apos;s Init stat. </description>
-      <modifiers/>
     </rule>
-    <rule id="34e0-c5a3-3998-5d0b" name="High Commander" hidden="false" book="BtGoA" page="134">
+    <rule id="34e0-c5a3-3998-5d0b" name="High Commander" book="BtGoA" page="134" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May re-roll every failed resist test once. May use command, hero, and follow special rules on any units.</description>
-      <modifiers/>
     </rule>
-    <rule id="b436-1f8a-5d3a-2d7d" name="HL Armor" hidden="false" book="BtGoA" page="93">
+    <rule id="b436-1f8a-5d3a-2d7d" name="HL Armor" book="BtGoA" page="93" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Ranges of 10&quot; or less, +1 to Res. Ranges of greater than 10&quot; +2 Res. Against any Blast hits, +3 Res. </description>
-      <modifiers/>
     </rule>
-    <rule id="56ab-52fc-9557-2586" name="HL Booster" hidden="false" book="BtGoA" page="93">
+    <rule id="56ab-52fc-9557-2586" name="HL Booster" book="BtGoA" page="93" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>+1 Res on top of all other bonuses.</description>
-      <modifiers/>
     </rule>
-    <rule id="3b84-9d0e-a3c1-6c1f" name="Inaccurate" hidden="false" book="BtGoA" page="70">
+    <rule id="3b84-9d0e-a3c1-6c1f" name="Inaccurate" book="BtGoA" page="70" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Additional -1 Acc penalty.</description>
-      <modifiers/>
     </rule>
-    <rule id="96c4-7a43-2a4c-d7d3" name="Infiltrator" hidden="false" book="BtGoA" page="134">
+    <rule id="96c4-7a43-2a4c-d7d3" name="Infiltrator" book="BtGoA" page="134" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May make a special pre-game run action. May sprint, test for exhaustion. May not move within 10&quot; of enemy. May lay a minefield before game starts.</description>
-      <modifiers/>
     </rule>
-    <rule id="a221-d53c-b4bd-b52c" name="Large" hidden="false" book="BtGoA" page="134">
+    <rule id="a221-d53c-b4bd-b52c" name="Large" book="BtGoA" page="134" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Cannot sprint unless also fast. Passes when testing Ag to move through dense terrain reduce movement to half. Passes on a one mean unit can move at full rate. Failure means unit cannot move, failure on a 10 gains one pin. 
 
 Units may fire over regular sized units at no penalty. Large targets never gain cover bonuses to their Res stat. May not enter buildings. </description>
-      <modifiers/>
     </rule>
-    <rule id="7cfb-9874-dfe0-b136" name="Lava Spit" hidden="false" book="BtGoA" page="135">
+    <rule id="7cfb-9874-dfe0-b136" name="Lava Spit" book="BtGoA" page="135" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Lavamites may shoot during point blank shooting at SV 2.</description>
-      <modifiers/>
     </rule>
-    <rule id="e441-c3a6-7d61-2c63" name="Leader" hidden="false" book="BtGoA" page="135">
+    <rule id="e441-c3a6-7d61-2c63" name="Leader" book="BtGoA" page="135" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May re-roll one failed res test per leader level. </description>
-      <modifiers/>
     </rule>
-    <rule id="7850-89e7-bab8-86e9" name="Leader 2" hidden="false" book="BtGoA">
+    <rule id="7850-89e7-bab8-86e9" name="Leader 2" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May re-roll one failed res test per leader level.</description>
-      <modifiers/>
     </rule>
-    <rule id="05bb-4d34-70cd-25d2" name="Leader 3" hidden="false" book="BtGoA">
+    <rule id="05bb-4d34-70cd-25d2" name="Leader 3" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May re-roll one failed res test per leader level.</description>
-      <modifiers/>
     </rule>
-    <rule id="5efa-64a9-bbc9-3dba" name="Limited Ammo" hidden="false" book="BtGoA" page="73,77">
+    <rule id="5efa-64a9-bbc9-3dba" name="Limited Ammo" book="BtGoA" page="73,77" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Risks running out of ammunition.</description>
-      <modifiers/>
     </rule>
-    <rule id="d8dc-cf25-ef95-c94b" name="Limited Choice" hidden="false" book="BtGoA">
+    <rule id="d8dc-cf25-ef95-c94b" name="Limited Choice" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May only be taken as 1 in 4 choices of entire force.</description>
-      <modifiers/>
     </rule>
-    <rule id="c863-510b-e239-be92" name="Massive Damage" hidden="false" book="BtGoA" page="75">
+    <rule id="c863-510b-e239-be92" name="Massive Damage" book="BtGoA" page="75" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>If the mag cannon&apos;s target rolls for damage on a damage table it suffers Massive Damage - page 37.</description>
-      <modifiers/>
     </rule>
-    <rule id="137e-c2b6-65b7-ecc3" name="Medic" hidden="false" book="BtGoA" page="135">
+    <rule id="137e-c2b6-65b7-ecc3" name="Medic" book="BtGoA" page="135" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Units within 5&quot; of a medic unit may re-roll one failed Res test each time it is shot at. Medi-probes and drones may add their re-rolls to total number of re-rolls.
 
 Cannot be used on non-humans. </description>
-      <modifiers/>
     </rule>
-    <rule id="5565-ce10-1c78-1ee7" name="MOD2" hidden="false" book="BtGoA" page="136">
+    <rule id="5565-ce10-1c78-1ee7" name="MOD2" book="BtGoA" page="136" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Unit contributes two die to the dice pool and may act twice per turn. Always treated as having used the most recent action.</description>
-      <modifiers/>
     </rule>
-    <rule id="8151-2e24-94ee-0477" name="MOD3" hidden="false" book="BtGoA">
+    <rule id="8151-2e24-94ee-0477" name="MOD3" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Unit contributes three die to the dice pool and may act thrice per turn. Always treated as having used the most recent action.</description>
-      <modifiers/>
     </rule>
-    <rule id="ac33-af99-2d76-c981" name="Net" hidden="false" book="BtGoA" page="88">
+    <rule id="ac33-af99-2d76-c981" name="Net" book="BtGoA" page="88" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Roll to hit as normal for a blast weapon. Target does not suffer blast damage, rather suffers pins:
 
 X-Launcher: D3+1 pin
@@ -4904,132 +8494,224 @@ X-Howitzer: D5+1 pin
 Mag Mortar: D10+1 pin
 
 Targets that would normally force an Acc re-roll suffer half the number of pins rounded down. Divide pins equally between two or more units as normal.</description>
-      <modifiers/>
     </rule>
-    <rule id="a41d-d55e-6d97-049d" name="No Cover" hidden="false" book="BtGoA" page="71">
+    <rule id="a41d-d55e-6d97-049d" name="No Cover" book="BtGoA" page="71" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>No cover bonus to Res roll.</description>
-      <modifiers/>
     </rule>
-    <rule id="f502-611e-9704-97bb" name="No Crew" hidden="false" book="BtGoA" page="7">
+    <rule id="f502-611e-9704-97bb" name="No Crew" book="BtGoA" page="7" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>When carried by a model in battle armor it counts as having full crew.</description>
-      <modifiers/>
     </rule>
-    <rule id="c3bc-87fd-fa5d-5055" name="OH" hidden="false" book="BtGoA" page="34">
+    <rule id="c3bc-87fd-fa5d-5055" name="OH" book="BtGoA" page="34" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Fires as an Overhead weapon.</description>
+    </rule>
+    <rule id="aef6-6934-1dee-6fa0" name="OHx2" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="aef6-6934-1dee-6fa0" name="OHx2" hidden="false" book="BtGoA">
+    <rule id="7db4-6bd3-fb59-706d" name="Outcast" book="BtGoA" page="136" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </rule>
-    <rule id="7db4-6bd3-fb59-706d" name="Outcast" hidden="false" book="BtGoA" page="136">
       <description>Command, hero, and follow rules only work on Outcast units. Cannot benefit from command, hero, or follow from non-Outcast unless it is a High Commander.</description>
-      <modifiers/>
     </rule>
-    <rule id="3559-4b87-980d-f90d" name="Overload Ammo" hidden="false" book="BtGoA" page="89">
+    <rule id="3559-4b87-980d-f90d" name="Overload Ammo" book="BtGoA" page="89" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Can only be used with direct fire. SV = 3, single hit. If a 10 is rolled on Acc roll, shot misses, cannot be re-rolled, and overload ammo cannot be used again.</description>
-      <modifiers/>
     </rule>
-    <rule id="b28d-571e-af69-4582" name="Phase Armor" hidden="false" book="BtGoA" page="93">
+    <rule id="b28d-571e-af69-4582" name="Phase Armor" book="BtGoA" page="93" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>10&quot; or less, +1 Res. Greater than 10&quot;, +2 Res. May make a down reaction even if it already has order die - flip to down if so. </description>
-      <modifiers/>
     </rule>
-    <rule id="6b03-2ad4-34c1-7f73" name="Plasma Fade" hidden="false" book="BtGoA" page="76">
+    <rule id="6b03-2ad4-34c1-7f73" name="Plasma Fade" book="BtGoA" page="76" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>On the Acc roll of a 10 to hit the shot is a miss and the unit goes down.</description>
-      <modifiers/>
     </rule>
-    <rule id="0f12-545e-1c86-f482" name="Plasma Reactor" hidden="false" book="BtGoA" page="1367">
+    <rule id="0f12-545e-1c86-f482" name="Plasma Reactor" book="BtGoA" page="1367" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Lucky hits are allocated by shooter and hit plasma reactor. On a Res failure of 10, roll for every other model in unit and on a 10 they are removed as well.</description>
-      <modifiers/>
     </rule>
-    <rule id="5d64-4bf5-e947-95d1" name="Point Blank Shooting Only" hidden="false" book="BtGoA" page="86">
+    <rule id="5d64-4bf5-e947-95d1" name="Point Blank Shooting Only" book="BtGoA" page="86" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May only be used for point blank shooting. Cannot be used for H2H.</description>
-      <modifiers/>
     </rule>
-    <rule id="b6e3-9cf0-1a9f-a941" name="Random SV" hidden="false" book="BtGoA" page="66">
+    <rule id="b6e3-9cf0-1a9f-a941" name="Random SV" book="BtGoA" page="66" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Roll every round for entire unit to determine SV. </description>
-      <modifiers/>
     </rule>
-    <rule id="9ad5-9fc3-726e-852a" name="Rapid Sprint" hidden="false" book="BtGoA" page="136">
+    <rule id="9ad5-9fc3-726e-852a" name="Rapid Sprint" book="BtGoA" page="136" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May sprint at 4M. </description>
-      <modifiers/>
     </rule>
-    <rule id="1863-c041-6dc4-c62d" name="RF D6 Fire Only" hidden="false" book="BtGoA" page="72">
+    <rule id="1863-c041-6dc4-c62d" name="RF D6 Fire Only" book="BtGoA" page="72" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Rapid Fire D6 when making a fire action. When shooting with advance action weapon has one shot. If issued in multiples, roll D6 for all weapons in unit.</description>
-      <modifiers/>
     </rule>
-    <rule id="0cb1-ea91-e5bc-4f75" name="RF2" hidden="false" book="BtGoA">
+    <rule id="0cb1-ea91-e5bc-4f75" name="RF2" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May fire two shots at rapid fire.</description>
-      <modifiers/>
     </rule>
-    <rule id="97d4-67cb-2671-ca29" name="RF3" hidden="false" book="BtGoA">
+    <rule id="97d4-67cb-2671-ca29" name="RF3" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May fire three shots at rapid fire.</description>
-      <modifiers/>
     </rule>
-    <rule id="b0cb-c022-0531-4852" name="RF5" hidden="false" book="BtGoA">
+    <rule id="b0cb-c022-0531-4852" name="RF5" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May fire five shots at rapid fire.</description>
-      <modifiers/>
     </rule>
-    <rule id="f7af-59ec-acde-2f75" name="Savage Strike" hidden="false" book="BtGoA" page="136">
+    <rule id="f7af-59ec-acde-2f75" name="Savage Strike" book="BtGoA" page="136" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Passes order check to assault on any roll except a 10, regardless of modifiers.</description>
-      <modifiers/>
     </rule>
-    <rule id="28a0-7151-a0c5-9495" name="Scoot" hidden="false" book="BtGoA" page="88">
+    <rule id="28a0-7151-a0c5-9495" name="Scoot" book="BtGoA" page="88" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Only affects infantry, mounted, weapon team, beast, and humongous beast, command, and bike mounted units with living crew. Affects scramble proof units. Any affected unit within 3&quot; canno tbe given any order except run or down. Cannot make any reaction apart from go down.</description>
-      <modifiers/>
     </rule>
-    <rule id="94f5-4a4c-92ad-94f9" name="Scramble Proof" hidden="false" book="BtGoA" page="137">
+    <rule id="94f5-4a4c-92ad-94f9" name="Scramble Proof" book="BtGoA" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Not affected by scrambler munitions. Vehicles may be affected by scoot. Subverter matrixes cannot affect model.</description>
-      <modifiers/>
     </rule>
-    <rule id="7a3b-74a5-3ced-dd88" name="Scrambler" hidden="false" book="BtGoA" page="88">
+    <rule id="7a3b-74a5-3ced-dd88" name="Scrambler" book="BtGoA" page="88" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Enemy units within 3&quot; that are not scramble proof it loses Reflex Armor, Hyperlight Armor, and Phase Armor along with any bonuses. Units in Phase Armor cannot use their armor to go down.
 
 Weapon Drone and vehicles have Res reduced by 2 within 3&quot;. Buddy drones cease to function if the unit is within 3&quot;. Probes can do nothing at all while marker is within 3&quot;. Penalties are not cumulative.</description>
-      <modifiers/>
     </rule>
-    <rule id="3377-9408-33bb-6a02" name="Self Repair" hidden="false" book="BtGoA" page="137">
+    <rule id="3377-9408-33bb-6a02" name="Self Repair" book="BtGoA" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Give unit rally order. If no pins exist after order, may attempt one repair on  immobilisation or weapon. 1-5 = success, 6-10 failure. Success = that function is working again.</description>
-      <modifiers/>
     </rule>
-    <rule id="00b8-b49c-4c61-2943" name="Shard" hidden="false" book="BtGoA" page="137">
+    <rule id="00b8-b49c-4c61-2943" name="Shard" book="BtGoA" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Every individual unit in the shard makes same action from order. Probes always run.
 
 Shard units never take pins. Always assumed to pass order tests. </description>
+    </rule>
+    <rule id="0c20-4983-db8a-0d56" name="Shared SV" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="0c20-4983-db8a-0d56" name="Shared SV" hidden="false" book="BtGoA">
+    <rule id="5bd0-9ab2-0523-cbc8" name="Slingnet Ammo" book="BtGoA" page="112" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </rule>
-    <rule id="5bd0-9ab2-0523-cbc8" name="Slingnet Ammo" hidden="false" book="BtGoA" page="112">
       <description>Fired direct unless from Micro X Launcher. Targets hit suffer no damage but take +1 additional pin. Cannot affect units that cannot be pinned when hit.</description>
-      <modifiers/>
     </rule>
-    <rule id="7c88-64d4-50ad-2313" name="Slow" hidden="false" book="BtGoA" page="137">
+    <rule id="7c88-64d4-50ad-2313" name="Slow" book="BtGoA" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Move at half pace.</description>
-      <modifiers/>
     </rule>
-    <rule id="6f47-5038-573a-b225" name="Sniper" hidden="false" book="BtGoA" page="137">
+    <rule id="6f47-5038-573a-b225" name="Sniper" book="BtGoA" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Deploy anywhere within player&apos;s half. Snipers may not be deployed within 20&quot; of other snipers, enemy may not deploy within 10&quot;. </description>
-      <modifiers/>
     </rule>
-    <rule id="1253-ef5b-67d4-3e18" name="Soma Graft" hidden="false" book="BtGoA" page="121">
+    <rule id="1253-ef5b-67d4-3e18" name="Soma Graft" book="BtGoA" page="121" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May activate when a unit takes a Co test. Will past any Co test on any score other than 10. If a 10 is rolled, unit goes out of control and must roll the order die to generate an order. The unit does not have to comply, but if it does an order that is the only one it can do.</description>
-      <modifiers/>
     </rule>
-    <rule id="b996-131f-b84a-4724" name="Special Munition" hidden="false" book="BtGoA" page="87">
+    <rule id="b996-131f-b84a-4724" name="Special Munition" book="BtGoA" page="87" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Stays on the battlefield until it ceases to work p87. Use a marker to locate where shot lands.</description>
+    </rule>
+    <rule id="cd8d-624c-ed86-e310" name="Subverter Matrix" book="BtGoA" page="122" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="cd8d-624c-ed86-e310" name="Subverter Matrix" hidden="false" book="BtGoA" page="122">
+    <rule id="ab37-33d8-41f3-7532" name="Transport 10" book="BtGoA" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </rule>
-    <rule id="ab37-33d8-41f3-7532" name="Transport 10" hidden="false" book="BtGoA" page="137">
       <description>May transport 10 human sized models.</description>
-      <modifiers/>
     </rule>
-    <rule id="99fd-f354-1703-5941" name="Variable Res/Strike" hidden="false" book="BtGoA" page="66">
-      <description>Use to boost Res +2 or give a SV +2 each round of fighting. If used as +2 SV, counts as Grenade. </description>
+    <rule id="99fd-f354-1703-5941" name="Variable Res/Strike" book="BtGoA" page="66" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>Use to boost Res +2 or give a SV +2 each round of fighting. If used as +2 SV, counts as Grenade. </description>
     </rule>
   </sharedRules>
   <sharedProfiles/>

--- a/Beyond_the_Gates_of_Antares.gst
+++ b/Beyond_the_Gates_of_Antares.gst
@@ -1,1084 +1,3727 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="c339-677a-60db-4060" revision="8" battleScribeVersion="1.15" name="Beyond the Gates of Antares" authorName="Muggins" authorContact="mugginns@gmail.com" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
-  <forceTypes>
-    <forceType id="ee766e00-0168-11be-e251-23243581de9e" name="Generic Scouting Force" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="500.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="3" maxSelections="4" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="0" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="fb94-6e5e-aabd-5b0f" name="Freeborn Scouting Force (500)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="500.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="0" maxSelections="2" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="3" maxSelections="5" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="1d85-ab3e-87a6-ef5b" name="Freeborn Skirmish Force (750)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="750.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="4" maxSelections="7" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="02f9-d3f1-6cd1-4f08" name="Freeborn Combat Force (1,000)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="1000.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="2" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="1" maxSelections="5" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="5" maxSelections="7" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="8353-e6a2-0f1a-1362" name="Freeborn Battle Force (1,250)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="1250.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="2" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="2" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="2" maxSelections="6" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="5" maxSelections="9" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="592e-6e36-8faf-6143" name="Freeborn Offensive Force (1,500)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="1000.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic " minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="3" maxSelections="8" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="6" maxSelections="11" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="1cfa-cc90-8c27-8c14" name="Freeborn Adventurers Scouting Force (500)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="500.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="0" maxSelections="2" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="3" maxSelections="5" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="7800-020b-e6c2-ad2f" name="Freeborn Adventurers Skirmish Force (750)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="750.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="4" maxSelections="7" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="c017-49b7-2886-5e03" name="Freeborn Adventurers Combat Force (1,000)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="1000.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="2" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="1" maxSelections="5" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="5" maxSelections="9" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="232c-96c5-26df-3a12" name="Concord Scouting Force (500)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="500.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="3" maxSelections="4" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="9d50-b363-aea6-5d8c" name="Concord Skirmish Force (750)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="750.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="0" maxSelections="2" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="4" maxSelections="6" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="5c34-43e6-1431-654b" name="Concord Combat Force (1,000)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="1000.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="2" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="1" maxSelections="4" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="5" maxSelections="7" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="ab0c-e540-605a-c233" name="Freeborn Invasion Force (1,750)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="1750.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="4" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="3" maxSelections="9" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="6" maxSelections="12" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="4368-542c-4854-e0d4" name="Freeborn Conquest Force (2,000)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="2000.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="5" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="3" maxSelections="10" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="6" maxSelections="13" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="1ace-e35b-2fa7-3411" name="Concord Offensive Force (1,500)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="1500.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="3.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="2" maxSelections="6" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="5" maxSelections="8" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="c8c5-110a-813b-7c6b" name="Concord Invasion Force (1,750)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="1750.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="4" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="2" maxSelections="7" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="5" maxSelections="9" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="4348-b528-3af6-4469" name="Concord Conquest Force (2,000)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="2000.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="5" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="2" maxSelections="8" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="5" maxSelections="10" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="3824-32aa-aba5-c6be" name="Ghar Empire Scouting Force (500)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="500.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="2" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="7f87-3ddf-967a-0850" name="Ghar Empire Skirmish Force (750)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="750.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="2" maxSelections="4" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="2794-6892-7d9a-a1ef" name="Ghar Empire Combat Force (1,000)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="1000.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="2" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="0" maxSelections="2" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="3" maxSelections="5" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="e7b2-59ea-a949-eab9" name="Ghar Empire Battle Force (1,250)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="1250.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="2" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="2" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="3" maxSelections="6" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="f049-1f10-339e-26e3" name="Ghar Empire Offensive Force (1,500)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="1500.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="0" maxSelections="4" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="4" maxSelections="8" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="724a-439e-69db-8edb" name="Ghar Empire Invasion Force (1,750)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="1750.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="4" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="0" maxSelections="5" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="4" maxSelections="9" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="a67a-17eb-9948-03ca" name="Ghar Empire Conquest Force (2,000)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="2000.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="5" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="0" maxSelections="6" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="4" maxSelections="10" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="808d-f9e1-1259-4ac7" name="Algoryn Scouting Force (500)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="500.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="3" maxSelections="4" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="d325-6afe-c895-db1d" name="Algoryn Skirmish Force (750)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="750.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="4" maxSelections="7" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="7117-184a-14f4-f0b3" name="Algoryn Combat Force (1,000)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="1000.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="2" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="1" maxSelections="5" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="4" maxSelections="8" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="ce7b-8798-071c-58d6" name="Algoryn Battle Force (1,250)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="1250.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="2" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="2" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="2" maxSelections="6" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="5" maxSelections="9" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="64f2-d570-bc2a-0521" name="Algoryn Offensive Force (1,500)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="1500.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="3" maxSelections="8" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="6" maxSelections="10" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="9648-7c59-dbd6-33b7" name="Algoryn Invasion Force (1,750)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="1750.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="4" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="3" maxSelections="9" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="6" maxSelections="11" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="c63f-81cf-ce79-c88b" name="Algoryn Conquest Force (2,000)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="2000.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="5" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="3" maxSelections="10" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="6" maxSelections="12" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="4f5b-6a54-81fe-16db" name="Boromites Scouting Force (500)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="500.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="0" maxSelections="2" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="3" maxSelections="5" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="1f80-5135-33b1-90b4" name="Boromites Skirmish Force (750)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="750.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="0" maxSelections="4" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="4" maxSelections="8" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="468a-bf6f-867a-3e4e" name="Boromites Combat Force (1,000)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="1000.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="2" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="1" maxSelections="5" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="5" maxSelections="9" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="f1db-b393-a7c5-f7c9" name="Boromites Battle Force (1,250)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="1250.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="2" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="2" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="2" maxSelections="7" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="5" maxSelections="10" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="a9b4-6474-81d8-a732" name="Boromites Offensive Force (1,500)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="1500.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="3" maxSelections="8" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="6" maxSelections="12" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="e8a5-a1fd-3f41-eaff" name="Boromites Invasion Force (1,750)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="1750.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="4" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="3" maxSelections="9" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="6" maxSelections="13" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="a334-ff64-f4b8-1b5c" name="Boromites Conquest Force (2,000)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="2000.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="5" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="3" maxSelections="10" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="6" maxSelections="14" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="208b-53d6-6649-2851" name="Isorian Scouting Force (500)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="500.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="3" maxSelections="4" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="5540-9152-9358-0676" name="Isorian Skirmish Force (750)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="750.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="0" maxSelections="2" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="4" maxSelections="6" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="13a8-7d8a-931c-fd5c" name="Isorian Combat Force (1,000)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="1000.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="2" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="1" maxSelections="4" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="4" maxSelections="6" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="cb2f-4f97-ed4d-bf03" name="Isorian Battle Force (1,250)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="1250.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="2" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="2" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="2" maxSelections="5" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="5" maxSelections="7" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="3fc7-f68b-886e-d515" name="Isorian Offensive Force (1,500)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="1500.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="2" maxSelections="6" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="5" maxSelections="8" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="5543-d96a-562b-2029" name="Isorian Invasion Force (1,750)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="1750.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="4" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="2" maxSelections="7" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="5" maxSelections="9" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="1030-7491-d0b0-06f1" name="Isorian Conquest Force (2,000)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="2000.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="5" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="2" maxSelections="8" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="5" maxSelections="10" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="9934-f394-7500-1258" name="Boromite Clan Scouting Force (500)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="500.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="0" maxSelections="2" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="3" maxSelections="5" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="0b1b-4266-fc32-2e4a" name="Boromite Clan Skirmish Force (750)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="750.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="0" maxSelections="4" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="4" maxSelections="8" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="f561-46ea-b930-a3fa" name="Boromite Clan Combat Force (1,000)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="1000.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="2" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="1" maxSelections="5" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="5" maxSelections="9" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="1683-5b84-3d66-ce7a" name="Ghar Rebel Scouting Force (500)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="500.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="4" maxSelections="10" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="fcf3-1da8-c351-885a" name="Ghar Rebel Skirmish Force (750)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="750.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="4" maxSelections="12" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="4bac-ca7f-4c5d-04f3" name="Ghar Rebel Combat Force (1,000)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="1000.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="2" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="1" maxSelections="5" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="5" maxSelections="15" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="c056-e260-930f-ce9f" name="Ghar Rebel Battle Force (1,250)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="1250.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="2" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="2" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="2" maxSelections="6" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="5" maxSelections="16" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="6be5-f059-b37f-1234" name="Ghar Rebel Offensive Force (1,500)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="1500.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="3" maxSelections="8" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="6" maxSelections="17" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="6b56-8b52-3ebe-5b96" name="Ghar Rebel Invasion Force (1,750)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="1750.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="4" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="3" maxSelections="9" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="6" maxSelections="17" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-    <forceType id="77b5-4960-7ef2-044f" name="Ghar Rebel Conquest Force (2,000)" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="2000.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-      <categories>
-        <category id="50ba-cf77-3941-189c" name="Army Options" minSelections="0" maxSelections="-1" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="10" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" minSelections="0" maxSelections="3" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" minSelections="0" maxSelections="5" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" minSelections="3" maxSelections="10" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-        <category id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" minSelections="6" maxSelections="18" minPoints="0.0" maxPoints="-1.0" minPercentage="0" maxPercentage="-1" countTowardsParentMinSelections="false" countTowardsParentMaxSelections="false" countTowardsParentMinPoints="false" countTowardsParentMaxPoints="false" countTowardsParentMinPercentage="false" countTowardsParentMaxPercentage="false">
-          <modifiers/>
-        </category>
-      </categories>
-      <forceTypes/>
-    </forceType>
-  </forceTypes>
+<gameSystem id="c339-677a-60db-4060" name="Beyond the Gates of Antares" revision="9" battleScribeVersion="2.00" authorName="Muggins" authorContact="mugginns@gmail.com" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+  <profiles/>
+  <rules/>
+  <infoLinks/>
+  <costTypes>
+    <costType id="points" name="pts" defaultCostLimit="0.0"/>
+  </costTypes>
   <profileTypes>
     <profileType id="1650-77b3-10d1-6406" name="Model">
-      <characteristics>
-        <characteristic id="cf30-f234-691c-47bd" name="Ag"/>
-        <characteristic id="017a-9b43-b7b3-030d" name="Acc"/>
-        <characteristic id="8294-36f1-6431-2145" name="Str"/>
-        <characteristic id="f214-abe8-c922-c51b" name="Res"/>
-        <characteristic id="08b9-e038-7ba6-488e" name="Init"/>
-        <characteristic id="3993-27b0-c3d9-de20" name="Co"/>
-        <characteristic id="3baa-9cfd-f273-822d" name="Special"/>
-      </characteristics>
+      <characteristicTypes>
+        <characteristicType id="cf30-f234-691c-47bd" name="Ag"/>
+        <characteristicType id="017a-9b43-b7b3-030d" name="Acc"/>
+        <characteristicType id="8294-36f1-6431-2145" name="Str"/>
+        <characteristicType id="f214-abe8-c922-c51b" name="Res"/>
+        <characteristicType id="08b9-e038-7ba6-488e" name="Init"/>
+        <characteristicType id="3993-27b0-c3d9-de20" name="Co"/>
+        <characteristicType id="3baa-9cfd-f273-822d" name="Special"/>
+      </characteristicTypes>
     </profileType>
     <profileType id="f9a2-eeae-3284-75fd" name="Limited Choice">
-      <characteristics>
-        <characteristic id="18c1-4764-7d08-708d" name="Ag"/>
-        <characteristic id="e39c-d7a4-86a8-d23d" name="Acc"/>
-        <characteristic id="0790-bfd5-1273-fe12" name="Str"/>
-        <characteristic id="5b77-3595-2819-675c" name="Res"/>
-        <characteristic id="c0d8-f6fd-a474-1385" name="Init"/>
-        <characteristic id="135d-efc3-5039-b6e6" name="Co"/>
-        <characteristic id="ab43-4d1c-4651-b424" name="Special"/>
-      </characteristics>
+      <characteristicTypes>
+        <characteristicType id="18c1-4764-7d08-708d" name="Ag"/>
+        <characteristicType id="e39c-d7a4-86a8-d23d" name="Acc"/>
+        <characteristicType id="0790-bfd5-1273-fe12" name="Str"/>
+        <characteristicType id="5b77-3595-2819-675c" name="Res"/>
+        <characteristicType id="c0d8-f6fd-a474-1385" name="Init"/>
+        <characteristicType id="135d-efc3-5039-b6e6" name="Co"/>
+        <characteristicType id="ab43-4d1c-4651-b424" name="Special"/>
+      </characteristicTypes>
     </profileType>
     <profileType id="ecae-8ac8-2c13-0dd3" name="Weapon">
-      <characteristics>
-        <characteristic id="c2de-17f1-10e2-2c0a" name="Effective"/>
-        <characteristic id="995e-b5e6-4c63-0baa" name="Long"/>
-        <characteristic id="bf58-0ad5-c7ee-3fd9" name="Extreme"/>
-        <characteristic id="897c-d3c4-3983-896a" name="Strike Value"/>
-        <characteristic id="7e87-2586-653f-d6ec" name="Special Rules"/>
-      </characteristics>
-    </profileType>
-    <profileType id="fb28-ac3c-fa3a-ece3" name="Army Option">
-      <characteristics/>
+      <characteristicTypes>
+        <characteristicType id="c2de-17f1-10e2-2c0a" name="Effective"/>
+        <characteristicType id="995e-b5e6-4c63-0baa" name="Long"/>
+        <characteristicType id="bf58-0ad5-c7ee-3fd9" name="Extreme"/>
+        <characteristicType id="897c-d3c4-3983-896a" name="Strike Value"/>
+        <characteristicType id="7e87-2586-653f-d6ec" name="Special Rules"/>
+      </characteristicTypes>
     </profileType>
   </profileTypes>
+  <forceEntries>
+    <forceEntry id="ee766e00-0168-11be-e251-23243581de9e" name="Generic Scouting Force" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="500.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="e9b6-f685-5dd5-3125" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="e9b6-f685-5dd5-3125" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="fb94-6e5e-aabd-5b0f" name="Freeborn Scouting Force (500)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="500.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="5e24-e62b-a1f6-d904" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="5e24-e62b-a1f6-d904" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="1d85-ab3e-87a6-ef5b" name="Freeborn Skirmish Force (750)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="750.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="3401-cd44-1890-68c3" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="3401-cd44-1890-68c3" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="02f9-d3f1-6cd1-4f08" name="Freeborn Combat Force (1,000)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="1000.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="8dfc-a306-f8fe-1f16" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="8dfc-a306-f8fe-1f16" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="8353-e6a2-0f1a-1362" name="Freeborn Battle Force (1,250)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="1250.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="10bd-5866-2cb5-2e0d" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="10bd-5866-2cb5-2e0d" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="592e-6e36-8faf-6143" name="Freeborn Offensive Force (1,500)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="1000.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic " hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="11.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="7374-76ae-2d8c-fd59" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="7374-76ae-2d8c-fd59" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="1cfa-cc90-8c27-8c14" name="Freeborn Adventurers Scouting Force (500)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="500.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="0e42-3e84-5171-99e5" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="0e42-3e84-5171-99e5" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="7800-020b-e6c2-ad2f" name="Freeborn Adventurers Skirmish Force (750)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="750.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="406c-e56e-9d69-3a23" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="406c-e56e-9d69-3a23" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="c017-49b7-2886-5e03" name="Freeborn Adventurers Combat Force (1,000)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="1000.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="25a7-ead1-dbe3-bc5b" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="25a7-ead1-dbe3-bc5b" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="232c-96c5-26df-3a12" name="Concord Scouting Force (500)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="500.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="347e-807b-1290-bba5" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="347e-807b-1290-bba5" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="9d50-b363-aea6-5d8c" name="Concord Skirmish Force (750)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="750.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="4dc4-1aac-e01e-b171" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="4dc4-1aac-e01e-b171" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="5c34-43e6-1431-654b" name="Concord Combat Force (1,000)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="1000.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="4497-d724-c159-31ec" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="4497-d724-c159-31ec" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="ab0c-e540-605a-c233" name="Freeborn Invasion Force (1,750)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="1750.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="02d0-3e8e-fc0f-e137" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="02d0-3e8e-fc0f-e137" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="4368-542c-4854-e0d4" name="Freeborn Conquest Force (2,000)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="2000.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="2c47-e90e-c485-51f9" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="2c47-e90e-c485-51f9" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="13.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="1ace-e35b-2fa7-3411" name="Concord Offensive Force (1,500)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="1500.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="d994-eae4-25b0-e747" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="d994-eae4-25b0-e747" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="points" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="c8c5-110a-813b-7c6b" name="Concord Invasion Force (1,750)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="1750.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="23fc-6637-bc7e-0d8a" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="23fc-6637-bc7e-0d8a" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="4348-b528-3af6-4469" name="Concord Conquest Force (2,000)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="2000.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="d724-8348-c722-a1cd" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="d724-8348-c722-a1cd" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="3824-32aa-aba5-c6be" name="Ghar Empire Scouting Force (500)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="500.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="c9ea-15b6-0bae-70a5" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="c9ea-15b6-0bae-70a5" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="7f87-3ddf-967a-0850" name="Ghar Empire Skirmish Force (750)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="750.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="630f-8618-b476-ec1a" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="630f-8618-b476-ec1a" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="2794-6892-7d9a-a1ef" name="Ghar Empire Combat Force (1,000)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="1000.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="2002-2efa-83c1-cd37" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="2002-2efa-83c1-cd37" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="e7b2-59ea-a949-eab9" name="Ghar Empire Battle Force (1,250)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="1250.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="6420-ed6b-80ea-9ca3" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="6420-ed6b-80ea-9ca3" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="f049-1f10-339e-26e3" name="Ghar Empire Offensive Force (1,500)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="1500.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="bd14-8c41-09e7-64fe" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="bd14-8c41-09e7-64fe" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="724a-439e-69db-8edb" name="Ghar Empire Invasion Force (1,750)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="1750.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="2142-fc70-b593-7d02" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="2142-fc70-b593-7d02" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="a67a-17eb-9948-03ca" name="Ghar Empire Conquest Force (2,000)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="2000.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="838f-9fc2-5465-5695" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="838f-9fc2-5465-5695" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="808d-f9e1-1259-4ac7" name="Algoryn Scouting Force (500)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="500.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="2833-f8d9-19d3-13ed" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="2833-f8d9-19d3-13ed" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="d325-6afe-c895-db1d" name="Algoryn Skirmish Force (750)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="750.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="fae9-2829-e254-7d8b" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="fae9-2829-e254-7d8b" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="7117-184a-14f4-f0b3" name="Algoryn Combat Force (1,000)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="1000.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="d0ef-9df7-f2e7-1220" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="d0ef-9df7-f2e7-1220" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="ce7b-8798-071c-58d6" name="Algoryn Battle Force (1,250)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="1250.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="8c1f-4a73-5574-f2b5" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="8c1f-4a73-5574-f2b5" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="64f2-d570-bc2a-0521" name="Algoryn Offensive Force (1,500)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="1500.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="67d1-27b2-f661-0c61" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="67d1-27b2-f661-0c61" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="9648-7c59-dbd6-33b7" name="Algoryn Invasion Force (1,750)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="1750.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="5226-2220-0b2a-b666" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="5226-2220-0b2a-b666" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="11.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="c63f-81cf-ce79-c88b" name="Algoryn Conquest Force (2,000)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="2000.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="535b-6bf0-bd55-4a65" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="535b-6bf0-bd55-4a65" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="4f5b-6a54-81fe-16db" name="Boromites Scouting Force (500)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="500.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="2c34-7ca7-31f5-7ec4" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="2c34-7ca7-31f5-7ec4" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="1f80-5135-33b1-90b4" name="Boromites Skirmish Force (750)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="750.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="710e-1906-f0a1-cf92" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="710e-1906-f0a1-cf92" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="468a-bf6f-867a-3e4e" name="Boromites Combat Force (1,000)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="1000.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="3ff8-3857-de3d-e7de" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="3ff8-3857-de3d-e7de" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="f1db-b393-a7c5-f7c9" name="Boromites Battle Force (1,250)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="1250.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="46d2-7800-2bc6-8f5e" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="46d2-7800-2bc6-8f5e" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="a9b4-6474-81d8-a732" name="Boromites Offensive Force (1,500)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="1500.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="342b-9ff6-474f-9b3b" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="342b-9ff6-474f-9b3b" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="e8a5-a1fd-3f41-eaff" name="Boromites Invasion Force (1,750)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="1750.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="4dc9-db44-a5a9-a4f4" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="4dc9-db44-a5a9-a4f4" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="13.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="a334-ff64-f4b8-1b5c" name="Boromites Conquest Force (2,000)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="2000.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="c0bb-fae5-d1c1-ca89" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="c0bb-fae5-d1c1-ca89" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="14.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="208b-53d6-6649-2851" name="Isorian Scouting Force (500)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="500.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="eb68-76c3-f98c-3b91" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="eb68-76c3-f98c-3b91" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="5540-9152-9358-0676" name="Isorian Skirmish Force (750)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="750.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="299b-4713-a2b3-e3f1" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="299b-4713-a2b3-e3f1" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="13a8-7d8a-931c-fd5c" name="Isorian Combat Force (1,000)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="1000.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="cf7f-0af2-707e-edde" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="cf7f-0af2-707e-edde" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="cb2f-4f97-ed4d-bf03" name="Isorian Battle Force (1,250)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="1250.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="1125-37b6-17bd-0931" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="1125-37b6-17bd-0931" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="3fc7-f68b-886e-d515" name="Isorian Offensive Force (1,500)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="1500.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="7aea-165c-5ba8-10f5" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="7aea-165c-5ba8-10f5" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="5543-d96a-562b-2029" name="Isorian Invasion Force (1,750)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="1750.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="b2ed-2128-3701-33f3" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="b2ed-2128-3701-33f3" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="1030-7491-d0b0-06f1" name="Isorian Conquest Force (2,000)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="2000.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="c55f-8a3e-81e4-b0b3" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="c55f-8a3e-81e4-b0b3" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="9934-f394-7500-1258" name="Boromite Clan Scouting Force (500)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="500.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="5393-a407-b1ff-a4cd" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="5393-a407-b1ff-a4cd" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="0b1b-4266-fc32-2e4a" name="Boromite Clan Skirmish Force (750)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="750.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="7bb9-3283-8387-f1c0" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="7bb9-3283-8387-f1c0" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="f561-46ea-b930-a3fa" name="Boromite Clan Combat Force (1,000)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="1000.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="f6da-65d4-a999-2069" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="f6da-65d4-a999-2069" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="1683-5b84-3d66-ce7a" name="Ghar Rebel Scouting Force (500)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="500.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="555b-fa1e-2299-666f" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="555b-fa1e-2299-666f" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="fcf3-1da8-c351-885a" name="Ghar Rebel Skirmish Force (750)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="750.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="6774-4dd8-6e26-32fb" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="6774-4dd8-6e26-32fb" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="4bac-ca7f-4c5d-04f3" name="Ghar Rebel Combat Force (1,000)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="1000.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="b82c-75f3-805b-82e9" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="b82c-75f3-805b-82e9" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="c056-e260-930f-ce9f" name="Ghar Rebel Battle Force (1,250)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="1250.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="2f7a-49b6-8e8d-2984" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="2f7a-49b6-8e8d-2984" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="16.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="6be5-f059-b37f-1234" name="Ghar Rebel Offensive Force (1,500)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="1500.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="58fa-c8f3-2ee2-850c" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="58fa-c8f3-2ee2-850c" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="17.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="6b56-8b52-3ebe-5b96" name="Ghar Rebel Invasion Force (1,750)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="1750.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="537a-edb8-b08c-b99a" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="537a-edb8-b08c-b99a" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="17.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="77b5-4960-7ef2-044f" name="Ghar Rebel Conquest Force (2,000)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="2000.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="42c0-6cf0-b9ee-12f5" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="42c0-6cf0-b9ee-12f5" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="10.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="18.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+    <forceEntry id="9156-c3eb-6dcb-dc89" name="Concord Battle Force (1,250)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="points" scope="parent" value="1250.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" id="maxPoints" type="max"/>
+      </constraints>
+      <categoryEntries>
+        <categoryEntry id="50ba-cf77-3941-189c" name="Army Options" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="9b2c-d7be-3f4e-9dae" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="9b2c-d7be-3f4e-9dae" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxPercentage" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="a01f5f58-334c-8442-d861-15099ebdf5e5" name="Strategic" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="5c47879b-41d0-1383-5fe5-a5989615db89" name="Support" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+        <categoryEntry id="481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="true" id="maxSelections" type="max"/>
+          </constraints>
+        </categoryEntry>
+      </categoryEntries>
+      <forceEntries/>
+    </forceEntry>
+  </forceEntries>
+  <selectionEntries/>
+  <entryLinks/>
+  <sharedSelectionEntries>
+    <selectionEntry id="529a-3e2a-4bd5-5e5f" name="Army Options" hidden="false" collective="false" categoryEntryId="50ba-cf77-3941-189c" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="363e-f291-c4af-bb26" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="2241-be91-8e26-54e7" name="Block!" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2f6f-51d9-fe70-3de6" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="48f5-af6d-b578-4820" name="Extra Shot" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ac2c-7bc1-71db-4d3f" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="350c-8c0a-5508-680d" name="Get Up!" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="03ed-b450-3ac3-851e" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b1ec-3a61-d06c-06e3" name="Marksman" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0f33-71bf-493f-7ec8" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5427-2cb0-4e97-1b7d" name="Pull Yourself Together!" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7f4f-49a8-8469-068b" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1784-4fcf-1f52-7f89" name="Well Prepared" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e34d-fa3b-1266-c55b" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2d28-c572-0476-74d4" name="Superior Shard" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="973e-2691-c627-cb37" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups/>
+  <sharedRules/>
+  <sharedProfiles/>
 </gameSystem>

--- a/Boromites.cat
+++ b/Boromites.cat
@@ -1,3265 +1,5788 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="18ef-359c-e44c-e44a" revision="8" gameSystemId="c339-677a-60db-4060" gameSystemRevision="4" battleScribeVersion="1.15" name="Boromites" authorName="zitheran" authorContact="@zitheran" authorUrl="http://zitheran.com/GoA_BSD" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
-  <entries>
-    <entry id="6e08-00fe-a929-223e" name="Army Options" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="brb" page="159">
-      <entries>
-        <entry id="e8ef-1777-4402-6ec0" name="Block!" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="brb" page="159">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-        <entry id="b615-30f1-ad69-12c1" name="Get Up!" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="brb" page="159">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-        <entry id="e641-c5b4-439e-fcf7" name="Extra Shot" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="brb" page="159">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-        <entry id="5ef9-ac40-fdd1-0f42" name="Pull Yourself Together" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="brb" page="159">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-        <entry id="dbf8-5a76-93e1-f4a8" name="Superior Shard" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="brb" page="159">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-        <entry id="7221-adbb-9c56-8b4f" name="Marksman" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="brb" page="159">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-        <entry id="15ba-5c8d-2015-d2bc" name="Well Prepared" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="brb" page="159">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="92cb-926a-97be-23cb" name="Boromie Engineer Squad" points="0.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="brb" page="189">
-      <entries>
-        <entry id="5283-9b2a-224e-8b1e" name="Plasma Pistols" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="brb" page="189">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="4.0" repeat="true" numRepeats="1" incrementParentId="92cb-926a-97be-23cb" incrementChildId="3c0e-62f9-dc1b-b705" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="4.0" repeat="true" numRepeats="1" incrementParentId="92cb-926a-97be-23cb" incrementChildId="cee6-dd9f-30b2-e834" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-        <entry id="cee6-dd9f-30b2-e834" name="Engineers" points="22.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="189">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="6a81-affb-f2e7-9809" profileTypeId="1650-77b3-10d1-6406" name="Engineers" hidden="false" book="BRB" page="189">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="4"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="6"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="6(7)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="6"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="4b41-93ef-dcba-4337" targetId="ddf6-21b8-6d01-7ac5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="7a0f-5f7b-ca7e-55e7" targetId="35b8-81bd-4c11-6bf8" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="eaa0-b9cc-a5f9-8574" name="Give Unit" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="964b-1afe-6b15-803b" targetId="c27e-d5ec-5ea4-9e3d" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="92cb-926a-97be-23cb" incrementChildId="cee6-dd9f-30b2-e834" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="92cb-926a-97be-23cb" incrementChildId="3c0e-62f9-dc1b-b705" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="9979-0e99-8fb7-a0be" targetId="5d18-58b5-a126-a741" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="92cb-926a-97be-23cb" incrementChildId="cee6-dd9f-30b2-e834" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="92cb-926a-97be-23cb" incrementChildId="3c0e-62f9-dc1b-b705" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="decrement" field="points" value="5.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="9979-0e99-8fb7-a0be" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="b78f-2645-a2f9-5e48" targetId="cd51-1764-7fd7-e8c1" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="8e60-2804-ad64-a57d" targetId="fc46-7b10-4c68-6d86" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="7afe-a931-c7ca-5313" targetId="9790-0964-ad21-f9e2" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="3c0e-62f9-dc1b-b705" targetId="86cc-b479-3571-ab96" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="3576-2ebd-52bf-2446" targetId="a1f9-70eb-a8cc-d9bf" linkType="entry">
-          <modifiers>
-            <modifier type="set" field="maxSelections" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="a1f9-70eb-a8cc-d9bf" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="a1f9-70eb-a8cc-d9bf" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="a1f9-70eb-a8cc-d9bf" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="set" field="maxSelections" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="a1f9-70eb-a8cc-d9bf" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="3163-a93c-1bca-cfa7" targetId="4e1f-9625-b99f-a50c" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="3.0" repeat="true" numRepeats="1" incrementParentId="roster" incrementChildId="8e77-960e-5505-3f67" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="eb62-8b73-15b9-6e43" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="3.0" repeat="true" numRepeats="1" incrementParentId="92cb-926a-97be-23cb" incrementChildId="cee6-dd9f-30b2-e834" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="3.0" repeat="true" numRepeats="1" incrementParentId="92cb-926a-97be-23cb" incrementChildId="3c0e-62f9-dc1b-b705" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-      </links>
-    </entry>
-    <entry id="ec14-449b-d3d2-25fc" name="Boromite Gang Fighter Squad" points="0.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="185">
-      <entries>
-        <entry id="a7e8-cc40-3206-6569" name="Gang Leader" points="25.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="8372-019b-1c7f-f539" name="Leader Level" defaultEntryId="e412-6d44-88b7-4fa8" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="4fd8-8c98-d964-fc0d" name="Leader Two" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="8e1c-da7a-9908-f96e" targetId="5819-f10c-2a26-41a2" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="e412-6d44-88b7-4fa8" name="Leader" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="e4c5-195c-7fea-a0b1" targetId="1ebf-4e01-6d59-3d0f" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-            <entryGroup id="3077-89bd-9dbc-4f8d" name="Give Gang Leader" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="4a3a-54bc-878a-08bc" targetId="b2de-b74b-feb6-e489" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="6013-4a21-bdde-4acc" targetId="5d18-58b5-a126-a741" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="adc0-80ec-c7d8-aae7" name="Weapon" defaultEntryId="3e73-ad93-2bf0-03be" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="3e73-ad93-2bf0-03be" name="Mag Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="781d-64fb-28e4-e499" targetId="eb88-0bbb-1f8d-009f" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="78a9-8ed2-9ca4-abf9" name="Mag Gun" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="ce7c-0bd7-511b-4c08" targetId="a8e8-1b26-2efd-8351" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="9082-ac4b-3f09-232c" profileTypeId="1650-77b3-10d1-6406" name="Gang Leader" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="4"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="6"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="6(7)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="6"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="10"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="43b3-8ad9-06e1-05d2" targetId="5958-48e4-8481-41ed" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="e995-1aad-c59a-180c" targetId="ff3a-5fc0-452b-22d7" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="aef4-66ad-c485-f280" name="Gangers" points="18.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="7" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="7ce5-1b92-8357-b3b5" profileTypeId="1650-77b3-10d1-6406" name="Gangers" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="4"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="6"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="6(7)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="6"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="2ee4-13a7-8471-c83e" targetId="a8e8-1b26-2efd-8351" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="9d0d-9adc-32c0-8459" targetId="ddf6-21b8-6d01-7ac5" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="434a-3ed5-7e56-cab4" targetId="31c0-3ca6-a69b-7132" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="roster" incrementChildId="aef4-66ad-c485-f280" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="a7e8-cc40-3206-6569" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="c8a4-a4aa-b20c-88bb" targetId="8e57-0c0e-9630-533d" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="e17f-ad05-cc5e-229c" name="Boromite Guildess Arran Gestalin (support)" points="0.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BFX" page="112">
-      <entries>
-        <entry id="2b05-68f7-4a1d-55cd" name="Arran Gestalin" points="120.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="85a4-a256-973e-7773" profileTypeId="f9a2-eeae-3284-75fd" name="Arran Gestalin" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="18c1-4764-7d08-708d" name="Ag" value="4"/>
-                <characteristic characteristicId="e39c-d7a4-86a8-d23d" name="Acc" value="6"/>
-                <characteristic characteristicId="0790-bfd5-1273-fe12" name="Str" value="8"/>
-                <characteristic characteristicId="5b77-3595-2819-675c" name="Res" value="7(8)"/>
-                <characteristic characteristicId="c0d8-f6fd-a474-1385" name="Init" value="8"/>
-                <characteristic characteristicId="135d-efc3-5039-b6e6" name="Co" value="10"/>
-                <characteristic characteristicId="ab43-4d1c-4651-b424" name="Special"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="63b2-ee33-1047-01f9" targetId="ff3a-5fc0-452b-22d7" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="0c3c-d9ba-efef-dbaf" targetId="5958-48e4-8481-41ed" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="99fc-6ab1-f581-9e92" targetId="903c-c5cd-53d4-52cc" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="0132-0557-5220-fc6b" targetId="6a72-9858-7f5e-22be" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="f273-73c6-ac4b-554d" targetId="418e-35d2-e555-d54f" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="879a-21ac-bc5b-4e89" targetId="ec07-8982-914d-8377" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="610e-1961-922b-b5c0" targetId="de1a-0dd2-8671-8dae" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="42bc-ca42-b1ef-1e2e" targetId="a916-0caf-6b2e-f2eb" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="f76e-78d4-9f33-15aa" targetId="ddf6-21b8-6d01-7ac5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="c0ec-0c24-7d46-8c58" targetId="803d-52a0-55ff-cdc4" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="47a5-20ee-01cb-a5c2" targetId="d6df-ce6c-51e8-40ea" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="5e71-488f-ea32-9e03" targetId="587b-7c27-52f5-56a7" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="1d8c-9949-1e7c-8f73" name="Rock Rider" points="31.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="bd0d-3a1b-9f7c-a3ad" profileTypeId="1650-77b3-10d1-6406" name="Rock Rider" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="4"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="8"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="7(8)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="6"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-                <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="40a0-0f71-a451-6003" targetId="ec07-8982-914d-8377" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="7286-5ca3-f4fe-0d77" targetId="ec07-8982-914d-8377" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="ec72-5498-8c63-c976" targetId="ddf6-21b8-6d01-7ac5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="a548-7615-4266-92ae" targetId="de1a-0dd2-8671-8dae" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="b2c8-c59c-bd4d-fde9" targetId="803d-52a0-55ff-cdc4" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="71b9-c297-793d-06ad" name="Weapon Drone" points="14.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="112">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="76f4-753c-b444-e489" targetId="de1a-0dd2-8671-8dae" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="dc9d-9972-e215-7b93" name="Weapon Drone" points="14.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="112">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="7a86-fad0-3887-b027" targetId="de1a-0dd2-8671-8dae" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers>
-        <modifier type="set" field="maxInForce" value="0.0" repeat="true" numRepeats="1" incrementParentId="roster" incrementChildId="2c0d-5521-071d-1952" incrementField="selections" incrementValue="1.0">
-          <conditions/>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="bc24-5e02-89a6-3a6e" targetId="c27e-d5ec-5ea4-9e3d" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="4.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="4.0" repeat="true" numRepeats="1" incrementParentId="roster" incrementChildId="1d8c-9949-1e7c-8f73" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="5e28-59d7-f0ff-157e" targetId="19aa-7fc5-12e2-97a3" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="9c1c-4218-a533-4a49" targetId="19aa-7fc5-12e2-97a3" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="336d-16ee-3817-f2ce" targetId="cd51-1764-7fd7-e8c1" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="7a29-11fb-0101-0b17" targetId="916d-c962-0de5-5b5d" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="4410-9f0d-2c1c-c623" targetId="68cd-a10e-45f7-2482" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="2c0d-5521-071d-1952" name="Boromite Guildess Arran Gestalin (tactical)" points="0.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BFX" page="112">
-      <entries>
-        <entry id="ba0d-a02f-d9c1-4d76" name="Arran Gestalin" points="120.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="9b1a-d526-c68e-a680" profileTypeId="f9a2-eeae-3284-75fd" name="Arran Gestalin" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="18c1-4764-7d08-708d" name="Ag" value="4"/>
-                <characteristic characteristicId="e39c-d7a4-86a8-d23d" name="Acc" value="6"/>
-                <characteristic characteristicId="0790-bfd5-1273-fe12" name="Str" value="8"/>
-                <characteristic characteristicId="5b77-3595-2819-675c" name="Res" value="7(8)"/>
-                <characteristic characteristicId="c0d8-f6fd-a474-1385" name="Init" value="8"/>
-                <characteristic characteristicId="135d-efc3-5039-b6e6" name="Co" value="10"/>
-                <characteristic characteristicId="ab43-4d1c-4651-b424" name="Special"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="0d38-940a-7447-94e9" targetId="ff3a-5fc0-452b-22d7" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="38ed-145f-dc31-69a7" targetId="5958-48e4-8481-41ed" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="5d7b-9651-ea89-8f00" targetId="903c-c5cd-53d4-52cc" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="14fa-d567-f169-4c37" targetId="6a72-9858-7f5e-22be" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="ab1e-7cb7-9a87-44a1" targetId="418e-35d2-e555-d54f" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="69f6-541a-c712-6f8f" targetId="ec07-8982-914d-8377" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="3624-7104-03ed-6a8b" targetId="de1a-0dd2-8671-8dae" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="6185-141a-ae9e-cc82" targetId="a916-0caf-6b2e-f2eb" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="1cc0-bac5-dbd2-f4dd" targetId="ddf6-21b8-6d01-7ac5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="d7aa-0286-7698-c7c8" targetId="803d-52a0-55ff-cdc4" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="7251-4617-ceba-d6da" targetId="d6df-ce6c-51e8-40ea" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="4df5-3363-28fc-3557" targetId="587b-7c27-52f5-56a7" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="b6ce-dbaf-fff8-b580" name="Rock Rider" points="31.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="db63-d36f-d2ce-2923" profileTypeId="1650-77b3-10d1-6406" name="Rock Rider" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="4"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="8"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="7(8)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="6"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-                <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="0686-4de1-34fe-a824" targetId="ec07-8982-914d-8377" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="1064-8898-63a9-36ed" targetId="ec07-8982-914d-8377" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="3058-a290-c56c-518d" targetId="ddf6-21b8-6d01-7ac5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="6613-af57-2032-c0ed" targetId="de1a-0dd2-8671-8dae" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="4f3c-cf7e-df52-2ef3" targetId="803d-52a0-55ff-cdc4" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="9fd5-ca63-0a55-1b0f" name="Weapon Drone" points="14.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="112">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="9794-b1ab-16e0-b2fc" targetId="de1a-0dd2-8671-8dae" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="dd80-cdb0-17af-a820" name="Weapon Drone" points="14.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="112">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="06c2-dc1c-d2d0-a350" targetId="de1a-0dd2-8671-8dae" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers>
-        <modifier type="set" field="maxInForce" value="0.0" repeat="true" numRepeats="1" incrementParentId="roster" incrementChildId="e17f-ad05-cc5e-229c" incrementField="selections" incrementValue="1.0">
-          <conditions/>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="6b36-332c-d95d-9d05" targetId="c27e-d5ec-5ea4-9e3d" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="4.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="4.0" repeat="true" numRepeats="1" incrementParentId="roster" incrementChildId="1d8c-9949-1e7c-8f73" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="92bd-d4d1-de6a-693c" targetId="19aa-7fc5-12e2-97a3" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="9771-d970-c095-e331" targetId="19aa-7fc5-12e2-97a3" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="032e-d27d-353c-a759" targetId="cd51-1764-7fd7-e8c1" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="7853-1611-ecc0-6863" targetId="916d-c962-0de5-5b5d" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="7700-0dcb-b7fb-0058" targetId="68cd-a10e-45f7-2482" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="6828-7101-7889-cdd8" name="Boromite Hauler" points="170.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="0" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="b3a6-4fcb-3ff0-ade3" name="Weapon Options" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="732d-f8d5-ccd8-b0a2" name="1st Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="0ccd-1e31-38e1-055b" targetId="90e0-4818-78ac-de67" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="11f1-eb2c-3a4a-9f48" targetId="e621-959c-b626-9ee0" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="3eaf-c538-d461-68ff" name="2nd Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="9e8f-0bba-698d-e8b4" targetId="90e0-4818-78ac-de67" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="b7fa-d6a8-5dda-54f0" targetId="e621-959c-b626-9ee0" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
-      <modifiers>
-        <modifier type="increment" field="maxInForce" value="1.0" repeat="true" numRepeats="1" incrementParentId="roster" incrementChildId="383b-6550-ee5b-d6cf" incrementField="selections" incrementValue="1.0">
-          <conditions/>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <rules/>
-      <profiles>
-        <profile id="ee38-60f6-3ab9-840b" profileTypeId="1650-77b3-10d1-6406" name="Boromite Hauler" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-            <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-            <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-            <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="13"/>
-            <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="6"/>
-            <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="b75d-7484-ae78-dab0" targetId="8d80-a4ff-fb59-92e9" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="2f79-dd76-bf5f-8690" targetId="418e-35d2-e555-d54f" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="061a-23f7-9da8-e9b6" targetId="9790-0964-ad21-f9e2" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="8539-9ebc-d8e4-f0f4" targetId="794b-5574-8388-0180" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="d245-c7e9-e4f8-3f64" targetId="cd51-1764-7fd7-e8c1" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="96b4-1bed-dcd3-8d2c" targetId="cd51-1764-7fd7-e8c1" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="449f-52d4-9e3b-e8e5" targetId="4a4d-04f6-0073-5c53" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="ce6a-575a-ec38-0ad8" targetId="19aa-7fc5-12e2-97a3" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="8592-52f5-95b3-acf4" targetId="19aa-7fc5-12e2-97a3" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="e756-1e74-0dba-d8e8" name="Boromite Heavy Hauler" points="332.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="2bf4-346f-0523-fdc5" name="Weapon Options" defaultEntryId="e9be-5158-1204-fdaa" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="e9be-5158-1204-fdaa" targetId="8934-d01f-ea71-ff3c" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="f6f3-9c26-d090-d71f" targetId="b1ac-43b1-d521-2c58" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="1bdb-30f7-0d9d-c04f" targetId="9147-c31d-55b2-ef27" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="6ffc-11da-a717-a763" targetId="6993-161f-e135-22eb" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="e4e4-cf36-7412-8229" targetId="1de8-e29c-e0c9-73db" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="408f-ee27-0f22-e08c" targetId="d258-74bb-712d-7c41" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="e3c7-f8f0-8856-05d4" profileTypeId="1650-77b3-10d1-6406" name="Boromite Hauler" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-            <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-            <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-            <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="15"/>
-            <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="6"/>
-            <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="0002-2eee-efcb-aba2" targetId="418e-35d2-e555-d54f" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="6eb6-34cf-683e-2ddc" targetId="9790-0964-ad21-f9e2" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="1a1e-3907-63b6-5582" targetId="794b-5574-8388-0180" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="e1c5-3c7c-b05e-fb67" targetId="cd51-1764-7fd7-e8c1" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="92c5-b6b2-3016-339f" targetId="19aa-7fc5-12e2-97a3" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="c5fc-c32a-e043-1853" targetId="7d25-d2b6-7130-a3c0" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="c2b7-f461-f18b-df55" targetId="7557-700d-2fc6-e203" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="3811-aec3-3cef-d27e" targetId="2687-f7ac-3c1e-fb30" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="ac32-8387-4155-9c3f" targetId="19aa-7fc5-12e2-97a3" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="cfb5-737a-e7e0-f42f" name="Boromite Heavy Support Team" points="45.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="0bef-01eb-3ad2-266a" name="Ganger Crew" points="13.0" categoryId="(No Category)" type="model" minSelections="3" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="6b20-a652-b846-8250" profileTypeId="1650-77b3-10d1-6406" name="Ganger Crew" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="4"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="6"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="6"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="6"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="0c87-9e41-7316-04cb" targetId="eb88-0bbb-1f8d-009f" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="1f62-7f4b-63c8-5390" name="Promote one crew member to Leader" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="640d-b97a-49b1-974d" targetId="1ebf-4e01-6d59-3d0f" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="1c3f-9d78-6227-330a" name="Give unit Reflex Armour" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="cfb5-737a-e7e0-f42f" incrementChildId="0bef-01eb-3ad2-266a" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="5e88-8b35-20d1-2c09" targetId="ddf6-21b8-6d01-7ac5" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="14fe-b781-6755-a6ef" name="Weapon Options" defaultEntryId="e1e4-e995-3e61-ece3" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="e1e4-e995-3e61-ece3" targetId="8934-d01f-ea71-ff3c" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="0e7e-1a01-145d-d5cd" targetId="b1ac-43b1-d521-2c58" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="9552-6b70-7474-5bb0" targetId="9147-c31d-55b2-ef27" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="f17f-cd4d-ae0a-14b4" targetId="1de8-e29c-e0c9-73db" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="9556-a2e7-dc93-06b6" targetId="d258-74bb-712d-7c41" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="2f6c-2b9c-d2a6-4ff1" targetId="fc46-7b10-4c68-6d86" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="4b36-55b9-eea8-8528" targetId="eb7b-7605-9eca-cb60" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="708c-9680-b0ce-6521" targetId="eb7b-7605-9eca-cb60" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="10b1-ce07-3cee-1888" targetId="418e-35d2-e555-d54f" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="304d-5ccd-7ab2-5ba9" targetId="7d25-d2b6-7130-a3c0" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="ed6f-029e-a945-c64a" targetId="cd51-1764-7fd7-e8c1" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="5755-dc85-c2d9-a6bb" name="Boromite Lavamites" points="0.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="7b76-20a4-9cc3-aa4f" name="Handler" points="31.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="9f71-a48e-0b8b-1a57" name="Leader Level" defaultEntryId="4f18-1d53-664b-509e" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="da4a-2fd2-8978-f0ba" name="Leader Two" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="bc01-2c0a-ae0f-5f94" targetId="5819-f10c-2a26-41a2" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="4f18-1d53-664b-509e" name="Leader" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="9793-53c0-b463-eb74" targetId="1ebf-4e01-6d59-3d0f" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="6945-a446-b965-8c9d" profileTypeId="1650-77b3-10d1-6406" name="Handler" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="4"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="6"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="6(7)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="6"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="b974-2e05-b197-8559" targetId="ddf6-21b8-6d01-7ac5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="b073-7727-20d0-c197" targetId="b622-8e27-2906-a350" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="f7c8-cbe9-4242-6236" targetId="2c85-ce08-21a5-6461" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="e0aa-e20a-0b8a-58e8" targetId="33d6-6c92-2948-c9ca" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="33d6-6c92-2948-c9ca" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="7f33-779c-0cf7-5696" name="Hatchling Swarm" points="16.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="0" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="maxSelections" value="1.0" repeat="true" numRepeats="1" incrementParentId="5755-dc85-c2d9-a6bb" incrementChildId="8449-e194-444f-f4f9" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
-          <profiles>
-            <profile id="78e0-49b8-7d8a-5bf2" profileTypeId="1650-77b3-10d1-6406" name="Hatchling Swarm" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="7"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="7"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="7"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="6"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="5"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="ab16-10de-c8f9-aba7" targetId="2a5d-364c-c495-0b53" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="8449-e194-444f-f4f9" name="Lavamites" points="17.0" categoryId="(No Category)" type="model" minSelections="3" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="4964-3188-e927-276d" profileTypeId="1650-77b3-10d1-6406" name="Lavamites" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="4"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="7"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="7"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="8"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="6"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="5"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-            <profile id="8eb8-202a-0f33-42ae" profileTypeId="ecae-8ac8-2c13-0dd3" name="Lavamite Attacks" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Lava Spit, 3 Attacks"/>
-              </characteristics>
-              <modifiers>
-                <modifier type="set" field="897c-d3c4-3983-896a" value="3.0" repeat="true" numRepeats="1" incrementParentId="5755-dc85-c2d9-a6bb" incrementChildId="b3ce-44a4-c6dc-2d52" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="set" field="7e87-2586-653f-d6ec" value="Lava Spit, 4 Attacks" repeat="true" numRepeats="1" incrementParentId="5755-dc85-c2d9-a6bb" incrementChildId="b3ce-44a4-c6dc-2d52" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-        <entry id="b3ce-44a4-c6dc-2d52" name="Lavamite Rock Brood Upgrade" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="4.0" repeat="true" numRepeats="1" incrementParentId="5755-dc85-c2d9-a6bb" incrementChildId="8449-e194-444f-f4f9" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="3f3e-cb10-bf7e-84a2" targetId="ec07-8982-914d-8377" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="42fe-d56e-c860-4954" targetId="3c9b-f86d-32c6-bf69" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="b625-bfc9-8a47-5c24" targetId="fc46-7b10-4c68-6d86" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="a79c-4719-0b12-ee25" name="Boromite Matriarch" points="0.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="185">
-      <entries>
-        <entry id="fe1c-39bc-56bc-f4f8" name="Matriarch" points="34.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="28f3-7994-9d9a-9f3b" name="Leader Level" defaultEntryId="b720-951e-a82f-a2c2" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="b720-951e-a82f-a2c2" name="Leader Two" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="b599-5180-4012-5b81" targetId="5819-f10c-2a26-41a2" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="7efd-0509-1e43-71d1" name="Leader Three" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="b6d4-194e-2730-90c1" targetId="903c-c5cd-53d4-52cc" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="a8c4-3da0-17ca-c2ff" profileTypeId="f9a2-eeae-3284-75fd" name="Matriarch" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="18c1-4764-7d08-708d" name="Ag" value="4"/>
-                <characteristic characteristicId="e39c-d7a4-86a8-d23d" name="Acc" value="5"/>
-                <characteristic characteristicId="0790-bfd5-1273-fe12" name="Str" value="6"/>
-                <characteristic characteristicId="5b77-3595-2819-675c" name="Res" value="6(7)"/>
-                <characteristic characteristicId="c0d8-f6fd-a474-1385" name="Init" value="6"/>
-                <characteristic characteristicId="135d-efc3-5039-b6e6" name="Co" value="10"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="6221-84d4-273d-ff27" targetId="5958-48e4-8481-41ed" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="7b96-06a2-3665-032a" targetId="ff3a-5fc0-452b-22d7" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="34f4-c27f-bda5-b882" targetId="ddf6-21b8-6d01-7ac5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="2ba5-acfd-731b-99ce" targetId="33d6-6c92-2948-c9ca" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="0f69-438b-64e4-cff1" targetId="ec07-8982-914d-8377" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="ad19-7b3d-627f-3f1b" name="Guildless" points="34.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="1c3e-fb7e-5b7e-5d91" name="Leader Level" defaultEntryId="cc78-7f08-e08c-d3b8" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="cc78-7f08-e08c-d3b8" name="Leader" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="be4b-0252-9586-065b" targetId="1ebf-4e01-6d59-3d0f" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="6f7b-f07f-22ed-f93b" name="Leader Two" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="7fb7-ff8d-0642-ddba" targetId="5819-f10c-2a26-41a2" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="2f66-4b53-a9cc-beb8" profileTypeId="f9a2-eeae-3284-75fd" name="Guildless" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="18c1-4764-7d08-708d" name="Ag" value="4"/>
-                <characteristic characteristicId="e39c-d7a4-86a8-d23d" name="Acc" value="5"/>
-                <characteristic characteristicId="0790-bfd5-1273-fe12" name="Str" value="6"/>
-                <characteristic characteristicId="5b77-3595-2819-675c" name="Res" value="6(7)"/>
-                <characteristic characteristicId="c0d8-f6fd-a474-1385" name="Init" value="6"/>
-                <characteristic characteristicId="135d-efc3-5039-b6e6" name="Co" value="10"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="8eeb-ec59-f89e-6e44" targetId="5958-48e4-8481-41ed" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="8e75-38b8-2ea8-0cca" targetId="ff3a-5fc0-452b-22d7" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="9011-3729-4950-fb8c" targetId="ddf6-21b8-6d01-7ac5" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="0fe1-e819-0f8d-8932" name="Weapon Drone" points="34.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="112">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="2fa0-7b8a-f95a-f379" targetId="de1a-0dd2-8671-8dae" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="0d16-80a3-a7ef-e455" name="Weapon Drone" points="14.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="112">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="e7c1-2f05-6476-0e8a" targetId="de1a-0dd2-8671-8dae" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="0546-6890-5894-149e" name="Weapon Drone" points="14.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="112">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="9687-e31c-69a0-ae99" targetId="de1a-0dd2-8671-8dae" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers>
-        <modifier type="set" field="maxInForce" value="0.0" repeat="true" numRepeats="1" incrementParentId="roster" incrementChildId="cc6a-97b9-b9d6-b3c6" incrementField="selections" incrementValue="1.0">
-          <conditions>
-            <condition parentId="roster" childId="a79c-4719-0b12-ee25" field="selections" type="at least" value="1.0"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="4bed-5692-0439-8e7b" targetId="d1fe-dbdc-fdd9-94c8" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="68f4-25bd-b462-db17" targetId="b72c-b9d6-e702-b322" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="3dd2-8cf5-8f29-d8f1" targetId="19aa-7fc5-12e2-97a3" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="bb22-f01e-f986-0511" targetId="cd51-1764-7fd7-e8c1" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="df4e-55b0-6360-c09f" targetId="19aa-7fc5-12e2-97a3" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="c1fc-097f-fd78-ede5" targetId="cd51-1764-7fd7-e8c1" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="e99b-e0a2-c99b-dd47" targetId="916d-c962-0de5-5b5d" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="64cb-08b1-a276-909e" name="Boromite Matronite Brood Mother" points="258.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="188">
-      <entries>
-        <entry id="7da3-b2db-cd21-7b62" name="Lavamite Hatchling Swarms" points="16.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="188">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="d70e-2762-48fd-a446" profileTypeId="1650-77b3-10d1-6406" name="Lavamite Hatchling Swarms" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="7"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="7"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="7"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="5"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="8a46-d452-441a-ecc6" targetId="2a5d-364c-c495-0b53" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="3616-f891-324f-74c1" name="Matronite Brood Mother" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="brb" page="188">
-          <entries>
-            <entry id="ece0-9647-e89d-ac89" name="Mag Light Support" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="4" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers>
-                <modifier type="decrement" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="64cb-08b1-a276-909e" childId="0e9a-2386-e809-ac20" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="decrement" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="64cb-08b1-a276-909e" childId="0e9a-2386-e809-ac20" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-          </entries>
-          <entryGroups>
-            <entryGroup id="0e9a-2386-e809-ac20" name="Replace One Mag Light Support with" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="6a29-e7c5-c7cf-5170" name="Heavey Mag Cannon" points="45.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links/>
-                </entry>
-                <entry id="3f76-1ca4-7b5e-8ce0" name="Mag Heavy Support" points="35.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links/>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="2469-385b-7def-2466" profileTypeId="1650-77b3-10d1-6406" name="Matronite Brood Mother" hidden="false" book="brb" page="188">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="10"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="15"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-            <profile id="e8c1-9468-2102-d230" profileTypeId="ecae-8ac8-2c13-0dd3" name="Matronite Brood Mother" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="4"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="7f11-5f90-9467-7bf0" targetId="4a4d-04f6-0073-5c53" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="9bf6-a343-52ed-a144" targetId="7d25-d2b6-7130-a3c0" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="f4d3-96e2-e278-582f" targetId="418e-35d2-e555-d54f" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="67fd-2ce9-1d94-da2a" name="Batter Drone" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="c30c-a2ac-dcc1-360b" targetId="cd51-1764-7fd7-e8c1" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="bad3-3ce1-0258-9da3" name="Boromite Overseer Squad" points="0.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="184">
-      <entries>
-        <entry id="4192-398e-c7d3-8752" name="Overseer" points="63.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="59a9-6996-155e-e7ce" name="Leader Level" defaultEntryId="88cf-9c54-2584-1c59" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="88cf-9c54-2584-1c59" name="Leader Two" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="43ff-21bc-1791-5cfa" targetId="5819-f10c-2a26-41a2" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="0563-0772-82c6-8e3e" name="Leader Three" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="3fcd-1c9b-ae6e-586c" targetId="903c-c5cd-53d4-52cc" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-            <entryGroup id="ac1e-ee80-997b-99d5" name="Give Overseer" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="cc48-05a5-0f8b-c119" targetId="b2de-b74b-feb6-e489" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="67cd-c0e2-0d32-be57" targetId="5d18-58b5-a126-a741" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="47fa-acfc-3f50-25d9" profileTypeId="f9a2-eeae-3284-75fd" name="Overseer" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="18c1-4764-7d08-708d" name="Ag" value="4"/>
-                <characteristic characteristicId="e39c-d7a4-86a8-d23d" name="Acc" value="5"/>
-                <characteristic characteristicId="0790-bfd5-1273-fe12" name="Str" value="6"/>
-                <characteristic characteristicId="5b77-3595-2819-675c" name="Res" value="6(7)"/>
-                <characteristic characteristicId="c0d8-f6fd-a474-1385" name="Init" value="6"/>
-                <characteristic characteristicId="135d-efc3-5039-b6e6" name="Co" value="10"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="03a9-28f6-49c4-6c18" targetId="5958-48e4-8481-41ed" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="2751-9122-b259-b986" targetId="ff3a-5fc0-452b-22d7" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="af7a-23eb-bbac-265c" targetId="5819-f10c-2a26-41a2" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="aa3b-41a1-2d43-e6d9" name="Gangers" points="21.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="705b-c577-58f4-b08a" profileTypeId="f9a2-eeae-3284-75fd" name="Gangers" hidden="false" book="brb" page="184">
-              <characteristics>
-                <characteristic characteristicId="18c1-4764-7d08-708d" name="Ag" value="4"/>
-                <characteristic characteristicId="e39c-d7a4-86a8-d23d" name="Acc" value="5"/>
-                <characteristic characteristicId="0790-bfd5-1273-fe12" name="Str" value="6"/>
-                <characteristic characteristicId="5b77-3595-2819-675c" name="Res" value="6(7)"/>
-                <characteristic characteristicId="c0d8-f6fd-a474-1385" name="Init" value="6"/>
-                <characteristic characteristicId="135d-efc3-5039-b6e6" name="Co" value="9"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="fc25-f9eb-eb67-3bed" targetId="de1a-0dd2-8671-8dae" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="7b2a-7bd1-05e4-d1c9" targetId="ddf6-21b8-6d01-7ac5" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="aff6-21ec-9c47-8bc1" targetId="cd51-1764-7fd7-e8c1" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="c9c8-f51d-d8cd-db65" targetId="31c0-3ca6-a69b-7132" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="bad3-3ce1-0258-9da3" incrementChildId="aa3b-41a1-2d43-e6d9" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="4192-398e-c7d3-8752" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="77a2-561e-3125-4535" targetId="b72c-b9d6-e702-b322" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="ea6e-5198-274e-c4e7" targetId="d1fe-dbdc-fdd9-94c8" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="4ed7-d047-208f-f1d2" targetId="916d-c962-0de5-5b5d" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="cc6a-97b9-b9d6-b3c6" name="Boromite Rock Father" points="0.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="185">
-      <entries>
-        <entry id="7e09-dd99-6954-274a" name="Rock Father" points="78.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="b8a2-ee20-bfdf-1841" name="Give Rock Father Plasma Carbine" points="9.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="2180-ccc1-1217-3f6f" targetId="de1a-0dd2-8671-8dae" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups>
-            <entryGroup id="5a11-099c-1257-048b" name="Give Rock Father" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="90c1-f37e-aac8-081e" targetId="b2de-b74b-feb6-e489" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="9d89-034c-068f-66a6" targetId="5d18-58b5-a126-a741" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="8efc-74ca-2fc5-0990" profileTypeId="f9a2-eeae-3284-75fd" name="Rock Father" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="18c1-4764-7d08-708d" name="Ag"/>
-                <characteristic characteristicId="e39c-d7a4-86a8-d23d" name="Acc"/>
-                <characteristic characteristicId="0790-bfd5-1273-fe12" name="Str"/>
-                <characteristic characteristicId="5b77-3595-2819-675c" name="Res"/>
-                <characteristic characteristicId="c0d8-f6fd-a474-1385" name="Init"/>
-                <characteristic characteristicId="135d-efc3-5039-b6e6" name="Co"/>
-                <characteristic characteristicId="ab43-4d1c-4651-b424" name="Special"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="a30c-5b68-8dae-4aa0" targetId="5958-48e4-8481-41ed" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="3269-0cc4-8901-4cbf" targetId="ff3a-5fc0-452b-22d7" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="75a2-08c4-6e69-9af4" targetId="903c-c5cd-53d4-52cc" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="94f9-4628-e6f6-9af3" targetId="ddf6-21b8-6d01-7ac5" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="63ac-5ef9-119c-c221" name="Gangers" points="23.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="5231-5921-50bd-83c4" profileTypeId="f9a2-eeae-3284-75fd" name="Gangers" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="18c1-4764-7d08-708d" name="Ag" value="4"/>
-                <characteristic characteristicId="e39c-d7a4-86a8-d23d" name="Acc" value="6"/>
-                <characteristic characteristicId="0790-bfd5-1273-fe12" name="Str" value="6"/>
-                <characteristic characteristicId="5b77-3595-2819-675c" name="Res" value="6(7)"/>
-                <characteristic characteristicId="c0d8-f6fd-a474-1385" name="Init" value="6"/>
-                <characteristic characteristicId="135d-efc3-5039-b6e6" name="Co" value="9"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="5969-e094-d94d-6846" targetId="de1a-0dd2-8671-8dae" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="b58c-ae29-0599-db36" targetId="ddf6-21b8-6d01-7ac5" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="a776-eab0-252d-b7e0" name="Shield Drone" points="10.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers>
-        <modifier type="set" field="maxInForce" value="0.0" repeat="true" numRepeats="1" incrementParentId="roster" incrementChildId="a79c-4719-0b12-ee25" incrementField="selections" incrementValue="1.0">
-          <conditions>
-            <condition parentId="roster" childId="cc6a-97b9-b9d6-b3c6" field="selections" type="at least" value="1.0"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="2681-6193-0e07-13a6" targetId="b72c-b9d6-e702-b322" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="d160-b1ae-39eb-9232" targetId="d1fe-dbdc-fdd9-94c8" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="03b9-aecd-f181-bcb6" targetId="19aa-7fc5-12e2-97a3" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="7019-6d54-a708-e7c4" targetId="19aa-7fc5-12e2-97a3" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="c54d-3ec9-714f-58fe" targetId="916d-c962-0de5-5b5d" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="0b2d-9790-62ec-8c53" name="Boromite Rock Rider Overseer Squad" points="0.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="184">
-      <entries>
-        <entry id="b314-af7f-d439-e6d0" name="Rock Rider Overseer" points="67.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="3b18-f456-4a8d-61d2" name="Leader Level" defaultEntryId="f45b-bb75-70c5-e9c6" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="f45b-bb75-70c5-e9c6" name="Leader Two" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="e55b-dfbc-2272-5d80" targetId="5819-f10c-2a26-41a2" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="d5fb-a7c9-ade3-c8b2" name="Leader Three" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="e31a-2683-b26a-ddb2" targetId="903c-c5cd-53d4-52cc" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-            <entryGroup id="3118-5133-edd9-82a0" name="Give Overseer" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="1d8c-39e8-2584-e6e9" targetId="b2de-b74b-feb6-e489" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="fce8-2284-43e6-50bc" targetId="5d18-58b5-a126-a741" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="f94c-a883-165a-2b47" profileTypeId="f9a2-eeae-3284-75fd" name="Rock Rider Overseer" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="18c1-4764-7d08-708d" name="Ag" value="4"/>
-                <characteristic characteristicId="e39c-d7a4-86a8-d23d" name="Acc" value="5"/>
-                <characteristic characteristicId="0790-bfd5-1273-fe12" name="Str" value="8"/>
-                <characteristic characteristicId="5b77-3595-2819-675c" name="Res" value="7(8)"/>
-                <characteristic characteristicId="c0d8-f6fd-a474-1385" name="Init" value="6"/>
-                <characteristic characteristicId="135d-efc3-5039-b6e6" name="Co" value="10"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="489f-41e1-04a5-6ff9" targetId="5958-48e4-8481-41ed" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="6945-0440-007a-3bdb" targetId="ff3a-5fc0-452b-22d7" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="eaf5-078d-83ef-bf46" name="Rock Rider" points="31.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="0435-282d-2546-0f73" profileTypeId="f9a2-eeae-3284-75fd" name="Rock Rider" hidden="false" book="BRB" page="187">
-              <characteristics>
-                <characteristic characteristicId="18c1-4764-7d08-708d" name="Ag" value="4"/>
-                <characteristic characteristicId="e39c-d7a4-86a8-d23d" name="Acc" value="5"/>
-                <characteristic characteristicId="0790-bfd5-1273-fe12" name="Str" value="8"/>
-                <characteristic characteristicId="5b77-3595-2819-675c" name="Res" value="7(8)"/>
-                <characteristic characteristicId="c0d8-f6fd-a474-1385" name="Init" value="6"/>
-                <characteristic characteristicId="135d-efc3-5039-b6e6" name="Co" value="9"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="a167-f192-52ce-1f9e" targetId="de1a-0dd2-8671-8dae" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="0832-bc00-9d08-07ef" targetId="ddf6-21b8-6d01-7ac5" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="adb7-a6cb-5e3a-1495" targetId="cd51-1764-7fd7-e8c1" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="8fab-e676-fef9-045c" targetId="c27e-d5ec-5ea4-9e3d" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="4.0" repeat="true" numRepeats="1" incrementParentId="0b2d-9790-62ec-8c53" incrementChildId="eaf5-078d-83ef-bf46" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="4.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="b314-af7f-d439-e6d0" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="9c4f-a31d-e5a8-9d32" targetId="b72c-b9d6-e702-b322" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="5bcb-5b0c-c584-db3b" targetId="ecb8-89fb-5d9e-2211" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="2fc1-d30f-00fe-8051" targetId="803d-52a0-55ff-cdc4" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="48d4-1461-0769-1773" targetId="418e-35d2-e555-d54f" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="d6ff-ab95-696d-d560" targetId="ec07-8982-914d-8377" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="d5ef-06cb-43ef-3095" name="Boromite Rock Rider Squad" points="0.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="184">
-      <entries>
-        <entry id="9c10-a215-a579-9c5e" name="Rock Rider Leader" points="35.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="6f6a-ff56-d20d-0821" name="Leader Level" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="681f-9466-b61c-e929" name="Leader" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="68d5-9416-a5e4-fa24" targetId="1ebf-4e01-6d59-3d0f" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="fc58-e90f-120c-3741" name="Leader Two" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="71bb-a2e3-1652-f1d4" targetId="5819-f10c-2a26-41a2" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-            <entryGroup id="ea3c-94ca-6a48-93e1" name="Give Overseer" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="c970-335b-5e0c-2b95" targetId="b2de-b74b-feb6-e489" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="6130-46d7-ca0b-d78a" targetId="5d18-58b5-a126-a741" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="3fe5-7db2-03d0-b4a4" profileTypeId="1650-77b3-10d1-6406" name="Rock Rider Leader" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="4"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="8"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="7(8)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="6"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-        <entry id="baf9-118c-df0d-4f96" name="Rock Rider" points="31.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="fed6-3349-14c9-7bb2" profileTypeId="1650-77b3-10d1-6406" name="Rock Rider" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="4"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="8"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="7(8)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="6"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers>
-        <modifier type="set" field="maxInForce" value="-1.0" repeat="true" numRepeats="1" incrementParentId="force type" incrementChildId="e17f-ad05-cc5e-229c" incrementField="selections" incrementValue="1.0">
-          <conditions/>
-          <conditionGroups/>
-        </modifier>
-        <modifier type="set" field="maxInForce" value="-1.0" repeat="true" numRepeats="1" incrementParentId="force type" incrementChildId="0b2d-9790-62ec-8c53" incrementField="selections" incrementValue="1.0">
-          <conditions/>
-          <conditionGroups/>
-        </modifier>
-        <modifier type="set" field="maxInForce" value="-1.0" repeat="true" numRepeats="1" incrementParentId="force type" incrementChildId="2c0d-5521-071d-1952" incrementField="selections" incrementValue="1.0">
-          <conditions/>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="7c39-3e51-275c-2122" targetId="de1a-0dd2-8671-8dae" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="0a2d-32b8-ed4c-e13d" targetId="ddf6-21b8-6d01-7ac5" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="2b62-8e87-e045-3c62" targetId="c27e-d5ec-5ea4-9e3d" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="4.0" repeat="true" numRepeats="1" incrementParentId="d5ef-06cb-43ef-3095" incrementChildId="baf9-118c-df0d-4f96" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="4.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="9c10-a215-a579-9c5e" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="58f5-96ae-51b5-3ec3" targetId="ecb8-89fb-5d9e-2211" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="482e-c9aa-b554-9293" targetId="803d-52a0-55ff-cdc4" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="bbc9-a073-071b-8750" targetId="418e-35d2-e555-d54f" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="0c07-2b3b-0131-f400" targetId="ec07-8982-914d-8377" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="82d5-be12-098b-3661" name="Boromite Specialist Support Team" points="40.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="ea4b-5da7-9809-305c" name="Ganger Crew" points="13.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="3a41-6e9f-3abe-5e5f" profileTypeId="1650-77b3-10d1-6406" name="Ganger Crew" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="4"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="6"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="6"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="6"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="3154-61e6-b5b2-ee4f" targetId="eb88-0bbb-1f8d-009f" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="08f7-7c3a-1090-a662" name="Promote one crew member to Leader" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="aa9c-a8b1-8e72-c626" targetId="1ebf-4e01-6d59-3d0f" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="a541-3439-90a3-c5ca" name="Give unit Reflex Armour" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="82d5-be12-098b-3661" incrementChildId="ea4b-5da7-9809-305c" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="228f-7367-7896-0303" targetId="ddf6-21b8-6d01-7ac5" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="9c18-16cd-c375-3a7f" name="Weapon Options" defaultEntryId="041b-4e35-d418-1b20" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="4102-dbc8-790f-5f7a" targetId="5b5a-ab27-f5be-90fd" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="041b-4e35-d418-1b20" targetId="3bf2-9136-e938-9b9b" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="8c0c-cd75-f088-f3f7" targetId="cd51-1764-7fd7-e8c1" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="3cd8-e0f3-ce0e-c2ea" targetId="fc46-7b10-4c68-6d86" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="74c1-a397-87af-454a" targetId="eb7b-7605-9eca-cb60" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="9c54-7e9b-3a46-2bc2" name="Boromite Support Team" points="10.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="3624-2301-4b0b-7255" name="Ganger Crew" points="13.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="2a43-fa04-e21a-8642" profileTypeId="1650-77b3-10d1-6406" name="Ganger Crew" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="4"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="6"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="6"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="6"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="ca28-09da-5b49-b7e1" targetId="eb88-0bbb-1f8d-009f" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="22a4-ebde-d10c-5674" name="Promote one crew member to Leader" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="814d-a648-2997-b594" targetId="1ebf-4e01-6d59-3d0f" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="8fa2-4460-9d3d-c858" name="Give unit Reflex Armour" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="9c54-7e9b-3a46-2bc2" incrementChildId="3624-2301-4b0b-7255" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="b1b6-8dc8-fca7-076d" targetId="ddf6-21b8-6d01-7ac5" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="e711-56e6-f8aa-aabe" name="Weapon Options" defaultEntryId="1946-83e7-4aaf-4046" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="c5e4-a7f6-77cc-cf65" targetId="a39b-838d-cc10-d873" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="1946-83e7-4aaf-4046" targetId="90e0-4818-78ac-de67" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="adb3-d7b7-6360-95bc" targetId="e621-959c-b626-9ee0" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="3a92-6c13-368f-35b2" targetId="b19a-b113-a5af-57cf" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="7090-89c5-43ef-c8fa" targetId="cd51-1764-7fd7-e8c1" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="985c-04b2-2b49-7dd6" targetId="fc46-7b10-4c68-6d86" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="8780-f8a8-73e2-dbc2" targetId="eb7b-7605-9eca-cb60" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="383b-6550-ee5b-d6cf" name="Boromite Work Gang" points="0.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="185">
-      <entries>
-        <entry id="eb62-8b73-15b9-6e43" name="Gang Leader" points="30.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="e9b0-49cb-2d4d-1310" profileTypeId="1650-77b3-10d1-6406" name="Gang Leader" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="4"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="6"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="6"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="6"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="7e2d-5f0d-441b-e806" targetId="1ebf-4e01-6d59-3d0f" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="ecc8-17ab-a6b5-c850" targetId="eb88-0bbb-1f8d-009f" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="8e77-960e-5505-3f67" name="Gangers" points="17.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="7" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="ab0f-c6f8-2da6-cbcc" profileTypeId="1650-77b3-10d1-6406" name="Gangers" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="4"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="6"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="6"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="6"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-        <entry id="2fbb-c0ed-1022-cb0e" name="Give unit Reflex Armour" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="eb62-8b73-15b9-6e43" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="roster" incrementChildId="8e77-960e-5505-3f67" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="51cf-af3a-87d3-c669" targetId="ddf6-21b8-6d01-7ac5" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="d11f-d3a5-d269-38b8" name="Weapons Choose" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="c12a-122d-a5ab-d03a" targetId="8fe1-02c7-9ede-7aaf" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="1ba6-ae24-3d83-5567" targetId="4f01-44bb-2188-fc1a" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="fee0-bc65-ecfb-7e49" targetId="4e1f-9625-b99f-a50c" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="3.0" repeat="true" numRepeats="1" incrementParentId="roster" incrementChildId="8e77-960e-5505-3f67" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="eb62-8b73-15b9-6e43" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="1d38-6bba-39a5-149d" targetId="8e57-0c0e-9630-533d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="8b59-e9e9-87b9-886e" targetId="fc46-7b10-4c68-6d86" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="aba8-21e3-1058-94c8" targetId="a1f9-70eb-a8cc-d9bf" linkType="entry">
-          <modifiers>
-            <modifier type="set" field="maxSelections" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="a1f9-70eb-a8cc-d9bf" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="a1f9-70eb-a8cc-d9bf" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-      </links>
-    </entry>
-    <entry id="9acf-c00a-365e-0d2c" name="Micromite Probe Shard" points="20.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="brb" page="189">
-      <entries>
-        <entry id="78e5-9fc4-d568-caef" name="Micromite Probes" points="0.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="brb" page="119">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="00da-4aeb-1a1d-2920" profileTypeId="1650-77b3-10d1-6406" name="Micromite Probes" hidden="false" book="brb" page="189">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="-"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="-"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="-"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="-"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="641e-aa49-d6d6-ca7a" targetId="6dc1-69d0-6655-5615" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="e4cb-daeb-8943-bb3f" targetId="5660-b448-a09d-5338" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="4c38-692a-04db-8d11" targetId="3e4c-8b6b-efa7-cdeb" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="fbff-00dc-f597-61b3" targetId="3e4c-8b6b-efa7-cdeb" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="2f50-145e-4f5a-220f" name="Scout Probe Shard" points="40.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="brb" page="189">
-      <entries>
-        <entry id="5752-7497-efd2-2786" name="Scout Probes" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="4" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="120">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="aec1-17f5-81d2-7812" profileTypeId="1650-77b3-10d1-6406" name="Scout Probes" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="-"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="-"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="-"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="-"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="cea7-7b6a-22c7-4643" targetId="6dc1-69d0-6655-5615" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="01e3-c7e8-5ec2-b4ce" targetId="5660-b448-a09d-5338" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="335c-63ad-8258-91ee" targetId="1840-59e5-dd80-f4bb" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="927a-c426-6efa-958b" targetId="1840-59e5-dd80-f4bb" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-  </entries>
+<catalogue id="18ef-359c-e44c-e44a" name="Boromites" revision="9" battleScribeVersion="2.00" authorName="zitheran" authorContact="@zitheran" authorUrl="http://zitheran.com/GoA_BSD" gameSystemId="c339-677a-60db-4060" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <profiles/>
   <rules/>
-  <links/>
-  <sharedEntries>
-    <entry id="35b8-81bd-4c11-6bf8" name="Auto-Workshop" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="brb" page="120">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
+  <infoLinks/>
+  <costTypes/>
+  <profileTypes/>
+  <forceEntries/>
+  <selectionEntries>
+    <selectionEntry id="6e08-00fe-a929-223e" name="Army Options" book="brb" page="159" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="9790-0964-ad21-f9e2" name="Batter Drone" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="110">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="e8ef-1777-4402-6ec0" name="Block!" book="brb" page="159" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b615-30f1-ad69-12c1" name="Get Up!" book="brb" page="159" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e641-c5b4-439e-fcf7" name="Extra Shot" book="brb" page="159" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5ef9-ac40-fdd1-0f42" name="Pull Yourself Together" book="brb" page="159" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="dbf8-5a76-93e1-f4a8" name="Superior Shard" book="brb" page="159" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7221-adbb-9c56-8b4f" name="Marksman" book="brb" page="159" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="15ba-5c8d-2015-d2bc" name="Well Prepared" book="brb" page="159" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="92cb-926a-97be-23cb" name="Boromie Engineer Squad" book="brb" page="189" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="fc46-7b10-4c68-6d86" name="Borer Drone" points="15.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="111">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="5283-9b2a-224e-8b1e" name="Plasma Pistols" book="brb" page="189" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="4.0">
+              <repeats>
+                <repeat field="selections" scope="92cb-926a-97be-23cb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3c0e-62f9-dc1b-b705" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="4.0">
+              <repeats>
+                <repeat field="selections" scope="92cb-926a-97be-23cb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cee6-dd9f-30b2-e834" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="cee6-dd9f-30b2-e834" name="Engineers" book="BRB" page="189" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="6a81-affb-f2e7-9809" name="Engineers" book="BRB" page="189" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="4"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="6"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6(7)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="6"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="4b41-93ef-dcba-4337" hidden="false" targetId="ddf6-21b8-6d01-7ac5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="7a0f-5f7b-ca7e-55e7" hidden="false" targetId="35b8-81bd-4c11-6bf8" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="22.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="eaa0-b9cc-a5f9-8574" name="Give Unit" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="964b-1afe-6b15-803b" hidden="false" targetId="c27e-d5ec-5ea4-9e3d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats>
+                    <repeat field="selections" scope="92cb-926a-97be-23cb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cee6-dd9f-30b2-e834" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats>
+                    <repeat field="selections" scope="92cb-926a-97be-23cb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3c0e-62f9-dc1b-b705" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="9979-0e99-8fb7-a0be" hidden="false" targetId="5d18-58b5-a126-a741" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats>
+                    <repeat field="selections" scope="92cb-926a-97be-23cb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cee6-dd9f-30b2-e834" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats>
+                    <repeat field="selections" scope="92cb-926a-97be-23cb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3c0e-62f9-dc1b-b705" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="decrement" field="points" value="5.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="b78f-2645-a2f9-5e48" hidden="false" targetId="cd51-1764-7fd7-e8c1" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="8e60-2804-ad64-a57d" hidden="false" targetId="fc46-7b10-4c68-6d86" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="7afe-a931-c7ca-5313" hidden="false" targetId="9790-0964-ad21-f9e2" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="3c0e-62f9-dc1b-b705" hidden="false" targetId="86cc-b479-3571-ab96" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="3576-2ebd-52bf-2446" hidden="false" targetId="a1f9-70eb-a8cc-d9bf" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="maxSelections" value="3.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="maxSelections" value="3.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="3163-a93c-1bca-cfa7" hidden="false" targetId="4e1f-9625-b99f-a50c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="3.0">
+              <repeats>
+                <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e77-960e-5505-3f67" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="3.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="3.0">
+              <repeats>
+                <repeat field="selections" scope="92cb-926a-97be-23cb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cee6-dd9f-30b2-e834" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="3.0">
+              <repeats>
+                <repeat field="selections" scope="92cb-926a-97be-23cb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3c0e-62f9-dc1b-b705" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ec14-449b-d3d2-25fc" name="Boromite Gang Fighter Squad" page="185" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="6993-161f-e135-22eb" name="Compression Bombard" points="45.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="089d-33fb-642d-67b5" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Bombard" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-50"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="150"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="9/7/5"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressio, No Cover, Cycle"/>
-          </characteristics>
+      <infoLinks>
+        <infoLink id="c8a4-a4aa-b20c-88bb" hidden="false" targetId="8e57-0c0e-9630-533d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="86cc-b479-3571-ab96" name="Engineers" points="12.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="brb" page="189">
-      <entries/>
-      <entryGroups/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="7e99-597b-5e94-ed21" profileTypeId="1650-77b3-10d1-6406" name="Engineers" hidden="false" book="brb" page="189">
-          <characteristics>
-            <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="4"/>
-            <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-            <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="6"/>
-            <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="6(7)"/>
-            <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="6"/>
-            <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-          </characteristics>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="a7e8-cc40-3206-6569" name="Gang Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="9082-ac4b-3f09-232c" name="Gang Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="4"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="6"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6(7)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="6"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="10"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="43b3-8ad9-06e1-05d2" hidden="false" targetId="5958-48e4-8481-41ed" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="e995-1aad-c59a-180c" hidden="false" targetId="ff3a-5fc0-452b-22d7" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="d973-0655-8589-8ddf" targetId="35b8-81bd-4c11-6bf8" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="8372-019b-1c7f-f539" name="Leader Level" hidden="false" collective="false" defaultSelectionEntryId="e412-6d44-88b7-4fa8">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="4fd8-8c98-d964-fc0d" name="Leader Two" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="8e1c-da7a-9908-f96e" hidden="false" targetId="5819-f10c-2a26-41a2" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="e412-6d44-88b7-4fa8" name="Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="e4c5-195c-7fea-a0b1" hidden="false" targetId="1ebf-4e01-6d59-3d0f" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="3077-89bd-9dbc-4f8d" name="Give Gang Leader" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="4a3a-54bc-878a-08bc" hidden="false" targetId="b2de-b74b-feb6-e489" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="6013-4a21-bdde-4acc" hidden="false" targetId="5d18-58b5-a126-a741" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="adc0-80ec-c7d8-aae7" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="3e73-ad93-2bf0-03be">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="3e73-ad93-2bf0-03be" name="Mag Pistol" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="781d-64fb-28e4-e499" hidden="false" targetId="eb88-0bbb-1f8d-009f" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="78a9-8ed2-9ca4-abf9" name="Mag Gun" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="ce7c-0bd7-511b-4c08" hidden="false" targetId="a8e8-1b26-2efd-8351" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="3.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="25.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="aef4-66ad-c485-f280" name="Gangers" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="7ce5-1b92-8357-b3b5" name="Gangers" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="4"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="6"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6(7)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="6"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="b49e-cc33-0d81-e5d9" targetId="ddf6-21b8-6d01-7ac5" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="2ee4-13a7-8471-c83e" hidden="false" targetId="a8e8-1b26-2efd-8351" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="18.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="9d0d-9adc-32c0-8459" hidden="false" targetId="ddf6-21b8-6d01-7ac5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="a916-0caf-6b2e-f2eb" name="Extasor" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BFX" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="425e-48fe-ae60-2a65" profileTypeId="ecae-8ac8-2c13-0dd3" name="Extasor" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="3 Attacks, Human Sync"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="b19a-b113-a5af-57cf" name="Frag Borer" points="40.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="77">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="bd4b-1e92-bfb0-b534" profileTypeId="ecae-8ac8-2c13-0dd3" name="Frag Borer" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="60"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3 (+1 max 10)"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Fratal Lock"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="9147-c31d-55b2-ef27" name="Heavy Frag Borer" points="35.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="83">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="7cbb-81be-b3b7-2fe9" profileTypeId="ecae-8ac8-2c13-0dd3" name="Heavy Frag Borer" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="60"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="6 (+1 max 10)"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="b1ac-43b1-d521-2c58" name="Heavy Mag Cannon" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="81">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="2360-c5a0-8cfa-7821" profileTypeId="ecae-8ac8-2c13-0dd3" name="Heavy Mag Cannon" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="50"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="250"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="6"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Massive Damage"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="8fe1-02c7-9ede-7aaf" name="Heavy Tractor Maul" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="65">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="1821-bda8-0994-cacd" profileTypeId="ecae-8ac8-2c13-0dd3" name="Heavy Tractor Maul" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="68cd-a10e-45f7-2482" name="HL Booster Drone" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BFX" page="??">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="434a-3ed5-7e56-cab4" hidden="false" targetId="31c0-3ca6-a69b-7132" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="aef4-66ad-c485-f280" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e17f-ad05-cc5e-229c" name="Boromite Guildess Arran Gestalin (support)" book="BFX" page="112" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="4e1f-9625-b99f-a50c" name="Implosion Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="85">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="1268-b2b9-1909-bca9" profileTypeId="ecae-8ac8-2c13-0dd3" name="Implosion Grenades" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Hazardous H2H"/>
-          </characteristics>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="maxInForce" value="0.0">
+          <repeats>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c0d-5521-071d-1952" repeats="1"/>
+          </repeats>
+          <conditions/>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="2b05-68f7-4a1d-55cd" name="Arran Gestalin" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="85a4-a256-973e-7773" name="Arran Gestalin" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="4"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="6"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="8"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="7(8)"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="8"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="10"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="63b2-ee33-1047-01f9" hidden="false" targetId="ff3a-5fc0-452b-22d7" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="0c3c-d9ba-efef-dbaf" hidden="false" targetId="5958-48e4-8481-41ed" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="99fc-6ab1-f581-9e92" hidden="false" targetId="903c-c5cd-53d4-52cc" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="0132-0557-5220-fc6b" hidden="false" targetId="6a72-9858-7f5e-22be" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="f273-73c6-ac4b-554d" hidden="false" targetId="418e-35d2-e555-d54f" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="879a-21ac-bc5b-4e89" hidden="false" targetId="ec07-8982-914d-8377" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="5e71-488f-ea32-9e03" hidden="false" targetId="587b-7c27-52f5-56a7" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="2a5d-364c-c495-0b53" name="Lavamite Hatchling Attacks" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="c41b-2eff-4050-981b" profileTypeId="ecae-8ac8-2c13-0dd3" name="Lavamite Hatchling Attacks" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Lava Spit, 3 Attacks"/>
-          </characteristics>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="610e-1961-922b-b5c0" hidden="false" targetId="de1a-0dd2-8671-8dae" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="42bc-ca42-b1ef-1e2e" hidden="false" targetId="a916-0caf-6b2e-f2eb" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="f76e-78d4-9f33-15aa" hidden="false" targetId="ddf6-21b8-6d01-7ac5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="c0ec-0c24-7d46-8c58" hidden="false" targetId="803d-52a0-55ff-cdc4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="47a5-20ee-01cb-a5c2" hidden="false" targetId="d6df-ce6c-51e8-40ea" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="120.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1d8c-9949-1e7c-8f73" name="Rock Rider" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="bd0d-3a1b-9f7c-a3ad" name="Rock Rider" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="4"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="8"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="7(8)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="6"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="40a0-0f71-a451-6003" hidden="false" targetId="ec07-8982-914d-8377" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="7286-5ca3-f4fe-0d77" hidden="false" targetId="ec07-8982-914d-8377" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="c27e-d5ec-5ea4-9e3d" name="Lectro Lance" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="66">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="5ca8-4ba6-5c99-3500" profileTypeId="ecae-8ac8-2c13-0dd3" name="Lectro Lance" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
-          </characteristics>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="ec72-5498-8c63-c976" hidden="false" targetId="ddf6-21b8-6d01-7ac5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="a548-7615-4266-92ae" hidden="false" targetId="de1a-0dd2-8671-8dae" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="b2c8-c59c-bd4d-fde9" hidden="false" targetId="803d-52a0-55ff-cdc4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="31.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="71b9-c297-793d-06ad" name="Weapon Drone" book="BRB" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="b2de-b74b-feb6-e489" name="Lectro Lash" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="65">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="70ed-6ea1-fb2c-28ed" profileTypeId="ecae-8ac8-2c13-0dd3" name="Lectro Lash" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="3 Attacks"/>
-          </characteristics>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="76f4-753c-b444-e489" hidden="false" targetId="de1a-0dd2-8671-8dae" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="14.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="dc9d-9972-e215-7b93" name="Weapon Drone" book="BRB" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="2c85-ce08-21a5-6461" name="Lectro Lash" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BRB" page="65">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="0222-e982-cef3-ae72" profileTypeId="ecae-8ac8-2c13-0dd3" name="Lectro Lash" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="3 Attacks"/>
-          </characteristics>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="7a86-fad0-3887-b027" hidden="false" targetId="de1a-0dd2-8671-8dae" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="14.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="bc24-5e02-89a6-3a6e" hidden="false" targetId="c27e-d5ec-5ea4-9e3d" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="4.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="4.0">
+              <repeats>
+                <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1d8c-9949-1e7c-8f73" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="5e28-59d7-f0ff-157e" hidden="false" targetId="19aa-7fc5-12e2-97a3" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="e621-959c-b626-9ee0" name="Mag Cannon" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="75">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="ecb1-15b0-9f66-9143" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Cannon" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="50"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="5"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Massive Damage"/>
-          </characteristics>
+          <constraints/>
+        </entryLink>
+        <entryLink id="9c1c-4218-a533-4a49" hidden="false" targetId="19aa-7fc5-12e2-97a3" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="a8e8-1b26-2efd-8351" name="Mag Gun" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BRB" page="75">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="569a-18bc-859d-de0a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Gun" hidden="false" book="BRB" page="69">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="60"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value=""/>
-          </characteristics>
+          <constraints/>
+        </entryLink>
+        <entryLink id="336d-16ee-3817-f2ce" hidden="false" targetId="cd51-1764-7fd7-e8c1" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="8934-d01f-ea71-ff3c" name="Mag Heavy Support" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="81">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="a18a-0afd-5c64-9c0c" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Heavy Support" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="50"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF5"/>
-          </characteristics>
+          <constraints/>
+        </entryLink>
+        <entryLink id="7a29-11fb-0101-0b17" hidden="false" targetId="916d-c962-0de5-5b5d" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="90e0-4818-78ac-de67" name="Mag Light support" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="75">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="1436-8c09-2631-ad5c" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Light support" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="50"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3"/>
-          </characteristics>
+          <constraints/>
+        </entryLink>
+        <entryLink id="4410-9f0d-2c1c-c623" hidden="false" targetId="68cd-a10e-45f7-2482" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="d258-74bb-712d-7c41" name="Mag Mortar" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="81">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="1a54-df98-2271-12b7" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Mortar" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OHx2, Blast D10, No Cover"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="92e9-5163-70db-9b19" targetId="a2c8-41ec-0899-d9b5" linkType="entry group">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="eb88-0bbb-1f8d-009f" name="Mag Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BRB" page="68">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="2f64-f6cc-36bc-66a3" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Pistol" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="30"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="4f01-44bb-2188-fc1a" name="Mass compactor" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="71">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="6f3b-1054-c0cd-9b2e" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mass compactor" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="30"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3/2/1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="3e4c-8b6b-efa7-cdeb" name="Micromite Probe" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="119">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="0b46-4732-9897-f36d" profileTypeId="1650-77b3-10d1-6406" name="Micromite Probe" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="-"/>
-            <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
-            <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="-"/>
-            <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-            <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="-"/>
-            <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="-"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="5b5a-ab27-f5be-90fd" name="Plasma Cannon" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="76">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="a3ea-4ad7-4ff8-ed55" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Cannon" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="6"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Plasma Fade"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="de1a-0dd2-8671-8dae" name="Plasma Carbine" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BRB" page="70">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="9578-05de-bc83-b6b8" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Carbine: Single Shot" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-        <profile id="6f68-80f7-c8d9-b857" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Carbine: Scatter" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="31c0-3ca6-a69b-7132" name="Plasma Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="85">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="05a6-502f-fb78-6163" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Grenades" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="3bf2-9136-e938-9b9b" name="Plasma Light Support" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="76">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="46b2-2faf-31c7-53eb" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Light Support" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="f8a4-26f3-412d-38e4" name="Plasma Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="68">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="6098-a498-b4eb-4c2b" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Pistol" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="30"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="b622-8e27-2906-a350" name="Plasma Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BRB" page="68">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="1ed2-834b-3870-3021" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Pistol" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="30"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="ddf6-21b8-6d01-7ac5" name="Reflex Armour" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BRB" page="93">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2c0d-5521-071d-1952" name="Boromite Guildess Arran Gestalin (tactical)" book="BFX" page="112" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="803d-52a0-55ff-cdc4" name="Riding Locomite" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BRB" page="130">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="d1b1-310f-7267-f00b" profileTypeId="ecae-8ac8-2c13-0dd3" name="Locomite Attack" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules"/>
-          </characteristics>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="maxInForce" value="0.0">
+          <repeats>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e17f-ad05-cc5e-229c" repeats="1"/>
+          </repeats>
+          <conditions/>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="ba0d-a02f-d9c1-4d76" name="Arran Gestalin" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="9b1a-d526-c68e-a680" name="Arran Gestalin" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="4"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="6"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="8"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="7(8)"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="8"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="10"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="0d38-940a-7447-94e9" hidden="false" targetId="ff3a-5fc0-452b-22d7" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="38ed-145f-dc31-69a7" hidden="false" targetId="5958-48e4-8481-41ed" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="5d7b-9651-ea89-8f00" hidden="false" targetId="903c-c5cd-53d4-52cc" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="14fa-d567-f169-4c37" hidden="false" targetId="6a72-9858-7f5e-22be" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="ab1e-7cb7-9a87-44a1" hidden="false" targetId="418e-35d2-e555-d54f" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="69f6-541a-c712-6f8f" hidden="false" targetId="ec07-8982-914d-8377" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="4df5-3363-28fc-3557" hidden="false" targetId="587b-7c27-52f5-56a7" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="3624-7104-03ed-6a8b" hidden="false" targetId="de1a-0dd2-8671-8dae" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="6185-141a-ae9e-cc82" hidden="false" targetId="a916-0caf-6b2e-f2eb" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="1cc0-bac5-dbd2-f4dd" hidden="false" targetId="ddf6-21b8-6d01-7ac5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="d7aa-0286-7698-c7c8" hidden="false" targetId="803d-52a0-55ff-cdc4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="7251-4617-ceba-d6da" hidden="false" targetId="d6df-ce6c-51e8-40ea" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="120.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b6ce-dbaf-fff8-b580" name="Rock Rider" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="db63-d36f-d2ce-2923" name="Rock Rider" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="4"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="8"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="7(8)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="6"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="0686-4de1-34fe-a824" hidden="false" targetId="ec07-8982-914d-8377" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="1064-8898-63a9-36ed" hidden="false" targetId="ec07-8982-914d-8377" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="3058-a290-c56c-518d" hidden="false" targetId="ddf6-21b8-6d01-7ac5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="6613-af57-2032-c0ed" hidden="false" targetId="de1a-0dd2-8671-8dae" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="4f3c-cf7e-df52-2ef3" hidden="false" targetId="803d-52a0-55ff-cdc4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="31.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9fd5-ca63-0a55-1b0f" name="Weapon Drone" book="BRB" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="9794-b1ab-16e0-b2fc" hidden="false" targetId="de1a-0dd2-8671-8dae" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="14.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="dd80-cdb0-17af-a820" name="Weapon Drone" book="BRB" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="06c2-dc1c-d2d0-a350" hidden="false" targetId="de1a-0dd2-8671-8dae" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="14.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="6b36-332c-d95d-9d05" hidden="false" targetId="c27e-d5ec-5ea4-9e3d" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="4.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="4.0">
+              <repeats>
+                <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1d8c-9949-1e7c-8f73" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="92bd-d4d1-de6a-693c" hidden="false" targetId="19aa-7fc5-12e2-97a3" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="9771-d970-c095-e331" hidden="false" targetId="19aa-7fc5-12e2-97a3" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="032e-d27d-353c-a759" hidden="false" targetId="cd51-1764-7fd7-e8c1" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="7853-1611-ecc0-6863" hidden="false" targetId="916d-c962-0de5-5b5d" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="7700-0dcb-b7fb-0058" hidden="false" targetId="68cd-a10e-45f7-2482" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6828-7101-7889-cdd8" name="Boromite Hauler" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="model">
+      <profiles>
+        <profile id="ee38-60f6-3ab9-840b" name="Boromite Hauler" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+            <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+            <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+            <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="13"/>
+            <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="6"/>
+            <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+            <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links/>
-    </entry>
-    <entry id="1840-59e5-dd80-f4bb" name="Scout Probe" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="120">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="794b-5574-8388-0180" name="Self-Repair" points="11.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="137">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="19aa-7fc5-12e2-97a3" name="Shield Drone" points="10.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="114">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="cd51-1764-7fd7-e8c1" name="Spotter Drone" points="10.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="114">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="33d6-6c92-2948-c9ca" name="Suspensor Platform" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="123">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="b576-fce5-dbfc-cba1" targetId="ec07-8982-914d-8377" linkType="rule">
+      <infoLinks>
+        <infoLink id="b75d-7484-ae78-dab0" hidden="false" targetId="8d80-a4ff-fb59-92e9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="916d-c962-0de5-5b5d" name="Synchronizer Drone" points="20.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BFX" page="79">
-      <entries/>
-      <entryGroups/>
+        </infoLink>
+        <infoLink id="2f79-dd76-bf5f-8690" hidden="false" targetId="418e-35d2-e555-d54f" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="449f-52d4-9e3b-e8e5" hidden="false" targetId="4a4d-04f6-0073-5c53" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers>
+        <modifier type="increment" field="maxInForce" value="1.0">
+          <repeats>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="383b-6550-ee5b-d6cf" repeats="1"/>
+          </repeats>
+          <conditions/>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="b3a6-4fcb-3ff0-ade3" name="Weapon Options" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="732d-f8d5-ccd8-b0a2" name="1st Weapon" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="0ccd-1e31-38e1-055b" hidden="false" targetId="90e0-4818-78ac-de67" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="11f1-eb2c-3a4a-9f48" hidden="false" targetId="e621-959c-b626-9ee0" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="3eaf-c538-d461-68ff" name="2nd Weapon" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="9e8f-0bba-698d-e8b4" hidden="false" targetId="90e0-4818-78ac-de67" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="b7fa-d6a8-5dda-54f0" hidden="false" targetId="e621-959c-b626-9ee0" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="061a-23f7-9da8-e9b6" hidden="false" targetId="9790-0964-ad21-f9e2" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="8539-9ebc-d8e4-f0f4" hidden="false" targetId="794b-5574-8388-0180" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="d245-c7e9-e4f8-3f64" hidden="false" targetId="cd51-1764-7fd7-e8c1" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="96b4-1bed-dcd3-8d2c" hidden="false" targetId="cd51-1764-7fd7-e8c1" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="ce6a-575a-ec38-0ad8" hidden="false" targetId="19aa-7fc5-12e2-97a3" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="8592-52f5-95b3-acf4" hidden="false" targetId="19aa-7fc5-12e2-97a3" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="170.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e756-1e74-0dba-d8e8" name="Boromite Heavy Hauler" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="model">
+      <profiles>
+        <profile id="e3c7-f8f0-8856-05d4" name="Boromite Hauler" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+            <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+            <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+            <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="15"/>
+            <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="6"/>
+            <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+            <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0002-2eee-efcb-aba2" hidden="false" targetId="418e-35d2-e555-d54f" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="c5fc-c32a-e043-1853" hidden="false" targetId="7d25-d2b6-7130-a3c0" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="c2b7-f461-f18b-df55" hidden="false" targetId="7557-700d-2fc6-e203" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3811-aec3-3cef-d27e" hidden="false" targetId="2687-f7ac-3c1e-fb30" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2bf4-346f-0523-fdc5" name="Weapon Options" hidden="false" collective="false" defaultSelectionEntryId="e9be-5158-1204-fdaa">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="e9be-5158-1204-fdaa" hidden="false" targetId="8934-d01f-ea71-ff3c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="f6f3-9c26-d090-d71f" hidden="false" targetId="b1ac-43b1-d521-2c58" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="1bdb-30f7-0d9d-c04f" hidden="false" targetId="9147-c31d-55b2-ef27" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="6ffc-11da-a717-a763" hidden="false" targetId="6993-161f-e135-22eb" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="e4e4-cf36-7412-8229" hidden="false" targetId="1de8-e29c-e0c9-73db" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="408f-ee27-0f22-e08c" hidden="false" targetId="d258-74bb-712d-7c41" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="6eb6-34cf-683e-2ddc" hidden="false" targetId="9790-0964-ad21-f9e2" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="1a1e-3907-63b6-5582" hidden="false" targetId="794b-5574-8388-0180" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="e1c5-3c7c-b05e-fb67" hidden="false" targetId="cd51-1764-7fd7-e8c1" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="92c5-b6b2-3016-339f" hidden="false" targetId="19aa-7fc5-12e2-97a3" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="ac32-8387-4155-9c3f" hidden="false" targetId="19aa-7fc5-12e2-97a3" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="332.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cfb5-737a-e7e0-f42f" name="Boromite Heavy Support Team" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="4b36-55b9-eea8-8528" hidden="false" targetId="eb7b-7605-9eca-cb60" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="708c-9680-b0ce-6521" hidden="false" targetId="eb7b-7605-9eca-cb60" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="10b1-ce07-3cee-1888" hidden="false" targetId="418e-35d2-e555-d54f" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="304d-5ccd-7ab2-5ba9" hidden="false" targetId="7d25-d2b6-7130-a3c0" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="0bef-01eb-3ad2-266a" name="Ganger Crew" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="6b20-a652-b846-8250" name="Ganger Crew" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="4"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="6"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="6"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="0c87-9e41-7316-04cb" hidden="false" targetId="eb88-0bbb-1f8d-009f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="13.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1f62-7f4b-63c8-5390" name="Promote one crew member to Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="640d-b97a-49b1-974d" hidden="false" targetId="1ebf-4e01-6d59-3d0f" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1c3f-9d78-6227-330a" name="Give unit Reflex Armour" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="cfb5-737a-e7e0-f42f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0bef-01eb-3ad2-266a" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="5e88-8b35-20d1-2c09" hidden="false" targetId="ddf6-21b8-6d01-7ac5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="14fe-b781-6755-a6ef" name="Weapon Options" hidden="false" collective="false" defaultSelectionEntryId="e1e4-e995-3e61-ece3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="e1e4-e995-3e61-ece3" hidden="false" targetId="8934-d01f-ea71-ff3c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="0e7e-1a01-145d-d5cd" hidden="false" targetId="b1ac-43b1-d521-2c58" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="9552-6b70-7474-5bb0" hidden="false" targetId="9147-c31d-55b2-ef27" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="f17f-cd4d-ae0a-14b4" hidden="false" targetId="1de8-e29c-e0c9-73db" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="9556-a2e7-dc93-06b6" hidden="false" targetId="d258-74bb-712d-7c41" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="2f6c-2b9c-d2a6-4ff1" hidden="false" targetId="fc46-7b10-4c68-6d86" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="ed6f-029e-a945-c64a" hidden="false" targetId="cd51-1764-7fd7-e8c1" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="45.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5755-dc85-c2d9-a6bb" name="Boromite Lavamites" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="42fe-d56e-c860-4954" hidden="false" targetId="3c9b-f86d-32c6-bf69" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="7b76-20a4-9cc3-aa4f" name="Handler" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="6945-a446-b965-8c9d" name="Handler" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="4"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="6"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6(7)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="6"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="9f71-a48e-0b8b-1a57" name="Leader Level" hidden="false" collective="false" defaultSelectionEntryId="4f18-1d53-664b-509e">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="da4a-2fd2-8978-f0ba" name="Leader Two" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="bc01-2c0a-ae0f-5f94" hidden="false" targetId="5819-f10c-2a26-41a2" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="4f18-1d53-664b-509e" name="Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="9793-53c0-b463-eb74" hidden="false" targetId="1ebf-4e01-6d59-3d0f" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="b974-2e05-b197-8559" hidden="false" targetId="ddf6-21b8-6d01-7ac5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="b073-7727-20d0-c197" hidden="false" targetId="b622-8e27-2906-a350" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="f7c8-cbe9-4242-6236" hidden="false" targetId="2c85-ce08-21a5-6461" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="e0aa-e20a-0b8a-58e8" hidden="false" targetId="33d6-6c92-2948-c9ca" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="31.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7f33-779c-0cf7-5696" name="Hatchling Swarm" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="78e0-49b8-7d8a-5bf2" name="Hatchling Swarm" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="7"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="7"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="7"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="6"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="5"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="maxSelections" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="5755-dc85-c2d9-a6bb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8449-e194-444f-f4f9" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="ab16-10de-c8f9-aba7" hidden="false" targetId="2a5d-364c-c495-0b53" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="16.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8449-e194-444f-f4f9" name="Lavamites" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="4964-3188-e927-276d" name="Lavamites" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="4"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="7"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="7"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="8"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="6"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="5"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+            <profile id="8eb8-202a-0f33-42ae" name="Lavamite Attacks" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="897c-d3c4-3983-896a" value="3.0">
+                  <repeats>
+                    <repeat field="selections" scope="5755-dc85-c2d9-a6bb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b3ce-44a4-c6dc-2d52" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="7e87-2586-653f-d6ec" value="Lava Spit, 4 Attacks">
+                  <repeats>
+                    <repeat field="selections" scope="5755-dc85-c2d9-a6bb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b3ce-44a4-c6dc-2d52" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Lava Spit, 3 Attacks"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="17.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b3ce-44a4-c6dc-2d52" name="Lavamite Rock Brood Upgrade" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="3f3e-cb10-bf7e-84a2" hidden="false" targetId="ec07-8982-914d-8377" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="points" value="4.0">
+              <repeats>
+                <repeat field="selections" scope="5755-dc85-c2d9-a6bb" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8449-e194-444f-f4f9" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="b625-bfc9-8a47-5c24" hidden="false" targetId="fc46-7b10-4c68-6d86" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a79c-4719-0b12-ee25" name="Boromite Matriarch" page="185" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="4bed-5692-0439-8e7b" hidden="false" targetId="d1fe-dbdc-fdd9-94c8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="68f4-25bd-b462-db17" hidden="false" targetId="b72c-b9d6-e702-b322" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers>
+        <modifier type="set" field="maxInForce" value="0.0">
+          <repeats>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc6a-97b9-b9d6-b3c6" repeats="1"/>
+          </repeats>
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a79c-4719-0b12-ee25" type="atLeast"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="fe1c-39bc-56bc-f4f8" name="Matriarch" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="a8c4-3da0-17ca-c2ff" name="Matriarch" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="4"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="6"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="6(7)"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="6"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="10"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="6221-84d4-273d-ff27" hidden="false" targetId="5958-48e4-8481-41ed" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="7b96-06a2-3665-032a" hidden="false" targetId="ff3a-5fc0-452b-22d7" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="0f69-438b-64e4-cff1" hidden="false" targetId="ec07-8982-914d-8377" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="28f3-7994-9d9a-9f3b" name="Leader Level" hidden="false" collective="false" defaultSelectionEntryId="b720-951e-a82f-a2c2">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="b720-951e-a82f-a2c2" name="Leader Two" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="b599-5180-4012-5b81" hidden="false" targetId="5819-f10c-2a26-41a2" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="7efd-0509-1e43-71d1" name="Leader Three" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="b6d4-194e-2730-90c1" hidden="false" targetId="903c-c5cd-53d4-52cc" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="34f4-c27f-bda5-b882" hidden="false" targetId="ddf6-21b8-6d01-7ac5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="2ba5-acfd-731b-99ce" hidden="false" targetId="33d6-6c92-2948-c9ca" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="34.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ad19-7b3d-627f-3f1b" name="Guildless" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="2f66-4b53-a9cc-beb8" name="Guildless" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="4"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="6"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="6(7)"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="6"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="10"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="8eeb-ec59-f89e-6e44" hidden="false" targetId="5958-48e4-8481-41ed" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="8e75-38b8-2ea8-0cca" hidden="false" targetId="ff3a-5fc0-452b-22d7" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="1c3e-fb7e-5b7e-5d91" name="Leader Level" hidden="false" collective="false" defaultSelectionEntryId="cc78-7f08-e08c-d3b8">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="cc78-7f08-e08c-d3b8" name="Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="be4b-0252-9586-065b" hidden="false" targetId="1ebf-4e01-6d59-3d0f" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="6f7b-f07f-22ed-f93b" name="Leader Two" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="7fb7-ff8d-0642-ddba" hidden="false" targetId="5819-f10c-2a26-41a2" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="9011-3729-4950-fb8c" hidden="false" targetId="ddf6-21b8-6d01-7ac5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="34.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0fe1-e819-0f8d-8932" name="Weapon Drone" book="BRB" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="2fa0-7b8a-f95a-f379" hidden="false" targetId="de1a-0dd2-8671-8dae" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="34.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0d16-80a3-a7ef-e455" name="Weapon Drone" book="BRB" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="e7c1-2f05-6476-0e8a" hidden="false" targetId="de1a-0dd2-8671-8dae" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="14.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0546-6890-5894-149e" name="Weapon Drone" book="BRB" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="9687-e31c-69a0-ae99" hidden="false" targetId="de1a-0dd2-8671-8dae" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="14.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="3dd2-8cf5-8f29-d8f1" hidden="false" targetId="19aa-7fc5-12e2-97a3" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="bb22-f01e-f986-0511" hidden="false" targetId="cd51-1764-7fd7-e8c1" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="df4e-55b0-6360-c09f" hidden="false" targetId="19aa-7fc5-12e2-97a3" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="c1fc-097f-fd78-ede5" hidden="false" targetId="cd51-1764-7fd7-e8c1" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="e99b-e0a2-c99b-dd47" hidden="false" targetId="916d-c962-0de5-5b5d" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="64cb-08b1-a276-909e" name="Boromite Matronite Brood Mother" book="BRB" page="188" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="7da3-b2db-cd21-7b62" name="Lavamite Hatchling Swarms" book="BRB" page="188" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="d70e-2762-48fd-a446" name="Lavamite Hatchling Swarms" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="7"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="7"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="7"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="5"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="8a46-d452-441a-ecc6" hidden="false" targetId="2a5d-364c-c495-0b53" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="16.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3616-f891-324f-74c1" name="Matronite Brood Mother" book="brb" page="188" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="2469-385b-7def-2466" name="Matronite Brood Mother" book="brb" page="188" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="10"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="15"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+            <profile id="e8c1-9468-2102-d230" name="Matronite Brood Mother" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="4"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="7f11-5f90-9467-7bf0" hidden="false" targetId="4a4d-04f6-0073-5c53" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="9bf6-a343-52ed-a144" hidden="false" targetId="7d25-d2b6-7130-a3c0" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="f4d3-96e2-e278-582f" hidden="false" targetId="418e-35d2-e555-d54f" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="ece0-9647-e89d-ac89" name="Mag Light Support" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="decrement" field="minSelections" value="1.0">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="64cb-08b1-a276-909e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0e9a-2386-e809-ac20" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="decrement" field="maxSelections" value="1.0">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="64cb-08b1-a276-909e" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0e9a-2386-e809-ac20" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="0e9a-2386-e809-ac20" name="Replace One Mag Light Support with" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="6a29-e7c5-c7cf-5170" name="Heavey Mag Cannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="45.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="3f76-1ca4-7b5e-8ce0" name="Mag Heavy Support" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="35.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="67fd-2ce9-1d94-da2a" name="Batter Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="25.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="c30c-a2ac-dcc1-360b" hidden="false" targetId="cd51-1764-7fd7-e8c1" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="258.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bad3-3ce1-0258-9da3" name="Boromite Overseer Squad" page="184" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="77a2-561e-3125-4535" hidden="false" targetId="b72c-b9d6-e702-b322" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ea6e-5198-274e-c4e7" hidden="false" targetId="d1fe-dbdc-fdd9-94c8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="4192-398e-c7d3-8752" name="Overseer" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="47fa-acfc-3f50-25d9" name="Overseer" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="4"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="6"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="6(7)"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="6"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="10"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="03a9-28f6-49c4-6c18" hidden="false" targetId="5958-48e4-8481-41ed" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="2751-9122-b259-b986" hidden="false" targetId="ff3a-5fc0-452b-22d7" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="af7a-23eb-bbac-265c" hidden="false" targetId="5819-f10c-2a26-41a2" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="59a9-6996-155e-e7ce" name="Leader Level" hidden="false" collective="false" defaultSelectionEntryId="88cf-9c54-2584-1c59">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="88cf-9c54-2584-1c59" name="Leader Two" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="43ff-21bc-1791-5cfa" hidden="false" targetId="5819-f10c-2a26-41a2" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="0563-0772-82c6-8e3e" name="Leader Three" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="3fcd-1c9b-ae6e-586c" hidden="false" targetId="903c-c5cd-53d4-52cc" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="ac1e-ee80-997b-99d5" name="Give Overseer" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="cc48-05a5-0f8b-c119" hidden="false" targetId="b2de-b74b-feb6-e489" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="67cd-c0e2-0d32-be57" hidden="false" targetId="5d18-58b5-a126-a741" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="63.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="aa3b-41a1-2d43-e6d9" name="Gangers" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="705b-c577-58f4-b08a" name="Gangers" book="brb" page="184" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="4"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="6"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="6(7)"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="6"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="9"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="21.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="fc25-f9eb-eb67-3bed" hidden="false" targetId="de1a-0dd2-8671-8dae" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="7b2a-7bd1-05e4-d1c9" hidden="false" targetId="ddf6-21b8-6d01-7ac5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="aff6-21ec-9c47-8bc1" hidden="false" targetId="cd51-1764-7fd7-e8c1" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="c9c8-f51d-d8cd-db65" hidden="false" targetId="31c0-3ca6-a69b-7132" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="bad3-3ce1-0258-9da3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="aa3b-41a1-2d43-e6d9" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="4ed7-d047-208f-f1d2" hidden="false" targetId="916d-c962-0de5-5b5d" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cc6a-97b9-b9d6-b3c6" name="Boromite Rock Father" page="185" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="2681-6193-0e07-13a6" hidden="false" targetId="b72c-b9d6-e702-b322" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="d160-b1ae-39eb-9232" hidden="false" targetId="d1fe-dbdc-fdd9-94c8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers>
+        <modifier type="set" field="maxInForce" value="0.0">
+          <repeats>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a79c-4719-0b12-ee25" repeats="1"/>
+          </repeats>
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cc6a-97b9-b9d6-b3c6" type="atLeast"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="7e09-dd99-6954-274a" name="Rock Father" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="8efc-74ca-2fc5-0990" name="Rock Father" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="a30c-5b68-8dae-4aa0" hidden="false" targetId="5958-48e4-8481-41ed" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="3269-0cc4-8901-4cbf" hidden="false" targetId="ff3a-5fc0-452b-22d7" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="75a2-08c4-6e69-9af4" hidden="false" targetId="903c-c5cd-53d4-52cc" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="b8a2-ee20-bfdf-1841" name="Give Rock Father Plasma Carbine" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="2180-ccc1-1217-3f6f" hidden="false" targetId="de1a-0dd2-8671-8dae" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="9.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="5a11-099c-1257-048b" name="Give Rock Father" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="90c1-f37e-aac8-081e" hidden="false" targetId="b2de-b74b-feb6-e489" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="9d89-034c-068f-66a6" hidden="false" targetId="5d18-58b5-a126-a741" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="94f9-4628-e6f6-9af3" hidden="false" targetId="ddf6-21b8-6d01-7ac5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="78.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="63ac-5ef9-119c-c221" name="Gangers" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="5231-5921-50bd-83c4" name="Gangers" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="4"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="6"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="6"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="6(7)"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="6"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="9"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="5969-e094-d94d-6846" hidden="false" targetId="de1a-0dd2-8671-8dae" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="b58c-ae29-0599-db36" hidden="false" targetId="ddf6-21b8-6d01-7ac5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="23.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a776-eab0-252d-b7e0" name="Shield Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="03b9-aecd-f181-bcb6" hidden="false" targetId="19aa-7fc5-12e2-97a3" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="7019-6d54-a708-e7c4" hidden="false" targetId="19aa-7fc5-12e2-97a3" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="c54d-3ec9-714f-58fe" hidden="false" targetId="916d-c962-0de5-5b5d" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0b2d-9790-62ec-8c53" name="Boromite Rock Rider Overseer Squad" page="184" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="9c4f-a31d-e5a8-9d32" hidden="false" targetId="b72c-b9d6-e702-b322" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="5bcb-5b0c-c584-db3b" hidden="false" targetId="ecb8-89fb-5d9e-2211" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="48d4-1461-0769-1773" hidden="false" targetId="418e-35d2-e555-d54f" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="d6ff-ab95-696d-d560" hidden="false" targetId="ec07-8982-914d-8377" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="b314-af7f-d439-e6d0" name="Rock Rider Overseer" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="f94c-a883-165a-2b47" name="Rock Rider Overseer" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="4"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="8"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="7(8)"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="6"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="10"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="489f-41e1-04a5-6ff9" hidden="false" targetId="5958-48e4-8481-41ed" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="6945-0440-007a-3bdb" hidden="false" targetId="ff3a-5fc0-452b-22d7" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="3b18-f456-4a8d-61d2" name="Leader Level" hidden="false" collective="false" defaultSelectionEntryId="f45b-bb75-70c5-e9c6">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="f45b-bb75-70c5-e9c6" name="Leader Two" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="e55b-dfbc-2272-5d80" hidden="false" targetId="5819-f10c-2a26-41a2" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="d5fb-a7c9-ade3-c8b2" name="Leader Three" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="e31a-2683-b26a-ddb2" hidden="false" targetId="903c-c5cd-53d4-52cc" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="3118-5133-edd9-82a0" name="Give Overseer" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="1d8c-39e8-2584-e6e9" hidden="false" targetId="b2de-b74b-feb6-e489" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="fce8-2284-43e6-50bc" hidden="false" targetId="5d18-58b5-a126-a741" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="67.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="eaf5-078d-83ef-bf46" name="Rock Rider" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="0435-282d-2546-0f73" name="Rock Rider" book="BRB" page="187" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="4"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="8"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="7(8)"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="6"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="9"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="31.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="a167-f192-52ce-1f9e" hidden="false" targetId="de1a-0dd2-8671-8dae" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="0832-bc00-9d08-07ef" hidden="false" targetId="ddf6-21b8-6d01-7ac5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="adb7-a6cb-5e3a-1495" hidden="false" targetId="cd51-1764-7fd7-e8c1" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="8fab-e676-fef9-045c" hidden="false" targetId="c27e-d5ec-5ea4-9e3d" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="4.0">
+              <repeats>
+                <repeat field="selections" scope="0b2d-9790-62ec-8c53" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eaf5-078d-83ef-bf46" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="4.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="2fc1-d30f-00fe-8051" hidden="false" targetId="803d-52a0-55ff-cdc4" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d5ef-06cb-43ef-3095" name="Boromite Rock Rider Squad" page="184" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="58f5-96ae-51b5-3ec3" hidden="false" targetId="ecb8-89fb-5d9e-2211" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="bbc9-a073-071b-8750" hidden="false" targetId="418e-35d2-e555-d54f" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="0c07-2b3b-0131-f400" hidden="false" targetId="ec07-8982-914d-8377" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers>
+        <modifier type="set" field="maxInForce" value="-1.0">
+          <repeats>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e17f-ad05-cc5e-229c" repeats="1"/>
+          </repeats>
+          <conditions/>
+          <conditionGroups/>
+        </modifier>
+        <modifier type="set" field="maxInForce" value="-1.0">
+          <repeats>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0b2d-9790-62ec-8c53" repeats="1"/>
+          </repeats>
+          <conditions/>
+          <conditionGroups/>
+        </modifier>
+        <modifier type="set" field="maxInForce" value="-1.0">
+          <repeats>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2c0d-5521-071d-1952" repeats="1"/>
+          </repeats>
+          <conditions/>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="9c10-a215-a579-9c5e" name="Rock Rider Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="3fe5-7db2-03d0-b4a4" name="Rock Rider Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="4"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="8"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="7(8)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="6"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="6f6a-ff56-d20d-0821" name="Leader Level" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="681f-9466-b61c-e929" name="Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="68d5-9416-a5e4-fa24" hidden="false" targetId="1ebf-4e01-6d59-3d0f" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="fc58-e90f-120c-3741" name="Leader Two" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="71bb-a2e3-1652-f1d4" hidden="false" targetId="5819-f10c-2a26-41a2" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="ea3c-94ca-6a48-93e1" name="Give Overseer" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="c970-335b-5e0c-2b95" hidden="false" targetId="b2de-b74b-feb6-e489" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="6130-46d7-ca0b-d78a" hidden="false" targetId="5d18-58b5-a126-a741" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="35.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="baf9-118c-df0d-4f96" name="Rock Rider" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="fed6-3349-14c9-7bb2" name="Rock Rider" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="4"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="8"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="7(8)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="6"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="31.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="7c39-3e51-275c-2122" hidden="false" targetId="de1a-0dd2-8671-8dae" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="0a2d-32b8-ed4c-e13d" hidden="false" targetId="ddf6-21b8-6d01-7ac5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="2b62-8e87-e045-3c62" hidden="false" targetId="c27e-d5ec-5ea4-9e3d" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="4.0">
+              <repeats>
+                <repeat field="selections" scope="d5ef-06cb-43ef-3095" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="baf9-118c-df0d-4f96" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="4.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="482e-c9aa-b554-9293" hidden="false" targetId="803d-52a0-55ff-cdc4" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="82d5-be12-098b-3661" name="Boromite Specialist Support Team" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="74c1-a397-87af-454a" hidden="false" targetId="eb7b-7605-9eca-cb60" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="ea4b-5da7-9809-305c" name="Ganger Crew" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="3a41-6e9f-3abe-5e5f" name="Ganger Crew" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="4"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="6"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="6"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="3154-61e6-b5b2-ee4f" hidden="false" targetId="eb88-0bbb-1f8d-009f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="13.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="08f7-7c3a-1090-a662" name="Promote one crew member to Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="aa9c-a8b1-8e72-c626" hidden="false" targetId="1ebf-4e01-6d59-3d0f" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a541-3439-90a3-c5ca" name="Give unit Reflex Armour" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="82d5-be12-098b-3661" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ea4b-5da7-9809-305c" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="228f-7367-7896-0303" hidden="false" targetId="ddf6-21b8-6d01-7ac5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="9c18-16cd-c375-3a7f" name="Weapon Options" hidden="false" collective="false" defaultSelectionEntryId="041b-4e35-d418-1b20">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="4102-dbc8-790f-5f7a" hidden="false" targetId="5b5a-ab27-f5be-90fd" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="041b-4e35-d418-1b20" hidden="false" targetId="3bf2-9136-e938-9b9b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="8c0c-cd75-f088-f3f7" hidden="false" targetId="cd51-1764-7fd7-e8c1" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="3cd8-e0f3-ce0e-c2ea" hidden="false" targetId="fc46-7b10-4c68-6d86" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9c54-7e9b-3a46-2bc2" name="Boromite Support Team" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="8780-f8a8-73e2-dbc2" hidden="false" targetId="eb7b-7605-9eca-cb60" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="3624-2301-4b0b-7255" name="Ganger Crew" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="2a43-fa04-e21a-8642" name="Ganger Crew" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="4"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="6"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="6"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="ca28-09da-5b49-b7e1" hidden="false" targetId="eb88-0bbb-1f8d-009f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="13.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="22a4-ebde-d10c-5674" name="Promote one crew member to Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="814d-a648-2997-b594" hidden="false" targetId="1ebf-4e01-6d59-3d0f" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8fa2-4460-9d3d-c858" name="Give unit Reflex Armour" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="9c54-7e9b-3a46-2bc2" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3624-2301-4b0b-7255" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="b1b6-8dc8-fca7-076d" hidden="false" targetId="ddf6-21b8-6d01-7ac5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e711-56e6-f8aa-aabe" name="Weapon Options" hidden="false" collective="false" defaultSelectionEntryId="1946-83e7-4aaf-4046">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="c5e4-a7f6-77cc-cf65" hidden="false" targetId="a39b-838d-cc10-d873" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="1946-83e7-4aaf-4046" hidden="false" targetId="90e0-4818-78ac-de67" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="adb3-d7b7-6360-95bc" hidden="false" targetId="e621-959c-b626-9ee0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="3a92-6c13-368f-35b2" hidden="false" targetId="b19a-b113-a5af-57cf" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="7090-89c5-43ef-c8fa" hidden="false" targetId="cd51-1764-7fd7-e8c1" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="985c-04b2-2b49-7dd6" hidden="false" targetId="fc46-7b10-4c68-6d86" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="383b-6550-ee5b-d6cf" name="Boromite Work Gang" page="185" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="1d38-6bba-39a5-149d" hidden="false" targetId="8e57-0c0e-9630-533d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="eb62-8b73-15b9-6e43" name="Gang Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="e9b0-49cb-2d4d-1310" name="Gang Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="4"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="6"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="6"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="7e2d-5f0d-441b-e806" hidden="false" targetId="1ebf-4e01-6d59-3d0f" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="ecc8-17ab-a6b5-c850" hidden="false" targetId="eb88-0bbb-1f8d-009f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="30.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8e77-960e-5505-3f67" name="Gangers" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="ab0f-c6f8-2da6-cbcc" name="Gangers" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="4"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="6"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="6"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="17.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2fbb-c0ed-1022-cb0e" name="Give unit Reflex Armour" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e77-960e-5505-3f67" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="51cf-af3a-87d3-c669" hidden="false" targetId="ddf6-21b8-6d01-7ac5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="d11f-d3a5-d269-38b8" name="Weapons Choose" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="c12a-122d-a5ab-d03a" hidden="false" targetId="8fe1-02c7-9ede-7aaf" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="1ba6-ae24-3d83-5567" hidden="false" targetId="4f01-44bb-2188-fc1a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="fee0-bc65-ecfb-7e49" hidden="false" targetId="4e1f-9625-b99f-a50c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="3.0">
+              <repeats>
+                <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8e77-960e-5505-3f67" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="3.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="8b59-e9e9-87b9-886e" hidden="false" targetId="fc46-7b10-4c68-6d86" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="aba8-21e3-1058-94c8" hidden="false" targetId="a1f9-70eb-a8cc-d9bf" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="maxSelections" value="3.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9acf-c00a-365e-0d2c" name="Micromite Probe Shard" book="brb" page="189" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="e4cb-daeb-8943-bb3f" hidden="false" targetId="5660-b448-a09d-5338" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="78e5-9fc4-d568-caef" name="Micromite Probes" book="brb" page="119" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="00da-4aeb-1a1d-2920" name="Micromite Probes" book="brb" page="189" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="641e-aa49-d6d6-ca7a" hidden="false" targetId="6dc1-69d0-6655-5615" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="4c38-692a-04db-8d11" hidden="false" targetId="3e4c-8b6b-efa7-cdeb" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="fbff-00dc-f597-61b3" hidden="false" targetId="3e4c-8b6b-efa7-cdeb" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2f50-145e-4f5a-220f" name="Scout Probe Shard" book="brb" page="189" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="01e3-c7e8-5ec2-b4ce" hidden="false" targetId="5660-b448-a09d-5338" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="5752-7497-efd2-2786" name="Scout Probes" book="BRB" page="120" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="aec1-17f5-81d2-7812" name="Scout Probes" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="cea7-7b6a-22c7-4643" hidden="false" targetId="6dc1-69d0-6655-5615" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="335c-63ad-8258-91ee" hidden="false" targetId="1840-59e5-dd80-f4bb" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="927a-c426-6efa-958b" hidden="false" targetId="1840-59e5-dd80-f4bb" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="40.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <entryLinks>
+    <entryLink id="f403-bb40-4da2-dc6b" name="Army Options" hidden="false" targetId="529a-3e2a-4bd5-5e5f" type="selectionEntry" categoryEntryId="50ba-cf77-3941-189c">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </entryLink>
+  </entryLinks>
+  <sharedSelectionEntries>
+    <selectionEntry id="35b8-81bd-4c11-6bf8" name="Auto-Workshop" book="brb" page="120" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9790-0964-ad21-f9e2" name="Batter Drone" book="BRB" page="110" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fc46-7b10-4c68-6d86" name="Borer Drone" book="BRB" page="111" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6993-161f-e135-22eb" name="Compression Bombard" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="089d-33fb-642d-67b5" name="Compression Bombard" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-50"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="150"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="9/7/5"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressio, No Cover, Cycle"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="45.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="86cc-b479-3571-ab96" name="Engineers" book="brb" page="189" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+      <profiles>
+        <profile id="7e99-597b-5e94-ed21" name="Engineers" book="brb" page="189" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="4"/>
+            <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+            <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="6"/>
+            <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6(7)"/>
+            <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="6"/>
+            <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+            <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="d973-0655-8589-8ddf" hidden="false" targetId="35b8-81bd-4c11-6bf8" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="b49e-cc33-0d81-e5d9" hidden="false" targetId="ddf6-21b8-6d01-7ac5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="12.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a916-0caf-6b2e-f2eb" name="Extasor" book="BFX" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="425e-48fe-ae60-2a65" name="Extasor" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="3 Attacks, Human Sync"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b19a-b113-a5af-57cf" name="Frag Borer" book="BRB" page="77" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="bd4b-1e92-bfb0-b534" name="Frag Borer" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3 (+1 max 10)"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fratal Lock"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9147-c31d-55b2-ef27" name="Heavy Frag Borer" book="BRB" page="83" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="7cbb-81be-b3b7-2fe9" name="Heavy Frag Borer" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6 (+1 max 10)"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="35.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b1ac-43b1-d521-2c58" name="Heavy Mag Cannon" book="BRB" page="81" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="2360-c5a0-8cfa-7821" name="Heavy Mag Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="50"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="250"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Massive Damage"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8fe1-02c7-9ede-7aaf" name="Heavy Tractor Maul" book="BRB" page="65" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="1821-bda8-0994-cacd" name="Heavy Tractor Maul" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="68cd-a10e-45f7-2482" name="HL Booster Drone" book="BFX" page="??" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4e1f-9625-b99f-a50c" name="Implosion Grenades" book="BRB" page="85" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="1268-b2b9-1909-bca9" name="Implosion Grenades" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Hazardous H2H"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2a5d-364c-c495-0b53" name="Lavamite Hatchling Attacks" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="c41b-2eff-4050-981b" name="Lavamite Hatchling Attacks" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Lava Spit, 3 Attacks"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c27e-d5ec-5ea4-9e3d" name="Lectro Lance" book="BRB" page="66" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="5ca8-4ba6-5c99-3500" name="Lectro Lance" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b2de-b74b-feb6-e489" name="Lectro Lash" book="BRB" page="65" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="70ed-6ea1-fb2c-28ed" name="Lectro Lash" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="3 Attacks"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2c85-ce08-21a5-6461" name="Lectro Lash" book="BRB" page="65" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="0222-e982-cef3-ae72" name="Lectro Lash" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="3 Attacks"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e621-959c-b626-9ee0" name="Mag Cannon" book="BRB" page="75" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="ecb1-15b0-9f66-9143" name="Mag Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="50"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="5"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Massive Damage"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a8e8-1b26-2efd-8351" name="Mag Gun" book="BRB" page="75" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="569a-18bc-859d-de0a" name="Mag Gun" book="BRB" page="69" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value=""/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8934-d01f-ea71-ff3c" name="Mag Heavy Support" book="BRB" page="81" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="a18a-0afd-5c64-9c0c" name="Mag Heavy Support" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="50"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF5"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="90e0-4818-78ac-de67" name="Mag Light support" book="BRB" page="75" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="1436-8c09-2631-ad5c" name="Mag Light support" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="50"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d258-74bb-712d-7c41" name="Mag Mortar" book="BRB" page="81" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="1a54-df98-2271-12b7" name="Mag Mortar" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OHx2, Blast D10, No Cover"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="92e9-5163-70db-9b19" hidden="false" targetId="a2c8-41ec-0899-d9b5" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eb88-0bbb-1f8d-009f" name="Mag Pistol" book="BRB" page="68" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="2f64-f6cc-36bc-66a3" name="Mag Pistol" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4f01-44bb-2188-fc1a" name="Mass compactor" book="BRB" page="71" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="6f3b-1054-c0cd-9b2e" name="Mass compactor" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3/2/1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3e4c-8b6b-efa7-cdeb" name="Micromite Probe" book="BRB" page="119" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="0b46-4732-9897-f36d" name="Micromite Probe" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+            <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+            <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+            <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+            <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+            <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+            <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5b5a-ab27-f5be-90fd" name="Plasma Cannon" book="BRB" page="76" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="a3ea-4ad7-4ff8-ed55" name="Plasma Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Plasma Fade"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="de1a-0dd2-8671-8dae" name="Plasma Carbine" book="BRB" page="70" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="9578-05de-bc83-b6b8" name="Plasma Carbine: Single Shot" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
+          </characteristics>
+        </profile>
+        <profile id="6f68-80f7-c8d9-b857" name="Plasma Carbine: Scatter" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="31c0-3ca6-a69b-7132" name="Plasma Grenades" book="BRB" page="85" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="05a6-502f-fb78-6163" name="Plasma Grenades" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3bf2-9136-e938-9b9b" name="Plasma Light Support" book="BRB" page="76" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="46b2-2faf-31c7-53eb" name="Plasma Light Support" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f8a4-26f3-412d-38e4" name="Plasma Pistol" book="BRB" page="68" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="6098-a498-b4eb-4c2b" name="Plasma Pistol" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b622-8e27-2906-a350" name="Plasma Pistol" book="BRB" page="68" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="1ed2-834b-3870-3021" name="Plasma Pistol" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ddf6-21b8-6d01-7ac5" name="Reflex Armour" book="BRB" page="93" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="803d-52a0-55ff-cdc4" name="Riding Locomite" book="BRB" page="130" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="d1b1-310f-7267-f00b" name="Locomite Attack" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1840-59e5-dd80-f4bb" name="Scout Probe" book="BRB" page="120" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="794b-5574-8388-0180" name="Self-Repair" book="BRB" page="137" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="11.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="19aa-7fc5-12e2-97a3" name="Shield Drone" book="BRB" page="114" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cd51-1764-7fd7-e8c1" name="Spotter Drone" book="BRB" page="114" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="33d6-6c92-2948-c9ca" name="Suspensor Platform" book="BRB" page="123" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="b576-fce5-dbfc-cba1" hidden="false" targetId="ec07-8982-914d-8377" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="916d-c962-0de5-5b5d" name="Synchronizer Drone" book="BFX" page="79" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+      <profiles/>
       <rules>
-        <rule id="fba2-3a5d-04e8-00ef" name="Synchoniser Drone" hidden="false" book="BfX" page="79">
+        <rule id="fba2-3a5d-04e8-00ef" name="Synchoniser Drone" book="BfX" page="79" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
           <description>If a unit with a Synchoroniser Drone is given an order, and if it passes any order test required, then after the unit has carried out its acton the player can use the drone to try to synchonise the unit with another unit within 10&quot; of it. If sucessful draw one of his order dice from the dice bag and give this second unit an order in the usual way
 10&quot; synchonisation distance is measured AFTER the synchoronising unit resolving anything resulting from the action itself (including enemy reactions.
 If the drone dies then you may no longer sync.
 May NOT &apos;Chain&apos; syncronisers to make unit 1 sync to unit 2, who syncs to unit 3.
 May NOT be used in combination with the Command rule.
 The unit may perform any action that it normally would be able to pick.</description>
-          <modifiers/>
         </rule>
       </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5d18-58b5-a126-a741" name="Tractor Maul" book="BRB" page="65" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="da52-e520-13e5-09c7" name="Tractor Maul" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a1f9-70eb-a8cc-d9bf" name="Vorpal Charges" book="BRB" page="123" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="5d18-58b5-a126-a741" name="Tractor Maul" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="65">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1de8-e29c-e0c9-73db" name="X-Howitzer" book="BRB" page="82" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="da52-e520-13e5-09c7" profileTypeId="ecae-8ac8-2c13-0dd3" name="Tractor Maul" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks"/>
-          </characteristics>
+        <profile id="3685-3f6a-1c59-3bf0" name="X-Howitzer" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-50"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="250"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D10, No Cover"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links/>
-    </entry>
-    <entry id="a1f9-70eb-a8cc-d9bf" name="Vorpal Charges" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="123">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="3a13-d902-91ba-791c" hidden="false" targetId="a2c8-41ec-0899-d9b5" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a39b-838d-cc10-d873" name="X-Launcher" book="BRB" page="78" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="607d-b27d-464b-06ed" name="X-Launcher" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D5, No Cover"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="5536-3f81-9591-4d40" hidden="false" targetId="a2c8-41ec-0899-d9b5" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d6df-ce6c-51e8-40ea" name="Xilos Stasis Key" book="BFX" page="57" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="a4c9-6fa1-10a8-b6cf" name="Xilos Stasis Key" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Requires Fire Order, Time Twisting"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="25.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="a2c8-41ec-0899-d9b5" name="Munitions" hidden="false" collective="false">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="1de8-e29c-e0c9-73db" name="X-Howitzer" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="82">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="3685-3f6a-1c59-3bf0" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Howitzer" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-50"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="250"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D10, No Cover"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="3a13-d902-91ba-791c" targetId="a2c8-41ec-0899-d9b5" linkType="entry group">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="a39b-838d-cc10-d873" name="X-Launcher" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="78">
-      <entries/>
-      <entryGroups/>
+      <infoLinks/>
       <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="607d-b27d-464b-06ed" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Launcher" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="60"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="120"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D5, No Cover"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="5536-3f81-9591-4d40" targetId="a2c8-41ec-0899-d9b5" linkType="entry group">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="d6df-ce6c-51e8-40ea" name="Xilos Stasis Key" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BFX" page="57">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="a4c9-6fa1-10a8-b6cf" profileTypeId="ecae-8ac8-2c13-0dd3" name="Xilos Stasis Key" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="30"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Requires Fire Order, Time Twisting"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-  </sharedEntries>
-  <sharedEntryGroups>
-    <entryGroup id="a2c8-41ec-0899-d9b5" name="Munitions" minSelections="0" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="8607-5721-1101-d1a5" name="Scrambler" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="88">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="8607-5721-1101-d1a5" name="Scrambler" book="BRB" page="88" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles/>
-          <links/>
-        </entry>
-        <entry id="e85a-baba-d0f8-1499" name="Arc" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="88">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
           <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-        <entry id="8d17-f19e-79a5-3667" name="Blur" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="89">
-          <entries/>
-          <entryGroups/>
+          <infoLinks/>
           <modifiers/>
-          <rules/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e85a-baba-d0f8-1499" name="Arc" book="BRB" page="88" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles/>
-          <links/>
-        </entry>
-        <entry id="19f9-74e9-e5bd-f68b" name="Scoot" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="88">
-          <entries/>
-          <entryGroups/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <rules/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8d17-f19e-79a5-3667" name="Blur" book="BRB" page="89" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles/>
-          <links/>
-        </entry>
-        <entry id="9428-5b5e-3896-953c" name="Net" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="88">
-          <entries/>
-          <entryGroups/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <rules/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="19f9-74e9-e5bd-f68b" name="Scoot" book="BRB" page="88" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles/>
-          <links/>
-        </entry>
-        <entry id="e4da-8cdc-3c0f-63f4" name="Grip" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="87">
-          <entries/>
-          <entryGroups/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <rules/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9428-5b5e-3896-953c" name="Net" book="BRB" page="88" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles/>
-          <links/>
-        </entry>
-        <entry id="2a56-f196-c90f-0166" name="All" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="87">
-          <entries/>
-          <entryGroups/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <rules/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e4da-8cdc-3c0f-63f4" name="Grip" book="BRB" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles/>
-          <links/>
-        </entry>
-        <entry id="5cbc-545b-e63a-eca3" name="Overload Ammo" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BRB" page="89">
-          <entries/>
-          <entryGroups/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <rules/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2a56-f196-c90f-0166" name="All" book="BRB" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles/>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <links/>
-    </entryGroup>
-  </sharedEntryGroups>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5cbc-545b-e63a-eca3" name="Overload Ammo" book="BRB" page="89" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
   <sharedRules>
-    <rule id="ff3a-5fc0-452b-22d7" name="Command" hidden="false" book="BRB" page="133">
+    <rule id="ff3a-5fc0-452b-22d7" name="Command" book="BRB" page="133" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="5958-48e4-8481-41ed" name="Follow" hidden="false" book="BRB" page="133">
+    <rule id="5958-48e4-8481-41ed" name="Follow" book="BRB" page="133" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="6a72-9858-7f5e-22be" name="Hero" hidden="false" book="BRB" page="134">
+    <rule id="6a72-9858-7f5e-22be" name="Hero" book="BRB" page="134" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="d1fe-dbdc-fdd9-94c8" name="Infantry Command Unit" hidden="false" book="BRB" page="9">
+    <rule id="d1fe-dbdc-fdd9-94c8" name="Infantry Command Unit" book="BRB" page="9" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="8e57-0c0e-9630-533d" name="Infantry Unit" hidden="false" book="BRB" page="9">
+    <rule id="8e57-0c0e-9630-533d" name="Infantry Unit" book="BRB" page="9" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="3c9b-f86d-32c6-bf69" name="Infantry/Beast Unit" hidden="false" book="BRB" page="10">
+    <rule id="3c9b-f86d-32c6-bf69" name="Infantry/Beast Unit" book="BRB" page="10" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="418e-35d2-e555-d54f" name="Large" hidden="false" book="BRB" page="134">
+    <rule id="418e-35d2-e555-d54f" name="Large" book="BRB" page="134" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="1ebf-4e01-6d59-3d0f" name="Leader" hidden="false" book="BRB" page="135">
+    <rule id="1ebf-4e01-6d59-3d0f" name="Leader" book="BRB" page="135" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="5819-f10c-2a26-41a2" name="Leader 2" hidden="false" book="BRB" page="135">
+    <rule id="5819-f10c-2a26-41a2" name="Leader 2" book="BRB" page="135" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="903c-c5cd-53d4-52cc" name="Leader 3" hidden="false" book="BRB" page="135">
+    <rule id="903c-c5cd-53d4-52cc" name="Leader 3" book="BRB" page="135" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="b72c-b9d6-e702-b322" name="Limited Choice" hidden="false" book="BRB" page="158">
+    <rule id="b72c-b9d6-e702-b322" name="Limited Choice" book="BRB" page="158" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="4a4d-04f6-0073-5c53" name="MOD2" hidden="false" book="BRB" page="136">
+    <rule id="4a4d-04f6-0073-5c53" name="MOD2" book="BRB" page="136" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="7557-700d-2fc6-e203" name="MOD3" hidden="false" book="BRB" page="136">
+    <rule id="7557-700d-2fc6-e203" name="MOD3" book="BRB" page="136" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="ecb8-89fb-5d9e-2211" name="Mounted Command Unit" hidden="false" book="BRB" page="95">
+    <rule id="ecb8-89fb-5d9e-2211" name="Mounted Command Unit" book="BRB" page="95" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="02cd-3f1c-faf4-46c2" name="Mounted Unit" hidden="false" book="BRB" page="95">
+    <rule id="02cd-3f1c-faf4-46c2" name="Mounted Unit" book="BRB" page="95" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="5660-b448-a09d-5338" name="Probe Unit" hidden="false" book="BRB" page="118">
+    <rule id="5660-b448-a09d-5338" name="Probe Unit" book="BRB" page="118" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="ec07-8982-914d-8377" name="Rapid Sprint" hidden="false" book="BRB" page="136">
+    <rule id="ec07-8982-914d-8377" name="Rapid Sprint" book="BRB" page="136" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="6dc1-69d0-6655-5615" name="Shard" hidden="false" book="BRB" page="137">
+    <rule id="6dc1-69d0-6655-5615" name="Shard" book="BRB" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="7d25-d2b6-7130-a3c0" name="Slow" hidden="false" book="BRB" page="137">
+    <rule id="7d25-d2b6-7130-a3c0" name="Slow" book="BRB" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="4107-3248-4948-5e1f" name="Spotter Drone" hidden="false" book="brb" page="114">
+    <rule id="4107-3248-4948-5e1f" name="Spotter Drone" book="brb" page="114" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="8d80-a4ff-fb59-92e9" name="Transport 10" hidden="false" book="BRB" page="95">
+    <rule id="8d80-a4ff-fb59-92e9" name="Transport 10" book="BRB" page="95" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="2687-f7ac-3c1e-fb30" name="Transport 15" hidden="false" book="BRB" page="95">
+    <rule id="2687-f7ac-3c1e-fb30" name="Transport 15" book="BRB" page="95" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="eb7b-7605-9eca-cb60" name="Weapon Team Unit" hidden="false" book="BRB" page="9">
+    <rule id="eb7b-7605-9eca-cb60" name="Weapon Team Unit" book="BRB" page="9" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="587b-7c27-52f5-56a7" name="Wound" hidden="false" book="BRB" page="230">
+    <rule id="587b-7c27-52f5-56a7" name="Wound" book="BRB" page="230" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
   </sharedRules>

--- a/Concord.cat
+++ b/Concord.cat
@@ -1,2600 +1,4754 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="162d-cc8a-d6e7-6973" revision="11" gameSystemId="c339-677a-60db-4060" gameSystemRevision="0" battleScribeVersion="1.15" name="Concord" authorName="Glasvandrare / Vescarea" authorContact="tkjellberg@gmail.com" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
-  <entries>
-    <entry id="e8e7-16fc-e243-8d1a" name="C3 Drop Command Squad " points="87.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="0654-4b4e-d76b-a53d" name="&gt; Drop Commander" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="4cfa-2333-4c35-356e" name="&lt; Drop Commander Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="c5d4-0296-5bcb-6a57" name="Sling net ammo" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links/>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="a457-9075-5210-be6c" targetId="a90a-fea5-107f-a019" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="6f56-916b-f1fe-7c9b" targetId="bf65-f7cb-1b50-d144" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="1fa7-b041-f35b-d0cc" targetId="eafe-a83e-6cfd-0559" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="65d5-37a5-8e9e-bf1a" targetId="e745-6ace-c0d4-6e35" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="18b8-5fc7-c03f-bd11" targetId="af36-fa25-9ae1-e8a1" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="23a7-b767-3191-f198" targetId="0f84-f206-4f28-921f" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="d1b3-dbb7-cee4-68b5" name="Drop Trooper" points="27.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="93c9-fc99-73d8-fdc4" targetId="bf65-f7cb-1b50-d144" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="5c7c-c88f-83d8-65ea" targetId="e745-6ace-c0d4-6e35" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="5b51-0381-71d1-051e" targetId="af36-fa25-9ae1-e8a1" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="6d03-a5b2-cc25-3a13" targetId="eafe-a83e-6cfd-0559" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="be66-7c2e-8273-6f5c" targetId="1219-e29a-7fa7-a09e" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="edc6-50b7-d35f-bb72" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="7d9c-ddf6-192a-27ea" targetId="9f16-5a27-44b5-7471" linkType="entry">
-              <modifiers>
-                <modifier type="set" field="points" value="6.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="e8e7-16fc-e243-8d1a" childId="d1b3-dbb7-cee4-68b5" field="selections" type="at least" value="3.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="e8e7-16fc-e243-8d1a" childId="d1b3-dbb7-cee4-68b5" field="selections" type="at least" value="4.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="28af-cbca-4fdb-d6f1" targetId="001a-9f15-b25b-b784" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="023c-d4fc-bc70-009a" targetId="057e-2e8a-1952-9de0" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="6459-ea8a-0c57-1278" name="C3 Drop Squad" points="98.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true">
-      <entries>
-        <entry id="3f1f-e456-24f8-eb1b" name="&gt; Drop Leader" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="627f-e775-551d-a76b" name="&lt; Strike Leader Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="79ce-0083-beba-1df0" name="Sling net ammo" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links/>
-                </entry>
-              </entries>
-              <entryGroups>
-                <entryGroup id="2650-32fc-460e-4bd6" name="&lt; Leader &gt;" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="4ceb-1f08-2fa3-949f" targetId="cd4f-0ce9-a6a4-b34a" linkType="entry">
-                      <modifiers/>
-                    </link>
-                    <link id="2d54-de93-7ec5-3c73" targetId="9e56-0965-ea32-7ff4" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-              </entryGroups>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="20fe-aedb-40f2-dd77" targetId="bf65-f7cb-1b50-d144" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="49a1-e23e-1226-5ab5" targetId="eafe-a83e-6cfd-0559" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="b815-3cfe-158d-b90e" targetId="6c13-252f-55b8-4de9" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="6482-ea66-8207-de6b" targetId="e18d-8dd1-d573-930f" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="823f-b505-a915-8e27" name="Drop Trooper" points="26.0" categoryId="(No Category)" type="model" minSelections="3" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="a8e9-302c-5a56-a3c3" targetId="1219-e29a-7fa7-a09e" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="5d06-d01f-15d3-1cc4" targetId="bf65-f7cb-1b50-d144" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="b2c6-6d61-9ac9-0a04" targetId="eafe-a83e-6cfd-0559" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="7d7d-a379-286b-228e" targetId="21a7-132d-6703-9ff6" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="0742-5d15-198f-f65a" name="Plasma Lance" points="5.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="b9fe-9de2-a5c8-8160" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="ceba-7a26-f028-d93c" targetId="001a-9f15-b25b-b784" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="c959-ea81-785f-fc70" targetId="9f16-5a27-44b5-7471" linkType="entry">
-              <modifiers>
-                <modifier type="set" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="6459-ea8a-0c57-1278" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="6459-ea8a-0c57-1278" childId="823f-b505-a915-8e27" field="selections" type="at least" value="4.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="6459-ea8a-0c57-1278" childId="823f-b505-a915-8e27" field="selections" type="at least" value="5.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="6459-ea8a-0c57-1278" childId="823f-b505-a915-8e27" field="selections" type="at least" value="6.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="6459-ea8a-0c57-1278" childId="0742-5d15-198f-f65a" field="selections" type="equal to" value="2.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers>
-        <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-          <conditions>
-            <condition parentId="roster" childId="e8e7-16fc-e243-8d1a" field="selections" type="equal to" value="1.0"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="0244-6cd5-9260-c12e" name="C3 Inerceptor Command Squad" points="168.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="fa12-b792-1fff-89e3" name="&lt; Interceptor Commander" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="ce12-0c6b-11e5-f498" name="&lt; Interceptor Commander Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="bd12-7ad6-eb09-08ba" targetId="a90a-fea5-107f-a019" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="5cac-dbde-7763-5ddd" targetId="9286-cbf7-0641-5ce1" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="c8d2-d4de-e467-c706" targetId="12f1-610b-0dc9-4732" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="77c5-7b49-1b1a-443b" targetId="eafe-a83e-6cfd-0559" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="ea21-ecb8-ce22-00d3" targetId="658c-b2dd-98f4-dafb" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="8b1d-c9da-076d-d08e" name="Interceptor Trooper" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="5f70-3d2c-69d6-3b63" targetId="34f9-12c5-7e7b-114c" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="3ad9-f6de-2222-14d7" targetId="12f1-610b-0dc9-4732" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="89fc-31e3-8d85-5d84" targetId="eafe-a83e-6cfd-0559" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="18db-e7fa-3661-289b" targetId="658c-b2dd-98f4-dafb" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="aba9-6548-4d89-9d71" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="01c1-76ad-1e19-2f22" name="&lt; Compactor Drone &gt;" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="7e3a-171d-c362-06f0" targetId="c87f-f5b0-1134-8ad9" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="792d-6942-fc08-f58a" targetId="d776-f344-44a4-c41b" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <links>
-            <link id="ffb4-8366-9f3a-ce9c" targetId="001a-9f15-b25b-b784" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="f8e2-982b-dc65-9be9" targetId="7dac-aa85-fc80-51d5" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="2f44-92da-46f8-619d" name="C3 Inerceptor Squad" points="136.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="de4c-b135-70a3-c87b" name="&lt; Interceptor Leader" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="8166-a3dd-75ec-ccde" name="&lt; Interceptor Leader Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="27d8-164a-139b-f635" targetId="cd4f-0ce9-a6a4-b34a" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="0179-fa9f-3b06-4db2" targetId="12f1-610b-0dc9-4732" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="5b9e-0f99-9282-7ef1" targetId="eafe-a83e-6cfd-0559" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="dd0f-496a-c08e-56b4" targetId="658c-b2dd-98f4-dafb" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="27e0-cc93-d2c1-3dec" targetId="9ed6-e3f2-8847-d7a2" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="8783-ed89-1004-1495" name="Interceptor Trooper" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="5664-48f1-1957-c3d8" targetId="34f9-12c5-7e7b-114c" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="1c5e-3cc6-d497-2644" targetId="12f1-610b-0dc9-4732" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="1318-0d29-4a43-dd78" targetId="eafe-a83e-6cfd-0559" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="0628-7b69-d134-8ece" targetId="658c-b2dd-98f4-dafb" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="2de5-7dde-c917-f126" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="eadf-8b1d-d337-25ad" name="&lt; Compactor Drone &gt;" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="16b9-1f19-f7e7-0da5" targetId="c87f-f5b0-1134-8ad9" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="221b-0c10-d482-195e" targetId="d776-f344-44a4-c41b" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <links>
-            <link id="ca55-43e4-8b73-294c" targetId="001a-9f15-b25b-b784" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="f96c-a56c-c07e-6da4" targetId="7dac-aa85-fc80-51d5" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers>
-        <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-          <conditions>
-            <condition parentId="roster" childId="0244-6cd5-9260-c12e" field="selections" type="equal to" value="1.0"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="f53b-8cb2-f46e-ec68" name="C3 Strike Command Squad" points="66.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="9217-51b5-1490-c20f" name="&lt; Strike Commander" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="4845-6259-0e92-0f04" name="&lt; Strike Commander Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="2d9d-8454-98ba-682e" name="Sling net ammo" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links/>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="6149-c82a-e122-2d99" targetId="a90a-fea5-107f-a019" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="e5ba-45ac-5c32-8928" targetId="9686-36fa-7ae7-f4dc" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="be34-e860-46d0-d7e6" targetId="6c13-252f-55b8-4de9" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="de1c-d5c3-afcd-f486" targetId="eafe-a83e-6cfd-0559" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="691a-aa46-2b4f-a09b" targetId="bf65-f7cb-1b50-d144" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="25b4-7c4e-e579-4fee" name="Strike Trooper" points="22.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="4d3d-b808-7a51-2ddb" targetId="6688-b331-6578-fb30" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="f7b9-5bbf-7725-846a" targetId="eafe-a83e-6cfd-0559" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="4ffe-2e60-ece1-d9c4" targetId="bf65-f7cb-1b50-d144" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="67f6-07bc-f0ba-b0bd" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="d30a-66b4-b1ee-5cdd" targetId="001a-9f15-b25b-b784" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="ead8-0218-98ae-8ddd" targetId="057e-2e8a-1952-9de0" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="5aef-5d71-d3a9-8546" targetId="9f16-5a27-44b5-7471" linkType="entry">
-              <modifiers>
-                <modifier type="set" field="points" value="6.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="f53b-8cb2-f46e-ec68" childId="25b4-7c4e-e579-4fee" field="selections" type="at least" value="4.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="f53b-8cb2-f46e-ec68" childId="25b4-7c4e-e579-4fee" field="selections" type="at least" value="3.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="a2f5-7c0a-21e5-7b0b" name="C3 Strike Squad" points="32.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="3dd7-c3aa-50ca-26b2" name="Strike Trooper" points="20.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="7" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="cfe4-65fc-7598-d48f" targetId="6688-b331-6578-fb30" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="3d5b-1da9-8a1e-fdff" targetId="bf65-f7cb-1b50-d144" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="333b-de0f-7f92-165d" targetId="eafe-a83e-6cfd-0559" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="da65-0727-324a-34da" name="Plasma Lance" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="73c1-5b5c-b994-a075" targetId="21a7-132d-6703-9ff6" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="5ce3-0d5d-4909-be5b" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="826e-6c50-646d-62a2" targetId="001a-9f15-b25b-b784" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="482c-adc0-0ca1-f078" targetId="9f16-5a27-44b5-7471" linkType="entry">
-              <modifiers>
-                <modifier type="set" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="a2f5-7c0a-21e5-7b0b" incrementChildId="3dd7-c3aa-50ca-26b2" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="a2f5-7c0a-21e5-7b0b" childId="3dd7-c3aa-50ca-26b2" field="selections" type="at least" value="5.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="a2f5-7c0a-21e5-7b0b" childId="3dd7-c3aa-50ca-26b2" field="selections" type="at least" value="6.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="a2f5-7c0a-21e5-7b0b" childId="3dd7-c3aa-50ca-26b2" field="selections" type="at least" value="7.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="a2f5-7c0a-21e5-7b0b" childId="da65-0727-324a-34da" field="selections" type="at least" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="b1e3-2d2a-8b67-fc51" name="Leader" defaultEntryId="f0c2-69ee-8b90-7528" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="f0c2-69ee-8b90-7528" name="&lt; Strike Leader" points="0.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups>
-                <entryGroup id="53a6-45f6-5682-c4e8" name="&lt; Strike Leader Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries>
-                    <entry id="80e9-9314-55b5-7258" name="Sling net ammo" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                      <entries/>
-                      <entryGroups/>
-                      <modifiers/>
-                      <rules/>
-                      <profiles/>
-                      <links/>
-                    </entry>
-                  </entries>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="4631-7558-0869-977f" targetId="cd4f-0ce9-a6a4-b34a" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-              </entryGroups>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="eb5d-a6e4-347d-da46" targetId="bf65-f7cb-1b50-d144" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="b5e3-8a48-3fba-2582" targetId="eafe-a83e-6cfd-0559" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="40dd-425c-09d9-342d" targetId="6c13-252f-55b8-4de9" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="68ed-3fd5-b951-fe6f" targetId="af6e-dcdb-77a5-b67e" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="b6b5-59e8-0142-f157" name="&lt; Strike Leade Kai Lek Atastrin" points="21.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="9f91-1033-28eb-60f6" targetId="bf65-f7cb-1b50-d144" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="a807-bd9c-3407-8f70" targetId="eafe-a83e-6cfd-0559" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="8772-8d7c-d285-cc64" targetId="6c13-252f-55b8-4de9" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="39fc-3f30-ab2f-a4ac" targetId="4d7e-f31f-84d4-d57a" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="37f1-afbf-0787-df72" name="C3 Support Team" points="10.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="6fd3-42ff-1e26-f82f" name="&lt; Strike Trooper Crew" points="15.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="9b44-134d-0947-ad18" targetId="ce28-e8fe-4290-f477" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="ab45-bb28-303d-7786" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="db05-8d5e-8d36-69a0" targetId="001a-9f15-b25b-b784" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="cc63-9a66-9dd6-3de7" targetId="3ac2-e4a6-9011-4985" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="37e9-4c4d-d67c-19ac" name="&lt; Promote &gt;" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="e31e-cc34-f520-8f22" targetId="cd4f-0ce9-a6a4-b34a" linkType="entry">
-              <modifiers>
-                <modifier type="set" field="points" value="20.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="87e7-1804-a911-dd27" targetId="41bd-5499-889a-ab16" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="a579-d4e9-1656-152c" name="&lt; Weapon Options &gt; " defaultEntryId="0bfa-efdd-8bd7-0f3a" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="7437-7bc1-490a-6628" targetId="10e6-b49c-4401-a1cd" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="0bfa-efdd-8bd7-0f3a" targetId="afc8-4f62-e1e2-1e4c" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="65ed-1aa6-1ac1-fef1" profileTypeId="1650-77b3-10d1-6406" name="Strike Trooper crew Leader" hidden="true">
-          <characteristics>
-            <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-            <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-            <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-            <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(7)"/>
-            <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-            <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-            <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Leader"/>
-          </characteristics>
-          <modifiers>
-            <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions>
-                <condition parentId="37f1-afbf-0787-df72" childId="e31e-cc34-f520-8f22" field="selections" type="equal to" value="1.0"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="show" field="cf30-f234-691c-47bd" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition parentId="37f1-afbf-0787-df72" childId="cd4f-0ce9-a6a4-b34a" field="selections" type="equal to" value="1.0"/>
-                    <condition parentId="37f1-afbf-0787-df72" childId="41bd-5499-889a-ab16" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="48b0-cf3d-3699-f8a3" name="C3 Support Team with Plasma Bombard" points="75.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="0d6a-0bd6-38ee-e3b2" name="&lt; Strike Trooper Crew" points="15.0" categoryId="(No Category)" type="model" minSelections="3" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="9ad4-375b-4388-7a6e" targetId="ce28-e8fe-4290-f477" linkType="profile">
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Large, Slow" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="b6de-5168-e608-a911" targetId="2f22-37fa-4076-d255" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="e4f5-f5f9-3728-2c55" targetId="bf65-f7cb-1b50-d144" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="b4fb-8d86-82bb-335d" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="c254-b4a0-5dc9-ed34" targetId="001a-9f15-b25b-b784" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="2f8e-78f4-d6ec-ed5b" targetId="3ac2-e4a6-9011-4985" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="6850-687d-e5a8-d9b1" name="&lt; Promote &gt;" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="8673-cdb1-4966-8463" targetId="cd4f-0ce9-a6a4-b34a" linkType="entry">
-              <modifiers>
-                <modifier type="set" field="points" value="20.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="68f5-c9b8-b86f-2e3e" targetId="41bd-5499-889a-ab16" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="b8eb-6958-badc-9897" profileTypeId="1650-77b3-10d1-6406" name="Strike Trooper crew Leader" hidden="true">
-          <characteristics>
-            <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-            <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-            <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-            <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(7)"/>
-            <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-            <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-            <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Leader"/>
-          </characteristics>
-          <modifiers>
-            <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions>
-                <condition parentId="48b0-cf3d-3699-f8a3" childId="8673-cdb1-4966-8463" field="selections" type="equal to" value="1.0"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="show" field="cf30-f234-691c-47bd" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition parentId="48b0-cf3d-3699-f8a3" childId="68f5-c9b8-b86f-2e3e" field="selections" type="equal to" value="1.0"/>
-                    <condition parentId="48b0-cf3d-3699-f8a3" childId="8673-cdb1-4966-8463" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-        </profile>
-      </profiles>
-      <links>
-        <link id="f37b-47c7-bddc-6bbe" targetId="e16f-acd1-265c-07f9" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="2b4a-afa0-4d3a-91da" targetId="1bc9-ce44-fdbe-ef90" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="50dc-8c05-18ca-21fd" name="C3 Support Team with X-Howitzer" points="65.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="2128-0f7e-a018-741c" name="&lt; Strike Trooper Crew" points="15.0" categoryId="(No Category)" type="model" minSelections="3" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="8fcd-aca2-3e34-86d5" targetId="ce28-e8fe-4290-f477" linkType="profile">
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Large, Slow" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="a432-4162-50cd-9141" targetId="2f22-37fa-4076-d255" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="b06e-1486-b609-2b22" targetId="bf65-f7cb-1b50-d144" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="5ec4-75b0-1c8b-ffb9" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="a0f9-f70a-57b7-afb5" targetId="001a-9f15-b25b-b784" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="3b25-3924-3cb4-8684" targetId="3ac2-e4a6-9011-4985" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="c595-3b46-4549-eb2a" name="&lt; Promote &gt;" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="4072-bde7-2e1d-c785" targetId="cd4f-0ce9-a6a4-b34a" linkType="entry">
-              <modifiers>
-                <modifier type="set" field="points" value="20.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="90e3-3446-28a3-e602" targetId="41bd-5499-889a-ab16" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="2d4e-a3f4-fe14-5878" profileTypeId="1650-77b3-10d1-6406" name="Strike Trooper crew Leader" hidden="true">
-          <characteristics>
-            <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-            <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-            <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-            <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(7)"/>
-            <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-            <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-            <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Leader"/>
-          </characteristics>
-          <modifiers>
-            <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions>
-                <condition parentId="50dc-8c05-18ca-21fd" childId="4072-bde7-2e1d-c785" field="selections" type="equal to" value="1.0"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="show" field="cf30-f234-691c-47bd" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition parentId="50dc-8c05-18ca-21fd" childId="4072-bde7-2e1d-c785" field="selections" type="equal to" value="1.0"/>
-                    <condition parentId="50dc-8c05-18ca-21fd" childId="90e3-3446-28a3-e602" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-        </profile>
-      </profiles>
-      <links>
-        <link id="b4ea-cc3f-579f-5e09" targetId="e16f-acd1-265c-07f9" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="443c-3093-f104-6df7" targetId="e2b4-a034-c8ce-e376" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="d626-a99a-6470-71ad" name="C3D1 Light Support Drone " points="0.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="37d5-656f-d5c1-4397" name="&lt; Weapon Drone" points="59.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="7f94-248b-3341-8ab0" targetId="18f2-0352-9cf8-66a5" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="cf0a-fdfc-c22e-fadb" name="&lt; Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="b508-d3f3-6f27-4975" targetId="001a-9f15-b25b-b784" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="50fc-d0da-6514-b4dd" targetId="3ac2-e4a6-9011-4985" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="e89f-034f-fda6-f951" targetId="5ed8-6bd4-d0f7-d7f0" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="4da3-5d4c-1262-53ab" name="&lt; Weapon Drone Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="c7a3-afb1-fa42-b4d3" targetId="8c55-0529-22ab-3fa6" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="maxSelections" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="d626-a99a-6470-71ad" childId="37d5-656f-d5c1-4397" field="selections" type="greater than" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="f089-4381-fa63-0074" targetId="c74e-2993-3474-7869" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="8bdd-d11f-ed0d-dac8" name="C3D1/GP Light General Purpose Drone" points="0.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="">
-      <entries>
-        <entry id="0fa5-4678-1a3f-decf" name="&lt; GP Drone" points="20.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="0411-749e-e748-cb7e" name="&lt; Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="418e-8281-9f52-5710" targetId="001a-9f15-b25b-b784" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="07b5-6bbe-485f-fa1d" targetId="3ac2-e4a6-9011-4985" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="b3d1-0620-3de8-f5b9" targetId="5ed8-6bd4-d0f7-d7f0" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="8c08-5e2f-7fda-f019" targetId="8c55-0529-22ab-3fa6" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="92b5-4abb-5821-b649" targetId="76e8-05d6-ff37-7205" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="0f76-aef5-4eed-fb15" targetId="f9ce-3eb5-0335-1b53" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="3601-a65d-7f14-cf86" name="C3D2 Medium Support Drone " points="0.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="156e-1f5a-b7e7-1783" name="&lt; Weapon Drone" points="93.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="bca1-3c81-da93-aefb" targetId="be8e-2c8f-8288-e92a" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="86e7-9193-c4cf-b4c7" name="&lt; Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="0f08-649f-cdb0-8d16" targetId="001a-9f15-b25b-b784" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="a405-a61d-2eb0-1e80" targetId="3ac2-e4a6-9011-4985" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="f787-39f9-566b-e5ff" targetId="5ed8-6bd4-d0f7-d7f0" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="f298-b1a6-4486-7b3a" name="&lt; Weapon Drone Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="34a7-a9ba-8af3-becb" name="&lt; Weapon Option &gt;" defaultEntryId="d929-5f73-e58b-90d8" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="d929-5f73-e58b-90d8" targetId="62c2-106a-28aa-6cf5" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="907e-68db-aaaf-9a2f" targetId="90ca-6c03-a803-a140" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="b25e-f181-2b5c-7cc4" targetId="6ded-5798-dd23-8e6f" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="2100-0b04-3ec7-174f" targetId="5a7d-3845-90ba-32eb" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <links>
-            <link id="4064-6c5e-df77-f08e" targetId="8c55-0529-22ab-3fa6" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="a829-1685-c4b5-55b6" name="C3M25 Heavy Combat Drone " points="0.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="9432-f296-0817-a41e" name="&lt; Heavy Combat Drone" points="418.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="52d9-2f82-4813-deb1" targetId="1c7c-b76a-8d9f-4405" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="fc27-7742-3460-32c5" targetId="c74e-2993-3474-7869" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="ba92-e188-5152-68a3" name="&lt; Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="25d4-fe83-5977-2551" targetId="001a-9f15-b25b-b784" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="3866-b4ff-b88f-c46f" targetId="2750-e65f-4c66-8235" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="2bbd-905d-dab7-121e" targetId="5ed8-6bd4-d0f7-d7f0" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="232d-2ec2-4ebb-33e8" name="&lt; Weapon Drone Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="ab1d-b82e-4fa4-af4b" name="&lt; Weapon Option &gt;" defaultEntryId="1f48-758b-70a2-1b46" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="a48c-1f8a-649a-6c31" targetId="c521-ffae-2a9d-88f9" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="1f48-758b-70a2-1b46" targetId="1bc9-ce44-fdbe-ef90" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <links>
-            <link id="c984-ceed-ca03-2965" targetId="8c55-0529-22ab-3fa6" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="3440-9714-d7d3-3653" name="C3M4 Combat Drone " points="249.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="c49a-cae5-0917-dff0" name="&lt; Weapon Drone" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="9c84-78ff-fad3-093b" targetId="eda1-434f-1771-a790" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="5980-fadb-0d1a-8e4b" name="&lt; Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="1015-29dc-212b-dc4d" targetId="001a-9f15-b25b-b784" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="5087-2dc6-723c-788e" targetId="2750-e65f-4c66-8235" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="4ea5-d717-39c9-e705" targetId="5ed8-6bd4-d0f7-d7f0" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="91d2-c0ae-c028-4591" name="&lt; Weapon Drone Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="fb98-64e6-ce83-57f9" name="&lt; Weapon Option &gt;" defaultEntryId="d8ef-55c7-2efb-ec04" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="6062-8f75-90de-9604" targetId="69d9-b84f-3c40-15fb" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="d0f0-9069-c124-7cd2" targetId="80bf-613e-52b4-f160" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="d8ef-55c7-2efb-ec04" targetId="3dfc-49e9-adcb-ae48" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <links>
-            <link id="04e7-e796-57e1-9c2e" targetId="8c55-0529-22ab-3fa6" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="ad84-1f7d-5b85-ad4a" targetId="e16f-acd1-265c-07f9" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="7d08-c97c-53ca-06ab" targetId="c74e-2993-3474-7869" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="9974-fc89-ef4b-59fe" name="C3M50 Heavy Support Drone " points="0.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="e948-5e36-fc7b-117e" name="&lt; Heavy Support Drone" points="418.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="28a5-2f84-29d4-5268" targetId="684e-ba3e-5aab-8be8" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="3a35-6d29-813c-6f2d" targetId="c74e-2993-3474-7869" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="d5e6-baf3-9376-d799" name="&lt; Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="cf51-b375-0b07-78ee" targetId="001a-9f15-b25b-b784" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="678e-362c-18b7-85e3" targetId="2750-e65f-4c66-8235" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="08b2-7bd2-ff20-2816" targetId="5ed8-6bd4-d0f7-d7f0" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="9794-aafd-9485-ca7f" name="&lt; Weapon Drone Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="70e3-44c8-f73e-4efe" name="&lt; Weapon Option &gt;" defaultEntryId="19fa-61bc-edea-8bb1" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="19fa-61bc-edea-8bb1" targetId="85bd-3565-8ecd-a94f" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="bf9f-7390-760a-cdb7" targetId="f482-b1f7-5e3a-1960" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="79bf-4d00-2ddc-738c" targetId="eb71-6245-efd5-67c9" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <links>
-            <link id="fbca-0758-1e93-c627" targetId="8c55-0529-22ab-3fa6" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="c4d4-9418-6246-d85d" name="C3T7 Transporter Drone " points="194.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="288e-be87-ca44-03e8" name="&lt; Transporter Drone" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="87f0-50e3-da01-55f0" targetId="1aa8-c7f2-fa2d-324a" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="460e-6cab-a7b9-878c" name="&lt; Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="9543-75e4-e4b2-ca03" targetId="001a-9f15-b25b-b784" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="03eb-ebb9-cdf3-ec98" targetId="3ac2-e4a6-9011-4985" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="b6d4-1bbf-8e0d-d2ac" targetId="5ed8-6bd4-d0f7-d7f0" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="c909-6003-f9c2-386e" name="&lt; Transporter Drone Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="daf1-967b-4024-7ec8" targetId="8c55-0529-22ab-3fa6" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="fb4e-c4f1-715d-c497" targetId="c74e-2993-3474-7869" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="6880-209f-8a1d-66e0" name="Commander Kamrana Josen" points="116.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="f086-dae6-6909-f7de" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="008d-8ba9-1c63-93b5" name="Strike Trooper" points="22.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="e57d-104e-c987-6e7a" targetId="6688-b331-6578-fb30" linkType="profile">
-                  <modifiers/>
-                </link>
-                <link id="ac02-ab26-6f62-e9fc" targetId="bf65-f7cb-1b50-d144" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="52f5-a617-55f3-24aa" targetId="eafe-a83e-6cfd-0559" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="4a2c-44b8-d548-19f4" targetId="001a-9f15-b25b-b784" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="1947-c19e-f8e5-1439" targetId="9f16-5a27-44b5-7471" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="6880-209f-8a1d-66e0" incrementChildId="008d-8ba9-1c63-93b5" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="6880-209f-8a1d-66e0" childId="f7e5-aff8-59a3-fb0d" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="7d36-9ad2-0909-dddf" name="&lt; Commander Options &gt; " minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="f7e5-aff8-59a3-fb0d" name="Plasma Grenade Bandoliers" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers>
-                <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="6880-209f-8a1d-66e0" childId="1947-c19e-f8e5-1439" field="selections" type="at least" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="4d4b-85f0-9e35-d04d" targetId="92a3-aaae-bc24-0d2d" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="6030-d671-9f86-c945" name="Jurry-Rigged HL Booster" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="53eb-6d1b-6804-c1e0" targetId="bf65-f7cb-1b50-d144" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="971d-3652-33ec-641a" targetId="eafe-a83e-6cfd-0559" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="182f-8079-ec5a-498b" targetId="218d-189c-09c7-3b45" linkType="profile">
-          <modifiers>
-            <modifier type="set" field="f214-abe8-c922-c51b" value="5(8)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions>
-                <condition parentId="6880-209f-8a1d-66e0" childId="6030-d671-9f86-c945" field="selections" type="equal to" value="1.0"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-      </links>
-    </entry>
-    <entry id="fcb7-7abc-470a-26fe" name="Medi-Probe Shard" points="0.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="c7bd-920e-b6e5-ef99" name="&lt; Medi-probe" points="10.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="d758-744a-7ac4-7804" targetId="078e-4753-3545-ba51" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="6429-1b89-b557-736b" name="NuHu Mandarin" points="164.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="ae11-f605-d815-9109" name="&lt; Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="6fd3-49ff-c60c-3624" targetId="f095-7ba3-b868-32de" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="bb6a-48bd-2cf1-f430" targetId="057e-2e8a-1952-9de0" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="775b-177d-e6ac-c3ac" targetId="5ed8-6bd4-d0f7-d7f0" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="2523-96e0-03f8-2625" targetId="5343-3c10-ccc3-0233" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="6fd9-afd5-d70f-d751" targetId="41d1-a002-0258-c407" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="1133-9cc8-d005-ca82" targetId="a2e9-2b00-2191-a410" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="7780-9268-8805-991a" name="Scout Probe Shard" points="0.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="275e-c158-8f26-53c9" name="&lt; Scout Probe" points="10.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="05b3-477e-3ab6-c2a4" targetId="56b9-5224-e0df-8218" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="2fa1-035d-c0c1-e653" name="Target Probe Shard" points="0.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="70f6-51e9-f4f6-761f" name="&lt; Target Probe" points="5.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="ec43-8043-3ccc-fe21" targetId="9ce3-1277-65a2-7ab0" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-  </entries>
+<catalogue id="162d-cc8a-d6e7-6973" name="Concord" revision="12" battleScribeVersion="2.00" authorName="Glasvandrare / Vescarea" authorContact="tkjellberg@gmail.com" gameSystemId="c339-677a-60db-4060" gameSystemRevision="0" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <profiles/>
   <rules/>
-  <links/>
-  <sharedEntries>
-    <entry id="e745-6ace-c0d4-6e35" name="AG Chute (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
+  <infoLinks/>
+  <costTypes/>
+  <profileTypes/>
+  <forceEntries/>
+  <selectionEntries>
+    <selectionEntry id="e8e7-16fc-e243-8d1a" name="C3 Drop Command Squad " hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="3ac2-e4a6-9011-4985" name="Batter Drone" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="2750-e65f-4c66-8235" name="Batter Drone (2)" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
+      <infoLinks/>
       <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="c87f-f5b0-1134-8ad9" name="Compactor Drone" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="d776-f344-44a4-c41b" name="Compactor Drone with Compacted Plasma Cannon" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="b2e8-9d64-9d68-23e5" targetId="ffe9-0b4e-fc35-d442" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="c521-ffae-2a9d-88f9" name="Compression Bombard" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="a79e-c4ad-b89d-ac26" targetId="a854-0768-aa9e-8d94" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="6ded-5798-dd23-8e6f" name="Compression Cannon" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="80bf-613e-52b4-f160" name="Compression Cannon" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="f482-b1f7-5e3a-1960" name="Fractal Bombard" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="9156-5e49-d0a8-7993" targetId="cfed-0e3a-38c7-9618" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="90ca-6c03-a803-a140" name="Fractal Cannon" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="bc22-c5b0-170a-0ca8" targetId="e262-8ce4-a7d5-4d81" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="69d9-b84f-3c40-15fb" name="Fractal Cannon" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="4a79-2c10-c161-2234" targetId="e262-8ce4-a7d5-4d81" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="5343-3c10-ccc3-0233" name="Gun Drone (2)" points="14.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="bf65-f7cb-1b50-d144" name="HL Armour (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="12f1-610b-0dc9-4732" name="HL Armour Boost (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="c7a8-840b-096e-e2b8" name="IMTeL Stave (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="658c-b2dd-98f4-dafb" name="Interceptor Bike with Twin Plasma Carbines" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="41bd-5499-889a-ab16" name="Leader" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="cd4f-0ce9-a6a4-b34a" name="Leader 2" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="a90a-fea5-107f-a019" name="Leader 3" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="9e56-0965-ea32-7ff4" name="Leader 3" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="eb71-6245-efd5-67c9" name="Mag Mortar" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="0e6a-0256-18e1-20af" name="&lt; Munition &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="a356-4661-a11e-41b8" name="Scrambler" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="0654-4b4e-d76b-a53d" name="&gt; Drop Commander" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="23a7-b767-3191-f198" hidden="false" targetId="0f84-f206-4f28-921f" type="profile">
               <profiles/>
-              <links/>
-            </entry>
-            <entry id="a24b-a381-fb00-eb9f" name="Arc" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
               <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-            <entry id="3925-0866-3aea-e356" name="Blur" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+              <infoLinks/>
               <modifiers/>
-              <rules/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="4cfa-2333-4c35-356e" name="&lt; Drop Commander Options &gt;" hidden="false" collective="false">
               <profiles/>
-              <links/>
-            </entry>
-            <entry id="0afe-04ff-398b-3496" name="Scoot" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <rules/>
+              <constraints/>
+              <selectionEntries>
+                <selectionEntry id="c5d4-0296-5bcb-6a57" name="Sling net ammo" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="a457-9075-5210-be6c" hidden="false" targetId="a90a-fea5-107f-a019" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="6f56-916b-f1fe-7c9b" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
               <profiles/>
-              <links/>
-            </entry>
-            <entry id="5271-6bc1-1ad7-e9ba" name="Net " points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <rules/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="1fa7-b041-f35b-d0cc" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
               <profiles/>
-              <links/>
-            </entry>
-            <entry id="1cd3-e444-8b62-dc9b" name="All" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <rules/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="65d5-37a5-8e9e-bf1a" hidden="false" targetId="e745-6ace-c0d4-6e35" type="selectionEntry">
               <profiles/>
-              <links/>
-            </entry>
-            <entry id="4d2c-7d84-fe17-0c8f" name="Grip" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <rules/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="18b8-5fc7-c03f-bd11" hidden="false" targetId="af36-fa25-9ae1-e8a1" type="selectionEntry">
               <profiles/>
-              <links/>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="9df9-40f7-3d08-b560" targetId="5ba2-ac85-01a5-31be" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="057e-2e8a-1952-9de0" name="Medi-Drone" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="a2e9-2b00-2191-a410" name="Nano Drone (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="1bc9-ce44-fdbe-ef90" name="Plasma Bombard (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="c3b5-10fe-6527-f82f" targetId="581f-ff61-2525-a4b4" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="10e6-b49c-4401-a1cd" name="Plasma Cannon" points="35.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="d5c2-2c99-c6f0-8b8e" targetId="ffe9-0b4e-fc35-d442" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="5a7d-3845-90ba-32eb" name="Plasma Cannon" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="96a4-2cce-4307-8f7b" targetId="ffe9-0b4e-fc35-d442" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="3dfc-49e9-adcb-ae48" name="Plasma Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="95ff-37b4-8a0c-72d9" targetId="ffe9-0b4e-fc35-d442" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="eafe-a83e-6cfd-0559" name="Plasma Carbine (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="a184-65ab-58d9-e876" targetId="4c0f-9a37-2cd9-3f28" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="fb83-6166-8d22-f6e2" targetId="acdc-a95e-a973-0c70" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="9f16-5a27-44b5-7471" name="Plasma Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="ae6b-5d5f-8311-739e" targetId="9c65-fbf8-41f5-47be" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="3dd4-3b5c-6873-e8f2" name="Plasma Lance" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="7122-7702-547f-efa1" targetId="3376-2497-6739-ec52" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="cc9d-d4f8-59db-be3c" targetId="db92-0aca-cde3-4d2d" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="6d1e-8151-bd04-c247" targetId="19f6-390a-0d7c-8acb" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="7dac-aa85-fc80-51d5" name="Plasma Lance (Bike)" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="95fd-068f-3527-ff41" targetId="3376-2497-6739-ec52" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="3303-cedc-7f35-8d8c" targetId="db92-0aca-cde3-4d2d" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="8d2b-05f1-d035-fca6" targetId="19f6-390a-0d7c-8acb" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="21a7-132d-6703-9ff6" name="Plasma Lance (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="eae9-4fdc-d5ae-f150" targetId="3376-2497-6739-ec52" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="44f0-8649-d04a-801b" targetId="db92-0aca-cde3-4d2d" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="e52e-5001-8214-66e6" targetId="19f6-390a-0d7c-8acb" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="62c2-106a-28aa-6cf5" name="Plasma Light Support Gun" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="7d58-9532-baa3-0f50" targetId="2940-5bc4-f1ca-b78c" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="c74e-2993-3474-7869" name="Plasma Light Support Gun (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="f652-56d4-3777-5ff0" targetId="2940-5bc4-f1ca-b78c" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="2f22-37fa-4076-d255" name="Plasma Pistol (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="f9da-9df8-37a5-92ff" targetId="23fa-052e-36db-13a3" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="8c55-0529-22ab-3fa6" name="Self Repair" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="de46-fbd5-d8f5-7454" name="Shield Drone " points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="5ed8-6bd4-d0f7-d7f0" name="Shield Drone (2)" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="001a-9f15-b25b-b784" name="Spotter Drone " points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="f095-7ba3-b868-32de" name="Spotter Drone (2)" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="e16f-acd1-265c-07f9" name="Spotter Drone (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="af36-fa25-9ae1-e8a1" name="Sub-M. X-Sling (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="76e8-05d6-ff37-7205" name="Subverter Matrix" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="e2b4-a034-c8ce-e376" name="X-Howitzer (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="4b18-33b8-84e0-5c2e" name="&lt; Munitions &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="c518-dc83-0b3b-d5d0" name="Scrambler" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <rules/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d1b3-dbb7-cee4-68b5" name="Drop Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="be66-7c2e-8273-6f5c" hidden="false" targetId="1219-e29a-7fa7-a09e" type="profile">
               <profiles/>
-              <links>
-                <link id="4f17-4153-49e1-f6dc" targetId="0a09-eb21-a6c6-ad31" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="16ea-fdb9-4f62-644a" name="Arc" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="a50f-9b72-3685-ce99" targetId="4052-0eb4-88d7-cab0" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="d695-e1d4-70ad-ab44" name="Blur" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="e23c-a9f0-0a42-b621" targetId="1373-7755-bef3-50d6" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="8a3f-6c9d-84ab-7ff7" name="Scoot" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="5e49-ad1b-3c02-c442" targetId="f2cb-33fd-610a-eda3" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="f919-51c2-e1f0-fa33" name="Net" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="5eb1-95d1-6117-e8d2" targetId="b81d-9f77-4c39-3887" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="6967-929f-0dac-4c2e" name="Grip" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="a1ce-1d22-c641-6d9d" targetId="053b-a389-59c4-0e00" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="f58f-7571-0bda-13b5" name="All" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="c003-c2b5-f035-4444" targetId="4052-0eb4-88d7-cab0" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="2b2f-ad1c-6533-e2d7" targetId="1373-7755-bef3-50d6" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="7cae-5b3f-2e71-6e33" targetId="053b-a389-59c4-0e00" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="be82-4f21-bf38-ae68" targetId="b81d-9f77-4c39-3887" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="ebcd-e2be-4841-8020" targetId="f2cb-33fd-610a-eda3" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="5bab-a371-53ed-88d2" targetId="0a09-eb21-a6c6-ad31" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="93c9-fc99-73d8-fdc4" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="5c7c-c88f-83d8-65ea" hidden="false" targetId="e745-6ace-c0d4-6e35" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="5b51-0381-71d1-051e" hidden="false" targetId="af36-fa25-9ae1-e8a1" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="6d03-a5b2-cc25-3a13" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="27.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="edc6-50b7-d35f-bb72" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="7d9c-ddf6-192a-27ea" hidden="false" targetId="9f16-5a27-44b5-7471" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="6.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="e8e7-16fc-e243-8d1a" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d1b3-dbb7-cee4-68b5" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="e8e7-16fc-e243-8d1a" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d1b3-dbb7-cee4-68b5" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="28af-cbca-4fdb-d6f1" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="023c-d4fc-bc70-009a" hidden="false" targetId="057e-2e8a-1952-9de0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="87.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6459-ea8a-0c57-1278" name="C3 Drop Squad" hidden="true" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
       <profiles/>
-      <links>
-        <link id="a4a1-491f-e195-4e0d" targetId="d0b6-5e2a-243d-b6ea" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="85bd-3565-8ecd-a94f" name="X-Howitzer (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="4473-5846-9144-3ed7" name="&lt; Munitions &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="869a-d024-f01b-902a" name="Scrambler" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="538e-8399-5fd9-972e" targetId="0a09-eb21-a6c6-ad31" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="09ad-e164-6041-3e77" name="Arc" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="c58d-a6d9-f53f-bf5d" targetId="4052-0eb4-88d7-cab0" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="aa49-b3f4-5d76-5b99" name="Blur" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="e8ea-4904-644f-2434" targetId="1373-7755-bef3-50d6" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="b9f0-d72f-1cf6-a855" name="Scoot" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="1eac-780b-e921-e0cf" targetId="f2cb-33fd-610a-eda3" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="a1b1-9170-9e10-fa54" name="Net" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="e95f-1bbe-70fb-e3cd" targetId="b81d-9f77-4c39-3887" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="b4ec-d02c-b3b1-e937" name="Grip" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="6e15-34d7-c75e-912d" targetId="053b-a389-59c4-0e00" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="6fb5-f33d-8fcc-5d00" name="All" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="4674-2dd7-fa1b-a44b" targetId="4052-0eb4-88d7-cab0" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="c46e-1126-4846-466d" targetId="1373-7755-bef3-50d6" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="b5e5-b58a-0bab-51af" targetId="053b-a389-59c4-0e00" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="4349-8848-6641-8a17" targetId="b81d-9f77-4c39-3887" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="af57-f563-f84f-2c9a" targetId="f2cb-33fd-610a-eda3" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="b5da-6f53-11d9-af5a" targetId="0a09-eb21-a6c6-ad31" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8e7-16fc-e243-8d1a" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="3f1f-e456-24f8-eb1b" name="&gt; Drop Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="6482-ea66-8207-de6b" hidden="false" targetId="e18d-8dd1-d573-930f" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="627f-e775-551d-a76b" name="&lt; Strike Leader Options &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <selectionEntries>
+                <selectionEntry id="79ce-0083-beba-1df0" name="Sling net ammo" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="2650-32fc-460e-4bd6" name="&lt; Leader &gt;" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="4ceb-1f08-2fa3-949f" hidden="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                    <entryLink id="2d54-de93-7ec5-3c73" hidden="false" targetId="9e56-0965-ea32-7ff4" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="20fe-aedb-40f2-dd77" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="49a1-e23e-1226-5ab5" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="b815-3cfe-158d-b90e" hidden="false" targetId="6c13-252f-55b8-4de9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="823f-b505-a915-8e27" name="Drop Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="a8e9-302c-5a56-a3c3" hidden="false" targetId="1219-e29a-7fa7-a09e" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="5d06-d01f-15d3-1cc4" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="b2c6-6d61-9ac9-0a04" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="7d7d-a379-286b-228e" hidden="false" targetId="21a7-132d-6703-9ff6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="26.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0742-5d15-198f-f65a" name="Plasma Lance" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="b9fe-9de2-a5c8-8160" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="ceba-7a26-f028-d93c" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="c959-ea81-785f-fc70" hidden="false" targetId="9f16-5a27-44b5-7471" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="6459-ea8a-0c57-1278" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="823f-b505-a915-8e27" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="6459-ea8a-0c57-1278" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="823f-b505-a915-8e27" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="6459-ea8a-0c57-1278" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="823f-b505-a915-8e27" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="6459-ea8a-0c57-1278" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0742-5d15-198f-f65a" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="98.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0244-6cd5-9260-c12e" name="C3 Interceptor Command Squad" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
       <profiles/>
-      <links>
-        <link id="9d54-86cf-f28d-a5ef" targetId="d0b6-5e2a-243d-b6ea" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="afc8-4f62-e1e2-1e4c" name="X-Launcher (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="c249-3049-66be-c18b" name="&lt; Munitions &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="855b-3877-638b-99e8" name="Scrambler" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="594f-82ff-5ad7-c68d" targetId="0a09-eb21-a6c6-ad31" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="cf1c-5cab-dced-a300" name="Arc" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="8bce-b783-3ffc-92aa" targetId="4052-0eb4-88d7-cab0" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="bed3-8a4c-71e0-9a86" name="Blur" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="9be8-c879-a109-2f53" targetId="1373-7755-bef3-50d6" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="7207-1027-8e26-6930" name="Scoot" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="9bd6-49f8-24e5-7631" targetId="f2cb-33fd-610a-eda3" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="9b37-d7f7-9bb7-6061" name="Net" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="d053-1be2-c8f4-3f6c" targetId="b81d-9f77-4c39-3887" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="f569-f291-bc3a-fa3a" name="Grip" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="3be2-c872-ad5c-35f7" targetId="053b-a389-59c4-0e00" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="a6d2-1391-22e8-008b" name="All" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="1741-ddc1-2f5f-3ff2" targetId="4052-0eb4-88d7-cab0" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="b229-c301-4b0d-2ccd" targetId="1373-7755-bef3-50d6" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="c3df-d0d2-6144-d3f9" targetId="053b-a389-59c4-0e00" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="ed17-cff8-54c6-cf4d" targetId="b81d-9f77-4c39-3887" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="ff70-9ddf-025e-0a2d" targetId="f2cb-33fd-610a-eda3" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="3125-0cd8-92ea-7904" targetId="0a09-eb21-a6c6-ad31" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
       <rules/>
-      <profiles/>
-      <links>
-        <link id="d588-2e56-e502-10ec" targetId="b984-90ae-a8e5-83c8" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="6c13-252f-55b8-4de9" name="X-Sling (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
+      <infoLinks/>
       <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="2d1d-7464-b34a-31f5" targetId="7c13-1aa1-5557-6103" linkType="profile">
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="fa12-b792-1fff-89e3" name="&lt; Interceptor Commander" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="5cac-dbde-7763-5ddd" hidden="false" targetId="9286-cbf7-0641-5ce1" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-  </sharedEntries>
-  <sharedEntryGroups/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="ce12-0c6b-11e5-f498" name="&lt; Interceptor Commander Options &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="bd12-7ad6-eb09-08ba" hidden="false" targetId="a90a-fea5-107f-a019" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="c8d2-d4de-e467-c706" hidden="false" targetId="12f1-610b-0dc9-4732" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="77c5-7b49-1b1a-443b" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="ea21-ecb8-ce22-00d3" hidden="false" targetId="658c-b2dd-98f4-dafb" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8b1d-c9da-076d-d08e" name="Interceptor Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="5f70-3d2c-69d6-3b63" hidden="false" targetId="34f9-12c5-7e7b-114c" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="3ad9-f6de-2222-14d7" hidden="false" targetId="12f1-610b-0dc9-4732" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="89fc-31e3-8d85-5d84" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="18db-e7fa-3661-289b" hidden="false" targetId="658c-b2dd-98f4-dafb" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="aba9-6548-4d89-9d71" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="01c1-76ad-1e19-2f22" name="&lt; Compactor Drone &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="7e3a-171d-c362-06f0" hidden="false" targetId="c87f-f5b0-1134-8ad9" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="792d-6942-fc08-f58a" hidden="false" targetId="d776-f344-44a4-c41b" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="ffb4-8366-9f3a-ce9c" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="f8e2-982b-dc65-9be9" hidden="false" targetId="7dac-aa85-fc80-51d5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="168.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2f44-92da-46f8-619d" name="C3 Interceptor Squad" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0244-6cd5-9260-c12e" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="de4c-b135-70a3-c87b" name="&lt; Interceptor Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="27e0-cc93-d2c1-3dec" hidden="false" targetId="9ed6-e3f2-8847-d7a2" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="8166-a3dd-75ec-ccde" name="&lt; Interceptor Leader Options &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="27d8-164a-139b-f635" hidden="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="0179-fa9f-3b06-4db2" hidden="false" targetId="12f1-610b-0dc9-4732" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="5b9e-0f99-9282-7ef1" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="dd0f-496a-c08e-56b4" hidden="false" targetId="658c-b2dd-98f4-dafb" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8783-ed89-1004-1495" name="Interceptor Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="5664-48f1-1957-c3d8" hidden="false" targetId="34f9-12c5-7e7b-114c" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="1c5e-3cc6-d497-2644" hidden="false" targetId="12f1-610b-0dc9-4732" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="1318-0d29-4a43-dd78" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="0628-7b69-d134-8ece" hidden="false" targetId="658c-b2dd-98f4-dafb" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2de5-7dde-c917-f126" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="eadf-8b1d-d337-25ad" name="&lt; Compactor Drone &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="16b9-1f19-f7e7-0da5" hidden="false" targetId="c87f-f5b0-1134-8ad9" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="221b-0c10-d482-195e" hidden="false" targetId="d776-f344-44a4-c41b" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="ca55-43e4-8b73-294c" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="f96c-a56c-c07e-6da4" hidden="false" targetId="7dac-aa85-fc80-51d5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="136.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f53b-8cb2-f46e-ec68" name="C3 Strike Command Squad" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="9217-51b5-1490-c20f" name="&lt; Strike Commander" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="e5ba-45ac-5c32-8928" hidden="false" targetId="9686-36fa-7ae7-f4dc" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="4845-6259-0e92-0f04" name="&lt; Strike Commander Options &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <selectionEntries>
+                <selectionEntry id="2d9d-8454-98ba-682e" name="Sling net ammo" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="6149-c82a-e122-2d99" hidden="false" targetId="a90a-fea5-107f-a019" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="be34-e860-46d0-d7e6" hidden="false" targetId="6c13-252f-55b8-4de9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="de1c-d5c3-afcd-f486" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="691a-aa46-2b4f-a09b" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="25b4-7c4e-e579-4fee" name="Strike Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="4d3d-b808-7a51-2ddb" hidden="false" targetId="6688-b331-6578-fb30" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="f7b9-5bbf-7725-846a" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="4ffe-2e60-ece1-d9c4" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="22.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="67f6-07bc-f0ba-b0bd" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="d30a-66b4-b1ee-5cdd" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="ead8-0218-98ae-8ddd" hidden="false" targetId="057e-2e8a-1952-9de0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="5aef-5d71-d3a9-8546" hidden="false" targetId="9f16-5a27-44b5-7471" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="6.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="f53b-8cb2-f46e-ec68" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="25b4-7c4e-e579-4fee" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="f53b-8cb2-f46e-ec68" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="25b4-7c4e-e579-4fee" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="66.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a2f5-7c0a-21e5-7b0b" name="C3 Strike Squad" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="3dd7-c3aa-50ca-26b2" name="Strike Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="cfe4-65fc-7598-d48f" hidden="false" targetId="6688-b331-6578-fb30" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="3d5b-1da9-8a1e-fdff" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="333b-de0f-7f92-165d" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="da65-0727-324a-34da" name="Plasma Lance" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="73c1-5b5c-b994-a075" hidden="false" targetId="21a7-132d-6703-9ff6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="3.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5ce3-0d5d-4909-be5b" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="826e-6c50-646d-62a2" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="482c-adc0-0ca1-f078" hidden="false" targetId="9f16-5a27-44b5-7471" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="a2f5-7c0a-21e5-7b0b" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3dd7-c3aa-50ca-26b2" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="a2f5-7c0a-21e5-7b0b" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3dd7-c3aa-50ca-26b2" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="a2f5-7c0a-21e5-7b0b" value="7.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3dd7-c3aa-50ca-26b2" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="a2f5-7c0a-21e5-7b0b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="da65-0727-324a-34da" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="b1e3-2d2a-8b67-fc51" name="Leader" hidden="false" collective="false" defaultSelectionEntryId="f0c2-69ee-8b90-7528">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f0c2-69ee-8b90-7528" name="&lt; Strike Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="68ed-3fd5-b951-fe6f" hidden="false" targetId="af6e-dcdb-77a5-b67e" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="53a6-45f6-5682-c4e8" name="&lt; Strike Leader Options &gt;" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <selectionEntries>
+                    <selectionEntry id="80e9-9314-55b5-7258" name="Sling net ammo" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                      </constraints>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="5.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="4631-7558-0869-977f" hidden="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="eb5d-a6e4-347d-da46" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="b5e3-8a48-3fba-2582" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="40dd-425c-09d9-342d" hidden="false" targetId="6c13-252f-55b8-4de9" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b6b5-59e8-0142-f157" name="&lt; Strike Leade Kai Lek Atastrin" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="39fc-3f30-ab2f-a4ac" hidden="false" targetId="4d7e-f31f-84d4-d57a" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="9f91-1033-28eb-60f6" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="a807-bd9c-3407-8f70" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="8772-8d7c-d285-cc64" hidden="false" targetId="6c13-252f-55b8-4de9" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="21.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="32.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="37f1-afbf-0787-df72" name="C3 Support Team" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles>
+        <profile id="65ed-1aa6-1ac1-fef1" name="Strike Trooper crew Leader" hidden="true" profileTypeId="1650-77b3-10d1-6406">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="37f1-afbf-0787-df72" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e31e-cc34-f520-8f22" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="37f1-afbf-0787-df72" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cd4f-0ce9-a6a4-b34a" type="equalTo"/>
+                    <condition field="selections" scope="37f1-afbf-0787-df72" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="41bd-5499-889a-ab16" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+            <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+            <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+            <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+            <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+            <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+            <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="6fd3-42ff-1e26-f82f" name="&lt; Strike Trooper Crew" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="9b44-134d-0947-ad18" hidden="false" targetId="ce28-e8fe-4290-f477" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ab45-bb28-303d-7786" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="db05-8d5e-8d36-69a0" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="cc63-9a66-9dd6-3de7" hidden="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="37e9-4c4d-d67c-19ac" name="&lt; Promote &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="e31e-cc34-f520-8f22" hidden="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="20.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="87e7-1804-a911-dd27" hidden="false" targetId="41bd-5499-889a-ab16" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="a579-d4e9-1656-152c" name="&lt; Weapon Options &gt; " hidden="false" collective="false" defaultSelectionEntryId="0bfa-efdd-8bd7-0f3a">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="7437-7bc1-490a-6628" hidden="false" targetId="10e6-b49c-4401-a1cd" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="0bfa-efdd-8bd7-0f3a" hidden="false" targetId="afc8-4f62-e1e2-1e4c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="48b0-cf3d-3699-f8a3" name="C3 Support Team with Plasma Bombard" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles>
+        <profile id="b8eb-6958-badc-9897" name="Strike Trooper crew Leader" hidden="true" profileTypeId="1650-77b3-10d1-6406">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="48b0-cf3d-3699-f8a3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8673-cdb1-4966-8463" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="48b0-cf3d-3699-f8a3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="68f5-c9b8-b86f-2e3e" type="equalTo"/>
+                    <condition field="selections" scope="48b0-cf3d-3699-f8a3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8673-cdb1-4966-8463" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+            <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+            <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+            <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+            <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+            <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+            <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="0d6a-0bd6-38ee-e3b2" name="&lt; Strike Trooper Crew" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="9ad4-375b-4388-7a6e" hidden="false" targetId="ce28-e8fe-4290-f477" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Large, Slow">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="b6de-5168-e608-a911" hidden="false" targetId="2f22-37fa-4076-d255" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="e4f5-f5f9-3728-2c55" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="b4fb-8d86-82bb-335d" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="c254-b4a0-5dc9-ed34" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="2f8e-78f4-d6ec-ed5b" hidden="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6850-687d-e5a8-d9b1" name="&lt; Promote &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="8673-cdb1-4966-8463" hidden="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="20.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="68f5-c9b8-b86f-2e3e" hidden="false" targetId="41bd-5499-889a-ab16" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="f37b-47c7-bddc-6bbe" hidden="false" targetId="e16f-acd1-265c-07f9" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="2b4a-afa0-4d3a-91da" hidden="false" targetId="1bc9-ce44-fdbe-ef90" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="75.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="50dc-8c05-18ca-21fd" name="C3 Support Team with X-Howitzer" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles>
+        <profile id="2d4e-a3f4-fe14-5878" name="Strike Trooper crew Leader" hidden="true" profileTypeId="1650-77b3-10d1-6406">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="50dc-8c05-18ca-21fd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4072-bde7-2e1d-c785" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="50dc-8c05-18ca-21fd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4072-bde7-2e1d-c785" type="equalTo"/>
+                    <condition field="selections" scope="50dc-8c05-18ca-21fd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="90e3-3446-28a3-e602" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+            <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+            <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+            <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+            <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+            <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+            <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="2128-0f7e-a018-741c" name="&lt; Strike Trooper Crew" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="8fcd-aca2-3e34-86d5" hidden="false" targetId="ce28-e8fe-4290-f477" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Large, Slow">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="a432-4162-50cd-9141" hidden="false" targetId="2f22-37fa-4076-d255" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="b06e-1486-b609-2b22" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5ec4-75b0-1c8b-ffb9" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="a0f9-f70a-57b7-afb5" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="3b25-3924-3cb4-8684" hidden="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="c595-3b46-4549-eb2a" name="&lt; Promote &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="4072-bde7-2e1d-c785" hidden="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="20.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="90e3-3446-28a3-e602" hidden="false" targetId="41bd-5499-889a-ab16" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="b4ea-cc3f-579f-5e09" hidden="false" targetId="e16f-acd1-265c-07f9" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="443c-3093-f104-6df7" hidden="false" targetId="e2b4-a034-c8ce-e376" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="65.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d626-a99a-6470-71ad" name="C3D1 Light Support Drone " hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="37d5-656f-d5c1-4397" name="&lt; Weapon Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="7f94-248b-3341-8ab0" hidden="false" targetId="18f2-0352-9cf8-66a5" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="59.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="cf0a-fdfc-c22e-fadb" name="&lt; Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="b508-d3f3-6f27-4975" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="50fc-d0da-6514-b4dd" hidden="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="e89f-034f-fda6-f951" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="4da3-5d4c-1262-53ab" name="&lt; Weapon Drone Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="c7a3-afb1-fa42-b4d3" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="maxSelections" value="2.0">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="d626-a99a-6470-71ad" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="37d5-656f-d5c1-4397" type="greaterThan"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="f089-4381-fa63-0074" hidden="false" targetId="c74e-2993-3474-7869" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8bdd-d11f-ed0d-dac8" name="C3D1/GP Light General Purpose Drone" book="" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="0fa5-4678-1a3f-decf" name="&lt; GP Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="0f76-aef5-4eed-fb15" hidden="false" targetId="f9ce-3eb5-0335-1b53" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="0411-749e-e748-cb7e" name="&lt; Options &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="418e-8281-9f52-5710" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="07b5-6bbe-485f-fa1d" hidden="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="b3d1-0620-3de8-f5b9" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="8c08-5e2f-7fda-f019" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="92b5-4abb-5821-b649" hidden="false" targetId="76e8-05d6-ff37-7205" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="20.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3601-a65d-7f14-cf86" name="C3D2 Medium Support Drone " hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="156e-1f5a-b7e7-1783" name="&lt; Weapon Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="bca1-3c81-da93-aefb" hidden="false" targetId="be8e-2c8f-8288-e92a" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="93.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="86e7-9193-c4cf-b4c7" name="&lt; Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="0f08-649f-cdb0-8d16" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="a405-a61d-2eb0-1e80" hidden="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="f787-39f9-566b-e5ff" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="f298-b1a6-4486-7b3a" name="&lt; Weapon Drone Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="34a7-a9ba-8af3-becb" name="&lt; Weapon Option &gt;" hidden="false" collective="false" defaultSelectionEntryId="d929-5f73-e58b-90d8">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="d929-5f73-e58b-90d8" hidden="false" targetId="62c2-106a-28aa-6cf5" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="907e-68db-aaaf-9a2f" hidden="false" targetId="90ca-6c03-a803-a140" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="b25e-f181-2b5c-7cc4" hidden="false" targetId="6ded-5798-dd23-8e6f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="2100-0b04-3ec7-174f" hidden="false" targetId="5a7d-3845-90ba-32eb" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="4064-6c5e-df77-f08e" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a829-1685-c4b5-55b6" name="C3M25 Heavy Combat Drone " hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="9432-f296-0817-a41e" name="&lt; Heavy Combat Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="52d9-2f82-4813-deb1" hidden="false" targetId="1c7c-b76a-8d9f-4405" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="fc27-7742-3460-32c5" hidden="false" targetId="c74e-2993-3474-7869" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="418.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ba92-e188-5152-68a3" name="&lt; Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="25d4-fe83-5977-2551" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="3866-b4ff-b88f-c46f" hidden="false" targetId="2750-e65f-4c66-8235" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="2bbd-905d-dab7-121e" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="232d-2ec2-4ebb-33e8" name="&lt; Weapon Drone Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="ab1d-b82e-4fa4-af4b" name="&lt; Weapon Option &gt;" hidden="false" collective="false" defaultSelectionEntryId="1f48-758b-70a2-1b46">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="a48c-1f8a-649a-6c31" hidden="false" targetId="c521-ffae-2a9d-88f9" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="1f48-758b-70a2-1b46" hidden="false" targetId="1bc9-ce44-fdbe-ef90" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="c984-ceed-ca03-2965" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3440-9714-d7d3-3653" name="C3M4 Combat Drone " hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="c49a-cae5-0917-dff0" name="&lt; Weapon Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="9c84-78ff-fad3-093b" hidden="false" targetId="eda1-434f-1771-a790" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5980-fadb-0d1a-8e4b" name="&lt; Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="1015-29dc-212b-dc4d" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="5087-2dc6-723c-788e" hidden="false" targetId="2750-e65f-4c66-8235" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="4ea5-d717-39c9-e705" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="91d2-c0ae-c028-4591" name="&lt; Weapon Drone Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="fb98-64e6-ce83-57f9" name="&lt; Weapon Option &gt;" hidden="false" collective="false" defaultSelectionEntryId="d8ef-55c7-2efb-ec04">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="6062-8f75-90de-9604" hidden="false" targetId="69d9-b84f-3c40-15fb" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="d0f0-9069-c124-7cd2" hidden="false" targetId="80bf-613e-52b4-f160" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="d8ef-55c7-2efb-ec04" hidden="false" targetId="3dfc-49e9-adcb-ae48" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="04e7-e796-57e1-9c2e" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="ad84-1f7d-5b85-ad4a" hidden="false" targetId="e16f-acd1-265c-07f9" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="7d08-c97c-53ca-06ab" hidden="false" targetId="c74e-2993-3474-7869" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="249.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9974-fc89-ef4b-59fe" name="C3M50 Heavy Support Drone " hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="e948-5e36-fc7b-117e" name="&lt; Heavy Support Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="28a5-2f84-29d4-5268" hidden="false" targetId="684e-ba3e-5aab-8be8" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="3a35-6d29-813c-6f2d" hidden="false" targetId="c74e-2993-3474-7869" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="418.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="d5e6-baf3-9376-d799" name="&lt; Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="cf51-b375-0b07-78ee" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="678e-362c-18b7-85e3" hidden="false" targetId="2750-e65f-4c66-8235" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="08b2-7bd2-ff20-2816" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="9794-aafd-9485-ca7f" name="&lt; Weapon Drone Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="70e3-44c8-f73e-4efe" name="&lt; Weapon Option &gt;" hidden="false" collective="false" defaultSelectionEntryId="19fa-61bc-edea-8bb1">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="19fa-61bc-edea-8bb1" hidden="false" targetId="85bd-3565-8ecd-a94f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="bf9f-7390-760a-cdb7" hidden="false" targetId="f482-b1f7-5e3a-1960" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="79bf-4d00-2ddc-738c" hidden="false" targetId="eb71-6245-efd5-67c9" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="fbca-0758-1e93-c627" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c4d4-9418-6246-d85d" name="C3T7 Transporter Drone " hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="288e-be87-ca44-03e8" name="&lt; Transporter Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="87f0-50e3-da01-55f0" hidden="false" targetId="1aa8-c7f2-fa2d-324a" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="460e-6cab-a7b9-878c" name="&lt; Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="9543-75e4-e4b2-ca03" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="03eb-ebb9-cdf3-ec98" hidden="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="b6d4-1bbf-8e0d-d2ac" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="c909-6003-f9c2-386e" name="&lt; Transporter Drone Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="daf1-967b-4024-7ec8" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="fb4e-c4f1-715d-c497" hidden="false" targetId="c74e-2993-3474-7869" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="194.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6880-209f-8a1d-66e0" name="Commander Kamrana Josen" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="182f-8079-ec5a-498b" hidden="false" targetId="218d-189c-09c7-3b45" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="f214-abe8-c922-c51b" value="5(8)">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="6880-209f-8a1d-66e0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6030-d671-9f86-c945" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="f086-dae6-6909-f7de" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="008d-8ba9-1c63-93b5" name="Strike Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="e57d-104e-c987-6e7a" hidden="false" targetId="6688-b331-6578-fb30" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="ac02-ab26-6f62-e9fc" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="52f5-a617-55f3-24aa" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="22.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="4a2c-44b8-d548-19f4" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="1947-c19e-f8e5-1439" hidden="false" targetId="9f16-5a27-44b5-7471" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="6880-209f-8a1d-66e0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="008d-8ba9-1c63-93b5" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="6880-209f-8a1d-66e0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f7e5-aff8-59a3-fb0d" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7d36-9ad2-0909-dddf" name="&lt; Commander Options &gt; " hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="f7e5-aff8-59a3-fb0d" name="Plasma Grenade Bandoliers" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="4d4b-85f0-9e35-d04d" hidden="false" targetId="92a3-aaae-bc24-0d2d" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="6880-209f-8a1d-66e0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1947-c19e-f8e5-1439" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6030-d671-9f86-c945" name="Jurry-Rigged HL Booster" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="53eb-6d1b-6804-c1e0" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="971d-3652-33ec-641a" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="116.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fcb7-7abc-470a-26fe" name="Medi-Probe Shard" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="c7bd-920e-b6e5-ef99" name="&lt; Medi-probe" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="d758-744a-7ac4-7804" hidden="false" targetId="078e-4753-3545-ba51" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6429-1b89-b557-736b" name="NuHu Mandarin" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="6fd9-afd5-d70f-d751" hidden="false" targetId="41d1-a002-0258-c407" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ae11-f605-d815-9109" name="&lt; Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="6fd3-49ff-c60c-3624" hidden="false" targetId="f095-7ba3-b868-32de" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="bb6a-48bd-2cf1-f430" hidden="false" targetId="057e-2e8a-1952-9de0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="775b-177d-e6ac-c3ac" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="2523-96e0-03f8-2625" hidden="false" targetId="5343-3c10-ccc3-0233" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="1133-9cc8-d005-ca82" hidden="false" targetId="a2e9-2b00-2191-a410" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="164.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7780-9268-8805-991a" name="Scout Probe Shard" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="275e-c158-8f26-53c9" name="&lt; Scout Probe" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="05b3-477e-3ab6-c2a4" hidden="false" targetId="56b9-5224-e0df-8218" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2fa1-035d-c0c1-e653" name="Target Probe Shard" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="70f6-51e9-f4f6-761f" name="&lt; Target Probe" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="ec43-8043-3ccc-fe21" hidden="false" targetId="9ce3-1277-65a2-7ab0" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <entryLinks>
+    <entryLink id="211c-ff88-c21d-4232" name="Army Options" hidden="false" targetId="529a-3e2a-4bd5-5e5f" type="selectionEntry" categoryEntryId="50ba-cf77-3941-189c">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </entryLink>
+  </entryLinks>
+  <sharedSelectionEntries>
+    <selectionEntry id="e745-6ace-c0d4-6e35" name="AG Chute (E)" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3ac2-e4a6-9011-4985" name="Batter Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2750-e65f-4c66-8235" name="Batter Drone (2)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c87f-f5b0-1134-8ad9" name="Compactor Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d776-f344-44a4-c41b" name="Compactor Drone with Compacted Plasma Cannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="b2e8-9d64-9d68-23e5" hidden="false" targetId="ffe9-0b4e-fc35-d442" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c521-ffae-2a9d-88f9" name="Compression Bombard" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a79e-c4ad-b89d-ac26" hidden="false" targetId="a854-0768-aa9e-8d94" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6ded-5798-dd23-8e6f" name="Compression Cannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="80bf-613e-52b4-f160" name="Compression Cannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f482-b1f7-5e3a-1960" name="Fractal Bombard" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="9156-5e49-d0a8-7993" hidden="false" targetId="cfed-0e3a-38c7-9618" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="90ca-6c03-a803-a140" name="Fractal Cannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="bc22-c5b0-170a-0ca8" hidden="false" targetId="e262-8ce4-a7d5-4d81" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="69d9-b84f-3c40-15fb" name="Fractal Cannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="4a79-2c10-c161-2234" hidden="false" targetId="e262-8ce4-a7d5-4d81" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5343-3c10-ccc3-0233" name="Gun Drone (2)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="14.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bf65-f7cb-1b50-d144" name="HL Armour (E)" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="12f1-610b-0dc9-4732" name="HL Armour Boost (E)" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c7a8-840b-096e-e2b8" name="IMTeL Stave (E)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="658c-b2dd-98f4-dafb" name="Interceptor Bike with Twin Plasma Carbines" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="41bd-5499-889a-ab16" name="Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cd4f-0ce9-a6a4-b34a" name="Leader 2" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a90a-fea5-107f-a019" name="Leader 3" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9e56-0965-ea32-7ff4" name="Leader 3" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eb71-6245-efd5-67c9" name="Mag Mortar" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="9df9-40f7-3d08-b560" hidden="false" targetId="5ba2-ac85-01a5-31be" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0e6a-0256-18e1-20af" name="&lt; Munition &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="a356-4661-a11e-41b8" name="Scrambler" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a24b-a381-fb00-eb9f" name="Arc" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3925-0866-3aea-e356" name="Blur" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0afe-04ff-398b-3496" name="Scoot" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5271-6bc1-1ad7-e9ba" name="Net " hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1cd3-e444-8b62-dc9b" name="All" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4d2c-7d84-fe17-0c8f" name="Grip" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="057e-2e8a-1952-9de0" name="Medi-Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a2e9-2b00-2191-a410" name="Nano Drone (E)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1bc9-ce44-fdbe-ef90" name="Plasma Bombard (E)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="c3b5-10fe-6527-f82f" hidden="false" targetId="581f-ff61-2525-a4b4" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="10e6-b49c-4401-a1cd" name="Plasma Cannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d5c2-2c99-c6f0-8b8e" hidden="false" targetId="ffe9-0b4e-fc35-d442" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="35.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5a7d-3845-90ba-32eb" name="Plasma Cannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="96a4-2cce-4307-8f7b" hidden="false" targetId="ffe9-0b4e-fc35-d442" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3dfc-49e9-adcb-ae48" name="Plasma Cannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="95ff-37b4-8a0c-72d9" hidden="false" targetId="ffe9-0b4e-fc35-d442" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eafe-a83e-6cfd-0559" name="Plasma Carbine (E)" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a184-65ab-58d9-e876" hidden="false" targetId="4c0f-9a37-2cd9-3f28" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="fb83-6166-8d22-f6e2" hidden="false" targetId="acdc-a95e-a973-0c70" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9f16-5a27-44b5-7471" name="Plasma Grenades" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="ae6b-5d5f-8311-739e" hidden="false" targetId="9c65-fbf8-41f5-47be" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3dd4-3b5c-6873-e8f2" name="Plasma Lance" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="7122-7702-547f-efa1" hidden="false" targetId="3376-2497-6739-ec52" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="cc9d-d4f8-59db-be3c" hidden="false" targetId="db92-0aca-cde3-4d2d" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6d1e-8151-bd04-c247" hidden="false" targetId="19f6-390a-0d7c-8acb" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="3.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7dac-aa85-fc80-51d5" name="Plasma Lance (Bike)" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="95fd-068f-3527-ff41" hidden="false" targetId="3376-2497-6739-ec52" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3303-cedc-7f35-8d8c" hidden="false" targetId="db92-0aca-cde3-4d2d" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="8d2b-05f1-d035-fca6" hidden="false" targetId="19f6-390a-0d7c-8acb" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="2.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="21a7-132d-6703-9ff6" name="Plasma Lance (E)" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="eae9-4fdc-d5ae-f150" hidden="false" targetId="3376-2497-6739-ec52" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="44f0-8649-d04a-801b" hidden="false" targetId="db92-0aca-cde3-4d2d" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="e52e-5001-8214-66e6" hidden="false" targetId="19f6-390a-0d7c-8acb" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="62c2-106a-28aa-6cf5" name="Plasma Light Support Gun" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="7d58-9532-baa3-0f50" hidden="false" targetId="2940-5bc4-f1ca-b78c" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c74e-2993-3474-7869" name="Plasma Light Support Gun (E)" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="f652-56d4-3777-5ff0" hidden="false" targetId="2940-5bc4-f1ca-b78c" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2f22-37fa-4076-d255" name="Plasma Pistol (E)" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="f9da-9df8-37a5-92ff" hidden="false" targetId="23fa-052e-36db-13a3" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8c55-0529-22ab-3fa6" name="Self Repair" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="de46-fbd5-d8f5-7454" name="Shield Drone " hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5ed8-6bd4-d0f7-d7f0" name="Shield Drone (2)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="001a-9f15-b25b-b784" name="Spotter Drone " hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f095-7ba3-b868-32de" name="Spotter Drone (2)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e16f-acd1-265c-07f9" name="Spotter Drone (E)" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="af36-fa25-9ae1-e8a1" name="Sub-M. X-Sling (E)" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="76e8-05d6-ff37-7205" name="Subverter Matrix" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e2b4-a034-c8ce-e376" name="X-Howitzer (E)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a4a1-491f-e195-4e0d" hidden="false" targetId="d0b6-5e2a-243d-b6ea" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="4b18-33b8-84e0-5c2e" name="&lt; Munitions &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="c518-dc83-0b3b-d5d0" name="Scrambler" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="4f17-4153-49e1-f6dc" hidden="false" targetId="0a09-eb21-a6c6-ad31" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="16ea-fdb9-4f62-644a" name="Arc" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="a50f-9b72-3685-ce99" hidden="false" targetId="4052-0eb4-88d7-cab0" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d695-e1d4-70ad-ab44" name="Blur" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="e23c-a9f0-0a42-b621" hidden="false" targetId="1373-7755-bef3-50d6" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8a3f-6c9d-84ab-7ff7" name="Scoot" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="5e49-ad1b-3c02-c442" hidden="false" targetId="f2cb-33fd-610a-eda3" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f919-51c2-e1f0-fa33" name="Net" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="5eb1-95d1-6117-e8d2" hidden="false" targetId="b81d-9f77-4c39-3887" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6967-929f-0dac-4c2e" name="Grip" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="a1ce-1d22-c641-6d9d" hidden="false" targetId="053b-a389-59c4-0e00" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f58f-7571-0bda-13b5" name="All" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="c003-c2b5-f035-4444" hidden="false" targetId="4052-0eb4-88d7-cab0" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="2b2f-ad1c-6533-e2d7" hidden="false" targetId="1373-7755-bef3-50d6" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="7cae-5b3f-2e71-6e33" hidden="false" targetId="053b-a389-59c4-0e00" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="be82-4f21-bf38-ae68" hidden="false" targetId="b81d-9f77-4c39-3887" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="ebcd-e2be-4841-8020" hidden="false" targetId="f2cb-33fd-610a-eda3" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="5bab-a371-53ed-88d2" hidden="false" targetId="0a09-eb21-a6c6-ad31" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="85bd-3565-8ecd-a94f" name="X-Howitzer (E)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="9d54-86cf-f28d-a5ef" hidden="false" targetId="d0b6-5e2a-243d-b6ea" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="4473-5846-9144-3ed7" name="&lt; Munitions &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="869a-d024-f01b-902a" name="Scrambler" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="538e-8399-5fd9-972e" hidden="false" targetId="0a09-eb21-a6c6-ad31" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="09ad-e164-6041-3e77" name="Arc" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="c58d-a6d9-f53f-bf5d" hidden="false" targetId="4052-0eb4-88d7-cab0" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="aa49-b3f4-5d76-5b99" name="Blur" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="e8ea-4904-644f-2434" hidden="false" targetId="1373-7755-bef3-50d6" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b9f0-d72f-1cf6-a855" name="Scoot" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="1eac-780b-e921-e0cf" hidden="false" targetId="f2cb-33fd-610a-eda3" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a1b1-9170-9e10-fa54" name="Net" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="e95f-1bbe-70fb-e3cd" hidden="false" targetId="b81d-9f77-4c39-3887" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b4ec-d02c-b3b1-e937" name="Grip" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="6e15-34d7-c75e-912d" hidden="false" targetId="053b-a389-59c4-0e00" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6fb5-f33d-8fcc-5d00" name="All" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="4674-2dd7-fa1b-a44b" hidden="false" targetId="4052-0eb4-88d7-cab0" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="c46e-1126-4846-466d" hidden="false" targetId="1373-7755-bef3-50d6" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="b5e5-b58a-0bab-51af" hidden="false" targetId="053b-a389-59c4-0e00" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="4349-8848-6641-8a17" hidden="false" targetId="b81d-9f77-4c39-3887" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="af57-f563-f84f-2c9a" hidden="false" targetId="f2cb-33fd-610a-eda3" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="b5da-6f53-11d9-af5a" hidden="false" targetId="0a09-eb21-a6c6-ad31" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="afc8-4f62-e1e2-1e4c" name="X-Launcher (E)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d588-2e56-e502-10ec" hidden="false" targetId="b984-90ae-a8e5-83c8" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c249-3049-66be-c18b" name="&lt; Munitions &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="855b-3877-638b-99e8" name="Scrambler" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="594f-82ff-5ad7-c68d" hidden="false" targetId="0a09-eb21-a6c6-ad31" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="cf1c-5cab-dced-a300" name="Arc" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="8bce-b783-3ffc-92aa" hidden="false" targetId="4052-0eb4-88d7-cab0" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="bed3-8a4c-71e0-9a86" name="Blur" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="9be8-c879-a109-2f53" hidden="false" targetId="1373-7755-bef3-50d6" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7207-1027-8e26-6930" name="Scoot" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="9bd6-49f8-24e5-7631" hidden="false" targetId="f2cb-33fd-610a-eda3" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9b37-d7f7-9bb7-6061" name="Net" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="d053-1be2-c8f4-3f6c" hidden="false" targetId="b81d-9f77-4c39-3887" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f569-f291-bc3a-fa3a" name="Grip" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="3be2-c872-ad5c-35f7" hidden="false" targetId="053b-a389-59c4-0e00" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a6d2-1391-22e8-008b" name="All" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="1741-ddc1-2f5f-3ff2" hidden="false" targetId="4052-0eb4-88d7-cab0" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="b229-c301-4b0d-2ccd" hidden="false" targetId="1373-7755-bef3-50d6" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="c3df-d0d2-6144-d3f9" hidden="false" targetId="053b-a389-59c4-0e00" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="ed17-cff8-54c6-cf4d" hidden="false" targetId="b81d-9f77-4c39-3887" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="ff70-9ddf-025e-0a2d" hidden="false" targetId="f2cb-33fd-610a-eda3" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="3125-0cd8-92ea-7904" hidden="false" targetId="0a09-eb21-a6c6-ad31" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6c13-252f-55b8-4de9" name="X-Sling (E)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="2d1d-7464-b34a-31f5" hidden="false" targetId="7c13-1aa1-5557-6103" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups/>
   <sharedRules>
-    <rule id="7680-b7ff-1ca0-9855" name="AG Chute" hidden="false" book="BtGoA" page="120">
-      <description>May make 2M move and shoot when given advance order. +1 Ag. Treat difficult ground as suspensored vehicle. </description>
+    <rule id="7680-b7ff-1ca0-9855" name="AG Chute" book="BtGoA" page="120" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>May make 2M move and shoot when given advance order. +1 Ag. Treat difficult ground as suspensored vehicle. </description>
     </rule>
-    <rule id="4052-0eb4-88d7-cab0" name="Arc" hidden="false" book="BtGoA" page="88">
+    <rule id="4052-0eb4-88d7-cab0" name="Arc" book="BtGoA" page="88" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Creates 3&quot; sink area. Affects any shooter attemping to draw LOS and shoot through the arc. Roll a D10 if LOS goes through - 1-5 the shot is normal, 6-10 the shot automatically misses. Make test before rolling Acc to hit. 
 
 OH shots are affected if the target is within 3&quot; of the marker. </description>
-      <modifiers/>
     </rule>
-    <rule id="178b-d746-0f1a-74ec" name="Batter Drone" hidden="false" book="BtGoA" page="110">
+    <rule id="178b-d746-0f1a-74ec" name="Batter Drone" book="BtGoA" page="110" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Projects curved shield as template - must be positioned with outer side facing away from drone, no part of template more than 5&quot; from drone base. Template may be repositioned any time unit receives an order die.
 
 Enemy units shooting through shield suffer -2 ACC. Models positioned inside the shield do not receive the -2 ACC protection. Troops shooting from the inside convex side of the shield do not suffer the ACC penalty. 
 
 No protection is offered for OH shots.</description>
-      <modifiers/>
     </rule>
-    <rule id="1cb7-4402-2f6c-b3cf" name="Blast D10" hidden="false" book="BtGoA">
+    <rule id="1cb7-4402-2f6c-b3cf" name="Blast D10" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Inflicts D10 hits on a successful shooting attack.</description>
-      <modifiers/>
     </rule>
-    <rule id="82bc-e8ec-5e5a-56d2" name="Blast D3" hidden="false" book="BtGoA">
+    <rule id="82bc-e8ec-5e5a-56d2" name="Blast D3" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Inflicts D3 hits on a successful shooting attack.</description>
-      <modifiers/>
     </rule>
-    <rule id="27db-c218-b60e-869b" name="Blast D4" hidden="false" book="BtGoA">
+    <rule id="27db-c218-b60e-869b" name="Blast D4" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Inflicts D4 hits on a successful shooting attack.</description>
-      <modifiers/>
     </rule>
-    <rule id="3934-2688-e509-dbc5" name="Blast D5" hidden="false" book="BtGoA">
+    <rule id="3934-2688-e509-dbc5" name="Blast D5" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Inflicts D5 hits on a successful shooting attack.</description>
-      <modifiers/>
     </rule>
-    <rule id="1373-7755-bef3-50d6" name="Blur" hidden="false" book="BtGoA" page="89">
-      <description>Any unit within 3&quot; reduces Acc by D3 each time it shoots. If within two or more blur markers, roll a D3 for each and take highest.</description>
+    <rule id="1373-7755-bef3-50d6" name="Blur" book="BtGoA" page="89" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>Any unit within 3&quot; reduces Acc by D3 each time it shoots. If within two or more blur markers, roll a D3 for each and take highest.</description>
     </rule>
     <rule id="5c9b-1bde-ee01-04a4" name="Command" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="b0ca-8e7d-d03f-f027" name="Fast" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="7bc9-5e98-2914-5abd" name="Follow" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="053b-a389-59c4-0e00" name="Grip" hidden="false" book="BtGoA" page="87">
+    <rule id="053b-a389-59c4-0e00" name="Grip" book="BtGoA" page="87" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Unit beginning its move within 3&quot; must take and pass an Ag test. If failed it may not move, if passed it can move half rate, failed on a 10 it takes a pin and cannot move.
 
 If a unit moves within 3&quot; it must take the Ag test as above. </description>
-      <modifiers/>
     </rule>
     <rule id="3c64-6022-a5f1-9c04" name="Hero" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="9d5f-b605-0d92-695d" name="HL Armor" hidden="false" book="BtGoA" page="93">
+    <rule id="9d5f-b605-0d92-695d" name="HL Armor" book="BtGoA" page="93" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Ranges of 10&quot; or less, +1 to Res. Ranges of greater than 10&quot; +2 Res. Against any Blast hits, +3 Res. </description>
-      <modifiers/>
     </rule>
-    <rule id="f62d-5e99-81f7-07dd" name="Inaccurate" hidden="false" book="BtGoA" page="70">
-      <description>Additional -1 Acc penalty.</description>
+    <rule id="f62d-5e99-81f7-07dd" name="Inaccurate" book="BtGoA" page="70" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>Additional -1 Acc penalty.</description>
     </rule>
     <rule id="a221-d53c-b4bd-b52c" name="Large" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="e441-c3a6-7d61-2c63" name="Leader" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="7850-89e7-bab8-86e9" name="Leader 2" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="05bb-4d34-70cd-25d2" name="Leader 3" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="d8dc-cf25-ef95-c94b" name="Limited Choice" hidden="false" book="">
+    <rule id="d8dc-cf25-ef95-c94b" name="Limited Choice" book="" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="2ff2-534c-34fe-b56b" name="Medi-Drone" hidden="false" book="BtGoA" page="113">
+    <rule id="2ff2-534c-34fe-b56b" name="Medi-Drone" book="BtGoA" page="113" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Can only attend humans - not machines or Skarks. Any friendly unit within 5&quot; may re-roll one failed Res test each time it is shot at, fights H2H, or otherwise suffers damage. Units within 5&quot; of more than one medi-drone may re-roll one failed Res test for each medi-drone. </description>
-      <modifiers/>
     </rule>
     <rule id="5565-ce10-1c78-1ee7" name="MOD2" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="8151-2e24-94ee-0477" name="MOD3" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="b81d-9f77-4c39-3887" name="Net" hidden="false" book="BtGoA" page="88">
+    <rule id="b81d-9f77-4c39-3887" name="Net" book="BtGoA" page="88" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Roll to hit as normal for a blast weapon. Target does not suffer blast damage, rather suffers pins:
 
 X-Launcher: D3+1 pin
@@ -2602,49 +4756,82 @@ X-Howitzer: D5+1 pin
 Mag Mortar: D10+1 pin
 
 Targets that would normally force an Acc re-roll suffer half the number of pins rounded down. Divide pins equally between two or more units as normal.</description>
-      <modifiers/>
     </rule>
     <rule id="4abc-52df-bbed-7b28" name="New Rule" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="fbb8-f81a-2985-1273" name="Plasma Fade" hidden="false" book="BtGoA" page="76">
+    <rule id="fbb8-f81a-2985-1273" name="Plasma Fade" book="BtGoA" page="76" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>On the Acc roll of a 10 to hit the shot is a miss and the unit goes down.</description>
-      <modifiers/>
     </rule>
-    <rule id="f2cb-33fd-610a-eda3" name="Scoot" hidden="false" book="BtGoA" page="88">
+    <rule id="f2cb-33fd-610a-eda3" name="Scoot" book="BtGoA" page="88" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Only affects infantry, mounted, weapon team, beast, and humongous beast, command, and bike mounted units with living crew. Affects scramble proof units. Any affected unit within 3&quot; canno tbe given any order except run or down. Cannot make any reaction apart from go down.</description>
-      <modifiers/>
     </rule>
-    <rule id="0a09-eb21-a6c6-ad31" name="Scrambler" hidden="false" book="BtGoA" page="88">
+    <rule id="0a09-eb21-a6c6-ad31" name="Scrambler" book="BtGoA" page="88" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Enemy units within 3&quot; that are not scramble proof it loses Reflex Armor, Hyperlight Armor, and Phase Armor along with any bonuses. Units in Phase Armor cannot use their armor to go down.
 
 Weapon Drone and vehicles have Res reduced by 2 within 3&quot;. Buddy drones cease to function if the unit is within 3&quot;. Probes can do nothing at all while marker is within 3&quot;. Penalties are not cumulative.</description>
-      <modifiers/>
     </rule>
     <rule id="3377-9408-33bb-6a02" name="Self Repair" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="1c4c-aaaf-0a08-e69e" name="Self Repair" hidden="false" book="BtGoA" page="137">
+    <rule id="1c4c-aaaf-0a08-e69e" name="Self Repair" book="BtGoA" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Give unit rally order. If no pins exist after order, may attempt one repair on  immobilisation or weapon. 1-5 = success, 6-10 failure. Success = that function is working again.</description>
-      <modifiers/>
     </rule>
-    <rule id="1b89-5e18-0f71-7dc5" name="Slingnet Ammo" hidden="false" book="BtGoA" page="112">
-      <description>Fired direct unless from Micro X Launcher. Targets hit suffer no damage but take +1 additional pin. Cannot affect units that cannot be pinned when hit.</description>
+    <rule id="1b89-5e18-0f71-7dc5" name="Slingnet Ammo" book="BtGoA" page="112" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>Fired direct unless from Micro X Launcher. Targets hit suffer no damage but take +1 additional pin. Cannot affect units that cannot be pinned when hit.</description>
     </rule>
     <rule id="7c88-64d4-50ad-2313" name="Slow" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="19d8-5c9a-2e1f-4d8e" name="Spotter Drone" hidden="false" book="BtGoA" page="114">
+    <rule id="19d8-5c9a-2e1f-4d8e" name="Spotter Drone" book="BtGoA" page="114" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Unit may re-roll one miss each time it shoots as long as drone has LOS to target. Units may fire OH using drone as spotter as long as it has LOS to target. 
 
 Spotter drones may spot through another spotter drone (within 20&quot;) with LOS to the target. Unit does not receive spotter re-roll as their spotter does not have LOS to target.</description>
-      <modifiers/>
     </rule>
     <rule id="ab37-33d8-41f3-7532" name="Transport 10" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="3f71-546f-6b34-b449" name="Weapon Drone" hidden="false" book="BtGoA" page="115">
+    <rule id="3f71-546f-6b34-b449" name="Weapon Drone" book="BtGoA" page="115" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Always measure to model, not base. Not allowed to assault. Never take a break test, however auto-break if suffer pins equal to their Co stat. If drone fails a Res test, roll on Weapon Drone Damage Chart.
 
 D10 Result:
@@ -2654,547 +4841,683 @@ D10 Result:
 4: Take D3 additional pins and go down. Weapon malfunction.
 5: Take D6 additional pins and take a break test - destroyed if failed, go down if passed.
 6-10: Destroyed</description>
-      <modifiers/>
     </rule>
   </sharedRules>
   <sharedProfiles>
-    <profile id="18f2-0352-9cf8-66a5" profileTypeId="1650-77b3-10d1-6406" name="C3D1 Light Support Drone" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="7"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="8"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="-"/>
-      </characteristics>
+    <profile id="18f2-0352-9cf8-66a5" name="C3D1 Light Support Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="f9ce-3eb5-0335-1b53" profileTypeId="1650-77b3-10d1-6406" name="C3D1/GP Light General Purpose Drone" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="7"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="0"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="8"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="-"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="7"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="8"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
       </characteristics>
+    </profile>
+    <profile id="f9ce-3eb5-0335-1b53" name="C3D1/GP Light General Purpose Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="be8e-2c8f-8288-e92a" profileTypeId="1650-77b3-10d1-6406" name="C3D2 Medium Support Drone" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="7"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="10"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="-"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="7"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="0"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="8"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
       </characteristics>
+    </profile>
+    <profile id="be8e-2c8f-8288-e92a" name="C3D2 Medium Support Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="1c7c-b76a-8d9f-4405" profileTypeId="1650-77b3-10d1-6406" name="C3M25 Heavy Combat Drone" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="15"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="MOD3, Slow, Large"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="7"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="10"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
       </characteristics>
+    </profile>
+    <profile id="1c7c-b76a-8d9f-4405" name="C3M25 Heavy Combat Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="eda1-434f-1771-a790" profileTypeId="1650-77b3-10d1-6406" name="C3M4 Combat Drone" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="13"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="MOD2, Large"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="15"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="MOD3, Slow, Large"/>
       </characteristics>
+    </profile>
+    <profile id="eda1-434f-1771-a790" name="C3M4 Combat Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="684e-ba3e-5aab-8be8" profileTypeId="1650-77b3-10d1-6406" name="C3M50 Heavy Support Drone" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="15"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="MOD3, Slow, Large"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="13"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="MOD2, Large"/>
       </characteristics>
+    </profile>
+    <profile id="684e-ba3e-5aab-8be8" name="C3M50 Heavy Support Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="1aa8-c7f2-fa2d-324a" profileTypeId="1650-77b3-10d1-6406" name="C3T7 Transporter Drone" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="13"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="MOD2, Transport 10, Large"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="15"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="MOD3, Slow, Large"/>
       </characteristics>
+    </profile>
+    <profile id="1aa8-c7f2-fa2d-324a" name="C3T7 Transporter Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="218d-189c-09c7-3b45" profileTypeId="1650-77b3-10d1-6406" name="Commander Kamrana Josen" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="6"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(7)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="9"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Command, Follow, Hero, Unstoppable, Wound 3, Leader3"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="13"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="MOD2, Transport 10, Large"/>
       </characteristics>
+    </profile>
+    <profile id="218d-189c-09c7-3b45" name="Commander Kamrana Josen" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="a854-0768-aa9e-8d94" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Bombard" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-50"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="150"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="9/7/5"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Cycle"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="6"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="9"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Follow, Hero, Unstoppable, Wound 3, Leader3"/>
       </characteristics>
+    </profile>
+    <profile id="a854-0768-aa9e-8d94" name="Compression Bombard" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="fb4a-7317-0e7a-7278" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Cannon" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="7/4/2"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Cycle"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-50"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="150"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="9/7/5"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Cycle"/>
       </characteristics>
+    </profile>
+    <profile id="fb4a-7317-0e7a-7278" name="Compression Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="0f84-f206-4f28-921f" profileTypeId="1650-77b3-10d1-6406" name="Drop Commander" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5(6)"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(7)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Command, Follow, Leader 2"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="7/4/2"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Cycle"/>
       </characteristics>
+    </profile>
+    <profile id="0f84-f206-4f28-921f" name="Drop Commander" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers>
-        <modifier type="set" field="3baa-9cfd-f273-822d" value="Command, Follow, Leader 3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+        <modifier type="set" field="3baa-9cfd-f273-822d" value="Command, Follow, Leader 3">
+          <repeats/>
           <conditions>
-            <condition parentId="direct parent" childId="a90a-fea5-107f-a019" field="selections" type="equal to" value="1.0"/>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a90a-fea5-107f-a019" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
       </modifiers>
-    </profile>
-    <profile id="e18d-8dd1-d573-930f" profileTypeId="1650-77b3-10d1-6406" name="Drop Leader" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5(6)"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(7)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Leader"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5(6)"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Follow, Leader 2"/>
       </characteristics>
+    </profile>
+    <profile id="e18d-8dd1-d573-930f" name="Drop Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers>
-        <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+        <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 3">
+          <repeats/>
           <conditions>
-            <condition parentId="direct parent" childId="9e56-0965-ea32-7ff4" field="selections" type="equal to" value="1.0"/>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9e56-0965-ea32-7ff4" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
-        <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+        <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2">
+          <repeats/>
           <conditions>
-            <condition parentId="direct parent" childId="cd4f-0ce9-a6a4-b34a" field="selections" type="equal to" value="1.0"/>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cd4f-0ce9-a6a4-b34a" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
       </modifiers>
-    </profile>
-    <profile id="1219-e29a-7fa7-a09e" profileTypeId="1650-77b3-10d1-6406" name="Drop Trooper" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5(6)"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(7)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="-"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5(6)"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader"/>
       </characteristics>
+    </profile>
+    <profile id="1219-e29a-7fa7-a09e" name="Drop Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="cfed-0e3a-38c7-9618" profileTypeId="ecae-8ac8-2c13-0dd3" name="Fractal Bombard" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="50"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="200"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3 +2 max 10"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5(6)"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
       </characteristics>
+    </profile>
+    <profile id="cfed-0e3a-38c7-9618" name="Fractal Bombard" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="e262-8ce4-a7d5-4d81" profileTypeId="ecae-8ac8-2c13-0dd3" name="Fractal Cannon" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2 +1 max 10"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="50"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="200"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3 +2 max 10"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock"/>
       </characteristics>
+    </profile>
+    <profile id="e262-8ce4-a7d5-4d81" name="Fractal Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="34f9-12c5-7e7b-114c" profileTypeId="1650-77b3-10d1-6406" name="Inerceptor Trooper" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5 (8)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Fast, Large"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2 +1 max 10"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock"/>
       </characteristics>
+    </profile>
+    <profile id="34f9-12c5-7e7b-114c" name="Interceptor Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="9286-cbf7-0641-5ce1" profileTypeId="1650-77b3-10d1-6406" name="Interceptor Commander" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(8)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Command, Follow, Fast, Large, Leader 2"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5 (8)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Fast, Large"/>
       </characteristics>
+    </profile>
+    <profile id="9286-cbf7-0641-5ce1" name="Interceptor Commander" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers>
-        <modifier type="set" field="3baa-9cfd-f273-822d" value="Command, Follow, Fast, Large, Leader 3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+        <modifier type="set" field="3baa-9cfd-f273-822d" value="Command, Follow, Fast, Large, Leader 3">
+          <repeats/>
           <conditions>
-            <condition parentId="direct parent" childId="bd12-7ad6-eb09-08ba" field="selections" type="equal to" value="1.0"/>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bd12-7ad6-eb09-08ba" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
       </modifiers>
-    </profile>
-    <profile id="9ed6-e3f2-8847-d7a2" profileTypeId="1650-77b3-10d1-6406" name="Interceptor Leader" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(8)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Fast, Large, Leader"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(8)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Follow, Fast, Large, Leader 2"/>
       </characteristics>
+    </profile>
+    <profile id="9ed6-e3f2-8847-d7a2" name="Interceptor Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers>
-        <modifier type="set" field="3baa-9cfd-f273-822d" value="Fast, Large, Leader 2" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+        <modifier type="set" field="3baa-9cfd-f273-822d" value="Fast, Large, Leader 2">
+          <repeats/>
+          <conditions/>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(8)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Fast, Large, Leader"/>
+      </characteristics>
+    </profile>
+    <profile id="5ba2-ac85-01a5-31be" name="Mag Mortar" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OHx2, Blast D10, No Cover"/>
+      </characteristics>
+    </profile>
+    <profile id="078e-4753-3545-ba51" name="Medi-Probe" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Shard"/>
+      </characteristics>
+    </profile>
+    <profile id="74c6-e541-9bf3-7b75" name="New Profile" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+      </characteristics>
+    </profile>
+    <profile id="41d1-a002-0258-c407" name="NuHu Mandarin" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="4"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(7)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="9"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Hero, Follow, Leader 3"/>
+      </characteristics>
+    </profile>
+    <profile id="581f-ff61-2525-a4b4" name="Plasma Bombard" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="50"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="200"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="7"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Plasma Fade"/>
+      </characteristics>
+    </profile>
+    <profile id="ffe9-0b4e-fc35-d442" name="Plasma Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Plasma Fade"/>
+      </characteristics>
+    </profile>
+    <profile id="4c0f-9a37-2cd9-3f28" name="Plasma Carbine - Scatter" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2"/>
+      </characteristics>
+    </profile>
+    <profile id="acdc-a95e-a973-0c70" name="Plasma Carbine - Single Shot" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
+      </characteristics>
+    </profile>
+    <profile id="9c65-fbf8-41f5-47be" name="Plasma Grenade" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
+      </characteristics>
+    </profile>
+    <profile id="92a3-aaae-bc24-0d2d" name="Plasma Grenade Bandolier" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="-"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, Hazardous H2H"/>
+      </characteristics>
+    </profile>
+    <profile id="3376-2497-6739-ec52" name="Plasma Lance - Lance" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="4"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Choose Target, Inaccurate"/>
+      </characteristics>
+    </profile>
+    <profile id="19f6-390a-0d7c-8acb" name="Plasma Lance - Scatter" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2"/>
+      </characteristics>
+    </profile>
+    <profile id="db92-0aca-cde3-4d2d" name="Plasma Lance - Single Shot" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
+      </characteristics>
+    </profile>
+    <profile id="2940-5bc4-f1ca-b78c" name="Plasma Light Support Gun" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3"/>
+      </characteristics>
+    </profile>
+    <profile id="23fa-052e-36db-13a3" name="Plasma Pistol" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
+      </characteristics>
+    </profile>
+    <profile id="56b9-5224-e0df-8218" name="Scout Probe" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Shard"/>
+      </characteristics>
+    </profile>
+    <profile id="9686-36fa-7ae7-f4dc" name="Strike Commander" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="3baa-9cfd-f273-822d" value="Command, Follow, Leader 3">
+          <repeats/>
           <conditions>
-            <condition parentId="direct parent" childId="27d8-164a-139b-f635" field="selections" type="equal to" value="1.0"/>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a90a-fea5-107f-a019" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
       </modifiers>
-    </profile>
-    <profile id="5ba2-ac85-01a5-31be" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Mortar" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OHx2, Blast D10, No Cover"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Follow, Leader 2"/>
       </characteristics>
-      <modifiers/>
     </profile>
-    <profile id="078e-4753-3545-ba51" profileTypeId="1650-77b3-10d1-6406" name="Medi-Probe" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="-"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="-"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="-"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="-"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Shard"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
-    <profile id="74c6-e541-9bf3-7b75" profileTypeId="1650-77b3-10d1-6406" name="New Profile" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
-    <profile id="41d1-a002-0258-c407" profileTypeId="1650-77b3-10d1-6406" name="NuHu Mandarin" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="4"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="4(7)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="9"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Command, Hero, Follow, Leader 3"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
-    <profile id="581f-ff61-2525-a4b4" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Bombard" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="50"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="200"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="7"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Plasma Fade"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
-    <profile id="ffe9-0b4e-fc35-d442" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Cannon" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="6"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Plasma Fade"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
-    <profile id="4c0f-9a37-2cd9-3f28" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Carbine - Scatter" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
-    <profile id="acdc-a95e-a973-0c70" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Carbine - Single Shot" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
-    <profile id="9c65-fbf8-41f5-47be" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Grenade" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
-    <profile id="92a3-aaae-bc24-0d2d" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Grenade Bandolier" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="-"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="-"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D4, Hazardous H2H"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
-    <profile id="3376-2497-6739-ec52" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Lance" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="4"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Choose Target, Inaccurate"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
-    <profile id="19f6-390a-0d7c-8acb" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Scatter" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
-    <profile id="db92-0aca-cde3-4d2d" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Single Shot" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
-    <profile id="2940-5bc4-f1ca-b78c" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Light Support Gun" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
-    <profile id="23fa-052e-36db-13a3" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Pistol" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="30"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
-    <profile id="56b9-5224-e0df-8218" profileTypeId="1650-77b3-10d1-6406" name="Scout Probe" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="-"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="-"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="-"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="-"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Shard"/>
-      </characteristics>
-      <modifiers/>
-    </profile>
-    <profile id="9686-36fa-7ae7-f4dc" profileTypeId="1650-77b3-10d1-6406" name="Strike Commander" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(7)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Command, Follow, Leader 2"/>
-      </characteristics>
+    <profile id="af6e-dcdb-77a5-b67e" name="Strike Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers>
-        <modifier type="set" field="3baa-9cfd-f273-822d" value="Command, Follow, Leader 3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+        <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2">
+          <repeats/>
           <conditions>
-            <condition parentId="direct parent" childId="a90a-fea5-107f-a019" field="selections" type="equal to" value="1.0"/>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cd4f-0ce9-a6a4-b34a" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
       </modifiers>
-    </profile>
-    <profile id="af6e-dcdb-77a5-b67e" profileTypeId="1650-77b3-10d1-6406" name="Strike Leader" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(7)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Leader"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader"/>
       </characteristics>
-      <modifiers>
-        <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-          <conditions>
-            <condition parentId="direct parent" childId="cd4f-0ce9-a6a4-b34a" field="selections" type="equal to" value="1.0"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
     </profile>
-    <profile id="4d7e-f31f-84d4-d57a" profileTypeId="f9a2-eeae-3284-75fd" name="Strike Leader Kai Lek Atasrin" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="18c1-4764-7d08-708d" name="Ag" value="5 "/>
-        <characteristic characteristicId="e39c-d7a4-86a8-d23d" name="Acc" value="5"/>
-        <characteristic characteristicId="0790-bfd5-1273-fe12" name="Str" value="5"/>
-        <characteristic characteristicId="5b77-3595-2819-675c" name="Res" value="6(8)"/>
-        <characteristic characteristicId="c0d8-f6fd-a474-1385" name="Init" value="7"/>
-        <characteristic characteristicId="135d-efc3-5039-b6e6" name="Co" value="9"/>
-        <characteristic characteristicId="ab43-4d1c-4651-b424" name="Special" value="One for All, Wound, Leader 3"/>
-      </characteristics>
+    <profile id="4d7e-f31f-84d4-d57a" name="Strike Leader Kai Lek Atasrin" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="6688-b331-6578-fb30" profileTypeId="1650-77b3-10d1-6406" name="Strike Trooper" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(7)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="-"/>
+        <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="5 "/>
+        <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="5"/>
+        <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="6(8)"/>
+        <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="7"/>
+        <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="9"/>
+        <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424" value="One for All, Wound, Leader 3"/>
       </characteristics>
-      <modifiers/>
     </profile>
-    <profile id="ce28-e8fe-4290-f477" profileTypeId="1650-77b3-10d1-6406" name="Strike Trooper Crew" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(7)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="-"/>
-      </characteristics>
+    <profile id="6688-b331-6578-fb30" name="Strike Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
+      </characteristics>
     </profile>
-    <profile id="7aba-2a70-034d-4b60" profileTypeId="1650-77b3-10d1-6406" name="Strike Trooper crew Leader" hidden="true">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(7)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Leader"/>
-      </characteristics>
+    <profile id="ce28-e8fe-4290-f477" name="Strike Trooper Crew" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
+      </characteristics>
     </profile>
-    <profile id="9ce3-1277-65a2-7ab0" profileTypeId="1650-77b3-10d1-6406" name="Targeter Probe" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="-"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="-"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="-"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="-"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Shard"/>
-      </characteristics>
+    <profile id="7aba-2a70-034d-4b60" name="Strike Trooper crew Leader" hidden="true" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader"/>
+      </characteristics>
     </profile>
-    <profile id="d0b6-5e2a-243d-b6ea" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Howitzer" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-50"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="250"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D10, No Cover"/>
-      </characteristics>
+    <profile id="9ce3-1277-65a2-7ab0" name="Targeter Probe" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Shard"/>
+      </characteristics>
     </profile>
-    <profile id="b984-90ae-a8e5-83c8" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Launcher" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="60"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="120"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D5, No Cover"/>
-      </characteristics>
+    <profile id="d0b6-5e2a-243d-b6ea" name="X-Howitzer" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-50"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="250"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D10, No Cover"/>
+      </characteristics>
     </profile>
-    <profile id="7c13-1aa1-5557-6103" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Sling" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D3"/>
-      </characteristics>
+    <profile id="b984-90ae-a8e5-83c8" name="X-Launcher" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D5, No Cover"/>
+      </characteristics>
+    </profile>
+    <profile id="7c13-1aa1-5557-6103" name="X-Sling" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D3"/>
+      </characteristics>
     </profile>
   </sharedProfiles>
 </catalogue>

--- a/Freeborn.cat
+++ b/Freeborn.cat
@@ -1,6092 +1,10821 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="64d6-1cd3-6226-4554" revision="5" gameSystemId="c339-677a-60db-4060" gameSystemRevision="0" battleScribeVersion="1.15" name="Freeborn" authorName="Michael Ovsenik / Vescarea" authorContact="FB" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
-  <entries>
-    <entry id="66a7-b2ec-cfcc-8359" name="&lt; Command Squad Options - Must choose first" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="c017-7f96-06bd-fd6b" name="Select one of the following option and the relevent selection will appear" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="3933-5e9f-f85c-ba75" name="1&lt; Add 2 extra bodygaurds" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
+<catalogue id="64d6-1cd3-6226-4554" name="Freeborn" revision="6" battleScribeVersion="2.00" authorName="Michael Ovsenik / Vescarea" authorContact="FB" gameSystemId="c339-677a-60db-4060" gameSystemRevision="0" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <profiles/>
+  <rules/>
+  <infoLinks/>
+  <costTypes/>
+  <profileTypes/>
+  <forceEntries/>
+  <selectionEntries>
+    <selectionEntry id="66a7-b2ec-cfcc-8359" name="&lt; Command Squad Options - Must choose first" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c017-7f96-06bd-fd6b" name="Select one of the following option and the relevent selection will appear" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3933-5e9f-f85c-ba75" name="1&lt; Add 2 extra bodygaurds" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links/>
-            </entry>
-            <entry id="a400-34cd-f726-fbf6" name="9&lt; Add Batter Drone" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
               <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-            <entry id="ad0d-a741-67ad-5d5c" name="7&lt; Add up to 2 Gun Drones" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+              <infoLinks/>
               <modifiers/>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a400-34cd-f726-fbf6" name="9&lt; Add Batter Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links/>
-            </entry>
-            <entry id="d17a-ef4d-2148-25e8" name="8&lt; Add up to 2 shield Drones" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ad0d-a741-67ad-5d5c" name="7&lt; Add up to 2 Gun Drones" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links/>
-            </entry>
-            <entry id="6559-a8ba-d266-7c27" name="2&lt; HL Armour for unit" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d17a-ef4d-2148-25e8" name="8&lt; Add up to 2 shield Drones" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links/>
-            </entry>
-            <entry id="1ef5-d006-6a32-fddb" name="3&lt; Phase Armour for unit" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6559-a8ba-d266-7c27" name="2&lt; HL Armour for unit" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links/>
-            </entry>
-            <entry id="a04c-3029-b790-0cdb" name="4&lt; Give Captain plasma Carbine" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1ef5-d006-6a32-fddb" name="3&lt; Phase Armour for unit" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links/>
-            </entry>
-            <entry id="a90a-cec1-cd13-3c17" name="5&lt; Give Captain Compression Carbine" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a04c-3029-b790-0cdb" name="4&lt; Give Captain plasma Carbine" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links/>
-            </entry>
-            <entry id="7f96-ddf7-af5d-958a" name="6&lt; Give Bodygaurds Compression carbines" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a90a-cec1-cd13-3c17" name="5&lt; Give Captain Compression Carbine" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links/>
-            </entry>
-            <entry id="39a7-bedc-c912-a9f0" name="0&lt; None" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7f96-ddf7-af5d-958a" name="6&lt; Give Bodygaurds Compression carbines" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="39a7-bedc-c912-a9f0" name="0&lt; None" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="set" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="minSelections" value="0.0">
+                  <repeats/>
                   <conditions>
-                    <condition parentId="direct parent" childId="39a7-bedc-c912-a9f0" field="selections" type="equal to" value="0.0"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="39a7-bedc-c912-a9f0" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ed16-8f24-873e-f6cd" name="Replace with Amano Harran and Bodyguards" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links/>
-            </entry>
-            <entry id="ed16-8f24-873e-f6cd" name="Replace with Amano Harran and Bodyguards" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7a95-8632-0c25-d086" name="Amano Harran and Bodyguards" book="Battle for Xilos" page="115" hidden="true" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="7a95-8632-0c25-d086" name="Amano Harran and Bodyguards" points="126.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true" book="Battle for Xilos" page="115">
-      <entries>
-        <entry id="8fe8-c920-4357-5561" name="Amano Harran, Oszoni Freeborn Mercenary Captain" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="955c-f291-a035-8308" name="&lt;Weapons&gt;" minSelections="1" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="0197-c3d6-ee4b-351e" name="Zantu Plasma Duelling Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Battle for Xilos" page="115">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules>
-                    <rule id="a0dc-c29f-3f0d-da12" name="Dead Eye" hidden="false" book="Battle for Xilos" page="115">
-                      <description>When shooting with a Fire order, add +2 to Acc value rather than standard +1</description>
-                      <modifiers/>
-                    </rule>
-                    <rule id="5ffd-287d-8644-d70c" name="Duellist" hidden="false" book="Battle for Xilos" page="115">
-                      <description>When shooting simultaenously with an enemy unit, both sides roll 1d10. If the controlling player rolls higher, he shoots first and any result is applied to the target before it can fire back, including casualty removal and pinning.</description>
-                      <modifiers/>
-                    </rule>
-                  </rules>
-                  <profiles>
-                    <profile id="980e-e86b-7de6-4cff" profileTypeId="ecae-8ac8-2c13-0dd3" name="Zantu Plasma Duelling Pistol" hidden="false" book="Battle for Xilos" page="115">
-                      <characteristics>
-                        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="40"/>
-                        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-                        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Dead Eye, Duellist"/>
-                      </characteristics>
-                      <modifiers/>
-                    </profile>
-                  </profiles>
-                  <links/>
-                </entry>
-                <entry id="72ab-7a5e-1ef3-875a" name="Xilos Stasis Key" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Battle for Xilos" page="57">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules>
-                    <rule id="7ecb-bcba-21d4-a388" name="Stasis" hidden="false" book="Battle for Xilos" page="57">
-                      <description>Weapon can ONLY be fired with a Fire order, applying normal +1 Acc bonus. If target unit is hit, either switch its current Order Die to a Down order, or if it does not yet have an order, retrieve an Order Die from the bag and issue it a down order. Then, add a Stasis marker to the unit.			If a unit is in stasis at the turn end phase, then instead of making a recovery test to recover the Down Order Die, make a recovery test to remove the Stasis marker. The unit then remains Down until the next chance to make a recovery test, at which point the test applies to the Down Order Die.</description>
-                      <modifiers/>
-                    </rule>
-                  </rules>
-                  <profiles>
-                    <profile id="ce34-6972-faf0-fc0e" profileTypeId="ecae-8ac8-2c13-0dd3" name="Xilos Stasis Key" hidden="false" book="Battle for Xilos" page="57">
-                      <characteristics>
-                        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-                        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long"/>
-                        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme"/>
-                        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value"/>
-                        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Stasis"/>
-                      </characteristics>
-                      <modifiers/>
-                    </profile>
-                  </profiles>
-                  <links/>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules>
-            <rule id="4346-96cf-a909-9ab2" name="Fast Shot" hidden="false" book="Battle for Xilos" page="115">
-              <description>With any hand or standard weapon, this model shoots twice instead of once using the same weapon at the same target. This ability CAN be used with the Xilos Stasis Key, but the key can still only fire with a Fire order.</description>
-              <modifiers/>
-            </rule>
-            <rule id="191b-64ea-3f8e-b6e2" name="Charismatic Aura" hidden="false" book="Battle for Xilos" page="115">
-              <description>If any enemy unit is within 10&quot; of the Amano Harran model then it cannot be given an order without taking an Order test against its Command, even if it has no pins, and both its Command and Initiative stat are reduced by -1 when making order and/or reaction tests.</description>
-              <modifiers/>
-            </rule>
-            <rule id="1c55-16af-48d1-e10f" name="Wound" hidden="false" book="Battle for Xilos" page="115">
-              <description>If Amano Harran fails a Res test then instead of falling casualty he is wounded. Once wounded, if any further Res test is failed he is removed as a casualty. If Amano Harran is wounded then the unit cannot lose its last 1 pin. It can lose other pins as normal, but will always retain at least one.</description>
-              <modifiers/>
-            </rule>
-          </rules>
-          <profiles>
-            <profile id="ac61-5231-2810-84b0" profileTypeId="1650-77b3-10d1-6406" name="Amano Harran, Oszoni Freeborn Mercenary Captain" hidden="false" book="Battle for Xilos" page="115">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="6"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="10"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="10"/>
-                <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Command, Follow, Hero, Leader 3, Wound, Fast Shot, Charismatic Aura"/>
-              </characteristics>
-              <modifiers>
-                <modifier type="append" field="f214-abe8-c922-c51b" value="(7)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups>
-                    <conditionGroup type="or">
-                      <conditions>
-                        <condition parentId="7a95-8632-0c25-d086" childId="ddb6-781a-85af-eeeb" field="selections" type="equal to" value="1.0"/>
-                        <condition parentId="7a95-8632-0c25-d086" childId="aa87-9d00-ec90-c775" field="selections" type="equal to" value="1.0"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-            </profile>
-          </profiles>
-          <links>
-            <link id="12e9-6e86-5af0-79e8" targetId="7bc9-5e98-2914-5abd" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="5cce-7f58-827d-5129" targetId="5c9b-1bde-ee01-04a4" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="eca5-0e3f-2e2f-371a" targetId="3c64-6022-a5f1-9c04" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="f56e-220b-8d8d-e9c7" targetId="05bb-4d34-70cd-25d2" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="dc88-b28b-0f31-61c9" name="Bodyguard" points="21.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="ceda-f66e-0469-f72a" targetId="9fba-d6b7-c66d-99f0" linkType="profile">
-              <modifiers>
-                <modifier type="append" field="f214-abe8-c922-c51b" value="(7)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups>
-                    <conditionGroup type="or">
-                      <conditions>
-                        <condition parentId="7a95-8632-0c25-d086" childId="ddb6-781a-85af-eeeb" field="selections" type="equal to" value="1.0"/>
-                        <condition parentId="7a95-8632-0c25-d086" childId="aa87-9d00-ec90-c775" field="selections" type="equal to" value="1.0"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="35f7-fede-27fa-da27" targetId="b018-6101-d2e3-b4ea" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="fa49-db82-4230-6855" name="&lt;Unit Armor&gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="ddb6-781a-85af-eeeb" targetId="eff8-bb0e-1b1d-bbb2" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="7a95-8632-0c25-d086" incrementChildId="8fe8-c920-4357-5561" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="7a95-8632-0c25-d086" incrementChildId="dc88-b28b-0f31-61c9" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="aa87-9d00-ec90-c775" targetId="eb94-d1e8-1084-71b3" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="7a95-8632-0c25-d086" incrementChildId="8fe8-c920-4357-5561" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="7a95-8632-0c25-d086" incrementChildId="dc88-b28b-0f31-61c9" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="5b9c-ebf8-2d76-ed50" targetId="03c2-174e-8617-cf04" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="ac48-df93-6a89-8648" name="&lt;Unit Options&gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="bf74-08ce-f02a-25d6" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="9ef5-e7d3-8f94-9a38" targetId="502c-9855-7269-eaa2" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="fae6-07a8-03bf-e759" targetId="573b-88bc-97d7-d890" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="4cf9-9568-6a33-5f18" targetId="d571-d584-85fc-9110" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="1b1b-5f67-48e7-b04d" targetId="4b9d-a0bf-396e-384b" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="81af-1353-1e75-955f" targetId="1707-586b-01df-0f80" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="1e83-2d30-37c1-f54f" targetId="d118-8115-df5f-2402" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="7a95-8632-0c25-d086" incrementChildId="8fe8-c920-4357-5561" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="7a95-8632-0c25-d086" incrementChildId="dc88-b28b-0f31-61c9" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="cad5-b340-7463-f360" targetId="059e-3ead-10ef-9fd5" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <rules/>
+      <infoLinks/>
       <modifiers>
-        <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+        <modifier type="set" field="hidden" value="false">
+          <repeats/>
           <conditions>
-            <condition parentId="roster" childId="ed16-8f24-873e-f6cd" field="selections" type="equal to" value="1.0"/>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed16-8f24-873e-f6cd" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
       </modifiers>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="1871-8acd-7ec8-8700" name="Block!" points="5.0" categoryId="50ba-cf77-3941-189c" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="aadf-c739-5770-7605" targetId="5d2e-45d2-1707-87db" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="a44f-4447-aff2-0dcd" name="Domari Squad (Household Troops)" points="22.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="192">
-      <entries>
-        <entry id="c61f-6de1-069d-821f" name="&lt; Household Leader" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="191">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="eeeb-14fc-3015-51fc" name="&lt; Leader Level &gt;" defaultEntryId="af81-32d2-905d-4525" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="5b49-8a4d-07d2-fb89" targetId="02f3-3134-ae39-afed" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="af81-32d2-905d-4525" targetId="fc7e-7c0e-65e0-8c33" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="614f-b64a-4c29-8d4f" name="&lt; Ranged Weapon &gt;" defaultEntryId="2bc1-4f6e-02ba-7d1c" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="2bc1-4f6e-02ba-7d1c" targetId="8690-3ab7-9fef-06ee" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="48df-d58e-e0d1-d8df" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-                <link id="526a-3475-ccc6-063a" targetId="9cd6-dbb8-bdcb-0299" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-                <link id="052b-0bbe-d078-8a35" targetId="1631-5857-2139-960a" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="6.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="c976-a3c2-48e7-a65d" targetId="ed77-e875-0302-9bf4" linkType="profile">
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="c61f-6de1-069d-821f" childId="5b49-8a4d-07d2-fb89" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="d441-f08b-6ae0-3ce1" name="Household Trooper" points="15.0" categoryId="(No Category)" type="model" minSelections="5" maxSelections="7" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="192">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="9c0c-e485-c447-84fb" name="Ranged Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="20d8-1c96-d87e-6005" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="f4de-742c-31aa-3973" targetId="45dd-c1c8-46d5-0107" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="a960-249c-ef1d-5e8c" name="Micro-X Launcher" points="0.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="a9e5-f8a1-aadd-0667" name="SlingNet Ammo for Micro-X Launcher" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="eb51-606e-6b9f-6c33" targetId="e7b0-651a-cc7c-f27e" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="678a-8f30-acb7-0053" name="&lt; Unit Armor &gt;" defaultEntryId="a03c-46bd-0028-b43e" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="a03c-46bd-0028-b43e" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="e31c-0032-c416-8471" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="606b-c5e6-d436-9d3c" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="5163-e03b-fc25-9afe" targetId="d118-8115-df5f-2402" linkType="entry">
-              <modifiers>
-                <modifier type="set" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="a44f-4447-aff2-0dcd" incrementChildId="d441-f08b-6ae0-3ce1" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="a44f-4447-aff2-0dcd" incrementChildId="a960-249c-ef1d-5e8c" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="307c-9503-74f9-f4b3" name="Extra Shot" points="10.0" categoryId="50ba-cf77-3941-189c" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="4864-9551-d5ab-0fd1" targetId="e77b-02da-5143-229e" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="d05f-990a-ae91-4196" name="Feral Meld Skark (Mhagris)" points="115.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="193">
-      <entries>
-        <entry id="d398-8780-d6cb-1241" name="&gt; Feral Leader" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="193">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="fa1b-d08c-0a23-97f5" name="&lt; Leader Level &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="64c7-ce38-13a1-0a67" targetId="02f3-3134-ae39-afed" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="6230-3ae4-17d6-9052" targetId="5a4c-2f5e-40a2-91d4" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="1aa6-aff0-4b33-9f78" name="Ranged Weapon" defaultEntryId="43cf-0bae-d100-956c" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="43cf-0bae-d100-956c" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="ee88-cab4-5a29-66fe" targetId="b018-6101-d2e3-b4ea" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="8fe8-c920-4357-5561" name="Amano Harran, Oszoni Freeborn Mercenary Captain" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles>
-            <profile id="fa1e-41af-d09a-4df9" profileTypeId="1650-77b3-10d1-6406" name="Feral Leader" hidden="false" book="BtGoA" page="193">
+            <profile id="ac61-5231-2810-84b0" name="Amano Harran, Oszoni Freeborn Mercenary Captain" book="Battle for Xilos" page="115" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="append" field="f214-abe8-c922-c51b" value="(7)">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="7a95-8632-0c25-d086" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ddb6-781a-85af-eeeb" type="equalTo"/>
+                        <condition field="selections" scope="7a95-8632-0c25-d086" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="aa87-9d00-ec90-c775" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
               <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="8"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="7 (8)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="6"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="10"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="10"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Follow, Hero, Leader 3, Wound, Fast Shot, Charismatic Aura"/>
               </characteristics>
-              <modifiers/>
             </profile>
           </profiles>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="0b29-d80a-20b5-7e35" name="Armor" defaultEntryId="6f2d-ec4e-ce5c-1488" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="6f2d-ec4e-ce5c-1488" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="199e-4b69-cffe-68a5" name="Close Combat Weapon" defaultEntryId="3f7a-4f46-1255-79ab" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="3f7a-4f46-1255-79ab" targetId="b5e9-5297-04d2-2bf8" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="375e-22a4-1200-b6c6" name="Meld Skark" defaultEntryId="ee4b-0b0e-386d-99b2" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="ee4b-0b0e-386d-99b2" targetId="eafe-29d5-1222-4155" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="bd78-00f6-6a00-c0c7" targetId="a221-d53c-b4bd-b52c" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="be9d-0689-3672-7135" targetId="b0ca-8e7d-d03f-f027" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="1196-e275-ef1a-7a7c" targetId="3878-9363-1705-9eda" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="c7f9-56fe-b1f2-8d86" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="ff01-5f28-c344-f670" targetId="f7af-59ec-acde-2f75" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="1044-b654-0ca0-e5ad" name="Feral Skark Squad (Mhagris)" points="115.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="193">
-      <entries>
-        <entry id="c7f9-56fe-b1f2-8d86" name="&lt; Feral Leader" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="193">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="fdfc-05ca-f8f0-d848" name="&lt; Leader Level &gt;" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="7938-5e37-03c2-36f9" name="Leader Two" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="3c91-9185-0302-3739" targetId="7850-89e7-bab8-86e9" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="86b4-5321-c678-9f8e" name="Leader Three" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="f1b2-17c3-5c01-f840" targetId="05bb-4d34-70cd-25d2" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-            <entryGroup id="4835-5cca-c5ab-b665" name="Ranged Weapon" defaultEntryId="a4b6-8b90-d408-47e6" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="a4b6-8b90-d408-47e6" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="ac42-4a97-d2ca-35a4" targetId="e6db-6ed3-1a26-ea56" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-                <link id="4ed0-25b7-d8a9-9620" targetId="790a-6841-6372-870b" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="249d-04f1-6637-584a" targetId="1631-5857-2139-960a" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="5.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="ef9d-4e79-290c-20bc" targetId="41f2-0f61-9758-5e8d" linkType="profile">
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Large, Fast, Skark 3 Attacks SV1, Leader 2" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="c7f9-56fe-b1f2-8d86" childId="7938-5e37-03c2-36f9" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Large, Fast, Skark 3 Attacks SV1, Leader 3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="c7f9-56fe-b1f2-8d86" childId="86b4-5321-c678-9f8e" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="66d4-fa07-1bbf-5da2" name="Feral Fighter" points="0.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="193">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="438b-90c8-d7c4-125e" targetId="1069-6287-7c2a-af01" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="6a38-a612-5d6b-f4b0" name="&lt; Unit Ranged Weapon &gt;" defaultEntryId="fe21-b7fd-711d-b2f5" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="fe21-b7fd-711d-b2f5" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="835f-70e0-eb3b-6fe3" name="&lt; Unit Armor&gt;" defaultEntryId="3555-0453-6307-704b" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="3555-0453-6307-704b" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="f1fd-e630-1832-069b" name="&lt; Unit Close Combat Weapon &gt;" defaultEntryId="ae29-c766-0fde-446c" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="ae29-c766-0fde-446c" targetId="b5e9-5297-04d2-2bf8" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="0d4c-9f77-f0bf-9e0c" targetId="a221-d53c-b4bd-b52c" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="fcbc-0bcd-8b26-fc45" targetId="b0ca-8e7d-d03f-f027" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="bfab-953d-8387-49ad" targetId="1e33-99fa-00fc-0a32" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="4426-94bd-2acc-1aff" targetId="3878-9363-1705-9eda" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="6.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="c7f9-56fe-b1f2-8d86" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="1044-b654-0ca0-e5ad" incrementChildId="66d4-fa07-1bbf-5da2" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-      </links>
-    </entry>
-    <entry id="5cda-2300-7dae-8090" name="Feral Squad (Mhagris)" points="18.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BTGOA" page="191">
-      <entries>
-        <entry id="060b-a9a7-c641-af07" name="&lt; Feral Leader" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="191">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="7bf3-7f8c-bb36-8056" name="&lt; Leader Level &gt;" defaultEntryId="02c0-bf97-34ab-30c2" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="cb7e-226f-de17-d52a" targetId="02f3-3134-ae39-afed" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="28b8-d291-d4ee-cb65" targetId="5a4c-2f5e-40a2-91d4" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="02c0-bf97-34ab-30c2" targetId="fc7e-7c0e-65e0-8c33" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="f6c4-adbe-a27d-129a" name="&lt; Ranged Weapon &gt;" defaultEntryId="b6be-4b77-ef52-cd3a" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="b6be-4b77-ef52-cd3a" targetId="8690-3ab7-9fef-06ee" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="f89e-fb57-67ee-cd21" targetId="9cd6-dbb8-bdcb-0299" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-                <link id="9f8e-1152-80b5-a7b3" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-                <link id="4a2f-9e80-09af-2aec" targetId="1631-5857-2139-960a" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="6.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="a390-861b-ce2b-149f" targetId="f23b-60da-348a-e6db" linkType="profile">
-              <modifiers>
-                <modifier type="append" field="f214-abe8-c922-c51b" value="(6)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="5cda-2300-7dae-8090" childId="7959-d3d0-3fa6-31d2" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="26dc-46a0-f598-e869" name="Feral Fighter" points="11.0" categoryId="(No Category)" type="model" minSelections="5" maxSelections="11" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="b699-14bd-4f42-6832" name="&lt; Ranged Weapon &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="7b8a-0e82-ab5e-59cb" targetId="8f47-408e-cc6e-7a19" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="63e8-7025-f4e9-e92d" targetId="2ae1-18d0-fbc8-21ad" linkType="profile">
-              <modifiers>
-                <modifier type="append" field="f214-abe8-c922-c51b" value="(6)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="5cda-2300-7dae-8090" childId="7959-d3d0-3fa6-31d2" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="2223-cd79-2176-f186" name="Micro-X Launcher" points="0.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="aae4-047f-f2ad-3a9a" targetId="e7b0-651a-cc7c-f27e" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="13f2-f4e6-8cb9-000e" name="&lt; Unit Armor &gt;" defaultEntryId="0479-9c51-eb5f-7880" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="0479-9c51-eb5f-7880" name="None" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
+          <rules>
+            <rule id="4346-96cf-a909-9ab2" name="Fast Shot" book="Battle for Xilos" page="115" hidden="false">
               <profiles/>
-              <links/>
-            </entry>
-          </entries>
-          <entryGroups/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <description>With any hand or standard weapon, this model shoots twice instead of once using the same weapon at the same target. This ability CAN be used with the Xilos Stasis Key, but the key can still only fire with a Fire order.</description>
+            </rule>
+            <rule id="191b-64ea-3f8e-b6e2" name="Charismatic Aura" book="Battle for Xilos" page="115" hidden="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <description>If any enemy unit is within 10&quot; of the Amano Harran model then it cannot be given an order without taking an Order test against its Command, even if it has no pins, and both its Command and Initiative stat are reduced by -1 when making order and/or reaction tests.</description>
+            </rule>
+            <rule id="1c55-16af-48d1-e10f" name="Wound" book="Battle for Xilos" page="115" hidden="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <description>If Amano Harran fails a Res test then instead of falling casualty he is wounded. Once wounded, if any further Res test is failed he is removed as a casualty. If Amano Harran is wounded then the unit cannot lose its last 1 pin. It can lose other pins as normal, but will always retain at least one.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="12e9-6e86-5af0-79e8" hidden="false" targetId="7bc9-5e98-2914-5abd" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="5cce-7f58-827d-5129" hidden="false" targetId="5c9b-1bde-ee01-04a4" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="eca5-0e3f-2e2f-371a" hidden="false" targetId="3c64-6022-a5f1-9c04" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="f56e-220b-8d8d-e9c7" hidden="false" targetId="05bb-4d34-70cd-25d2" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-          <links>
-            <link id="7959-d3d0-3fa6-31d2" targetId="2396-4159-e26c-6c42" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="955c-f291-a035-8308" name="&lt;Weapons&gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="0197-c3d6-ee4b-351e" name="Zantu Plasma Duelling Pistol" book="Battle for Xilos" page="115" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles>
+                    <profile id="980e-e86b-7de6-4cff" name="Zantu Plasma Duelling Pistol" book="Battle for Xilos" page="115" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="40"/>
+                        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+                        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Dead Eye, Duellist"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules>
+                    <rule id="a0dc-c29f-3f0d-da12" name="Dead Eye" book="Battle for Xilos" page="115" hidden="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <description>When shooting with a Fire order, add +2 to Acc value rather than standard +1</description>
+                    </rule>
+                    <rule id="5ffd-287d-8644-d70c" name="Duellist" book="Battle for Xilos" page="115" hidden="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <description>When shooting simultaenously with an enemy unit, both sides roll 1d10. If the controlling player rolls higher, he shoots first and any result is applied to the target before it can fire back, including casualty removal and pinning.</description>
+                    </rule>
+                  </rules>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="72ab-7a5e-1ef3-875a" name="Xilos Stasis Key" book="Battle for Xilos" page="57" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles>
+                    <profile id="ce34-6972-faf0-fc0e" name="Xilos Stasis Key" book="Battle for Xilos" page="57" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+                        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa"/>
+                        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9"/>
+                        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a"/>
+                        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Stasis"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules>
+                    <rule id="7ecb-bcba-21d4-a388" name="Stasis" book="Battle for Xilos" page="57" hidden="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <description>Weapon can ONLY be fired with a Fire order, applying normal +1 Acc bonus. If target unit is hit, either switch its current Order Die to a Down order, or if it does not yet have an order, retrieve an Order Die from the bag and issue it a down order. Then, add a Stasis marker to the unit.			If a unit is in stasis at the turn end phase, then instead of making a recovery test to recover the Down Order Die, make a recovery test to remove the Stasis marker. The unit then remains Down until the next chance to make a recovery test, at which point the test applies to the Down Order Die.</description>
+                    </rule>
+                  </rules>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="25.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="dc88-b28b-0f31-61c9" name="Bodyguard" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="ceda-f66e-0469-f72a" hidden="false" targetId="9fba-d6b7-c66d-99f0" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="5cda-2300-7dae-8090" incrementChildId="060b-a9a7-c641-af07" incrementField="selections" incrementValue="1.0">
+                <modifier type="append" field="f214-abe8-c922-c51b" value="(7)">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="7a95-8632-0c25-d086" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ddb6-781a-85af-eeeb" type="equalTo"/>
+                        <condition field="selections" scope="7a95-8632-0c25-d086" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="aa87-9d00-ec90-c775" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="35f7-fede-27fa-da27" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="21.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="fa49-db82-4230-6855" name="&lt;Unit Armor&gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="ddb6-781a-85af-eeeb" hidden="false" targetId="eff8-bb0e-1b1d-bbb2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="7a95-8632-0c25-d086" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8fe8-c920-4357-5561" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="5cda-2300-7dae-8090" incrementChildId="26dc-46a0-f598-e869" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="7a95-8632-0c25-d086" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dc88-b28b-0f31-61c9" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="aa87-9d00-ec90-c775" hidden="false" targetId="eb94-d1e8-1084-71b3" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="7a95-8632-0c25-d086" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8fe8-c920-4357-5561" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="7a95-8632-0c25-d086" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dc88-b28b-0f31-61c9" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="5b9c-ebf8-2d76-ed50" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="ac48-df93-6a89-8648" name="&lt;Unit Options&gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="bf74-08ce-f02a-25d6" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="9ef5-e7d3-8f94-9a38" hidden="false" targetId="502c-9855-7269-eaa2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="fae6-07a8-03bf-e759" hidden="false" targetId="573b-88bc-97d7-d890" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="4cf9-9568-6a33-5f18" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="1b1b-5f67-48e7-b04d" hidden="false" targetId="4b9d-a0bf-396e-384b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="81af-1353-1e75-955f" hidden="false" targetId="1707-586b-01df-0f80" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="1e83-2d30-37c1-f54f" hidden="false" targetId="d118-8115-df5f-2402" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="7a95-8632-0c25-d086" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8fe8-c920-4357-5561" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="7a95-8632-0c25-d086" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dc88-b28b-0f31-61c9" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="cad5-b340-7463-f360" hidden="false" targetId="059e-3ead-10ef-9fd5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="126.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1871-8acd-7ec8-8700" name="Block!" hidden="false" collective="false" categoryEntryId="50ba-cf77-3941-189c" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="aadf-c739-5770-7605" hidden="false" targetId="5d2e-45d2-1707-87db" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a44f-4447-aff2-0dcd" name="Domari Squad (Household Troops)" book="BtGoA" page="192" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="c61f-6de1-069d-821f" name="&lt; Household Leader" book="BtGoA" page="191" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="c976-a3c2-48e7-a65d" hidden="false" targetId="ed77-e875-0302-9bf4" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2">
+                  <repeats/>
                   <conditions>
-                    <condition parentId="5cda-2300-7dae-8090" childId="2223-cd79-2176-f186" field="selections" type="equal to" value="1.0"/>
+                    <condition field="selections" scope="c61f-6de1-069d-821f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5b49-8a4d-07d2-fb89" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="eeeb-14fc-3015-51fc" name="&lt; Leader Level &gt;" hidden="false" collective="false" defaultSelectionEntryId="af81-32d2-905d-4525">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="5b49-8a4d-07d2-fb89" hidden="false" targetId="02f3-3134-ae39-afed" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="af81-32d2-905d-4525" hidden="false" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="614f-b64a-4c29-8d4f" name="&lt; Ranged Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="2bc1-4f6e-02ba-7d1c">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="2bc1-4f6e-02ba-7d1c" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="48df-d58e-e0d1-d8df" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="3.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="526a-3475-ccc6-063a" hidden="false" targetId="9cd6-dbb8-bdcb-0299" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="1.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="052b-0bbe-d078-8a35" hidden="false" targetId="1631-5857-2139-960a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="6.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d441-f08b-6ae0-3ce1" name="Household Trooper" book="BtGoA" page="192" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="f4de-742c-31aa-3973" hidden="false" targetId="45dd-c1c8-46d5-0107" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="9c0c-e485-c447-84fb" name="Ranged Weapon" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="20d8-1c96-d87e-6005" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a960-249c-ef1d-5e8c" name="Micro-X Launcher" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="a9e5-f8a1-aadd-0667" name="SlingNet Ammo for Micro-X Launcher" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="eb51-606e-6b9f-6c33" hidden="false" targetId="e7b0-651a-cc7c-f27e" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="678a-8f30-acb7-0053" name="&lt; Unit Armor &gt;" hidden="false" collective="false" defaultSelectionEntryId="a03c-46bd-0028-b43e">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="a03c-46bd-0028-b43e" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e31c-0032-c416-8471" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="606b-c5e6-d436-9d3c" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="5163-e03b-fc25-9afe" hidden="false" targetId="d118-8115-df5f-2402" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="2.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="a44f-4447-aff2-0dcd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d441-f08b-6ae0-3ce1" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="a44f-4447-aff2-0dcd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a960-249c-ef1d-5e8c" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="22.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="307c-9503-74f9-f4b3" name="Extra Shot" hidden="false" collective="false" categoryEntryId="50ba-cf77-3941-189c" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="4864-9551-d5ab-0fd1" hidden="false" targetId="e77b-02da-5143-229e" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d05f-990a-ae91-4196" name="Feral Meld Skark (Mhagris)" book="BtGoA" page="193" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="bd78-00f6-6a00-c0c7" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="be9d-0689-3672-7135" hidden="false" targetId="b0ca-8e7d-d03f-f027" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ff01-5f28-c344-f670" hidden="false" targetId="f7af-59ec-acde-2f75" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="d398-8780-d6cb-1241" name="&gt; Feral Leader" book="BtGoA" page="193" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="fa1e-41af-d09a-4df9" name="Feral Leader" book="BtGoA" page="193" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="8"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="7 (8)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="fa1b-d08c-0a23-97f5" name="&lt; Leader Level &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="64c7-ce38-13a1-0a67" hidden="false" targetId="02f3-3134-ae39-afed" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="6230-3ae4-17d6-9052" hidden="false" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="1aa6-aff0-4b33-9f78" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="43cf-0bae-d100-956c">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="43cf-0bae-d100-956c" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="ee88-cab4-5a29-66fe" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="3.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0b29-d80a-20b5-7e35" name="Armor" hidden="false" collective="false" defaultSelectionEntryId="6f2d-ec4e-ce5c-1488">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="6f2d-ec4e-ce5c-1488" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="199e-4b69-cffe-68a5" name="Close Combat Weapon" hidden="false" collective="false" defaultSelectionEntryId="3f7a-4f46-1255-79ab">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="3f7a-4f46-1255-79ab" hidden="false" targetId="b5e9-5297-04d2-2bf8" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="375e-22a4-1200-b6c6" name="Meld Skark" hidden="false" collective="false" defaultSelectionEntryId="ee4b-0b0e-386d-99b2">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="ee4b-0b0e-386d-99b2" hidden="false" targetId="eafe-29d5-1222-4155" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="1196-e275-ef1a-7a7c" hidden="false" targetId="3878-9363-1705-9eda" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="115.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1044-b654-0ca0-e5ad" name="Feral Skark Squad (Mhagris)" book="BtGoA" page="193" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0d4c-9f77-f0bf-9e0c" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="fcbc-0bcd-8b26-fc45" hidden="false" targetId="b0ca-8e7d-d03f-f027" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="c7f9-56fe-b1f2-8d86" name="&lt; Feral Leader" book="BtGoA" page="193" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="ef9d-4e79-290c-20bc" hidden="false" targetId="41f2-0f61-9758-5e8d" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Large, Fast, Skark 3 Attacks SV1, Leader 2">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="c7f9-56fe-b1f2-8d86" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7938-5e37-03c2-36f9" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Large, Fast, Skark 3 Attacks SV1, Leader 3">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="c7f9-56fe-b1f2-8d86" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="86b4-5321-c678-9f8e" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="fdfc-05ca-f8f0-d848" name="&lt; Leader Level &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="7938-5e37-03c2-36f9" name="Leader Two" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="3c91-9185-0302-3739" hidden="false" targetId="7850-89e7-bab8-86e9" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="86b4-5321-c678-9f8e" name="Leader Three" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="f1b2-17c3-5c01-f840" hidden="false" targetId="05bb-4d34-70cd-25d2" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="20.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="4835-5cca-c5ab-b665" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="a4b6-8b90-d408-47e6">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="a4b6-8b90-d408-47e6" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="ac42-4a97-d2ca-35a4" hidden="false" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="0.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="4ed0-25b7-d8a9-9620" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="249d-04f1-6637-584a" hidden="false" targetId="1631-5857-2139-960a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="5.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="66d4-fa07-1bbf-5da2" name="Feral Fighter" book="BtGoA" page="193" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="438b-90c8-d7c4-125e" hidden="false" targetId="1069-6287-7c2a-af01" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6a38-a612-5d6b-f4b0" name="&lt; Unit Ranged Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="fe21-b7fd-711d-b2f5">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="fe21-b7fd-711d-b2f5" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="835f-70e0-eb3b-6fe3" name="&lt; Unit Armor&gt;" hidden="false" collective="false" defaultSelectionEntryId="3555-0453-6307-704b">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="3555-0453-6307-704b" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="f1fd-e630-1832-069b" name="&lt; Unit Close Combat Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="ae29-c766-0fde-446c">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="ae29-c766-0fde-446c" hidden="false" targetId="b5e9-5297-04d2-2bf8" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="bfab-953d-8387-49ad" hidden="false" targetId="1e33-99fa-00fc-0a32" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="4426-94bd-2acc-1aff" hidden="false" targetId="3878-9363-1705-9eda" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="6.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="1044-b654-0ca0-e5ad" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="66d4-fa07-1bbf-5da2" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="115.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5cda-2300-7dae-8090" name="Feral Squad (Mhagris)" book="BTGOA" page="191" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
       <rules>
-        <rule id="0587-e7a6-cccd-a152" name="Infantry Unit" hidden="false" book="">
+        <rule id="0587-e7a6-cccd-a152" name="Infantry Unit" book="" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="0e45-6566-b04a-b718" targetId="3878-9363-1705-9eda" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="5cda-2300-7dae-8090" incrementChildId="060b-a9a7-c641-af07" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="5cda-2300-7dae-8090" incrementChildId="26dc-46a0-f598-e869" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions>
-                <condition parentId="5cda-2300-7dae-8090" childId="2223-cd79-2176-f186" field="selections" type="equal to" value="1.0"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="49e8-198a-92af-6784" targetId="d118-8115-df5f-2402" linkType="entry">
-          <modifiers>
-            <modifier type="set" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="5cda-2300-7dae-8090" incrementChildId="26dc-46a0-f598-e869" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions>
-                <condition parentId="5cda-2300-7dae-8090" childId="2223-cd79-2176-f186" field="selections" type="equal to" value="1.0"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-      </links>
-    </entry>
-    <entry id="04d7-b8fa-d20d-5a98" name="Freeborn Attack Skimmer (Striker)" points="148.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="193">
-      <entries>
-        <entry id="c30a-e7b6-bb84-7bb5" name="Striker" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="193">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="c647-b28b-df13-6d30" name="&lt; Unit Weapon &gt;" defaultEntryId="b030-5851-0170-e80b" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="b030-5851-0170-e80b" targetId="cf3a-e6a9-bdc0-e0ae" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="2691-8987-ab1a-2617" targetId="c2bf-0272-30c6-dd20" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="5.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="060b-a9a7-c641-af07" name="&lt; Feral Leader" book="BtGoA" page="191" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles/>
-          <links>
-            <link id="204f-7870-70cd-0175" targetId="2da6-e419-5126-a73b" linkType="profile">
+          <rules/>
+          <infoLinks>
+            <infoLink id="a390-861b-ce2b-149f" hidden="false" targetId="f23b-60da-348a-e6db" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="f214-abe8-c922-c51b" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="append" field="f214-abe8-c922-c51b" value="(6)">
+                  <repeats/>
                   <conditions>
-                    <condition parentId="04d7-b8fa-d20d-5a98" childId="d788-9457-e43f-3692" field="selections" type="equal to" value="1.0"/>
+                    <condition field="selections" scope="5cda-2300-7dae-8090" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7959-d3d0-3fa6-31d2" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="d788-9457-e43f-3692" name="HL Booster (adds +1 res)" points="24.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-          <rules/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="7bf3-7f8c-bb36-8056" name="&lt; Leader Level &gt;" hidden="false" collective="false" defaultSelectionEntryId="02c0-bf97-34ab-30c2">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="cb7e-226f-de17-d52a" hidden="false" targetId="02f3-3134-ae39-afed" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="28b8-d291-d4ee-cb65" hidden="false" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="02c0-bf97-34ab-30c2" hidden="false" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="f6c4-adbe-a27d-129a" name="&lt; Ranged Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="b6be-4b77-ef52-cd3a">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="b6be-4b77-ef52-cd3a" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="f89e-fb57-67ee-cd21" hidden="false" targetId="9cd6-dbb8-bdcb-0299" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="1.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="9f8e-1152-80b5-a7b3" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="3.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="4a2f-9e80-09af-2aec" hidden="false" targetId="1631-5857-2139-960a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="6.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="26dc-46a0-f598-e869" name="Feral Fighter" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles/>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="eb1e-c626-334f-2865" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="63e8-7025-f4e9-e92d" hidden="false" targetId="2ae1-18d0-fbc8-21ad" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="append" field="f214-abe8-c922-c51b" value="(6)">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="5cda-2300-7dae-8090" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7959-d3d0-3fa6-31d2" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-          <links>
-            <link id="a72d-0f8c-e2c5-99f2" targetId="d571-d584-85fc-9110" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="11.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="b699-14bd-4f42-6832" name="&lt; Ranged Weapon &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="2979-eed7-b244-aefc" targetId="f3aa-148a-0460-c7e5" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="7b8a-0e82-ab5e-59cb" hidden="false" targetId="8f47-408e-cc6e-7a19" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="11.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2223-cd79-2176-f186" name="Micro-X Launcher" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="aae4-047f-f2ad-3a9a" hidden="false" targetId="e7b0-651a-cc7c-f27e" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="13f2-f4e6-8cb9-000e" name="&lt; Unit Armor &gt;" hidden="false" collective="false" defaultSelectionEntryId="0479-9c51-eb5f-7880">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="0479-9c51-eb5f-7880" name="None" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="7959-d3d0-3fa6-31d2" hidden="false" targetId="2396-4159-e26c-6c42" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="5cda-2300-7dae-8090" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="060b-a9a7-c641-af07" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="5cda-2300-7dae-8090" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="26dc-46a0-f598-e869" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="5cda-2300-7dae-8090" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2223-cd79-2176-f186" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="0e45-6566-b04a-b718" hidden="false" targetId="3878-9363-1705-9eda" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="5cda-2300-7dae-8090" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="060b-a9a7-c641-af07" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="5cda-2300-7dae-8090" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="26dc-46a0-f598-e869" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="5cda-2300-7dae-8090" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2223-cd79-2176-f186" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="49e8-198a-92af-6784" hidden="false" targetId="d118-8115-df5f-2402" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="points" value="2.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="5cda-2300-7dae-8090" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="26dc-46a0-f598-e869" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="5cda-2300-7dae-8090" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2223-cd79-2176-f186" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="18.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="04d7-b8fa-d20d-5a98" name="Freeborn Attack Skimmer (Striker)" book="BtGoA" page="193" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
       <rules>
         <rule id="3282-4fa8-4571-f511" name="Vehicle Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
+      <infoLinks>
+        <infoLink id="b3ea-1e90-ad90-ee02" hidden="false" targetId="5565-ce10-1c78-1ee7" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="48a7-1194-3630-6d90" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="c30a-e7b6-bb84-7bb5" name="Striker" book="BtGoA" page="193" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="204f-7870-70cd-0175" hidden="false" targetId="2da6-e419-5126-a73b" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="f214-abe8-c922-c51b" value="1">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="04d7-b8fa-d20d-5a98" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d788-9457-e43f-3692" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="c647-b28b-df13-6d30" name="&lt; Unit Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="b030-5851-0170-e80b">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="b030-5851-0170-e80b" hidden="false" targetId="cf3a-e6a9-bdc0-e0ae" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="2691-8987-ab1a-2617" hidden="false" targetId="c2bf-0272-30c6-dd20" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="5.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d788-9457-e43f-3692" name="HL Booster (adds +1 res)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="24.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="eb1e-c626-334f-2865" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="a72d-0f8c-e2c5-99f2" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="2979-eed7-b244-aefc" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="148.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b73b-6140-e2ca-f0c1" name="Freeborn Command Squad" hidden="true" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
       <profiles/>
-      <links>
-        <link id="b3ea-1e90-ad90-ee02" targetId="5565-ce10-1c78-1ee7" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="48a7-1194-3630-6d90" targetId="a221-d53c-b4bd-b52c" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="b73b-6140-e2ca-f0c1" name="Freeborn Command Squad" points="69.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true">
-      <entries>
-        <entry id="b36d-f9f6-80eb-6f8a" name="&lt; Freeborn Captain" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="ee93-85a8-a748-3858" name="&lt; Leader Level &gt;" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="3a47-103d-769c-3d59" targetId="5a4c-2f5e-40a2-91d4" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="0c11-a12d-3376-0b4b" name="&lt;Freeborn Captain Equipment &gt;" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups>
-                <entryGroup id="d72b-f17d-2842-5908" name="&lt; Armour &gt;" defaultEntryId="d821-bfad-6e70-be4a" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="d821-bfad-6e70-be4a" targetId="03c2-174e-8617-cf04" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-                <entryGroup id="6343-7996-c9c2-e583" name="&lt; Weapons &gt;" defaultEntryId="c38c-46e0-0457-f57d" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="c38c-46e0-0457-f57d" targetId="e6db-6ed3-1a26-ea56" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-              </entryGroups>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="75cc-7baf-4390-4597" targetId="2d89-bcdb-b942-b900" linkType="profile">
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="b73b-6140-e2ca-f0c1" childId="3a47-103d-769c-3d59" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="6b48-ec12-ab6c-2063" name="Bodyguards" points="21.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="c9a4-5ee7-f187-8235" name="&lt; Armour &gt;" defaultEntryId="5b9a-d663-bb0e-6480" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="5b9a-d663-bb0e-6480" targetId="03c2-174e-8617-cf04" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="ce36-0f86-ad2b-2de0" name="&lt; Weapons &gt;" defaultEntryId="ffe5-b36e-981d-67c8" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="ffe5-b36e-981d-67c8" targetId="b018-6101-d2e3-b4ea" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers>
-            <modifier type="increment" field="maxSelections" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions>
-                <condition parentId="roster" childId="3933-5e9f-f85c-ba75" field="selections" type="equal to" value="1.0"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="16f3-2f8c-3e35-5557" targetId="9fba-d6b7-c66d-99f0" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="87b2-db05-700b-2ce2" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="4e48-b0be-38f0-fb84" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="25ec-bc01-1917-42a1" targetId="502c-9855-7269-eaa2" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="e804-8e7c-7660-6271" targetId="573b-88bc-97d7-d890" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="19db-d0e1-8415-81fa" targetId="d118-8115-df5f-2402" linkType="entry">
-              <modifiers>
-                <modifier type="set" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="b73b-6140-e2ca-f0c1" incrementChildId="6b48-ec12-ab6c-2063" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="3b4d-27c4-5549-02cb" targetId="4b9d-a0bf-396e-384b" linkType="entry">
-              <modifiers>
-                <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="roster" childId="ad0d-a741-67ad-5d5c" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="2c36-464a-243b-0e55" targetId="1707-586b-01df-0f80" linkType="entry">
-              <modifiers>
-                <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="roster" childId="d17a-ef4d-2148-25e8" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="8de0-52be-784c-00ce" targetId="d571-d584-85fc-9110" linkType="entry">
-              <modifiers>
-                <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="roster" childId="a400-34cd-f726-fbf6" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <rules/>
+      <infoLinks/>
       <modifiers>
-        <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+        <modifier type="set" field="hidden" value="false">
+          <repeats/>
           <conditions/>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition parentId="roster" childId="3933-5e9f-f85c-ba75" field="selections" type="equal to" value="1.0"/>
-                <condition parentId="roster" childId="a400-34cd-f726-fbf6" field="selections" type="equal to" value="1.0"/>
-                <condition parentId="roster" childId="ad0d-a741-67ad-5d5c" field="selections" type="equal to" value="1.0"/>
-                <condition parentId="roster" childId="d17a-ef4d-2148-25e8" field="selections" type="equal to" value="1.0"/>
-                <condition parentId="roster" childId="39a7-bedc-c912-a9f0" field="selections" type="equal to" value="1.0"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3933-5e9f-f85c-ba75" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a400-34cd-f726-fbf6" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad0d-a741-67ad-5d5c" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d17a-ef4d-2148-25e8" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="39a7-bedc-c912-a9f0" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="15e4-e4af-15f1-94c3" name="Freeborn Command Squad" points="70.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true">
-      <entries>
-        <entry id="8b00-b972-e10d-1390" name="&lt; Freeborn Captain" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="b997-071f-1f47-aee8" name="&lt; Leader Level &gt;" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="ed96-be90-06f3-0beb" targetId="5a4c-2f5e-40a2-91d4" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="992a-ced2-9419-513c" name="&lt;Freeborn Captain Equipment &gt;" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups>
-                <entryGroup id="f80a-cee4-23df-5b8d" name="&lt; Armour &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="0ca1-9662-209b-eb0d" targetId="03c2-174e-8617-cf04" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-                <entryGroup id="a5f8-02a4-689a-510f" name="&lt; Weapons &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="c1d9-84de-92d6-cb72" targetId="e6db-6ed3-1a26-ea56" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-              </entryGroups>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="b36d-f9f6-80eb-6f8a" name="&lt; Freeborn Captain" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles/>
-          <links>
-            <link id="5545-8414-45f3-4c97" targetId="2d89-bcdb-b942-b900" linkType="profile">
+          <rules/>
+          <infoLinks>
+            <infoLink id="75cc-7baf-4390-4597" hidden="false" targetId="2d89-bcdb-b942-b900" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
+                  <repeats/>
                   <conditions>
-                    <condition parentId="15e4-e4af-15f1-94c3" childId="ed96-be90-06f3-0beb" field="selections" type="equal to" value="1.0"/>
+                    <condition field="selections" scope="b73b-6140-e2ca-f0c1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3a47-103d-769c-3d59" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="16e2-4b59-8a36-351a" name="Bodygaurds" points="26.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="70fa-1e75-d60b-2e16" name="&lt; Armour &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="ee93-85a8-a748-3858" name="&lt; Leader Level &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <links>
-                <link id="f41b-1c7d-c117-325d" targetId="03c2-174e-8617-cf04" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="3a47-103d-769c-3d59" hidden="false" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="05c5-0dc8-f360-2012" name="&lt; Weapons &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="0c11-a12d-3376-0b4b" name="&lt;Freeborn Captain Equipment &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <links>
-                <link id="b106-d8e7-67b5-3daf" targetId="059b-38f7-0313-5ae4" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="d72b-f17d-2842-5908" name="&lt; Armour &gt;" hidden="false" collective="false" defaultSelectionEntryId="d821-bfad-6e70-be4a">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="d821-bfad-6e70-be4a" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="6343-7996-c9c2-e583" name="&lt; Weapons &gt;" hidden="false" collective="false" defaultSelectionEntryId="c38c-46e0-0457-f57d">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="c38c-46e0-0457-f57d" hidden="false" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6b48-ec12-ab6c-2063" name="Bodyguards" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="16f3-2f8c-3e35-5557" hidden="false" targetId="9fba-d6b7-c66d-99f0" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers>
-            <modifier type="increment" field="maxSelections" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+            <modifier type="increment" field="maxSelections" value="2.0">
+              <repeats/>
               <conditions>
-                <condition parentId="roster" childId="3933-5e9f-f85c-ba75" field="selections" type="equal to" value="1.0"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3933-5e9f-f85c-ba75" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
           </modifiers>
-          <rules/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="c9a4-5ee7-f187-8235" name="&lt; Armour &gt;" hidden="false" collective="false" defaultSelectionEntryId="5b9a-d663-bb0e-6480">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="5b9a-d663-bb0e-6480" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="ce36-0f86-ad2b-2de0" name="&lt; Weapons &gt;" hidden="false" collective="false" defaultSelectionEntryId="ffe5-b36e-981d-67c8">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="ffe5-b36e-981d-67c8" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="21.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="87b2-db05-700b-2ce2" name="&lt; Unit Options &gt;" hidden="false" collective="false">
           <profiles/>
-          <links>
-            <link id="5e80-a56f-41a7-b337" targetId="9fba-d6b7-c66d-99f0" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="4fd9-336f-cb2a-74cb" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="5c84-6fcb-23cb-c531" targetId="f3aa-148a-0460-c7e5" linkType="entry">
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="4e48-b0be-38f0-fb84" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="0534-209c-6e63-b751" targetId="502c-9855-7269-eaa2" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="25ec-bc01-1917-42a1" hidden="false" targetId="502c-9855-7269-eaa2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="3cc5-bd4f-f987-bb96" targetId="573b-88bc-97d7-d890" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="e804-8e7c-7660-6271" hidden="false" targetId="573b-88bc-97d7-d890" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="9289-3ce8-ce3b-c398" targetId="d118-8115-df5f-2402" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="19db-d0e1-8415-81fa" hidden="false" targetId="d118-8115-df5f-2402" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="set" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="points" value="2.0">
+                  <repeats/>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="15e4-e4af-15f1-94c3" incrementChildId="16e2-4b59-8a36-351a" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="b73b-6140-e2ca-f0c1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6b48-ec12-ab6c-2063" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers>
-        <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-          <conditions>
-            <condition parentId="roster" childId="7f96-ddf7-af5d-958a" field="selections" type="equal to" value="1.0"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="4224-b512-8e27-a7ae" name="Freeborn Command Squad" points="70.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true">
-      <entries>
-        <entry id="8166-8ae2-85a7-d508" name="&lt; Freeborn Captain" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="ec55-a3a6-79d2-3d8d" name="&lt; Leader Level &gt;" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="7539-56fe-d7c4-3436" targetId="5a4c-2f5e-40a2-91d4" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="bc83-ae90-8685-ec61" name="&lt;Freeborn Captain Equipment &gt;" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups>
-                <entryGroup id="8610-880b-d363-2842" name="&lt; Armour &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="9413-43f9-5e3c-0e39" targetId="03c2-174e-8617-cf04" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-                <entryGroup id="b05f-e970-7acf-b5c2" name="&lt; Weapons &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="dc7e-0219-458d-80af" targetId="e6db-6ed3-1a26-ea56" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-              </entryGroups>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="74c9-0721-edb2-fe31" targetId="2d89-bcdb-b942-b900" linkType="profile">
+              <constraints/>
+            </entryLink>
+            <entryLink id="3b4d-27c4-5549-02cb" hidden="false" targetId="4b9d-a0bf-396e-384b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="hidden" value="false">
+                  <repeats/>
                   <conditions>
-                    <condition parentId="4224-b512-8e27-a7ae" childId="ec55-a3a6-79d2-3d8d" field="selections" type="equal to" value="1.0"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad0d-a741-67ad-5d5c" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="733f-d5cf-9ed2-cd37" name="Bodygaurds" points="26.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="2a25-debf-a112-08f8" name="&lt; Armour &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="94d8-34e0-0bd0-2f8f" targetId="03c2-174e-8617-cf04" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="64e2-25c4-0a20-fd6f" name="&lt; Weapons &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="f2d1-fbb0-ae51-637a" targetId="059b-38f7-0313-5ae4" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers>
-            <modifier type="increment" field="maxSelections" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions>
-                <condition parentId="roster" childId="3933-5e9f-f85c-ba75" field="selections" type="equal to" value="1.0"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="433d-17af-98e2-e708" targetId="9fba-d6b7-c66d-99f0" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="01c0-de81-eb4f-6520" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="2313-6b51-b6fc-4334" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="55b3-8e97-1f9f-99c1" targetId="502c-9855-7269-eaa2" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="6334-02c5-fe28-46b2" targetId="573b-88bc-97d7-d890" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="94a7-abc4-e849-288a" targetId="d118-8115-df5f-2402" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="2c36-464a-243b-0e55" hidden="false" targetId="1707-586b-01df-0f80" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="set" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="4224-b512-8e27-a7ae" incrementChildId="733f-d5cf-9ed2-cd37" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
+                <modifier type="set" field="hidden" value="false">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d17a-ef4d-2148-25e8" type="equalTo"/>
+                  </conditions>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+              <constraints/>
+            </entryLink>
+            <entryLink id="8de0-52be-784c-00ce" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="hidden" value="false">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a400-34cd-f726-fbf6" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="69.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="15e4-e4af-15f1-94c3" name="Freeborn Command Squad" hidden="true" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers>
-        <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+        <modifier type="set" field="hidden" value="false">
+          <repeats/>
           <conditions>
-            <condition parentId="roster" childId="a90a-cec1-cd13-3c17" field="selections" type="equal to" value="1.0"/>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f96-ddf7-af5d-958a" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
       </modifiers>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="0f65-b8ed-b8b2-294a" name="Freeborn Command Squad" points="70.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true">
-      <entries>
-        <entry id="6f3f-e7de-8b1f-9a45" name="&lt; Freeborn Captain" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="3f21-c5d0-9056-3513" name="&lt; Leader Level &gt;" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="8b00-b972-e10d-1390" name="&lt; Freeborn Captain" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="5545-8414-45f3-4c97" hidden="false" targetId="2d89-bcdb-b942-b900" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="15e4-e4af-15f1-94c3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ed96-be90-06f3-0beb" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="b997-071f-1f47-aee8" name="&lt; Leader Level &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <links>
-                <link id="6ef1-5f41-d717-8432" targetId="5a4c-2f5e-40a2-91d4" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="ed96-be90-06f3-0beb" hidden="false" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="eba6-42f4-e601-d9d4" name="&lt;Freeborn Captain Equipment &gt;" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups>
-                <entryGroup id="0c25-94d1-2ee1-8f97" name="&lt; Armour &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="992a-ced2-9419-513c" name="&lt;Freeborn Captain Equipment &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="f80a-cee4-23df-5b8d" name="&lt; Armour &gt;" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                  <links>
-                    <link id="fd6b-8d29-bb72-1f1a" targetId="03c2-174e-8617-cf04" linkType="entry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="0ca1-9662-209b-eb0d" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
                       <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-                <entryGroup id="1d89-7fac-a8ca-dea9" name="&lt; Weapons &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="a5f8-02a4-689a-510f" name="&lt; Weapons &gt;" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                  <links>
-                    <link id="bfcd-6dc1-7032-9eca" targetId="059b-38f7-0313-5ae4" linkType="entry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="c1d9-84de-92d6-cb72" hidden="false" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="16e2-4b59-8a36-351a" name="Bodygaurds" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="5e80-a56f-41a7-b337" hidden="false" targetId="9fba-d6b7-c66d-99f0" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="maxSelections" value="2.0">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3933-5e9f-f85c-ba75" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="70fa-1e75-d60b-2e16" name="&lt; Armour &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="f41b-1c7d-c117-325d" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="05c5-0dc8-f360-2012" name="&lt; Weapons &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="b106-d8e7-67b5-3daf" hidden="false" targetId="059b-38f7-0313-5ae4" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="26.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="4fd9-336f-cb2a-74cb" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="5c84-6fcb-23cb-c531" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="0534-209c-6e63-b751" hidden="false" targetId="502c-9855-7269-eaa2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="3cc5-bd4f-f987-bb96" hidden="false" targetId="573b-88bc-97d7-d890" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="9289-3ce8-ce3b-c398" hidden="false" targetId="d118-8115-df5f-2402" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="2.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="15e4-e4af-15f1-94c3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="16e2-4b59-8a36-351a" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="70.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4224-b512-8e27-a7ae" name="Freeborn Command Squad" hidden="true" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a90a-cec1-cd13-3c17" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="8166-8ae2-85a7-d508" name="&lt; Freeborn Captain" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="74c9-0721-edb2-fe31" hidden="false" targetId="2d89-bcdb-b942-b900" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="4224-b512-8e27-a7ae" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ec55-a3a6-79d2-3d8d" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="ec55-a3a6-79d2-3d8d" name="&lt; Leader Level &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="7539-56fe-d7c4-3436" hidden="false" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="bc83-ae90-8685-ec61" name="&lt;Freeborn Captain Equipment &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="8610-880b-d363-2842" name="&lt; Armour &gt;" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="9413-43f9-5e3c-0e39" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="b05f-e970-7acf-b5c2" name="&lt; Weapons &gt;" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="dc7e-0219-458d-80af" hidden="false" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="733f-d5cf-9ed2-cd37" name="Bodygaurds" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="433d-17af-98e2-e708" hidden="false" targetId="9fba-d6b7-c66d-99f0" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="maxSelections" value="2.0">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3933-5e9f-f85c-ba75" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="2a25-debf-a112-08f8" name="&lt; Armour &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="94d8-34e0-0bd0-2f8f" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="64e2-25c4-0a20-fd6f" name="&lt; Weapons &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="f2d1-fbb0-ae51-637a" hidden="false" targetId="059b-38f7-0313-5ae4" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="26.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="01c0-de81-eb4f-6520" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="2313-6b51-b6fc-4334" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="55b3-8e97-1f9f-99c1" hidden="false" targetId="502c-9855-7269-eaa2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="6334-02c5-fe28-46b2" hidden="false" targetId="573b-88bc-97d7-d890" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="94a7-abc4-e849-288a" hidden="false" targetId="d118-8115-df5f-2402" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="2.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="4224-b512-8e27-a7ae" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="733f-d5cf-9ed2-cd37" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="70.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0f65-b8ed-b8b2-294a" name="Freeborn Command Squad" hidden="true" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a04c-3029-b790-0cdb" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="6f3f-e7de-8b1f-9a45" name="&lt; Freeborn Captain" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="9559-7359-c187-35e7" hidden="false" targetId="2d89-bcdb-b942-b900" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="0f65-b8ed-b8b2-294a" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6ef1-5f41-d717-8432" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="3f21-c5d0-9056-3513" name="&lt; Leader Level &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="6ef1-5f41-d717-8432" hidden="false" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="eba6-42f4-e601-d9d4" name="&lt;Freeborn Captain Equipment &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="0c25-94d1-2ee1-8f97" name="&lt; Armour &gt;" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="fd6b-8d29-bb72-1f1a" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="1d89-7fac-a8ca-dea9" name="&lt; Weapons &gt;" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="bfcd-6dc1-7032-9eca" hidden="false" targetId="059b-38f7-0313-5ae4" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
                       <modifiers>
-                        <modifier type="set" field="points" value="8.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                        <modifier type="set" field="points" value="8.0">
+                          <repeats/>
                           <conditions/>
                           <conditionGroups/>
                         </modifier>
                       </modifiers>
-                    </link>
-                  </links>
-                </entryGroup>
-              </entryGroups>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f539-7c50-1fed-c0fe" name="Bodygaurds" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles/>
-          <links>
-            <link id="9559-7359-c187-35e7" targetId="2d89-bcdb-b942-b900" linkType="profile">
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="0f65-b8ed-b8b2-294a" childId="6ef1-5f41-d717-8432" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="f539-7c50-1fed-c0fe" name="Bodygaurds" points="26.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="db1b-d74c-4488-f114" name="&lt; Armour &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="c830-2ab1-3be7-3427" hidden="false" targetId="9fba-d6b7-c66d-99f0" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <links>
-                <link id="9dbd-a1b9-f7e2-b802" targetId="03c2-174e-8617-cf04" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="da8e-2b95-0031-818a" name="&lt; Weapons &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="bcc8-515f-8cbc-7a6c" targetId="b018-6101-d2e3-b4ea" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
+            </infoLink>
+          </infoLinks>
           <modifiers>
-            <modifier type="increment" field="maxSelections" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+            <modifier type="increment" field="maxSelections" value="2.0">
+              <repeats/>
               <conditions>
-                <condition parentId="roster" childId="3933-5e9f-f85c-ba75" field="selections" type="equal to" value="1.0"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3933-5e9f-f85c-ba75" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
           </modifiers>
-          <rules/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="db1b-d74c-4488-f114" name="&lt; Armour &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="9dbd-a1b9-f7e2-b802" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="da8e-2b95-0031-818a" name="&lt; Weapons &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="bcc8-515f-8cbc-7a6c" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="26.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6c4b-1586-3d8b-dbda" name="&lt; Unit Options &gt;" hidden="false" collective="false">
           <profiles/>
-          <links>
-            <link id="c830-2ab1-3be7-3427" targetId="9fba-d6b7-c66d-99f0" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="6c4b-1586-3d8b-dbda" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="712a-24b1-dd4d-c34e" targetId="f3aa-148a-0460-c7e5" linkType="entry">
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="712a-24b1-dd4d-c34e" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="7484-dc39-dbc9-ced2" targetId="502c-9855-7269-eaa2" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="7484-dc39-dbc9-ced2" hidden="false" targetId="502c-9855-7269-eaa2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="2981-4427-c93a-87d1" targetId="573b-88bc-97d7-d890" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="2981-4427-c93a-87d1" hidden="false" targetId="573b-88bc-97d7-d890" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="7113-0a49-238b-ccc3" targetId="d118-8115-df5f-2402" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="7113-0a49-238b-ccc3" hidden="false" targetId="d118-8115-df5f-2402" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="set" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="points" value="2.0">
+                  <repeats/>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="0f65-b8ed-b8b2-294a" incrementChildId="f539-7c50-1fed-c0fe" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="0f65-b8ed-b8b2-294a" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f539-7c50-1fed-c0fe" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="70.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ff83-951c-1523-67b4" name="Freeborn Command Squad" hidden="true" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers>
-        <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+        <modifier type="set" field="hidden" value="false">
+          <repeats/>
           <conditions>
-            <condition parentId="roster" childId="a04c-3029-b790-0cdb" field="selections" type="equal to" value="1.0"/>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6559-a8ba-d266-7c27" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
       </modifiers>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="ff83-951c-1523-67b4" name="Freeborn Command Squad" points="70.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true">
-      <entries>
-        <entry id="0b68-b15d-4f21-400d" name="&lt; Freeborn Captain" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="4f77-859f-d36f-3f51" name="&lt; Leader Level &gt;" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="0b68-b15d-4f21-400d" name="&lt; Freeborn Captain" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="865b-5fee-3347-eedb" hidden="false" targetId="2d89-bcdb-b942-b900" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="ff83-951c-1523-67b4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fab0-fb87-4db4-b758" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="4f77-859f-d36f-3f51" name="&lt; Leader Level &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <links>
-                <link id="fab0-fb87-4db4-b758" targetId="5a4c-2f5e-40a2-91d4" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="fab0-fb87-4db4-b758" hidden="false" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="534d-0cc6-dc8f-0e4a" name="&lt;Freeborn Captain Equipment &gt;" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups>
-                <entryGroup id="6168-628e-5ed2-eaa9" name="&lt; Armour &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="534d-0cc6-dc8f-0e4a" name="&lt;Freeborn Captain Equipment &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="6168-628e-5ed2-eaa9" name="&lt; Armour &gt;" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                  <links>
-                    <link id="be23-8e40-689c-4584" targetId="eff8-bb0e-1b1d-bbb2" linkType="entry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="be23-8e40-689c-4584" hidden="false" targetId="eff8-bb0e-1b1d-bbb2" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
                       <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-                <entryGroup id="5ec4-d224-e3cc-e5a6" name="&lt; Weapons &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="5ec4-d224-e3cc-e5a6" name="&lt; Weapons &gt;" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                  <links>
-                    <link id="bff1-9762-306f-171b" targetId="b018-6101-d2e3-b4ea" linkType="entry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="bff1-9762-306f-171b" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
                       <modifiers>
-                        <modifier type="set" field="points" value="8.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                        <modifier type="set" field="points" value="8.0">
+                          <repeats/>
                           <conditions/>
                           <conditionGroups/>
                         </modifier>
                       </modifiers>
-                    </link>
-                  </links>
-                </entryGroup>
-              </entryGroups>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b52c-6be6-7a76-ba77" name="Bodygaurds" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles/>
-          <links>
-            <link id="865b-5fee-3347-eedb" targetId="2d89-bcdb-b942-b900" linkType="profile">
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="ff83-951c-1523-67b4" childId="fab0-fb87-4db4-b758" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="b52c-6be6-7a76-ba77" name="Bodygaurds" points="26.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="48ac-19f4-04e6-2834" name="&lt; Armour &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="f1f4-b68d-48a0-6c7f" targetId="eff8-bb0e-1b1d-bbb2" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="1095-6dad-810d-ff4f" name="&lt; Weapons &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="dde5-232c-c035-35fa" targetId="b018-6101-d2e3-b4ea" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
           <rules/>
-          <profiles/>
-          <links>
-            <link id="248c-567b-902f-d5d5" targetId="9fba-d6b7-c66d-99f0" linkType="profile">
+          <infoLinks>
+            <infoLink id="248c-567b-902f-d5d5" hidden="false" targetId="9fba-d6b7-c66d-99f0" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="4329-ec3b-739b-0050" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-          <links>
-            <link id="9bc9-cab0-4841-6c2c" targetId="f3aa-148a-0460-c7e5" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="48ac-19f4-04e6-2834" name="&lt; Armour &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="c86a-f1fe-6d59-873f" targetId="502c-9855-7269-eaa2" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="f1f4-b68d-48a0-6c7f" hidden="false" targetId="eff8-bb0e-1b1d-bbb2" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="1095-6dad-810d-ff4f" name="&lt; Weapons &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="e0aa-ee5e-c24a-c338" targetId="573b-88bc-97d7-d890" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="dde5-232c-c035-35fa" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="26.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="4329-ec3b-739b-0050" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="9bc9-cab0-4841-6c2c" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="0aac-c5ca-badb-4434" targetId="d118-8115-df5f-2402" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="c86a-f1fe-6d59-873f" hidden="false" targetId="502c-9855-7269-eaa2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="e0aa-ee5e-c24a-c338" hidden="false" targetId="573b-88bc-97d7-d890" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="0aac-c5ca-badb-4434" hidden="false" targetId="d118-8115-df5f-2402" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="set" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="points" value="2.0">
+                  <repeats/>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="ff83-951c-1523-67b4" incrementChildId="b52c-6be6-7a76-ba77" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="ff83-951c-1523-67b4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b52c-6be6-7a76-ba77" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="70.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d603-36ff-a2eb-312f" name="Freeborn Command Squad" hidden="true" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers>
-        <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+        <modifier type="set" field="hidden" value="false">
+          <repeats/>
           <conditions>
-            <condition parentId="roster" childId="6559-a8ba-d266-7c27" field="selections" type="equal to" value="1.0"/>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1ef5-d006-6a32-fddb" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
       </modifiers>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="d603-36ff-a2eb-312f" name="Freeborn Command Squad" points="70.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true">
-      <entries>
-        <entry id="3c30-80dd-c936-7ccf" name="&lt; Freeborn Captain" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="6111-3b3b-a2ef-bdbc" name="&lt; Leader Level &gt;" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="7671-d1cb-8583-32f9" targetId="5a4c-2f5e-40a2-91d4" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="c091-1c08-a4c1-1e30" name="&lt;Freeborn Captain Equipment &gt;" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups>
-                <entryGroup id="90d1-c02b-6791-3678" name="&lt; Armour &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="ef1a-0b88-41e9-520f" targetId="eb94-d1e8-1084-71b3" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-                <entryGroup id="954d-9823-9e71-fdb2" name="&lt; Weapons &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="9620-1c29-bbc5-277d" targetId="e6db-6ed3-1a26-ea56" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-              </entryGroups>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="3c30-80dd-c936-7ccf" name="&lt; Freeborn Captain" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles/>
-          <links>
-            <link id="86ad-520b-f8d8-0b4d" targetId="2d89-bcdb-b942-b900" linkType="profile">
+          <rules/>
+          <infoLinks>
+            <infoLink id="86ad-520b-f8d8-0b4d" hidden="false" targetId="2d89-bcdb-b942-b900" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
+                  <repeats/>
                   <conditions>
-                    <condition parentId="d603-36ff-a2eb-312f" childId="7671-d1cb-8583-32f9" field="selections" type="equal to" value="1.0"/>
+                    <condition field="selections" scope="d603-36ff-a2eb-312f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7671-d1cb-8583-32f9" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="70ef-17b0-4cc6-59d6" name="Bodygaurds" points="26.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="b2b0-8472-6f6f-b03b" name="&lt; Armour &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="4966-a136-1d34-1648" targetId="eb94-d1e8-1084-71b3" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="cd16-bf68-6808-737f" name="&lt; Weapons &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="7c24-c3ed-edef-f97d" targetId="b018-6101-d2e3-b4ea" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-          <rules/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="6111-3b3b-a2ef-bdbc" name="&lt; Leader Level &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="7671-d1cb-8583-32f9" hidden="false" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="c091-1c08-a4c1-1e30" name="&lt;Freeborn Captain Equipment &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="90d1-c02b-6791-3678" name="&lt; Armour &gt;" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="ef1a-0b88-41e9-520f" hidden="false" targetId="eb94-d1e8-1084-71b3" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="954d-9823-9e71-fdb2" name="&lt; Weapons &gt;" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="9620-1c29-bbc5-277d" hidden="false" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="70ef-17b0-4cc6-59d6" name="Bodygaurds" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles/>
-          <links>
-            <link id="8523-7e21-40bd-02f6" targetId="9fba-d6b7-c66d-99f0" linkType="profile">
+          <rules/>
+          <infoLinks>
+            <infoLink id="8523-7e21-40bd-02f6" hidden="false" targetId="9fba-d6b7-c66d-99f0" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="1359-b8c0-aedb-1bbe" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-          <links>
-            <link id="3c36-c80e-c93c-f6a4" targetId="f3aa-148a-0460-c7e5" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="b2b0-8472-6f6f-b03b" name="&lt; Armour &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="9092-1d24-81d4-4b37" targetId="502c-9855-7269-eaa2" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="4966-a136-1d34-1648" hidden="false" targetId="eb94-d1e8-1084-71b3" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="cd16-bf68-6808-737f" name="&lt; Weapons &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="e184-cee5-0fd5-9e41" targetId="573b-88bc-97d7-d890" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="7c24-c3ed-edef-f97d" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="26.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="1359-b8c0-aedb-1bbe" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="3c36-c80e-c93c-f6a4" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="6f0c-0da4-1e67-2635" targetId="d118-8115-df5f-2402" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="9092-1d24-81d4-4b37" hidden="false" targetId="502c-9855-7269-eaa2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="e184-cee5-0fd5-9e41" hidden="false" targetId="573b-88bc-97d7-d890" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="6f0c-0da4-1e67-2635" hidden="false" targetId="d118-8115-df5f-2402" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="set" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="points" value="2.0">
+                  <repeats/>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="d603-36ff-a2eb-312f" incrementChildId="70ef-17b0-4cc6-59d6" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="d603-36ff-a2eb-312f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70ef-17b0-4cc6-59d6" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers>
-        <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-          <conditions>
-            <condition parentId="roster" childId="1ef5-d006-6a32-fddb" field="selections" type="equal to" value="1.0"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <rules/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="70.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6a1d-c668-c7e8-ed9f" name="Freeborn Heavy Support Team" book="BtGoA" page="194" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="6a1d-c668-c7e8-ed9f" name="Freeborn Heavy Support Team" points="25.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="194">
-      <entries>
-        <entry id="d45c-a6e2-b912-4bcd" name="Freeborn Crew" points="12.0" categoryId="(No Category)" type="upgrade" minSelections="3" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="193">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="8b71-ca9c-1ca2-0abc" name="&lt; Unit Weapon &gt;" defaultEntryId="42ad-31e5-60a7-9e01" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="42ad-31e5-60a7-9e01" targetId="8690-3ab7-9fef-06ee" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="d718-d349-ce44-fe7e" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="9dd0-b9bb-59a6-5f05" name="&lt; Unit Armor &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="7632-f6c2-622d-6f3a" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="4d7b-6ff6-c6f1-e988" targetId="7267-3051-f1b4-0a88" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="e688-49e6-a2dd-5f3f" targetId="87a3-460d-879a-92a5" linkType="profile">
-              <modifiers>
-                <modifier type="show" field="None" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="6a1d-c668-c7e8-ed9f" childId="5afb-493a-f716-72df" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="a4e6-016c-c52f-4548" name="&lt; Support Weapon &gt;" defaultEntryId="f434-b021-4e80-826a" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="f434-b021-4e80-826a" targetId="cea7-8511-2208-1b1f" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="a076-8dc7-3360-7f97" targetId="b9f1-a313-3e59-57ab" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="9d3d-0bdc-592a-8e5a" targetId="9733-7039-e306-26b5" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="a2ac-6dfc-f14e-fcab" targetId="5149-5183-64d5-feaf" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="16f8-cbcf-1527-66e2" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="5afb-493a-f716-72df" name="Promote Crew Member to Leader" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="fb3e-d593-1cf1-ad9d" targetId="fc7e-7c0e-65e0-8c33" linkType="entry">
-                  <modifiers>
-                    <modifier type="set" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <links>
-            <link id="b8ea-0f50-8af5-3fec" targetId="d571-d584-85fc-9110" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="97c0-d505-6d11-a769" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="b771-d383-4d92-ea6b" targetId="4364-45ee-ee83-ca30" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="6a1d-c668-c7e8-ed9f" incrementChildId="d45c-a6e2-b912-4bcd" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
       <rules>
         <rule id="99d8-ad33-bc0e-0a91" name="Weapon Team Unit" hidden="false">
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links>
-        <link id="b8d9-62b2-a114-98f3" targetId="e329-9443-6cb2-bc53" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="1405-a43b-534b-ab05" name="Freeborn Nuhu Renegade" points="114.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="191">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="a2f4-4dc6-77ae-47c3" name="&lt; Freeborn Renegade Option &gt;" defaultEntryId="df76-0766-2149-0a05" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="df76-0766-2149-0a05" name="Freeborn Nuhu Renegade" points="0.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="191">
-              <entries/>
-              <entryGroups>
-                <entryGroup id="b8fc-7c31-a28e-2734" name="&lt; Close Combat Weapon &gt;" defaultEntryId="6411-27f7-6c9d-41d5" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="6411-27f7-6c9d-41d5" targetId="b357-a997-60e5-053e" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-                <entryGroup id="dfa1-9c18-5508-8d84" name="&lt; Ranged Weapon &gt;" defaultEntryId="5252-b85f-713e-89e3" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="5252-b85f-713e-89e3" targetId="e6db-6ed3-1a26-ea56" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-              </entryGroups>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="c045-a625-7025-1578" targetId="5c9b-1bde-ee01-04a4" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="4078-9939-a810-38ce" targetId="7bc9-5e98-2914-5abd" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="0cec-0def-8aec-1297" targetId="05bb-4d34-70cd-25d2" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="dfe4-8f70-63fd-fcb2" targetId="3c64-6022-a5f1-9c04" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="70d1-ee75-ecc4-1c5e" targetId="0c03-96a3-4833-bc67" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="1b3e-6788-9f9a-5ed5" name="Freeborn NuHu Renegade Meld" points="163.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups>
-                <entryGroup id="7f1e-6fe3-4c0d-1835" name="&lt; Close Combat Weapon &gt;" defaultEntryId="4e50-184a-086b-ddf4" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="4e50-184a-086b-ddf4" targetId="b357-a997-60e5-053e" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-                <entryGroup id="71f0-8ea7-438d-6aaf" name="&lt; Ranged Weapon &gt;" defaultEntryId="7123-c19b-8cec-f0c7" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="7123-c19b-8cec-f0c7" targetId="e6db-6ed3-1a26-ea56" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-              </entryGroups>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="a00c-80d5-2a22-dfbf" targetId="5c9b-1bde-ee01-04a4" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="1773-4ee5-6db6-6430" targetId="7bc9-5e98-2914-5abd" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="10a2-0000-14c0-e073" targetId="3c64-6022-a5f1-9c04" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="79d1-47e4-312e-04d3" targetId="05bb-4d34-70cd-25d2" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="b9b0-d17f-a96e-d0c3" targetId="5565-ce10-1c78-1ee7" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="6355-4d83-0120-3b82" targetId="a97f-4540-de7b-5734" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="6792-be66-d3a6-276b" targetId="5e3d-6905-2b14-8cd1" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="062e-3dd5-efd6-8a93" targetId="68fe-17c2-2841-2cde" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="b2d5-107a-301c-db27" name="Limited Choice" hidden="false" book="">
-          <modifiers/>
-        </rule>
-        <rule id="05ad-d2b8-2f3f-67e1" name="Infantry Command Unit" hidden="false" book="">
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links>
-        <link id="11d3-ea88-2582-dbc0" targetId="a1c9-551b-1532-ef5a" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="8c9e-c5c0-4339-2c9e" targetId="1707-586b-01df-0f80" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="b557-70e8-d27c-aa9d" targetId="cadc-e1ce-3615-ac4b" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="0223-7d39-0a7c-f8a9" name="Freeborn Skyraider Squad" points="121.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="174">
-      <entries>
-        <entry id="cffa-15d6-0631-ed32" name="&lt; Skyraider Leader" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="192">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="6fb4-5cba-7e48-83e2" name="Leader Level" defaultEntryId="e5fb-0118-831e-f517" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="86cc-1a90-418d-75d5" targetId="02f3-3134-ae39-afed" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="e5fb-0118-831e-f517" targetId="fc7e-7c0e-65e0-8c33" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
           <profiles/>
-          <links>
-            <link id="7e77-cac2-feab-67d6" targetId="5c9b-1bde-ee01-04a4" linkType="rule">
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="d45c-a6e2-b912-4bcd" name="Freeborn Crew" book="BtGoA" page="193" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="4d7b-6ff6-c6f1-e988" hidden="false" targetId="7267-3051-f1b4-0a88" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="a17a-173b-6907-b7ee" targetId="7bc9-5e98-2914-5abd" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="1491-1d08-a7c9-d0f4" targetId="e18f-34de-2624-4133" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="212a-5750-9cf2-9c7a" targetId="e18f-34de-2624-4133" linkType="profile">
+            </infoLink>
+            <infoLink id="e688-49e6-a2dd-5f3f" hidden="false" targetId="87a3-460d-879a-92a5" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Large, Fast, Leader 2" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="hidden" value="false">
+                  <repeats/>
                   <conditions>
-                    <condition parentId="cffa-15d6-0631-ed32" childId="86cc-1a90-418d-75d5" field="selections" type="equal to" value="1.0"/>
+                    <condition field="selections" scope="6a1d-c668-c7e8-ed9f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5afb-493a-f716-72df" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="b5b1-72ee-b28c-ed4a" name="Skyraider Trooper" points="0.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="192">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="d042-54cc-962c-5c4e" name="&lt; Ranged Weapon &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="8b71-ca9c-1ca2-0abc" name="&lt; Unit Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="42ad-31e5-60a7-9e01">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <links>
-                <link id="60da-034a-d954-5cfc" targetId="84ac-0f31-c388-d0bd" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="42ad-31e5-60a7-9e01" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="d718-d349-ce44-fe7e" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="3.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="9dd0-b9bb-59a6-5f05" name="&lt; Unit Armor &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="7632-f6c2-622d-6f3a" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="12.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="a4e6-016c-c52f-4548" name="&lt; Support Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="f434-b021-4e80-826a">
           <profiles/>
-          <links>
-            <link id="7303-1648-6de4-25ea" targetId="a654-5213-64f2-703a" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="84fe-b5cd-ab19-23e4" name="&lt; Skyraider &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="87a0-db4c-17e6-d240" targetId="a1a8-ba0b-2e45-8020" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="f434-b021-4e80-826a" hidden="false" targetId="cea7-8511-2208-1b1f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="46d3-88f8-ecac-204c" name="&lt; Special Weapon Option &gt;" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="a076-8dc7-3360-7f97" hidden="false" targetId="b9f1-a313-3e59-57ab" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="9d3d-0bdc-592a-8e5a" hidden="false" targetId="9733-7039-e306-26b5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="a2ac-6dfc-f14e-fcab" hidden="false" targetId="5149-5183-64d5-feaf" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="16f8-cbcf-1527-66e2" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="e34a-7c57-c72d-b20e" targetId="47d9-8149-9744-9849" linkType="entry">
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="5afb-493a-f716-72df" name="Promote Crew Member to Leader" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="8a5a-b8d3-b9f7-cffb" targetId="a00c-0542-f2a5-8124" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="fb3e-d593-1cf1-ad9d" hidden="false" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="10.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="b8ea-0f50-8af5-3fec" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="f5d5-4b78-eab5-56a2" name="&lt; Unit Armor &gt;" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="97c0-d505-6d11-a769" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="b771-d383-4d92-ea6b" hidden="false" targetId="4364-45ee-ee83-ca30" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="6a1d-c668-c7e8-ed9f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d45c-a6e2-b912-4bcd" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="b8d9-62b2-a114-98f3" hidden="false" targetId="e329-9443-6cb2-bc53" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="3304-35c1-b35b-5a16" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="41f4-516b-6edc-fa24" targetId="2e3d-bbaa-3f5c-ac53" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="d56e-be22-258f-698c" name="&lt; Unit Options &gt; " minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1405-a43b-534b-ab05" name="Freeborn Nuhu Renegade" book="BtGoA" page="191" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="b2d5-107a-301c-db27" name="Limited Choice" book="" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="a434-7a9b-75cb-d4be" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+        </rule>
+        <rule id="05ad-d2b8-2f3f-67e1" name="Infantry Command Unit" book="" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks/>
       <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="a2f4-4dc6-77ae-47c3" name="&lt; Freeborn Renegade Option &gt;" hidden="false" collective="false" defaultSelectionEntryId="df76-0766-2149-0a05">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="df76-0766-2149-0a05" name="Freeborn Nuhu Renegade" book="BtGoA" page="191" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="c045-a625-7025-1578" hidden="false" targetId="5c9b-1bde-ee01-04a4" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="4078-9939-a810-38ce" hidden="false" targetId="7bc9-5e98-2914-5abd" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="0cec-0def-8aec-1297" hidden="false" targetId="05bb-4d34-70cd-25d2" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="dfe4-8f70-63fd-fcb2" hidden="false" targetId="3c64-6022-a5f1-9c04" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="70d1-ee75-ecc4-1c5e" hidden="false" targetId="0c03-96a3-4833-bc67" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="b8fc-7c31-a28e-2734" name="&lt; Close Combat Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="6411-27f7-6c9d-41d5">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="6411-27f7-6c9d-41d5" hidden="false" targetId="b357-a997-60e5-053e" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="dfa1-9c18-5508-8d84" name="&lt; Ranged Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="5252-b85f-713e-89e3">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="5252-b85f-713e-89e3" hidden="false" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1b3e-6788-9f9a-5ed5" name="Freeborn NuHu Renegade Meld" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="a00c-80d5-2a22-dfbf" hidden="false" targetId="5c9b-1bde-ee01-04a4" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="1773-4ee5-6db6-6430" hidden="false" targetId="7bc9-5e98-2914-5abd" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="10a2-0000-14c0-e073" hidden="false" targetId="3c64-6022-a5f1-9c04" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="79d1-47e4-312e-04d3" hidden="false" targetId="05bb-4d34-70cd-25d2" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="b9b0-d17f-a96e-d0c3" hidden="false" targetId="5565-ce10-1c78-1ee7" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="6355-4d83-0120-3b82" hidden="false" targetId="a97f-4540-de7b-5734" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="6792-be66-d3a6-276b" hidden="false" targetId="5e3d-6905-2b14-8cd1" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="062e-3dd5-efd6-8a93" hidden="false" targetId="68fe-17c2-2841-2cde" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="7f1e-6fe3-4c0d-1835" name="&lt; Close Combat Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="4e50-184a-086b-ddf4">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="4e50-184a-086b-ddf4" hidden="false" targetId="b357-a997-60e5-053e" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="71f0-8ea7-438d-6aaf" name="&lt; Ranged Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="7123-c19b-8cec-f0c7">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="7123-c19b-8cec-f0c7" hidden="false" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="163.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="11d3-ea88-2582-dbc0" hidden="false" targetId="a1c9-551b-1532-ef5a" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="8c9e-c5c0-4339-2c9e" hidden="false" targetId="1707-586b-01df-0f80" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="b557-70e8-d27c-aa9d" hidden="false" targetId="cadc-e1ce-3615-ac4b" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="114.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0223-7d39-0a7c-f8a9" name="Freeborn Skyraider Squad" book="BtGoA" page="174" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
       <rules>
         <rule id="a61b-d8b1-c4a3-6102" name="Mounted Command Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
         <rule id="572f-a685-c7aa-3d42" name="Limited Choice" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="c8b0-00c2-4509-d681" targetId="b0ca-8e7d-d03f-f027" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="3fb0-934a-d1a8-ed1e" targetId="a221-d53c-b4bd-b52c" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="5db6-c261-8463-2fde" name="Freeborn Specialist Heavy Support Team" points="45.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="194">
-      <entries>
-        <entry id="bb44-58f4-62b7-989d" name="Freeborn Crew" points="12.0" categoryId="(No Category)" type="upgrade" minSelections="3" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="193">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="da65-0295-8e02-4356" name="&lt; Unit Weapon &gt;" defaultEntryId="e081-6f9b-47f1-8d2e" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="e081-6f9b-47f1-8d2e" targetId="8690-3ab7-9fef-06ee" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="1af1-0c6d-46fc-9a90" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="8003-fecb-500b-a2f1" name="&lt; Unit Armor &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="76fe-447d-63af-8c97" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+      <infoLinks>
+        <infoLink id="c8b0-00c2-4509-d681" hidden="false" targetId="b0ca-8e7d-d03f-f027" type="rule">
           <profiles/>
-          <links>
-            <link id="7e69-7f6d-660b-ada8" targetId="7267-3051-f1b4-0a88" linkType="profile">
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3fb0-934a-d1a8-ed1e" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="cffa-15d6-0631-ed32" name="&lt; Skyraider Leader" book="BtGoA" page="192" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="7e77-cac2-feab-67d6" hidden="false" targetId="5c9b-1bde-ee01-04a4" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="f359-8e60-9b6c-caf8" targetId="87a3-460d-879a-92a5" linkType="profile">
+            </infoLink>
+            <infoLink id="a17a-173b-6907-b7ee" hidden="false" targetId="7bc9-5e98-2914-5abd" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="1491-1d08-a7c9-d0f4" hidden="false" targetId="e18f-34de-2624-4133" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="212a-5750-9cf2-9c7a" hidden="false" targetId="e18f-34de-2624-4133" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="show" field="None" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Large, Fast, Leader 2">
+                  <repeats/>
                   <conditions>
-                    <condition parentId="5db6-c261-8463-2fde" childId="4117-a3fe-bf51-e9fe" field="selections" type="equal to" value="1.0"/>
+                    <condition field="selections" scope="cffa-15d6-0631-ed32" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="86cc-1a90-418d-75d5" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="7b8f-9d4d-fe28-010d" name="&lt; Support Weapon &gt;" defaultEntryId="c4cb-5ad3-29f5-e064" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-          <links>
-            <link id="1d83-6417-d5ba-71b0" targetId="2cec-e1d7-c680-7ca0" linkType="entry">
-              <modifiers>
-                <modifier type="set" field="points" value="15.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="c4cb-5ad3-29f5-e064" targetId="67b6-d6f5-5ba3-e50d" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="8ae5-cb57-4392-b6d3" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="4117-a3fe-bf51-e9fe" name="Promote one crew to Leader" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="6fb4-5cba-7e48-83e2" name="Leader Level" hidden="false" collective="false" defaultSelectionEntryId="e5fb-0118-831e-f517">
               <profiles/>
-              <links/>
-            </entry>
-          </entries>
-          <entryGroups/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="86cc-1a90-418d-75d5" hidden="false" targetId="02f3-3134-ae39-afed" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="e5fb-0118-831e-f517" hidden="false" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b5b1-72ee-b28c-ed4a" name="Skyraider Trooper" book="BtGoA" page="192" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="7303-1648-6de4-25ea" hidden="false" targetId="a654-5213-64f2-703a" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-          <links>
-            <link id="6735-38dd-ba7c-0697" targetId="d571-d584-85fc-9110" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="d042-54cc-962c-5c4e" name="&lt; Ranged Weapon &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="58d6-220a-a277-4d27" targetId="f3aa-148a-0460-c7e5" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="60da-034a-d954-5cfc" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="84fe-b5cd-ab19-23e4" name="&lt; Skyraider &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="87a0-db4c-17e6-d240" hidden="false" targetId="a1a8-ba0b-2e45-8020" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="1bed-3774-e8f1-9891" targetId="4364-45ee-ee83-ca30" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="5db6-c261-8463-2fde" incrementChildId="bb44-58f4-62b7-989d" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="46d3-88f8-ecac-204c" name="&lt; Special Weapon Option &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="e34a-7c57-c72d-b20e" hidden="false" targetId="47d9-8149-9744-9849" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="8a5a-b8d3-b9f7-cffb" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="f5d5-4b78-eab5-56a2" name="&lt; Unit Armor &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="3304-35c1-b35b-5a16" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="41f4-516b-6edc-fa24" hidden="false" targetId="2e3d-bbaa-3f5c-ac53" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d56e-be22-258f-698c" name="&lt; Unit Options &gt; " hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="a434-7a9b-75cb-d4be" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="121.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5db6-c261-8463-2fde" name="Freeborn Specialist Heavy Support Team" book="BtGoA" page="194" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
       <rules>
         <rule id="cfca-4aa7-d6d4-b77e" name="Weapon Team Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="a700-75fe-fedc-4a1d" targetId="e329-9443-6cb2-bc53" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="e040-74bb-81d2-742f" name="Freeborn Specialist Heavy Support Team w/ Compression Bombard" points="45.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Battle for Xilos" page="19483">
-      <entries>
-        <entry id="3f02-0f65-aa87-f29b" name="Freeborn Crew" points="12.0" categoryId="(No Category)" type="upgrade" minSelections="3" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="193">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="e24b-2ff8-7c27-8ba7" name="&lt; Unit Weapon &gt;" defaultEntryId="ff3e-645a-e8d0-d896" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="ff3e-645a-e8d0-d896" targetId="8690-3ab7-9fef-06ee" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="b5d8-4f59-792a-5aa0" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="a0b8-45f2-80c2-2e6f" name="&lt; Unit Armor &gt;" defaultEntryId="9db6-ea3f-f9ce-9280" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="9db6-ea3f-f9ce-9280" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="bb44-58f4-62b7-989d" name="Freeborn Crew" book="BtGoA" page="193" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles/>
-          <links>
-            <link id="2e53-4fbd-d21f-0ff4" targetId="7267-3051-f1b4-0a88" linkType="profile">
+          <rules/>
+          <infoLinks>
+            <infoLink id="7e69-7f6d-660b-ada8" hidden="false" targetId="7267-3051-f1b4-0a88" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="a311-98bd-dc31-1e18" targetId="87a3-460d-879a-92a5" linkType="profile">
+            </infoLink>
+            <infoLink id="f359-8e60-9b6c-caf8" hidden="false" targetId="87a3-460d-879a-92a5" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="show" field="None" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="hidden" value="false">
+                  <repeats/>
                   <conditions>
-                    <condition parentId="e040-74bb-81d2-742f" childId="30cb-c08e-9c00-1db2" field="selections" type="equal to" value="1.0"/>
+                    <condition field="selections" scope="5db6-c261-8463-2fde" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4117-a3fe-bf51-e9fe" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="10be-7777-50bb-0438" name="&lt; Support Weapon &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-          <links>
-            <link id="1f73-aed3-4502-cebb" targetId="af24-45f9-4669-bf98" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="b980-251d-2639-9888" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="30cb-c08e-9c00-1db2" name="Promote one crew to Leader" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="da65-0295-8e02-4356" name="&lt; Unit Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="e081-6f9b-47f1-8d2e">
               <profiles/>
-              <links/>
-            </entry>
-          </entries>
-          <entryGroups/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="e081-6f9b-47f1-8d2e" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="1af1-0c6d-46fc-9a90" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="3.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="8003-fecb-500b-a2f1" name="&lt; Unit Armor &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="76fe-447d-63af-8c97" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="12.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="7b8f-9d4d-fe28-010d" name="&lt; Support Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="c4cb-5ad3-29f5-e064">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="cdac-db4e-1fea-369a" targetId="d571-d584-85fc-9110" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="2daa-0c1c-11a8-0cb0" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="de04-6777-8685-d52a" targetId="4364-45ee-ee83-ca30" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="1d83-6417-d5ba-71b0" hidden="false" targetId="2cec-e1d7-c680-7ca0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="e040-74bb-81d2-742f" incrementChildId="3f02-0f65-aa87-f29b" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="points" value="15.0">
+                  <repeats/>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="c4cb-5ad3-29f5-e064" hidden="false" targetId="67b6-d6f5-5ba3-e50d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="8ae5-cb57-4392-b6d3" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="4117-a3fe-bf51-e9fe" name="Promote one crew to Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="6735-38dd-ba7c-0697" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="58d6-220a-a277-4d27" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="1bed-3774-e8f1-9891" hidden="false" targetId="4364-45ee-ee83-ca30" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="5db6-c261-8463-2fde" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bb44-58f4-62b7-989d" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="a700-75fe-fedc-4a1d" hidden="false" targetId="e329-9443-6cb2-bc53" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="45.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e040-74bb-81d2-742f" name="Freeborn Specialist Heavy Support Team w/ Compression Bombard" book="Battle for Xilos" page="19483" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
       <rules>
         <rule id="b131-f742-1197-dc55" name="Weapon Team Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="9ba6-236f-73dc-a81d" targetId="e329-9443-6cb2-bc53" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="0f2b-5fd2-86c3-563b" name="Freeborn Support Team" points="10.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="193">
-      <entries>
-        <entry id="3b68-a4c9-03bb-dd68" name="Freeborn Crew" points="12.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="193">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="09ce-fa1f-63c6-0dee" name="&lt; Unit Weapon &gt;" defaultEntryId="e022-953c-7321-fa34" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="e022-953c-7321-fa34" targetId="8690-3ab7-9fef-06ee" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="af1b-11cd-5a0f-d758" name="&lt; Unit Armor &gt;" defaultEntryId="20cd-dacc-9c25-5545" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="20cd-dacc-9c25-5545" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="3f02-0f65-aa87-f29b" name="Freeborn Crew" book="BtGoA" page="193" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles/>
-          <links>
-            <link id="6f07-d1a0-a27b-5ab4" targetId="c245-fa49-1569-2f23" linkType="profile">
+          <rules/>
+          <infoLinks>
+            <infoLink id="2e53-4fbd-d21f-0ff4" hidden="false" targetId="7267-3051-f1b4-0a88" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="0ced-d327-0411-d442" targetId="a770-8327-b96d-b92e" linkType="profile">
+            </infoLink>
+            <infoLink id="a311-98bd-dc31-1e18" hidden="false" targetId="87a3-460d-879a-92a5" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="show" field="None" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="hidden" value="false">
+                  <repeats/>
                   <conditions>
-                    <condition parentId="0f2b-5fd2-86c3-563b" childId="8943-c8c6-eaa4-c959" field="selections" type="equal to" value="1.0"/>
+                    <condition field="selections" scope="e040-74bb-81d2-742f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="30cb-c08e-9c00-1db2" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="85a1-9aa5-986c-0134" name="Weapon" defaultEntryId="5764-6087-e7b6-4c73" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-          <links>
-            <link id="7198-55af-d564-f2fd" targetId="6a2b-50c5-9a33-b756" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="4711-a1d0-8193-4ddf" targetId="eed0-b68f-b5fb-92c7" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="e24b-2ff8-7c27-8ba7" name="&lt; Unit Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="ff3e-645a-e8d0-d896">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="5764-6087-e7b6-4c73" targetId="a00c-0542-f2a5-8124" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="8c57-5f05-54c3-3b50" targetId="93db-3751-fdd4-08f9" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="40.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="0bef-09de-cda1-001e" targetId="c2bf-0272-30c6-dd20" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="35.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="3f8a-3a73-e583-707c" targetId="cf3a-e6a9-bdc0-e0ae" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="30.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="a7eb-103f-f984-c4f9" targetId="71c9-4382-01cf-c737" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="52c4-3f29-7cff-341f" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="3860-7352-2507-b377" name="Promote Crew Member to Leader" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="8943-c8c6-eaa4-c959" targetId="fc7e-7c0e-65e0-8c33" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="ff3e-645a-e8d0-d896" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="b5d8-4f59-792a-5aa0" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers>
-                    <modifier type="set" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                    <modifier type="increment" field="points" value="3.0">
+                      <repeats/>
                       <conditions/>
                       <conditionGroups/>
                     </modifier>
                   </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="a0b8-45f2-80c2-2e6f" name="&lt; Unit Armor &gt;" hidden="false" collective="false" defaultSelectionEntryId="9db6-ea3f-f9ce-9280">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="9db6-ea3f-f9ce-9280" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="12.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="10be-7777-50bb-0438" name="&lt; Support Weapon &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="d6e9-f088-ecba-53b8" targetId="d571-d584-85fc-9110" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="1f73-aed3-4502-cebb" hidden="false" targetId="af24-45f9-4669-bf98" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="e4a1-35cb-9989-c083" targetId="f3aa-148a-0460-c7e5" linkType="entry">
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="b980-251d-2639-9888" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="30cb-c08e-9c00-1db2" name="Promote one crew to Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="22d3-07af-fc6e-749c" targetId="4364-45ee-ee83-ca30" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="cdac-db4e-1fea-369a" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="2daa-0c1c-11a8-0cb0" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="de04-6777-8685-d52a" hidden="false" targetId="4364-45ee-ee83-ca30" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="0f2b-5fd2-86c3-563b" incrementChildId="3b68-a4c9-03bb-dd68" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="e040-74bb-81d2-742f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3f02-0f65-aa87-f29b" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="9ba6-236f-73dc-a81d" hidden="false" targetId="e329-9443-6cb2-bc53" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="45.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0f2b-5fd2-86c3-563b" name="Freeborn Support Team" book="BtGoA" page="193" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
       <rules>
         <rule id="a6d0-fc64-ad5d-674a" name="Weapon Team Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="cff3-e0da-411a-cbd9" name="Get Up!" points="10.0" categoryId="50ba-cf77-3941-189c" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
+      <infoLinks/>
       <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="8563-f338-4ece-a2d7" targetId="2afe-05bf-268b-84c2" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="4881-30cd-5020-cf21" name="Hound Probe shard" points="0.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="196">
-      <entries>
-        <entry id="b84e-d168-f074-70e9" name="&gt; Hound Probe" points="5.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="3b68-a4c9-03bb-dd68" name="Freeborn Crew" book="BtGoA" page="193" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles/>
-          <links>
-            <link id="de6a-8e84-305b-6721" targetId="00b8-b49c-4c61-2943" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="8bc7-33a7-b05c-29d5" targetId="d0a1-129b-f8e5-b1ad" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules>
-        <rule id="a2c9-24be-fc58-b2ce" name="Probe Unit" hidden="false" book="">
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="bd58-a73b-e17b-89ae" name="Light General Purpose Drone" points="20.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="196">
-      <entries>
-        <entry id="136e-670b-fde8-eb08" name="GP Drone" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
           <rules/>
-          <profiles/>
-          <links>
-            <link id="ee6d-c97a-5f05-6da2" targetId="2dbd-14c5-219e-d37d" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="3dc6-b2b7-80a4-d6db" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="7189-205b-e43f-4b47" name="Self Repair" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <rules/>
+          <infoLinks>
+            <infoLink id="6f07-d1a0-a27b-5ab4" hidden="false" targetId="c245-fa49-1569-2f23" type="profile">
               <profiles/>
-              <links>
-                <link id="4f3f-a904-dfd8-30e0" targetId="3377-9408-33bb-6a02" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="9c14-af40-c4a6-8c01" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="8fc1-59dc-574d-d478" targetId="d571-d584-85fc-9110" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="b30a-6adc-e0b9-35b5" targetId="1707-586b-01df-0f80" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="ee36-d310-391a-5a23" targetId="fb8b-7402-c5a9-8644" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="ae83-e15b-aca4-e246" name="Weapon Drone Unit" hidden="false" book="BtGoA">
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links>
-        <link id="bd92-cca5-ea64-865d" targetId="e167-a8e4-c26a-cafd" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="9cfb-19e0-05ac-1e47" name="M25 Type Heavy Combat Drone" points="418.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="195">
-      <entries>
-        <entry id="01f5-c3d0-42de-8d99" name="&gt; Transporter Drone" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="195">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="0bd6-01b0-8347-296b" name="&lt; Weapon &gt;" defaultEntryId="dd0c-d323-b658-fa67" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="dd0c-d323-b658-fa67" targetId="67b6-d6f5-5ba3-e50d" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="62ea-7660-3ccf-313c" targetId="af24-45f9-4669-bf98" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="25.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="2c9f-5d67-5f75-022c" targetId="5425-1edf-f536-d5a1" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="bcac-a955-0a97-bdb0" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="e39c-f576-faa5-f1da" name="Self Repair" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
               <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="0ced-d327-0411-d442" hidden="false" targetId="a770-8327-b96d-b92e" type="profile">
               <profiles/>
-              <links>
-                <link id="ee9f-3fa4-0af8-ce9e" targetId="3377-9408-33bb-6a02" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="f37d-a025-3c15-4abf" targetId="1707-586b-01df-0f80" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="80cd-1a9a-13f7-0d35" targetId="8f68-d09d-6e26-c6ea" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="ecf7-a64a-293a-de72" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="3edb-e997-53e8-ad4a" targetId="e329-9443-6cb2-bc53" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="27e0-0043-07dc-ece0" targetId="a221-d53c-b4bd-b52c" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="9d1c-1cca-ed53-b1b0" targetId="7c88-64d4-50ad-2313" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="04b2-5695-d4ce-6256" targetId="8151-2e24-94ee-0477" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="530f-c210-1c10-4819" name="M4 Type Combat Drone" points="249.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="195">
-      <entries>
-        <entry id="30bd-b309-a7e2-ce17" name="&gt; Combat Drone" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="195">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="e349-a387-3011-cdb4" name="&lt; Main Weapon &gt;" defaultEntryId="64cd-d0a7-af3d-bd56" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="64cd-d0a7-af3d-bd56" targetId="c2bf-0272-30c6-dd20" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="905e-efa8-94c5-0f56" targetId="93db-3751-fdd4-08f9" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="5.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-                <link id="c54e-bd52-591e-31d6" targetId="71c9-4382-01cf-c737" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="5.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="e4b6-ff25-d3f7-7d36" targetId="0f97-9dbe-566a-5ab0" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="a8b4-2c55-d8de-de72" targetId="eb0f-0718-35d7-1a00" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="42d3-0396-7538-2afe" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="3d7b-8b6c-0bc7-2176" name="Self Repair" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
               <rules/>
-              <profiles/>
-              <links>
-                <link id="50db-2d5d-b0d3-7ab6" targetId="3377-9408-33bb-6a02" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="5b5a-646b-cdc9-70c6" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="6b3d-030d-2e2f-db4e" targetId="8f68-d09d-6e26-c6ea" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="c15c-7bd3-0f3e-e876" targetId="1707-586b-01df-0f80" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="b25f-8a2f-5932-bb6a" targetId="5565-ce10-1c78-1ee7" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="1334-f2ea-a5eb-674c" targetId="a221-d53c-b4bd-b52c" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="1504-b595-21a5-1772" targetId="e329-9443-6cb2-bc53" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="3df6-b3d9-248f-350b" name="M50 Type Heavy Combat Drone" points="418.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="195">
-      <entries>
-        <entry id="aaf8-6738-2b45-c252" name="&gt; Heavy Support Drone" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="195">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="5086-9f66-b442-f987" name="&lt; Weapon &gt;" defaultEntryId="1e4a-57fb-e968-6982" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="1e4a-57fb-e968-6982" targetId="b9f1-a313-3e59-57ab" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="2b26-87e7-1e8f-ea79" targetId="9733-7039-e306-26b5" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="7053-b744-1b1a-bbeb" targetId="2cec-e1d7-c680-7ca0" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="25.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="250a-e588-2f82-7123" targetId="9e2a-f076-d4df-b60a" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="c089-dc26-6ac4-a9e0" targetId="0f97-9dbe-566a-5ab0" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="8226-5f69-098e-16a2" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="b1c4-3032-4af5-5874" name="Self Repair" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="dc4e-ba2d-8399-9b36" targetId="3377-9408-33bb-6a02" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="92d7-f414-c1e1-175b" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="7a1a-41e1-fcdc-3390" targetId="8f68-d09d-6e26-c6ea" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="a7a7-9da8-ef6f-2592" targetId="1707-586b-01df-0f80" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="2e55-1966-d767-c4f5" targetId="a221-d53c-b4bd-b52c" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="b56d-83bb-8c53-a2ee" targetId="7c88-64d4-50ad-2313" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="8342-2c8c-460a-7d1d" targetId="8151-2e24-94ee-0477" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="6d78-6ff1-689b-45b9" targetId="e329-9443-6cb2-bc53" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="68e5-824d-8e72-1018" name="Marksman" points="15.0" categoryId="50ba-cf77-3941-189c" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="1054-eaa0-48d3-3dfa" targetId="5741-af68-9dc0-519f" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="771e-7953-547e-2082" name="Misgenic Rejects" points="0.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="196">
-      <entries>
-        <entry id="6098-b5c2-1d8a-a1b6" name="Misgenic Rejects" points="5.0" categoryId="(No Category)" type="model" minSelections="6" maxSelections="12" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="196">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="7079-9c86-12a0-461d" profileTypeId="1650-77b3-10d1-6406" name="Misgenic Rejects" hidden="false" book="BtGoA" page="196">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="7"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-        <entry id="523a-c675-bb65-766b" name="Promote one reject to Leader" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="85a6-e9d0-03ac-593c" name="Leader One" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="5b45-20ce-68b0-7e0c" targetId="e441-c3a6-7d61-2c63" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-        <entry id="e3fa-3d4f-d370-193c" name="More Misgenic Abilities" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="196">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="627d-95ce-0cb7-067d" targetId="db7a-5bd4-6400-f6d1" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="e1f2-aa77-1cf5-d89f" name="Pull Yourself Together!" points="15.0" categoryId="50ba-cf77-3941-189c" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="96ff-949d-ec39-33e0" targetId="8056-104a-5a5d-2089" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="969a-8139-9654-9cdf" name="Skyraider Command Squad" points="164.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="174">
-      <entries>
-        <entry id="d40e-0a4d-13fa-863b" name="&lt; Skyraider Captain" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="192">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="e0b2-8c3a-7575-9736" name="Leader Level" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="4ac0-b84e-687f-e73b" targetId="5a4c-2f5e-40a2-91d4" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="0b4f-18e9-64d4-1bc8" targetId="5c9b-1bde-ee01-04a4" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="7780-1ba7-1b1c-b4c2" targetId="7bc9-5e98-2914-5abd" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="f186-3a30-6680-477f" targetId="e18f-34de-2624-4133" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="8ac3-35e0-d064-d5b0" targetId="74dc-b388-dc1d-fb61" linkType="profile">
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command, Hero, Follow, Large, Fast, Leader 3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="hidden" value="false">
+                  <repeats/>
                   <conditions>
-                    <condition parentId="d40e-0a4d-13fa-863b" childId="4ac0-b84e-687f-e73b" field="selections" type="equal to" value="1.0"/>
+                    <condition field="selections" scope="0f2b-5fd2-86c3-563b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8943-c8c6-eaa4-c959" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="2c42-d94f-83c4-fb4f" name="Skyraider Trooper" points="0.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="192">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="62da-827c-1a4c-bfef" name="&lt; Ranged Weapon &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="09ce-fa1f-63c6-0dee" name="&lt; Unit Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="e022-953c-7321-fa34">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <links>
-                <link id="5c2c-6873-9857-0546" targetId="84ac-0f31-c388-d0bd" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="e022-953c-7321-fa34" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="af1b-11cd-5a0f-d758" name="&lt; Unit Armor &gt;" hidden="false" collective="false" defaultSelectionEntryId="20cd-dacc-9c25-5545">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="20cd-dacc-9c25-5545" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="12.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="85a1-9aa5-986c-0134" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="5764-6087-e7b6-4c73">
           <profiles/>
-          <links>
-            <link id="a18a-ce88-b9af-89e7" targetId="a654-5213-64f2-703a" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="2996-96fd-31e3-fe8c" name="&lt; Skyraider &gt;" defaultEntryId="92a3-2543-174e-504b" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="92a3-2543-174e-504b" targetId="a1a8-ba0b-2e45-8020" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="7198-55af-d564-f2fd" hidden="false" targetId="6a2b-50c5-9a33-b756" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="4711-a1d0-8193-4ddf" hidden="false" targetId="eed0-b68f-b5fb-92c7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="5f94-8423-056d-5f54" name="&lt; Special Weapon Option &gt;" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="5764-6087-e7b6-4c73" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="8c57-5f05-54c3-3b50" hidden="false" targetId="93db-3751-fdd4-08f9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="40.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="0bef-09de-cda1-001e" hidden="false" targetId="c2bf-0272-30c6-dd20" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="35.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="3f8a-3a73-e583-707c" hidden="false" targetId="cf3a-e6a9-bdc0-e0ae" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="30.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="a7eb-103f-f984-c4f9" hidden="false" targetId="71c9-4382-01cf-c737" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="52c4-3f29-7cff-341f" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="b3cb-790e-d4ae-710a" targetId="47d9-8149-9744-9849" linkType="entry">
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="3860-7352-2507-b377" name="Promote Crew Member to Leader" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="0f9b-216d-3f08-d82e" targetId="a00c-0542-f2a5-8124" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="8943-c8c6-eaa4-c959" hidden="false" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="10.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="d6e9-f088-ecba-53b8" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="2d2f-4f61-9b31-50b5" name="&lt; Unit Armor &gt;" defaultEntryId="6df8-de07-b4b9-201f" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="e4a1-35cb-9989-c083" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="22d3-07af-fc6e-749c" hidden="false" targetId="4364-45ee-ee83-ca30" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="0f2b-5fd2-86c3-563b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3b68-a4c9-03bb-dd68" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cff3-e0da-411a-cbd9" name="Get Up!" hidden="false" collective="false" categoryEntryId="50ba-cf77-3941-189c" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="8563-f338-4ece-a2d7" hidden="false" targetId="2afe-05bf-268b-84c2" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="6df8-de07-b4b9-201f" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="0eff-479f-05c9-7f65" targetId="2e3d-bbaa-3f5c-ac53" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="1858-3233-777b-6a0f" name="&lt; Unit Options &gt; " minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="8350-a307-4835-3176" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4881-30cd-5020-cf21" name="Hound Probe shard" book="BtGoA" page="196" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="a2c9-24be-fc58-b2ce" name="Probe Unit" book="" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="b84e-d168-f074-70e9" name="&gt; Hound Probe" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="de6a-8e84-305b-6721" hidden="false" targetId="00b8-b49c-4c61-2943" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="8bc7-33a7-b05c-29d5" hidden="false" targetId="d0a1-129b-f8e5-b1ad" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bd58-a73b-e17b-89ae" name="Light General Purpose Drone" book="BtGoA" page="196" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="ae83-e15b-aca4-e246" name="Weapon Drone Unit" book="BtGoA" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="bd92-cca5-ea64-865d" hidden="false" targetId="e167-a8e4-c26a-cafd" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="136e-670b-fde8-eb08" name="GP Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="ee6d-c97a-5f05-6da2" hidden="false" targetId="2dbd-14c5-219e-d37d" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="3dc6-b2b7-80a4-d6db" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="7189-205b-e43f-4b47" name="Self Repair" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="4f3f-a904-dfd8-30e0" hidden="false" targetId="3377-9408-33bb-6a02" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="9c14-af40-c4a6-8c01" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="8fc1-59dc-574d-d478" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="b30a-6adc-e0b9-35b5" hidden="false" targetId="1707-586b-01df-0f80" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="ee36-d310-391a-5a23" hidden="false" targetId="fb8b-7402-c5a9-8644" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9cfb-19e0-05ac-1e47" name="M25 Type Heavy Combat Drone" book="BtGoA" page="195" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="27e0-0043-07dc-ece0" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="9d1c-1cca-ed53-b1b0" hidden="false" targetId="7c88-64d4-50ad-2313" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="04b2-5695-d4ce-6256" hidden="false" targetId="8151-2e24-94ee-0477" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="01f5-c3d0-42de-8d99" name="&gt; Transporter Drone" book="BtGoA" page="195" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="2c9f-5d67-5f75-022c" hidden="false" targetId="5425-1edf-f536-d5a1" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="0bd6-01b0-8347-296b" name="&lt; Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="dd0c-d323-b658-fa67">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="dd0c-d323-b658-fa67" hidden="false" targetId="67b6-d6f5-5ba3-e50d" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="62ea-7660-3ccf-313c" hidden="false" targetId="af24-45f9-4669-bf98" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="25.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="bcac-a955-0a97-bdb0" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="e39c-f576-faa5-f1da" name="Self Repair" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="ee9f-3fa4-0af8-ce9e" hidden="false" targetId="3377-9408-33bb-6a02" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="f37d-a025-3c15-4abf" hidden="false" targetId="1707-586b-01df-0f80" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="80cd-1a9a-13f7-0d35" hidden="false" targetId="8f68-d09d-6e26-c6ea" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="ecf7-a64a-293a-de72" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="3edb-e997-53e8-ad4a" hidden="false" targetId="e329-9443-6cb2-bc53" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="418.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="530f-c210-1c10-4819" name="M4 Type Combat Drone" book="BtGoA" page="195" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="b25f-8a2f-5932-bb6a" hidden="false" targetId="5565-ce10-1c78-1ee7" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="1334-f2ea-a5eb-674c" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="30bd-b309-a7e2-ce17" name="&gt; Combat Drone" book="BtGoA" page="195" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="a8b4-2c55-d8de-de72" hidden="false" targetId="eb0f-0718-35d7-1a00" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="e349-a387-3011-cdb4" name="&lt; Main Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="64cd-d0a7-af3d-bd56">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="64cd-d0a7-af3d-bd56" hidden="false" targetId="c2bf-0272-30c6-dd20" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="905e-efa8-94c5-0f56" hidden="false" targetId="93db-3751-fdd4-08f9" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="5.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="c54e-bd52-591e-31d6" hidden="false" targetId="71c9-4382-01cf-c737" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="5.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="e4b6-ff25-d3f7-7d36" hidden="false" targetId="0f97-9dbe-566a-5ab0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="42d3-0396-7538-2afe" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="3d7b-8b6c-0bc7-2176" name="Self Repair" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="50db-2d5d-b0d3-7ab6" hidden="false" targetId="3377-9408-33bb-6a02" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="5b5a-646b-cdc9-70c6" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="6b3d-030d-2e2f-db4e" hidden="false" targetId="8f68-d09d-6e26-c6ea" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="c15c-7bd3-0f3e-e876" hidden="false" targetId="1707-586b-01df-0f80" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="1504-b595-21a5-1772" hidden="false" targetId="e329-9443-6cb2-bc53" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="249.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3df6-b3d9-248f-350b" name="M50 Type Heavy Combat Drone" book="BtGoA" page="195" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="2e55-1966-d767-c4f5" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b56d-83bb-8c53-a2ee" hidden="false" targetId="7c88-64d4-50ad-2313" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="8342-2c8c-460a-7d1d" hidden="false" targetId="8151-2e24-94ee-0477" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="aaf8-6738-2b45-c252" name="&gt; Heavy Support Drone" book="BtGoA" page="195" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="250a-e588-2f82-7123" hidden="false" targetId="9e2a-f076-d4df-b60a" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="5086-9f66-b442-f987" name="&lt; Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="1e4a-57fb-e968-6982">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="1e4a-57fb-e968-6982" hidden="false" targetId="b9f1-a313-3e59-57ab" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="2b26-87e7-1e8f-ea79" hidden="false" targetId="9733-7039-e306-26b5" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="7053-b744-1b1a-bbeb" hidden="false" targetId="2cec-e1d7-c680-7ca0" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="25.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="c089-dc26-6ac4-a9e0" hidden="false" targetId="0f97-9dbe-566a-5ab0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="8226-5f69-098e-16a2" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="b1c4-3032-4af5-5874" name="Self Repair" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="dc4e-ba2d-8399-9b36" hidden="false" targetId="3377-9408-33bb-6a02" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="92d7-f414-c1e1-175b" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="7a1a-41e1-fcdc-3390" hidden="false" targetId="8f68-d09d-6e26-c6ea" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="a7a7-9da8-ef6f-2592" hidden="false" targetId="1707-586b-01df-0f80" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="6d78-6ff1-689b-45b9" hidden="false" targetId="e329-9443-6cb2-bc53" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="418.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="68e5-824d-8e72-1018" name="Marksman" hidden="false" collective="false" categoryEntryId="50ba-cf77-3941-189c" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="1054-eaa0-48d3-3dfa" hidden="false" targetId="5741-af68-9dc0-519f" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="771e-7953-547e-2082" name="Misgenic Rejects" book="BtGoA" page="196" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="627d-95ce-0cb7-067d" hidden="false" targetId="db7a-5bd4-6400-f6d1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="6098-b5c2-1d8a-a1b6" name="Misgenic Rejects" book="BtGoA" page="196" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="7079-9c86-12a0-461d" name="Misgenic Rejects" book="BtGoA" page="196" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="523a-c675-bb65-766b" name="Promote one reject to Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="85a6-e9d0-03ac-593c" name="Leader One" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="5b45-20ce-68b0-7e0c" hidden="false" targetId="e441-c3a6-7d61-2c63" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e3fa-3d4f-d370-193c" name="More Misgenic Abilities" book="BtGoA" page="196" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e1f2-aa77-1cf5-d89f" name="Pull Yourself Together!" hidden="false" collective="false" categoryEntryId="50ba-cf77-3941-189c" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="96ff-949d-ec39-33e0" hidden="false" targetId="8056-104a-5a5d-2089" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="969a-8139-9654-9cdf" name="Skyraider Command Squad" book="BtGoA" page="174" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
       <rules>
         <rule id="76be-d990-01b2-40b5" name="Mounted Command Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
         <rule id="801f-37d3-aeef-35ef" name="Limited Choice" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="8ada-48df-990a-b1c6" targetId="b0ca-8e7d-d03f-f027" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="0026-0fee-242b-f524" targetId="a221-d53c-b4bd-b52c" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="1fc7-db89-4652-3c98" name="Superior Shard" points="15.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="661d-86ab-a747-8bb5" targetId="d4f5-697e-dbf0-ced2" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="859c-f6ff-bc8a-74cf" name="T7 Type Transporter Drone" points="164.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="195">
-      <entries>
-        <entry id="e215-3b85-89ba-1fc8" name="&gt; Transporter Drone" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="195">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="8a07-2ee4-8417-4ab3" name="&lt; Weapon &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="4ff7-f2df-7ced-d8f0" targetId="a00c-0542-f2a5-8124" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="d2cf-994c-12f0-9c5b" targetId="6a2b-50c5-9a33-b756" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-                <link id="5a7f-0ae6-6b32-4321" targetId="cf3a-e6a9-bdc0-e0ae" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="30.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-                <link id="439c-15d6-48b7-16d2" targetId="ac1e-a740-57b7-cc64" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+      <infoLinks>
+        <infoLink id="8ada-48df-990a-b1c6" hidden="false" targetId="b0ca-8e7d-d03f-f027" type="rule">
           <profiles/>
-          <links>
-            <link id="a5f0-4afc-16c4-72f9" targetId="5425-1edf-f536-d5a1" linkType="profile">
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="0026-0fee-242b-f524" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="d40e-0a4d-13fa-863b" name="&lt; Skyraider Captain" book="BtGoA" page="192" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="0b4f-18e9-64d4-1bc8" hidden="false" targetId="5c9b-1bde-ee01-04a4" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="48a3-5d25-ade2-1097" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="ad46-f5e3-e9f3-a7de" name="Self Repair" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+            </infoLink>
+            <infoLink id="7780-1ba7-1b1c-b4c2" hidden="false" targetId="7bc9-5e98-2914-5abd" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="f186-3a30-6680-477f" hidden="false" targetId="e18f-34de-2624-4133" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="8ac3-35e0-d064-d5b0" hidden="false" targetId="74dc-b388-dc1d-fb61" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command, Hero, Follow, Large, Fast, Leader 3">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="d40e-0a4d-13fa-863b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4ac0-b84e-687f-e73b" type="equalTo"/>
+                  </conditions>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-              <rules/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="e0b2-8c3a-7575-9736" name="Leader Level" hidden="false" collective="false">
               <profiles/>
-              <links>
-                <link id="4565-ded9-505e-aced" targetId="3377-9408-33bb-6a02" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="064d-4c81-4e23-79d4" targetId="f3aa-148a-0460-c7e5" linkType="entry">
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="b2ad-61e0-f7fe-f5d0" targetId="d571-d584-85fc-9110" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="6f20-1361-0577-c4cf" targetId="1707-586b-01df-0f80" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="c985-b014-70bf-635d" targetId="5565-ce10-1c78-1ee7" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="40c3-e6f7-a42a-fd30" targetId="a221-d53c-b4bd-b52c" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="8eaf-ef10-dfe5-8f3a" targetId="ab37-33d8-41f3-7532" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="aa6c-67b7-3d3b-2a61" name="Targeter Probe Shard" points="0.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="196">
-      <entries>
-        <entry id="31ff-3d6d-2a30-3b5a" name="&gt; Targeter Probe" points="5.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="58b0-e470-5c3a-0e30" targetId="00b8-b49c-4c61-2943" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="6620-e65c-9afa-7ed9" targetId="4d5f-ccb4-75c2-cbf2" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules>
-        <rule id="8104-2eac-f495-21f9" name="Probe Unit" hidden="false" book="">
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="40ad-08b6-fa6a-0171" name="Vardanari Squad (Guards)" points="42.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="191">
-      <entries>
-        <entry id="c3fa-7787-a4d1-50f8" name="&lt; Vardanari Leader" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="191">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="189f-239f-cc54-f496" name="&lt; Leader Level &gt;" defaultEntryId="7ea8-bf13-37df-8acf" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="6cd8-052e-b9da-e94e" name="Leader 2" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="4ac0-b84e-687f-e73b" hidden="false" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
                   <profiles/>
-                  <links>
-                    <link id="f2ac-6316-75a8-0504" targetId="7850-89e7-bab8-86e9" linkType="rule">
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2c42-d94f-83c4-fb4f" name="Skyraider Trooper" book="BtGoA" page="192" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="a18a-ce88-b9af-89e7" hidden="false" targetId="a654-5213-64f2-703a" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="62da-827c-1a4c-bfef" name="&lt; Ranged Weapon &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="5c2c-6873-9857-0546" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2996-96fd-31e3-fe8c" name="&lt; Skyraider &gt;" hidden="false" collective="false" defaultSelectionEntryId="92a3-2543-174e-504b">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="92a3-2543-174e-504b" hidden="false" targetId="a1a8-ba0b-2e45-8020" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="5f94-8423-056d-5f54" name="&lt; Special Weapon Option &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="b3cb-790e-d4ae-710a" hidden="false" targetId="47d9-8149-9744-9849" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="0f9b-216d-3f08-d82e" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="2d2f-4f61-9b31-50b5" name="&lt; Unit Armor &gt;" hidden="false" collective="false" defaultSelectionEntryId="6df8-de07-b4b9-201f">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="6df8-de07-b4b9-201f" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="0eff-479f-05c9-7f65" hidden="false" targetId="2e3d-bbaa-3f5c-ac53" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1858-3233-777b-6a0f" name="&lt; Unit Options &gt; " hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="8350-a307-4835-3176" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="164.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1fc7-db89-4652-3c98" name="Superior Shard" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="661d-86ab-a747-8bb5" hidden="false" targetId="d4f5-697e-dbf0-ced2" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="859c-f6ff-bc8a-74cf" name="T7 Type Transporter Drone" book="BtGoA" page="195" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="c985-b014-70bf-635d" hidden="false" targetId="5565-ce10-1c78-1ee7" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="40c3-e6f7-a42a-fd30" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="8eaf-ef10-dfe5-8f3a" hidden="false" targetId="ab37-33d8-41f3-7532" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="e215-3b85-89ba-1fc8" name="&gt; Transporter Drone" book="BtGoA" page="195" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="a5f0-4afc-16c4-72f9" hidden="false" targetId="5425-1edf-f536-d5a1" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="8a07-2ee4-8417-4ab3" name="&lt; Weapon &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="4ff7-f2df-7ced-d8f0" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="d2cf-994c-12f0-9c5b" hidden="false" targetId="6a2b-50c5-9a33-b756" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="10.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="5a7f-0ae6-6b32-4321" hidden="false" targetId="cf3a-e6a9-bdc0-e0ae" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="30.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="439c-15d6-48b7-16d2" hidden="false" targetId="ac1e-a740-57b7-cc64" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="10.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="48a3-5d25-ade2-1097" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="ad46-f5e3-e9f3-a7de" name="Self Repair" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="4565-ded9-505e-aced" hidden="false" targetId="3377-9408-33bb-6a02" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="064d-4c81-4e23-79d4" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="b2ad-61e0-f7fe-f5d0" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="6f20-1361-0577-c4cf" hidden="false" targetId="1707-586b-01df-0f80" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="164.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="aa6c-67b7-3d3b-2a61" name="Targeter Probe Shard" book="BtGoA" page="196" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="8104-2eac-f495-21f9" name="Probe Unit" book="" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="31ff-3d6d-2a30-3b5a" name="&gt; Targeter Probe" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="58b0-e470-5c3a-0e30" hidden="false" targetId="00b8-b49c-4c61-2943" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="6620-e65c-9afa-7ed9" hidden="false" targetId="4d5f-ccb4-75c2-cbf2" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="40ad-08b6-fa6a-0171" name="Vardanari Squad (Guards)" book="BtGoA" page="191" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="c3fa-7787-a4d1-50f8" name="&lt; Vardanari Leader" book="BtGoA" page="191" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="1a89-bc54-c850-a7a0" hidden="false" targetId="62fc-1d76-c6fd-a3eb" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="189f-239f-cc54-f496" name="&lt; Leader Level &gt;" hidden="false" collective="false" defaultSelectionEntryId="7ea8-bf13-37df-8acf">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="6cd8-052e-b9da-e94e" name="Leader 2" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="f2ac-6316-75a8-0504" hidden="false" targetId="7850-89e7-bab8-86e9" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
                       <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="7ea8-bf13-37df-8acf" targetId="fc7e-7c0e-65e0-8c33" linkType="entry">
+                    </infoLink>
+                  </infoLinks>
                   <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="f5ed-8cd5-154e-1987" name="&lt; Ranged Weapon &gt;" defaultEntryId="c12f-a100-2c77-940b" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="c12f-a100-2c77-940b" targetId="b018-6101-d2e3-b4ea" linkType="entry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="7ea8-bf13-37df-8acf" hidden="false" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-                <link id="02d9-18d6-822b-c297" targetId="179a-c0cc-49cc-c946" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="dbcb-5feb-24da-acaf" targetId="8de3-1e72-72ef-e7a3" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="1a89-bc54-c850-a7a0" targetId="62fc-1d76-c6fd-a3eb" linkType="profile">
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="97e8-d8ef-1bec-906d" name="Vardanari Guard" points="19.0" categoryId="(No Category)" type="model" minSelections="5" maxSelections="7" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="191">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="4ca6-7e89-8b59-f1d5" targetId="702f-c8a7-d8cf-01c1" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="fff7-d85d-7713-194d" name="Ranged Weapon" defaultEntryId="1b32-6cc9-8dc9-64b3" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="1b32-6cc9-8dc9-64b3" targetId="b018-6101-d2e3-b4ea" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="8836-8c4d-3a4f-5d40" name="Armor" defaultEntryId="a575-c942-e1b2-0d29" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="a575-c942-e1b2-0d29" targetId="03c2-174e-8617-cf04" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="7876-6071-860a-2b8f" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="a7b4-9779-24e9-b2a7" targetId="573b-88bc-97d7-d890" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="4e0f-95bb-f4f1-6030" name="Well Prepared" points="5.0" categoryId="50ba-cf77-3941-189c" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="69f3-3470-5212-8eaa" targetId="75d2-6efa-9640-61df" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-  </entries>
-  <rules/>
-  <links/>
-  <sharedEntries>
-    <entry id="e9dd-1dc6-3c92-4305" name="AG Chute" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="120">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="54c4-0df3-268c-9fe1" targetId="7daf-414b-c030-7626" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="828e-3aa2-3dbf-f2cb" name="Auto-Workshop" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="120">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="2aa0-3909-ff3b-5bfe" targetId="b7c6-fc7c-d48b-aae4" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="d571-d584-85fc-9110" name="Batter Drone" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="11">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="2686-6df4-4601-e99f" targetId="f0d9-1e5a-ec20-b27c" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="8f68-d09d-6e26-c6ea" name="Batter Drone (2)" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="11">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="0a02-46cc-7e6f-28b0" targetId="f0d9-1e5a-ec20-b27c" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="af35-43cb-665c-f896" name="Booster Drone" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="111">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="77b8-dc0d-36ff-0f1d" name="Borer Drone" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="111">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="f67e-b103-c5e0-7d92" targetId="4e34-753f-b082-2e00" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="4933-25f0-2896-ac60" name="Camo Drone" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="0235-7440-f324-d8e9" targetId="5f48-f41c-fd96-6a1a" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="babd-f951-933b-1254" name="Compactor Drone" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="d5b5-2649-62fd-e305" targetId="3995-c066-c957-5ffe" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="666e-aa69-6e72-f168" name="Compactor Drone with Mag Cannon" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="9c4f-f6de-c09c-eab2" targetId="6a2b-50c5-9a33-b756" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="663f-33f4-57b5-7a11" targetId="3995-c066-c957-5ffe" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="2144-e450-c8f2-af26" name="Compactor Drone with Mag Light Support" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="d525-3a93-38f1-7e4e" targetId="a00c-0542-f2a5-8124" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="4e01-7b13-2e6c-0f97" targetId="3995-c066-c957-5ffe" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="0299-39fc-32bd-8ac2" name="Compactor Drone with Plasma Cannon" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="e506-bd0d-b513-7050" targetId="c2bf-0272-30c6-dd20" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="ae6e-0698-5ad9-8d26" targetId="3995-c066-c957-5ffe" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="af24-45f9-4669-bf98" name="Compression Bombard" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="84">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="f3f6-794b-82b3-a39a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Bombard" hidden="false" book="BtGoA" page="84">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-50"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="150"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="9/7/5"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Cycle, Heavy Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="d318-c320-5b7c-b089" targetId="7db4-2d14-3984-37d9" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="a2f7-528d-dd59-9d00" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="b53d-32d6-c4fc-cefc" targetId="cf7f-6f85-e64e-0363" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="71c9-4382-01cf-c737" name="Compression Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="78">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="b626-3a7f-ecf5-ea69" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Cannon" hidden="false" book="BtGoA" page="78">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="7/4/2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Cycle,  Light Support Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="a6f9-23ce-e99d-7c15" targetId="7db4-2d14-3984-37d9" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="3003-31fb-fb6c-3084" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="70d5-a230-ba57-ead0" targetId="cf7f-6f85-e64e-0363" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="059b-38f7-0313-5ae4" name="Compression Carbine" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="72">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="e580-6389-7ec6-d445" targetId="7db4-2d14-3984-37d9" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="b230-6dc2-fc21-9332" targetId="75cb-cf9b-dd3d-9177" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="72ba-15e7-dbf7-816c" name="D-Spinner" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="66">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="bc08-23ff-215d-d442" profileTypeId="ecae-8ac8-2c13-0dd3" name="D-Spinner" hidden="false" book="BtGoA" page="66">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="Varies"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks, Variable Res/Strike, Grenade, Hand Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="bf1e-fb77-9e71-f9fe" targetId="2cbd-47c9-de87-ec2a" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="363c-73f0-41ad-dfb8" targetId="99fd-f354-1703-5941" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="91a4-fa2b-910b-b8f8" targetId="b466-7990-db34-55b1" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="ff6c-f8d8-94e6-57bc" name="Disruptor Bomber" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="77">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="c100-99b7-2ff6-24a0" profileTypeId="ecae-8ac8-2c13-0dd3" name="Disruptor Bomber" hidden="false" book="BtGoA" page="77">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="60"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="120"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D5, No Crew, Limited Ammo, No Cover, Disruptor,  Light Support Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="5bfd-e568-cff9-ff1b" targetId="c3bc-87fd-fa5d-5055" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="ada8-a0a5-d314-27a6" targetId="b050-496a-ed16-2b2a" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="c9a5-e124-997c-44ea" targetId="f502-611e-9704-97bb" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="b3e6-5aa3-ef1f-f7b1" targetId="5efa-64a9-bbc9-3dba" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="df53-3436-c62e-c73e" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="7fb2-1ffe-610d-7f33" targetId="6305-72fa-da02-235b" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="f771-f4b5-0047-de53" name="Disruptor Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="79">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="17db-4b84-9d1b-122d" profileTypeId="ecae-8ac8-2c13-0dd3" name="Disruptor Cannon" hidden="false" book="BtGoA" page="79">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D4, No Cover, Disruptor, Light Support Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="48bb-4c87-e0f2-08b4" targetId="ca96-58c9-9551-d4fe" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="3b06-bc9e-4002-8aeb" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="8e03-d6b4-1fab-5cd2" targetId="6305-72fa-da02-235b" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="396e-b157-b3bb-a5e7" name="Disruptor Discharger" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="86">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="de01-ba7b-11ee-55ca" profileTypeId="ecae-8ac8-2c13-0dd3" name="Disruptor Discharger" hidden="false" book="BtGoA" page="86">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="Point blank shooting only"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="Point blank shooting only"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="Point blank shooting only"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D4, No Cover, Disruptor, Grenade"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="e755-a7a2-1343-d27a" targetId="5d64-4bf5-e947-95d1" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="b2cb-0542-2c44-9f1b" targetId="ca96-58c9-9551-d4fe" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="049f-1e26-3f5d-a4f9" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="adad-ebe2-3953-6510" targetId="6305-72fa-da02-235b" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="2cec-e1d7-c680-7ca0" name="Fractal Bombard" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="83">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="279b-22b3-c3ff-1320" profileTypeId="ecae-8ac8-2c13-0dd3" name="Fractal Bombard" hidden="false" book="BtGoA" page="83">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="50"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="200"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3 + 2 Max 10"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock, Heavy Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="fe6a-32a9-1211-b766" targetId="d50c-3bbe-c62d-34c3" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="93db-3751-fdd4-08f9" name="Fractal Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="76">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="cb47-aad3-9a1b-1266" profileTypeId="ecae-8ac8-2c13-0dd3" name="Fractal Cannon" hidden="false" book="BtGoA" page="76">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2 + 1 Max 10"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock,  Light Support Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="b7b4-01fa-5f1f-ebee" targetId="d50c-3bbe-c62d-34c3" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="aac7-43b0-4a5c-05bb" name="Frag Borer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="77">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="5cb2-9abf-ed28-03ff" profileTypeId="ecae-8ac8-2c13-0dd3" name="Frag Borer" hidden="false" book="BtGoA" page="77">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="60"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3 + 1 Max 10"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock,  Light Support Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="eac9-8b04-b66c-5db6" targetId="d50c-3bbe-c62d-34c3" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="3975-3892-22f2-0c8e" name="Ghar Plasma Claw" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="66">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="57de-9415-94c2-a9cd" profileTypeId="ecae-8ac8-2c13-0dd3" name="Ghar Plasma Claw" hidden="false" book="BtGoA" page="66">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="D4"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Random SV,  Hand Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="7eb4-a0e1-1e61-3d82" targetId="b6e3-9cf0-1a9f-a941" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="f319-5d36-f853-9d45" name="Gouger Gun" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="74">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="5caa-0eb3-a2c8-d79c" profileTypeId="ecae-8ac8-2c13-0dd3" name="Gouger Gun" hidden="false" book="BtGoA" page="74">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Down, Inaccurate, Standard Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="6c43-9149-1b89-35e5" targetId="9444-e2a0-8048-5ce9" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="aa66-a1ad-73f1-8bd2" targetId="3b84-9d0e-a3c1-6c1f" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="b8d1-46be-c623-ad68" name="Gun Drone" points="14.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="4b9d-a0bf-396e-384b" name="Gun Drone (2)" points="14.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="f9cf-568d-998b-c3ca" name="Heavy Disruptor Bomber" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="80">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="a9a7-e90e-e54a-e37c" profileTypeId="ecae-8ac8-2c13-0dd3" name="Heavy Disruptor Bomber" hidden="false" book="BtGoA" page="80">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="60"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="120"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH x2, Blast D10, Limited Ammo, No Cover, Disruptor, Heavy Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="baaa-0b37-7581-545a" targetId="aef6-6934-1dee-6fa0" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="ad5f-454c-b4ec-0b29" targetId="04d9-a48d-7b25-4dd3" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="3dc5-ce4c-aaf4-7bc4" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="1d69-8270-126c-b660" targetId="6305-72fa-da02-235b" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="564d-3561-f5e4-783d" name="Heavy Frag Borer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="83">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="4001-9da2-86d1-6b80" profileTypeId="ecae-8ac8-2c13-0dd3" name="Heavy Frag Borer" hidden="false" book="BtGoA" page="83">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="60"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="6 + 1 Max 10"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock, Heavy Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="174d-fb91-0ee1-de89" targetId="d50c-3bbe-c62d-34c3" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="5149-5183-64d5-feaf" name="Heavy Mag Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="81">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="49f7-05c7-8536-e088" profileTypeId="ecae-8ac8-2c13-0dd3" name="Heavy Mag Cannon" hidden="false" book="BtGoA" page="81">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="50"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="10"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="250"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="6"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Massive Damage, Heavy Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="2226-327b-9cef-5629" targetId="c863-510b-e239-be92" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="4fbe-feab-de05-5312" name="Heavy Tractor Maul" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="65">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="05cc-6d3b-93d8-0b0e" profileTypeId="ecae-8ac8-2c13-0dd3" name="Heavy Tractor Maul" hidden="false" book="BtGoA" page="65">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks, Hand Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="c401-a6db-93c9-69e0" targetId="2cbd-47c9-de87-ec2a" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="eff8-bb0e-1b1d-bbb2" name="HL armor" points="0.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="93">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="2a6f-a102-e7b6-54c7" targetId="b436-1f8a-5d3a-2d7d" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="2e3d-bbaa-3f5c-ac53" name="HL Booster (Eq)" points="1.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="b458-ac53-f980-4960" targetId="56ab-52fc-9557-2586" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="573b-88bc-97d7-d890" name="HL Booster Drone" points="20.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="121">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="68d9-bb11-1862-acca" targetId="56ab-52fc-9557-2586" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="1b16-412b-662a-5467" name="Homer Drone" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="e015-e1a0-3cd3-a350" targetId="ca2b-9550-eb1e-77c8" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="4364-45ee-ee83-ca30" name="Impact Cloak " points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="93">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules>
-        <rule id="5da7-d6db-a841-0ff0" name="Impact Cloak" hidden="false" book="BtGoA" page="93">
-          <description>Add +2 to Res in hand to hand combat.</description>
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="74e7-3e15-6b19-94e8" name="Impact Cloak (Eq)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="93">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules>
-        <rule id="a94d-f3ac-90df-d53a" name="Impact Cloak" hidden="false" book="BtGoA" page="93">
-          <description>Add +2 to Res in hand to hand combat.</description>
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="f99c-daab-b3d7-9c61" name="Implosion Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="85">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="50ac-e85f-6480-9e2e" profileTypeId="ecae-8ac8-2c13-0dd3" name="Implosion Grenades" hidden="false" book="BtGoA" page="85">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Hazardous H2H, Grenade"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="9868-0703-9743-d4b5" targetId="1c2c-6574-0a17-f90c" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="b357-a997-60e5-053e" name="IMTel Stave" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="67">
-      <entries>
-        <entry id="d6be-b9a8-1ea3-d1ee" name="IMTel Stave - Standard" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="9cc5-5341-3598-a655" profileTypeId="ecae-8ac8-2c13-0dd3" name="IMTel Stave - Standard" hidden="false" book="BtGoA" page="67">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="3 Attacks, Hand Weapon"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="051e-0412-fe0f-16d2" targetId="61e2-3707-ade3-c9ad" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="da2f-6bd2-fb0e-5e5e" name="IMTel Stave - Nano Drone Boost" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="cf0b-c836-c681-d9c0" profileTypeId="ecae-8ac8-2c13-0dd3" name="IMTel Stave - Nano Drone Boost" hidden="false" book="BtGoA" page="67">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="6"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="3 Attacks, Blast D3, Exhausted, Hand Weapon"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="8918-00b1-258e-5005" targetId="61e2-3707-ade3-c9ad" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="a14f-0f5e-7b8f-63f5" targetId="1acd-39d3-94e7-48e1" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="e461-67a4-a88e-a136" targetId="4232-2801-36cf-704c" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="5346-a420-8994-c5ed" name="Interceptor Bike" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="100">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="c7d2-5723-e428-dd5a" name="Ranged Weapon" minSelections="3" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="fa7c-b456-730f-167f" targetId="47d9-8149-9744-9849" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="ec8f-9506-26e0-53ec" targetId="78dd-7840-1210-fb35" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="d3a3-d3e0-1480-e349" name="Intruder Skimmer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="9">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="e102-2c84-66f5-fba9" name="Ranged Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="ed95-b0bc-1c54-77ce" name="Twin Mag Repeaters" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="f5ed-8cd5-154e-1987" name="&lt; Ranged Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="c12f-a100-2c77-940b">
               <profiles/>
-              <links/>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="3aa7-ded4-1810-f136" targetId="f31c-6e5c-19c0-ada7" linkType="entry">
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="c12f-a100-2c77-940b" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="02d9-18d6-822b-c297" hidden="false" targetId="179a-c0cc-49cc-c946" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="dbcb-5feb-24da-acaf" hidden="false" targetId="8de3-1e72-72ef-e7a3" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="97e8-d8ef-1bec-906d" name="Vardanari Guard" book="BtGoA" page="191" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="4ca6-7e89-8b59-f1d5" hidden="false" targetId="702f-c8a7-d8cf-01c1" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="19.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="fff7-d85d-7713-194d" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="1b32-6cc9-8dc9-64b3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="1b32-6cc9-8dc9-64b3" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="8836-8c4d-3a4f-5d40" name="Armor" hidden="false" collective="false" defaultSelectionEntryId="a575-c942-e1b2-0d29">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="a575-c942-e1b2-0d29" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="7876-6071-860a-2b8f" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="a7b4-9779-24e9-b2a7" hidden="false" targetId="573b-88bc-97d7-d890" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="42.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4e0f-95bb-f4f1-6030" name="Well Prepared" hidden="false" collective="false" categoryEntryId="50ba-cf77-3941-189c" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="fc7e-7c0e-65e0-8c33" name="Leader" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="69f3-3470-5212-8eaa" hidden="false" targetId="75d2-6efa-9640-61df" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <entryLinks>
+    <entryLink id="4f23-852d-0d45-b2d1" name="Army Options" hidden="false" targetId="529a-3e2a-4bd5-5e5f" type="selectionEntry" categoryEntryId="50ba-cf77-3941-189c">
       <profiles/>
-      <links>
-        <link id="b121-6dcc-8053-c5a2" targetId="e441-c3a6-7d61-2c63" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="02f3-3134-ae39-afed" name="Leader 2" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="135">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </entryLink>
+  </entryLinks>
+  <sharedSelectionEntries>
+    <selectionEntry id="e9dd-1dc6-3c92-4305" name="AG Chute" book="BtGoA" page="120" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="0240-940c-2896-fe6d" targetId="7850-89e7-bab8-86e9" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="5a4c-2f5e-40a2-91d4" name="Leader 3" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="135">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="54c4-0df3-268c-9fe1" hidden="false" targetId="7daf-414b-c030-7626" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="828e-3aa2-3dbf-f2cb" name="Auto-Workshop" book="BtGoA" page="120" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="0722-f7c8-1f58-524e" targetId="05bb-4d34-70cd-25d2" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="222a-c399-636e-c285" name="Lectro Lance" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="66">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="1194-e016-79d8-8f37" profileTypeId="ecae-8ac8-2c13-0dd3" name="Lectro Lance" hidden="false" book="BtGoA" page="66">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Hand Weapon"/>
-          </characteristics>
+      <infoLinks>
+        <infoLink id="2aa0-3909-ff3b-5bfe" hidden="false" targetId="b7c6-fc7c-d48b-aae4" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="10e4-842d-bb66-6204" name="Lectro Lash" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="65">
-      <entries/>
-      <entryGroups/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="0e1a-a803-d9c9-9f0a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Lectro Lash" hidden="false" book="BtGoA" page="65">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="3 Attacks, Hand Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="485e-5cd5-458a-5b01" targetId="61e2-3707-ade3-c9ad" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="3ad3-bfdd-6120-7c29" name="Lugger Gun" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="73">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="5c6f-c4ef-b4a1-32eb" profileTypeId="ecae-8ac8-2c13-0dd3" name="Lugger Gun" hidden="false" book="BtGoA" page="73">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2, Limited Ammo, Standard Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="a5ed-7915-9221-076b" targetId="0cb1-ea91-e5bc-4f75" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="cc2c-1225-57ca-f1ed" targetId="5efa-64a9-bbc9-3dba" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="6a2b-50c5-9a33-b756" name="Mag Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="75">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="295a-d623-e2d2-c684" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Cannon" hidden="false" book="BtGoA" page="75">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="5"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="5"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Massive Damage, Light Support Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="ba14-c26b-33c6-8283" targetId="c863-510b-e239-be92" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="84ac-0f31-c388-d0bd" name="Mag Gun" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="69">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="d809-b3af-7007-a7b3" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Gun" hidden="false" book="BtGoA" page="69">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="60"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="8f47-408e-cc6e-7a19" name="Mag Gun (Eq)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="69">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="33ca-cc05-d33e-3d00" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Gun" hidden="false" book="BtGoA" page="69">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="60"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="cea7-8511-2208-1b1f" name="Mag Heavy Support" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="81">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="c318-2375-d610-2950" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Heavy Support" hidden="false" book="BtGoA" page="81">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="5"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF5, Heavy Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="d752-3c59-1096-f66d" targetId="b0cb-c022-0531-4852" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="b5e9-5297-04d2-2bf8" name="Mag Lash" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="67">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="f404-2eda-272f-57cf" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Lash" hidden="false" book="BtGoA" page="67">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="a97e-ddef-2a97-6023" targetId="2cbd-47c9-de87-ec2a" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="a00c-0542-f2a5-8124" name="Mag Light Support" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="75">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="df5b-35ce-669c-6aee" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Light Support" hidden="false" book="BtGoA" page="75">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="50"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3, Light Support Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="1edc-0547-c0b3-df09" targetId="97d4-67cb-2671-ca29" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="9733-7039-e306-26b5" name="Mag Mortar" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="81">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="d461-69b8-c506-322a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Mortar" hidden="false" book="BtGoA" page="81">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH x2, Blast D10, No Cover, Heavy Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="f42c-7e9e-5b27-6658" targetId="aef6-6934-1dee-6fa0" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="bfd1-e214-1717-c121" targetId="04d9-a48d-7b25-4dd3" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="f78e-6fd2-fff5-58e2" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="3203-24a2-4083-bc0d" targetId="bc4e-7cd8-4017-d911" linkType="entry group">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="8690-3ab7-9fef-06ee" name="Mag Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="68">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="57f9-ac99-e46c-2757" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Pistol" hidden="false" book="BtGoA" page="68">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="30"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Hand Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="790a-6841-6372-870b" name="Mag Repeater" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="69">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="1c20-93a8-d402-9d61" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Repeater" hidden="false" book="BtGoA" page="69">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2, Standard Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="af4a-bed9-243c-993e" targetId="0cb1-ea91-e5bc-4f75" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="3ecf-d559-4559-c1bb" name="Mass Compactor" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="71">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="b468-06b2-1a5d-2ec0" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mass Compactor" hidden="false" book="BtGoA" page="71">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="30"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3/2/1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Standard Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="068c-0048-aa5f-9906" targetId="7db4-2d14-3984-37d9" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="af50-5808-cb3e-2ec9" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="502c-9855-7269-eaa2" name="Medi-Drone" points="20.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="113">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d571-d584-85fc-9110" name="Batter Drone" book="BtGoA" page="11" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="a034-e97d-eddd-d272" targetId="4039-88e8-9f6d-bfb3" linkType="rule">
+      <rules/>
+      <infoLinks>
+        <infoLink id="2686-6df4-4601-e99f" hidden="false" targetId="f0d9-1e5a-ec20-b27c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="eafe-29d5-1222-4155" name="Meld Skark" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8f68-d09d-6e26-c6ea" name="Batter Drone (2)" book="BtGoA" page="11" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0a02-46cc-7e6f-28b0" hidden="false" targetId="f0d9-1e5a-ec20-b27c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="af35-43cb-665c-f896" name="Booster Drone" book="BtGoA" page="111" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="77b8-dc0d-36ff-0f1d" name="Borer Drone" book="BtGoA" page="111" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="f67e-b103-c5e0-7d92" hidden="false" targetId="4e34-753f-b082-2e00" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4933-25f0-2896-ac60" name="Camo Drone" book="BtGoA" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0235-7440-f324-d8e9" hidden="false" targetId="5f48-f41c-fd96-6a1a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="babd-f951-933b-1254" name="Compactor Drone" book="BtGoA" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d5b5-2649-62fd-e305" hidden="false" targetId="3995-c066-c957-5ffe" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="666e-aa69-6e72-f168" name="Compactor Drone with Mag Cannon" book="BtGoA" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="663f-33f4-57b5-7a11" hidden="false" targetId="3995-c066-c957-5ffe" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="9c4f-f6de-c09c-eab2" hidden="false" targetId="6a2b-50c5-9a33-b756" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2144-e450-c8f2-af26" name="Compactor Drone with Mag Light Support" book="BtGoA" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="4e01-7b13-2e6c-0f97" hidden="false" targetId="3995-c066-c957-5ffe" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="d525-3a93-38f1-7e4e" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0299-39fc-32bd-8ac2" name="Compactor Drone with Plasma Cannon" book="BtGoA" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="ae6e-0698-5ad9-8d26" hidden="false" targetId="3995-c066-c957-5ffe" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="e506-bd0d-b513-7050" hidden="false" targetId="c2bf-0272-30c6-dd20" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="af24-45f9-4669-bf98" name="Compression Bombard" book="BtGoA" page="84" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="f3f6-794b-82b3-a39a" name="Compression Bombard" book="BtGoA" page="84" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-50"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="150"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="9/7/5"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Cycle, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d318-c320-5b7c-b089" hidden="false" targetId="7db4-2d14-3984-37d9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="a2f7-528d-dd59-9d00" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b53d-32d6-c4fc-cefc" hidden="false" targetId="cf7f-6f85-e64e-0363" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="71c9-4382-01cf-c737" name="Compression Cannon" book="BtGoA" page="78" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="b626-3a7f-ecf5-ea69" name="Compression Cannon" book="BtGoA" page="78" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="7/4/2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Cycle,  Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a6f9-23ce-e99d-7c15" hidden="false" targetId="7db4-2d14-3984-37d9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3003-31fb-fb6c-3084" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="70d5-a230-ba57-ead0" hidden="false" targetId="cf7f-6f85-e64e-0363" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="059b-38f7-0313-5ae4" name="Compression Carbine" book="BtGoA" page="72" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="e580-6389-7ec6-d445" hidden="false" targetId="7db4-2d14-3984-37d9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b230-6dc2-fc21-9332" hidden="false" targetId="75cb-cf9b-dd3d-9177" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="72ba-15e7-dbf7-816c" name="D-Spinner" book="BtGoA" page="66" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="bc08-23ff-215d-d442" name="D-Spinner" book="BtGoA" page="66" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="Varies"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks, Variable Res/Strike, Grenade, Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="bf1e-fb77-9e71-f9fe" hidden="false" targetId="2cbd-47c9-de87-ec2a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="363c-73f0-41ad-dfb8" hidden="false" targetId="99fd-f354-1703-5941" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="91a4-fa2b-910b-b8f8" hidden="false" targetId="b466-7990-db34-55b1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ff6c-f8d8-94e6-57bc" name="Disruptor Bomber" book="BtGoA" page="77" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="c100-99b7-2ff6-24a0" name="Disruptor Bomber" book="BtGoA" page="77" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D5, No Crew, Limited Ammo, No Cover, Disruptor,  Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="5bfd-e568-cff9-ff1b" hidden="false" targetId="c3bc-87fd-fa5d-5055" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ada8-a0a5-d314-27a6" hidden="false" targetId="b050-496a-ed16-2b2a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="c9a5-e124-997c-44ea" hidden="false" targetId="f502-611e-9704-97bb" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b3e6-5aa3-ef1f-f7b1" hidden="false" targetId="5efa-64a9-bbc9-3dba" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="df53-3436-c62e-c73e" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7fb2-1ffe-610d-7f33" hidden="false" targetId="6305-72fa-da02-235b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f771-f4b5-0047-de53" name="Disruptor Cannon" book="BtGoA" page="79" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="17db-4b84-9d1b-122d" name="Disruptor Cannon" book="BtGoA" page="79" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, No Cover, Disruptor, Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="48bb-4c87-e0f2-08b4" hidden="false" targetId="ca96-58c9-9551-d4fe" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3b06-bc9e-4002-8aeb" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="8e03-d6b4-1fab-5cd2" hidden="false" targetId="6305-72fa-da02-235b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="396e-b157-b3bb-a5e7" name="Disruptor Discharger" book="BtGoA" page="86" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="de01-ba7b-11ee-55ca" name="Disruptor Discharger" book="BtGoA" page="86" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="Point blank shooting only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="Point blank shooting only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="Point blank shooting only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, No Cover, Disruptor, Grenade"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="e755-a7a2-1343-d27a" hidden="false" targetId="5d64-4bf5-e947-95d1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b2cb-0542-2c44-9f1b" hidden="false" targetId="ca96-58c9-9551-d4fe" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="049f-1e26-3f5d-a4f9" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="adad-ebe2-3953-6510" hidden="false" targetId="6305-72fa-da02-235b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2cec-e1d7-c680-7ca0" name="Fractal Bombard" book="BtGoA" page="83" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="279b-22b3-c3ff-1320" name="Fractal Bombard" book="BtGoA" page="83" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="50"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="200"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3 + 2 Max 10"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="fe6a-32a9-1211-b766" hidden="false" targetId="d50c-3bbe-c62d-34c3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="93db-3751-fdd4-08f9" name="Fractal Cannon" book="BtGoA" page="76" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="cb47-aad3-9a1b-1266" name="Fractal Cannon" book="BtGoA" page="76" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2 + 1 Max 10"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock,  Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="b7b4-01fa-5f1f-ebee" hidden="false" targetId="d50c-3bbe-c62d-34c3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="aac7-43b0-4a5c-05bb" name="Frag Borer" book="BtGoA" page="77" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="5cb2-9abf-ed28-03ff" name="Frag Borer" book="BtGoA" page="77" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3 + 1 Max 10"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock,  Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="eac9-8b04-b66c-5db6" hidden="false" targetId="d50c-3bbe-c62d-34c3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3975-3892-22f2-0c8e" name="Ghar Plasma Claw" book="BtGoA" page="66" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="57de-9415-94c2-a9cd" name="Ghar Plasma Claw" book="BtGoA" page="66" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="D4"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Random SV,  Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="7eb4-a0e1-1e61-3d82" hidden="false" targetId="b6e3-9cf0-1a9f-a941" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f319-5d36-f853-9d45" name="Gouger Gun" book="BtGoA" page="74" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="5caa-0eb3-a2c8-d79c" name="Gouger Gun" book="BtGoA" page="74" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Down, Inaccurate, Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="6c43-9149-1b89-35e5" hidden="false" targetId="9444-e2a0-8048-5ce9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="aa66-a1ad-73f1-8bd2" hidden="false" targetId="3b84-9d0e-a3c1-6c1f" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b8d1-46be-c623-ad68" name="Gun Drone" book="BtGoA" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="14.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4b9d-a0bf-396e-384b" name="Gun Drone (2)" book="BtGoA" page="112" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="14.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f9cf-568d-998b-c3ca" name="Heavy Disruptor Bomber" book="BtGoA" page="80" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="a9a7-e90e-e54a-e37c" name="Heavy Disruptor Bomber" book="BtGoA" page="80" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH x2, Blast D10, Limited Ammo, No Cover, Disruptor, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="baaa-0b37-7581-545a" hidden="false" targetId="aef6-6934-1dee-6fa0" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ad5f-454c-b4ec-0b29" hidden="false" targetId="04d9-a48d-7b25-4dd3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3dc5-ce4c-aaf4-7bc4" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="1d69-8270-126c-b660" hidden="false" targetId="6305-72fa-da02-235b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="564d-3561-f5e4-783d" name="Heavy Frag Borer" book="BtGoA" page="83" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="4001-9da2-86d1-6b80" name="Heavy Frag Borer" book="BtGoA" page="83" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6 + 1 Max 10"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="174d-fb91-0ee1-de89" hidden="false" targetId="d50c-3bbe-c62d-34c3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5149-5183-64d5-feaf" name="Heavy Mag Cannon" book="BtGoA" page="81" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="49f7-05c7-8536-e088" name="Heavy Mag Cannon" book="BtGoA" page="81" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="50"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="10"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="250"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Massive Damage, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="2226-327b-9cef-5629" hidden="false" targetId="c863-510b-e239-be92" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4fbe-feab-de05-5312" name="Heavy Tractor Maul" book="BtGoA" page="65" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="05cc-6d3b-93d8-0b0e" name="Heavy Tractor Maul" book="BtGoA" page="65" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks, Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="c401-a6db-93c9-69e0" hidden="false" targetId="2cbd-47c9-de87-ec2a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eff8-bb0e-1b1d-bbb2" name="HL armor" book="BtGoA" page="93" hidden="false" collective="true" categoryEntryId="(No Category)" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="2a6f-a102-e7b6-54c7" hidden="false" targetId="b436-1f8a-5d3a-2d7d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2e3d-bbaa-3f5c-ac53" name="HL Booster (Eq)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="b458-ac53-f980-4960" hidden="false" targetId="56ab-52fc-9557-2586" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="1.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="573b-88bc-97d7-d890" name="HL Booster Drone" book="BtGoA" page="121" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="68d9-bb11-1862-acca" hidden="false" targetId="56ab-52fc-9557-2586" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1b16-412b-662a-5467" name="Homer Drone" book="BtGoA" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="e015-e1a0-3cd3-a350" hidden="false" targetId="ca2b-9550-eb1e-77c8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4364-45ee-ee83-ca30" name="Impact Cloak " book="BtGoA" page="93" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
       <rules>
-        <rule id="68b7-72bd-610b-2ae3" name="Meld Skark" hidden="false" book="BtGoA" page="194">
+        <rule id="5da7-d6db-a841-0ff0" name="Impact Cloak" book="BtGoA" page="93" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>Add +2 to Res in hand to hand combat.</description>
+        </rule>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="74e7-3e15-6b19-94e8" name="Impact Cloak (Eq)" book="BtGoA" page="93" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules>
+        <rule id="a94d-f3ac-90df-d53a" name="Impact Cloak" book="BtGoA" page="93" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>Add +2 to Res in hand to hand combat.</description>
+        </rule>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f99c-daab-b3d7-9c61" name="Implosion Grenades" book="BtGoA" page="85" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="50ac-e85f-6480-9e2e" name="Implosion Grenades" book="BtGoA" page="85" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Hazardous H2H, Grenade"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="9868-0703-9743-d4b5" hidden="false" targetId="1c2c-6574-0a17-f90c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b357-a997-60e5-053e" name="IMTel Stave" book="BtGoA" page="67" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="d6be-b9a8-1ea3-d1ee" name="IMTel Stave - Standard" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="9cc5-5341-3598-a655" name="IMTel Stave - Standard" book="BtGoA" page="67" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="3 Attacks, Hand Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="051e-0412-fe0f-16d2" hidden="false" targetId="61e2-3707-ade3-c9ad" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="da2f-6bd2-fb0e-5e5e" name="IMTel Stave - Nano Drone Boost" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="cf0b-c836-c681-d9c0" name="IMTel Stave - Nano Drone Boost" book="BtGoA" page="67" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="3 Attacks, Blast D3, Exhausted, Hand Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="8918-00b1-258e-5005" hidden="false" targetId="61e2-3707-ade3-c9ad" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="a14f-0f5e-7b8f-63f5" hidden="false" targetId="1acd-39d3-94e7-48e1" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="e461-67a4-a88e-a136" hidden="false" targetId="4232-2801-36cf-704c" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5346-a420-8994-c5ed" name="Interceptor Bike" book="BtGoA" page="100" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c7d2-5723-e428-dd5a" name="Ranged Weapon" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="fa7c-b456-730f-167f" hidden="false" targetId="47d9-8149-9744-9849" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="ec8f-9506-26e0-53ec" hidden="false" targetId="78dd-7840-1210-fb35" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d3a3-d3e0-1480-e349" name="Intruder Skimmer" book="BtGoA" page="9" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e102-2c84-66f5-fba9" name="Ranged Weapon" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="ed95-b0bc-1c54-77ce" name="Twin Mag Repeaters" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="3aa7-ded4-1810-f136" hidden="false" targetId="f31c-6e5c-19c0-ada7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fc7e-7c0e-65e0-8c33" name="Leader" book="" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="b121-6dcc-8053-c5a2" hidden="false" targetId="e441-c3a6-7d61-2c63" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="02f3-3134-ae39-afed" name="Leader 2" book="BtGoA" page="135" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0240-940c-2896-fe6d" hidden="false" targetId="7850-89e7-bab8-86e9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5a4c-2f5e-40a2-91d4" name="Leader 3" book="BtGoA" page="135" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0722-f7c8-1f58-524e" hidden="false" targetId="05bb-4d34-70cd-25d2" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="222a-c399-636e-c285" name="Lectro Lance" book="BtGoA" page="66" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="1194-e016-79d8-8f37" name="Lectro Lance" book="BtGoA" page="66" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="10e4-842d-bb66-6204" name="Lectro Lash" book="BtGoA" page="65" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="0e1a-a803-d9c9-9f0a" name="Lectro Lash" book="BtGoA" page="65" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="3 Attacks, Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="485e-5cd5-458a-5b01" hidden="false" targetId="61e2-3707-ade3-c9ad" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3ad3-bfdd-6120-7c29" name="Lugger Gun" book="BtGoA" page="73" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="5c6f-c4ef-b4a1-32eb" name="Lugger Gun" book="BtGoA" page="73" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Limited Ammo, Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a5ed-7915-9221-076b" hidden="false" targetId="0cb1-ea91-e5bc-4f75" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="cc2c-1225-57ca-f1ed" hidden="false" targetId="5efa-64a9-bbc9-3dba" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6a2b-50c5-9a33-b756" name="Mag Cannon" book="BtGoA" page="75" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="295a-d623-e2d2-c684" name="Mag Cannon" book="BtGoA" page="75" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="5"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="5"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Massive Damage, Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="ba14-c26b-33c6-8283" hidden="false" targetId="c863-510b-e239-be92" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="84ac-0f31-c388-d0bd" name="Mag Gun" book="BtGoA" page="69" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="d809-b3af-7007-a7b3" name="Mag Gun" book="BtGoA" page="69" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8f47-408e-cc6e-7a19" name="Mag Gun (Eq)" book="BtGoA" page="69" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="33ca-cc05-d33e-3d00" name="Mag Gun" book="BtGoA" page="69" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cea7-8511-2208-1b1f" name="Mag Heavy Support" book="BtGoA" page="81" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="c318-2375-d610-2950" name="Mag Heavy Support" book="BtGoA" page="81" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="5"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF5, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d752-3c59-1096-f66d" hidden="false" targetId="b0cb-c022-0531-4852" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b5e9-5297-04d2-2bf8" name="Mag Lash" book="BtGoA" page="67" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="f404-2eda-272f-57cf" name="Mag Lash" book="BtGoA" page="67" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a97e-ddef-2a97-6023" hidden="false" targetId="2cbd-47c9-de87-ec2a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a00c-0542-f2a5-8124" name="Mag Light Support" book="BtGoA" page="75" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="df5b-35ce-669c-6aee" name="Mag Light Support" book="BtGoA" page="75" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="50"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3, Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="1edc-0547-c0b3-df09" hidden="false" targetId="97d4-67cb-2671-ca29" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9733-7039-e306-26b5" name="Mag Mortar" book="BtGoA" page="81" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="d461-69b8-c506-322a" name="Mag Mortar" book="BtGoA" page="81" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH x2, Blast D10, No Cover, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="f42c-7e9e-5b27-6658" hidden="false" targetId="aef6-6934-1dee-6fa0" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="bfd1-e214-1717-c121" hidden="false" targetId="04d9-a48d-7b25-4dd3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f78e-6fd2-fff5-58e2" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="3203-24a2-4083-bc0d" hidden="false" targetId="bc4e-7cd8-4017-d911" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8690-3ab7-9fef-06ee" name="Mag Pistol" book="BtGoA" page="68" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="57f9-ac99-e46c-2757" name="Mag Pistol" book="BtGoA" page="68" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="790a-6841-6372-870b" name="Mag Repeater" book="BtGoA" page="69" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="1c20-93a8-d402-9d61" name="Mag Repeater" book="BtGoA" page="69" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="af4a-bed9-243c-993e" hidden="false" targetId="0cb1-ea91-e5bc-4f75" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3ecf-d559-4559-c1bb" name="Mass Compactor" book="BtGoA" page="71" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="b468-06b2-1a5d-2ec0" name="Mass Compactor" book="BtGoA" page="71" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3/2/1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="068c-0048-aa5f-9906" hidden="false" targetId="7db4-2d14-3984-37d9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="af50-5808-cb3e-2ec9" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="502c-9855-7269-eaa2" name="Medi-Drone" book="BtGoA" page="113" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a034-e97d-eddd-d272" hidden="false" targetId="4039-88e8-9f6d-bfb3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eafe-29d5-1222-4155" name="Meld Skark" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules>
+        <rule id="68b7-72bd-610b-2ae3" name="Meld Skark" book="BtGoA" page="194" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
           <description>6 Attacks, SV1</description>
-          <modifiers/>
         </rule>
       </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1a9d-01a2-ee09-883c" name="Micro-X Launcher" book="BtGoA" page="71" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="1a9d-01a2-ee09-883c" name="Micro-X Launcher" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="71">
-      <entries>
-        <entry id="756b-b4d4-8824-056b" name="Micro X-Launcher - Overhead" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="756b-b4d4-8824-056b" name="Micro X-Launcher - Overhead" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles>
-            <profile id="b067-87fe-65b4-6bd8" profileTypeId="ecae-8ac8-2c13-0dd3" name="Micro X-Launcher Overhead" hidden="false" book="BtGoA" page="71">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="5"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D4, No Cover, Standard Weapon"/>
-              </characteristics>
+            <profile id="b067-87fe-65b4-6bd8" name="Micro X-Launcher Overhead" book="BtGoA" page="71" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="5"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D4, No Cover, Standard Weapon"/>
+              </characteristics>
             </profile>
           </profiles>
-          <links>
-            <link id="29b1-77a8-eac1-dcb8" targetId="c3bc-87fd-fa5d-5055" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="5888-4d4d-b427-d1f3" targetId="ca96-58c9-9551-d4fe" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="de68-1314-0e93-bc44" targetId="a41d-d55e-6d97-049d" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="b484-5b5d-96fb-e628" name="Micro X-Launcher - Direct Fire" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
           <rules/>
-          <profiles>
-            <profile id="c0c1-ee5f-5c1f-77a0" profileTypeId="ecae-8ac8-2c13-0dd3" name="Micro X-Launcher - Direct Fire" hidden="false" book="BtGoA" page="71">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
-              </characteristics>
+          <infoLinks>
+            <infoLink id="29b1-77a8-eac1-dcb8" hidden="false" targetId="c3bc-87fd-fa5d-5055" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
+            </infoLink>
+            <infoLink id="5888-4d4d-b427-d1f3" hidden="false" targetId="ca96-58c9-9551-d4fe" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="de68-1314-0e93-bc44" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b484-5b5d-96fb-e628" name="Micro X-Launcher - Direct Fire" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="c0c1-ee5f-5c1f-77a0" name="Micro X-Launcher - Direct Fire" book="BtGoA" page="71" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+              </characteristics>
             </profile>
           </profiles>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="e7b0-651a-cc7c-f27e" name="Micro-X Launcher (Eq)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="71">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e7b0-651a-cc7c-f27e" name="Micro-X Launcher (Eq)" book="BtGoA" page="71" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="3bdc-c653-a2ab-de1c" profileTypeId="ecae-8ac8-2c13-0dd3" name="Micro X-Launcher - Direct Fire" hidden="false" book="BtGoA" page="71">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
-          </characteristics>
+        <profile id="3bdc-c653-a2ab-de1c" name="Micro X-Launcher - Direct Fire" book="BtGoA" page="71" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+          </characteristics>
         </profile>
-        <profile id="7649-e5a8-d706-0d24" profileTypeId="ecae-8ac8-2c13-0dd3" name="Micro X-Launcher Overhead" hidden="false" book="BtGoA" page="71">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="5"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D4, No Cover, Standard Weapon"/>
-          </characteristics>
+        <profile id="7649-e5a8-d706-0d24" name="Micro X-Launcher Overhead" book="BtGoA" page="71" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="5"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D4, No Cover, Standard Weapon"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="ede2-e3e5-c94d-4378" targetId="ca96-58c9-9551-d4fe" linkType="rule">
+      <rules/>
+      <infoLinks>
+        <infoLink id="ede2-e3e5-c94d-4378" hidden="false" targetId="ca96-58c9-9551-d4fe" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="c25b-badb-e157-f945" targetId="a41d-d55e-6d97-049d" linkType="rule">
+        </infoLink>
+        <infoLink id="c25b-badb-e157-f945" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="83cb-eec9-94c0-8fc1" targetId="c3bc-87fd-fa5d-5055" linkType="rule">
+        </infoLink>
+        <infoLink id="83cb-eec9-94c0-8fc1" hidden="false" targetId="c3bc-87fd-fa5d-5055" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="7849-7fc2-0006-8fbd" name="Munitions" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="cf32-46fd-cdce-80dd" name="Munitions" minSelections="0" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="2f9e-d8b5-f1a8-6e4c" name="Scrambler" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-              <entries/>
-              <entryGroups/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7849-7fc2-0006-8fbd" name="Munitions" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="cf32-46fd-cdce-80dd" name="Munitions" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="2f9e-d8b5-f1a8-6e4c" name="Scrambler" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="c2fb-c9db-5e9c-dcfe" hidden="false" targetId="7a3b-74a5-3ced-dd88" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="9622-01bf-0303-e5f7" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
               <modifiers>
-                <modifier type="hide" field="maxSelections" value="0.0" repeat="true" numRepeats="1" incrementParentId="cf32-46fd-cdce-80dd" incrementChildId="057c-a217-e792-8ef7" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="hidden" value="true">
+                  <repeats>
+                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="47c5-9ed0-b50a-45b7" name="Arc" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links>
-                <link id="c2fb-c9db-5e9c-dcfe" targetId="7a3b-74a5-3ced-dd88" linkType="rule">
+              <rules/>
+              <infoLinks>
+                <infoLink id="1838-cbe5-7c85-395d" hidden="false" targetId="c1ba-c745-22a8-e2d7" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-                <link id="9622-01bf-0303-e5f7" targetId="b996-131f-b84a-4724" linkType="rule">
+                </infoLink>
+                <infoLink id="6568-0044-8497-b002" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="47c5-9ed0-b50a-45b7" name="Arc" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-              <entries/>
-              <entryGroups/>
+                </infoLink>
+              </infoLinks>
               <modifiers>
-                <modifier type="hide" field="maxSelections" value="0.0" repeat="true" numRepeats="1" incrementParentId="cf32-46fd-cdce-80dd" incrementChildId="057c-a217-e792-8ef7" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="hidden" value="true">
+                  <repeats>
+                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="876b-029d-8c49-cf28" name="Blur" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links>
-                <link id="1838-cbe5-7c85-395d" targetId="c1ba-c745-22a8-e2d7" linkType="rule">
+              <rules/>
+              <infoLinks>
+                <infoLink id="8a68-f508-7c9e-1ee4" hidden="false" targetId="117a-a2aa-4be7-dffe" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-                <link id="6568-0044-8497-b002" targetId="b996-131f-b84a-4724" linkType="rule">
+                </infoLink>
+                <infoLink id="1fe7-d90c-fd8b-2777" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="876b-029d-8c49-cf28" name="Blur" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-              <entries/>
-              <entryGroups/>
+                </infoLink>
+              </infoLinks>
               <modifiers>
-                <modifier type="hide" field="maxSelections" value="0.0" repeat="true" numRepeats="1" incrementParentId="cf32-46fd-cdce-80dd" incrementChildId="057c-a217-e792-8ef7" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="hidden" value="true">
+                  <repeats>
+                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2f18-3173-0eea-f19f" name="Scoot" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links>
-                <link id="8a68-f508-7c9e-1ee4" targetId="117a-a2aa-4be7-dffe" linkType="rule">
+              <rules/>
+              <infoLinks>
+                <infoLink id="a787-c45e-8df6-7cdb" hidden="false" targetId="28a0-7151-a0c5-9495" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-                <link id="1fe7-d90c-fd8b-2777" targetId="b996-131f-b84a-4724" linkType="rule">
+                </infoLink>
+                <infoLink id="4acd-4d6e-c5ce-c202" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="2f18-3173-0eea-f19f" name="Scoot" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-              <entries/>
-              <entryGroups/>
+                </infoLink>
+              </infoLinks>
               <modifiers>
-                <modifier type="hide" field="maxSelections" value="0.0" repeat="true" numRepeats="1" incrementParentId="cf32-46fd-cdce-80dd" incrementChildId="057c-a217-e792-8ef7" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="hidden" value="true">
+                  <repeats>
+                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="99d6-3f14-a1e9-779b" name="Net" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links>
-                <link id="a787-c45e-8df6-7cdb" targetId="28a0-7151-a0c5-9495" linkType="rule">
+              <rules/>
+              <infoLinks>
+                <infoLink id="c8d2-16b3-5523-a9b1" hidden="false" targetId="ac33-af99-2d76-c981" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-                <link id="4acd-4d6e-c5ce-c202" targetId="b996-131f-b84a-4724" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="99d6-3f14-a1e9-779b" name="Net" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-              <entries/>
-              <entryGroups/>
+                </infoLink>
+              </infoLinks>
               <modifiers>
-                <modifier type="hide" field="maxSelections" value="0.0" repeat="true" numRepeats="1" incrementParentId="cf32-46fd-cdce-80dd" incrementChildId="057c-a217-e792-8ef7" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="hidden" value="true">
+                  <repeats>
+                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e014-fd16-bd43-6ead" name="Grip" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links>
-                <link id="c8d2-16b3-5523-a9b1" targetId="ac33-af99-2d76-c981" linkType="rule">
+              <rules/>
+              <infoLinks>
+                <infoLink id="6ffa-8857-9b93-35b5" hidden="false" targetId="1045-95cb-5504-9050" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="e014-fd16-bd43-6ead" name="Grip" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-              <entries/>
-              <entryGroups/>
+                </infoLink>
+                <infoLink id="3eba-9eb4-bf44-4b04" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
               <modifiers>
-                <modifier type="hide" field="maxSelections" value="0.0" repeat="true" numRepeats="1" incrementParentId="cf32-46fd-cdce-80dd" incrementChildId="057c-a217-e792-8ef7" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="hidden" value="true">
+                  <repeats>
+                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="057c-a217-e792-8ef7" name="All" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links>
-                <link id="6ffa-8857-9b93-35b5" targetId="1045-95cb-5504-9050" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="3eba-9eb4-bf44-4b04" targetId="b996-131f-b84a-4724" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="057c-a217-e792-8ef7" name="All" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
               <rules/>
+              <infoLinks>
+                <infoLink id="7fae-ff88-b94e-934e" hidden="false" targetId="c1ba-c745-22a8-e2d7" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="49a1-2fba-ff8f-c1b0" hidden="false" targetId="117a-a2aa-4be7-dffe" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="7acb-0144-9a6a-9840" hidden="false" targetId="1045-95cb-5504-9050" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="878e-a6f2-d2ce-4e02" hidden="false" targetId="ac33-af99-2d76-c981" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="ed06-0ab3-bc83-05de" hidden="false" targetId="28a0-7151-a0c5-9495" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="03ee-325f-d6f1-fd20" hidden="false" targetId="7a3b-74a5-3ced-dd88" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="8d63-0835-da60-a624" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bf0f-913b-e028-8891" name="Nano Drone" book="BtGoA" page="113" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="4173-19e8-aa99-3e22" hidden="false" targetId="c1c6-f9c7-c84f-d57d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cadc-e1ce-3615-ac4b" name="Nano Drones (2)" book="BtGoA" page="113" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="ce7f-8e3d-c50c-b636" hidden="false" targetId="c1c6-f9c7-c84f-d57d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6b54-c223-3c4a-5de7" name="Overload Ammo" book="BtGoA" page="89" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="6edf-03c1-417f-13e8" hidden="false" targetId="3559-4b87-980d-f90d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eb94-d1e8-1084-71b3" name="Phase Armor" book="BtGoA" page="93" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="3da3-80ac-dc11-6809" hidden="false" targetId="b28d-571e-af69-4582" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5725-5e4d-d4f2-1dd0" name="Phase Rifle" book="BtGoA" page="72" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="d2b1-2482-5f97-a4e4" name="Phase Rifle" book="BtGoA" page="72" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="No Cover, RF D6 Fire Only, Concentrated Fire, Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0d4d-4f3f-c86d-9dbe" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b46e-26ca-aad6-e64b" hidden="false" targetId="1863-c041-6dc4-c62d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6fea-ec6b-df33-2abe" hidden="false" targetId="5fb8-4f09-d496-4ea9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a18f-8d16-f879-e590" name="Phaseshift Shield" book="BtGoA" page="122" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="67b6-d6f5-5ba3-e50d" name="Plasma Bombard" book="BtGoA" page="82" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="a5d1-11c5-eb13-f676" name="Plasma Bombard" book="BtGoA" page="82" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="200"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="7"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Plasma Fade, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="7388-9f57-6e2a-eadb" hidden="false" targetId="6b03-2ad4-34c1-7f73" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c2bf-0272-30c6-dd20" name="Plasma Cannon" book="BtGoA" page="76" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="dce6-92d7-7812-820a" name="Plasma Cannon" book="BtGoA" page="76" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="4"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Plasma Fade, Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="3c39-3d6d-7a5a-f2f5" hidden="false" targetId="6b03-2ad4-34c1-7f73" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1631-5857-2139-960a" name="Plasma Carbine " book="BtGoA" page="70" hidden="false" collective="true" categoryEntryId="(No Category)" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0212-5213-7d18-d37f" hidden="false" targetId="ee9c-ada6-953a-b774" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="d572-ea69-f6bd-9b8f" hidden="false" targetId="b56d-0f1d-de00-62c4" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b55d-3878-89ca-fb86" hidden="false" targetId="0cb1-ea91-e5bc-4f75" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b018-6101-d2e3-b4ea" name="Plasma Carbine (Eq)" book="BtGoA" page="70" hidden="false" collective="true" categoryEntryId="(No Category)" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="7c09-db8c-68d9-485b" hidden="false" targetId="ee9c-ada6-953a-b774" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="8179-73ab-e5c7-065c" hidden="false" targetId="b56d-0f1d-de00-62c4" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f29e-ac68-7310-1db0" hidden="false" targetId="0cb1-ea91-e5bc-4f75" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d118-8115-df5f-2402" name="Plasma Grenades" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="8771-f173-82cd-3509" hidden="false" targetId="96f9-325b-69f7-13b4" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="47d9-8149-9744-9849" name="Plasma Lance" book="BtGoA" page="70" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="b6e9-addd-c005-4547" name="Plasma Lance - Single Shot" book="BtGoA" page="70" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="3799-96cf-d949-da4e" name="Plasma Lance - Single Shot" book="BtGoA" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
               <profiles/>
-              <links>
-                <link id="7fae-ff88-b94e-934e" targetId="c1ba-c745-22a8-e2d7" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="49a1-2fba-ff8f-c1b0" targetId="117a-a2aa-4be7-dffe" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="7acb-0144-9a6a-9840" targetId="1045-95cb-5504-9050" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="878e-a6f2-d2ce-4e02" targetId="ac33-af99-2d76-c981" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="ed06-0ab3-bc83-05de" targetId="28a0-7151-a0c5-9495" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="03ee-325f-d6f1-fd20" targetId="7a3b-74a5-3ced-dd88" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="8d63-0835-da60-a624" targetId="b996-131f-b84a-4724" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="bf0f-913b-e028-8891" name="Nano Drone" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="113">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="4173-19e8-aa99-3e22" targetId="c1c6-f9c7-c84f-d57d" linkType="rule">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="80ed-e766-57b1-3d2a" name="Plasma Lance - Scatter" book="BtGoA" page="70" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="9ad5-3648-6628-2caa" name="Plasma Lance - Scatter" book="BtGoA" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Standard Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="3f8e-ffa3-e1eb-fde7" hidden="false" targetId="0cb1-ea91-e5bc-4f75" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="cadc-e1ce-3615-ac4b" name="Nano Drones (2)" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="113">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="ce7f-8e3d-c50c-b636" targetId="c1c6-f9c7-c84f-d57d" linkType="rule">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4069-4420-c5b5-56af" name="Plasma Lance - Lance" book="BtGoA" page="70" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="f44f-9fdb-7e3c-bf9e" name="Plasma Lance - Lance" book="BtGoA" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="4"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Choose Target, Inaccurate, Standard Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="7213-775a-deac-dce8" hidden="false" targetId="fd72-d48c-e8af-4883" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="9752-310b-98a1-37af" hidden="false" targetId="3b84-9d0e-a3c1-6c1f" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="6b54-c223-3c4a-5de7" name="Overload Ammo" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="89">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="6edf-03c1-417f-13e8" targetId="3559-4b87-980d-f90d" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="eb94-d1e8-1084-71b3" name="Phase Armor" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="93">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="3da3-80ac-dc11-6809" targetId="b28d-571e-af69-4582" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="5725-5e4d-d4f2-1dd0" name="Phase Rifle" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="72">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cf3a-e6a9-bdc0-e0ae" name="Plasma Light Support" book="BtGoA" page="76" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="d2b1-2482-5f97-a4e4" profileTypeId="ecae-8ac8-2c13-0dd3" name="Phase Rifle" hidden="false" book="BtGoA" page="72">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="No Cover, RF D6 Fire Only, Concentrated Fire, Standard Weapon"/>
-          </characteristics>
+        <profile id="d429-b8cc-aca0-aac9" name="Plasma Light Support" book="BtGoA" page="76" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="4"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3, Light Support Weapon"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="0d4d-4f3f-c86d-9dbe" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="b46e-26ca-aad6-e64b" targetId="1863-c041-6dc4-c62d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="6fea-ec6b-df33-2abe" targetId="5fb8-4f09-d496-4ea9" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="a18f-8d16-f879-e590" name="Phaseshift Shield" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="122">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="67b6-d6f5-5ba3-e50d" name="Plasma Bombard" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="82">
-      <entries/>
-      <entryGroups/>
+      <infoLinks>
+        <infoLink id="9e8b-6ee9-56f0-aedf" hidden="false" targetId="97d4-67cb-2671-ca29" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0f97-9dbe-566a-5ab0" name="Plasma Light Support (Eq)" book="BtGoA" page="76" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="a5d1-11c5-eb13-f676" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Bombard" hidden="false" book="BtGoA" page="82">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="200"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="7"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Plasma Fade, Heavy Weapon"/>
-          </characteristics>
+        <profile id="4477-6aca-5fe1-2d03" name="Plasma Light Support" book="BtGoA" page="76" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="4"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3, Light Support Weapon"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="7388-9f57-6e2a-eadb" targetId="6b03-2ad4-34c1-7f73" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="c2bf-0272-30c6-dd20" name="Plasma Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="76">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="dce6-92d7-7812-820a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Cannon" hidden="false" book="BtGoA" page="76">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="4"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="6"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Plasma Fade, Light Support Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="3c39-3d6d-7a5a-f2f5" targetId="6b03-2ad4-34c1-7f73" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="1631-5857-2139-960a" name="Plasma Carbine " points="0.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="70">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="0212-5213-7d18-d37f" targetId="ee9c-ada6-953a-b774" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="d572-ea69-f6bd-9b8f" targetId="b56d-0f1d-de00-62c4" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="b55d-3878-89ca-fb86" targetId="0cb1-ea91-e5bc-4f75" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="b018-6101-d2e3-b4ea" name="Plasma Carbine (Eq)" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="70">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="7c09-db8c-68d9-485b" targetId="ee9c-ada6-953a-b774" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="8179-73ab-e5c7-065c" targetId="b56d-0f1d-de00-62c4" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="f29e-ac68-7310-1db0" targetId="0cb1-ea91-e5bc-4f75" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="d118-8115-df5f-2402" name="Plasma Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="8771-f173-82cd-3509" targetId="96f9-325b-69f7-13b4" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="47d9-8149-9744-9849" name="Plasma Lance" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="70">
-      <entries>
-        <entry id="b6e9-addd-c005-4547" name="Plasma Lance - Single Shot" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="70">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
+      <infoLinks>
+        <infoLink id="61c1-b16a-8335-9497" hidden="false" targetId="97d4-67cb-2671-ca29" type="rule">
+          <profiles/>
           <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9cd6-dbb8-bdcb-0299" name="Plasma Pistol" book="BtGoA" page="68" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="3d5e-ab8a-1859-49b2" hidden="false" targetId="2e7c-b5f9-e3e5-9125" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e6db-6ed3-1a26-ea56" name="Plasma Pistol (Eq)" book="BtGoA" page="68" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d7c4-2e9d-b85d-2cda" hidden="false" targetId="2e7c-b5f9-e3e5-9125" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2396-4159-e26c-6c42" name="Reflex Armor" book="BtGoA" page="93" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="6826-c718-8070-65a3" hidden="false" targetId="18c0-c86d-0b2c-23af" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9cdf-f068-bbde-2d0c" name="Reflex Armor (Eq)" book="BtGoA" page="93" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="fead-bc73-7559-09fc" hidden="false" targetId="18c0-c86d-0b2c-23af" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="03c2-174e-8617-cf04" name="Reflex Armor/ Impact Cloak (Eq)" book="BtGoA" page="93" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a445-3a2a-b5dc-dff6" hidden="false" targetId="18c0-c86d-0b2c-23af" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="abe2-ce1e-271f-5a85" name="Scourer Cannon" book="BtGoA" page="73" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="ccbf-d756-25d7-40f4" name="Scourer Cannon - Dispersed" book="BtGoA" page="73" hidden="true" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles>
-            <profile id="3799-96cf-d949-da4e" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Single Shot" hidden="false" book="BtGoA" page="70">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
-              </characteristics>
+            <profile id="03b8-44da-840d-df59" name="Scourer Cannon - Dispersed" book="BtGoA" page="73" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3, Standard Weapon"/>
+              </characteristics>
             </profile>
           </profiles>
-          <links/>
-        </entry>
-        <entry id="80ed-e766-57b1-3d2a" name="Plasma Lance - Scatter" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="70">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
           <rules/>
-          <profiles>
-            <profile id="9ad5-3648-6628-2caa" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Scatter" hidden="false" book="BtGoA" page="70">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2, Standard Weapon"/>
-              </characteristics>
+          <infoLinks>
+            <infoLink id="6631-7298-fd9d-ce64" hidden="false" targetId="97d4-67cb-2671-ca29" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="713c-944f-32ee-fe55" name="Scourer Cannon - Concentrated" book="BtGoA" page="73" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="0f28-d6ef-0f10-6e8f" name="Scourer Cannon - Concentrated" book="BtGoA" page="73" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="40"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="4"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+              </characteristics>
             </profile>
           </profiles>
-          <links>
-            <link id="3f8e-ffa3-e1eb-fde7" targetId="0cb1-ea91-e5bc-4f75" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="4069-4420-c5b5-56af" name="Plasma Lance - Lance" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="70">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
           <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9a2e-529c-2e81-0d99" name="Scourer Cannon - Disruptor" book="BtGoA" page="73" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles>
-            <profile id="f44f-9fdb-7e3c-bf9e" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Lance" hidden="false" book="BtGoA" page="70">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="4"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Choose Target, Inaccurate, Standard Weapon"/>
-              </characteristics>
+            <profile id="1b2e-f75a-2b45-9cde" name="Scourer Cannon - Disruptor" book="BtGoA" page="73" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, No Cover, Disruptor, Standard Weapon"/>
+              </characteristics>
             </profile>
           </profiles>
-          <links>
-            <link id="7213-775a-deac-dce8" targetId="fd72-d48c-e8af-4883" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="9752-310b-98a1-37af" targetId="3b84-9d0e-a3c1-6c1f" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="cf3a-e6a9-bdc0-e0ae" name="Plasma Light Support" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="76">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="d429-b8cc-aca0-aac9" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Light Support" hidden="false" book="BtGoA" page="76">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="4"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3, Light Support Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="9e8b-6ee9-56f0-aedf" targetId="97d4-67cb-2671-ca29" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="0f97-9dbe-566a-5ab0" name="Plasma Light Support (Eq)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="76">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="4477-6aca-5fe1-2d03" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Light Support" hidden="false" book="BtGoA" page="76">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="4"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3, Light Support Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="61c1-b16a-8335-9497" targetId="97d4-67cb-2671-ca29" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="9cd6-dbb8-bdcb-0299" name="Plasma Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="68">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="3d5e-ab8a-1859-49b2" targetId="2e7c-b5f9-e3e5-9125" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="e6db-6ed3-1a26-ea56" name="Plasma Pistol (Eq)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="68">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="d7c4-2e9d-b85d-2cda" targetId="2e7c-b5f9-e3e5-9125" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="2396-4159-e26c-6c42" name="Reflex Armor" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="93">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="6826-c718-8070-65a3" targetId="18c0-c86d-0b2c-23af" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="9cdf-f068-bbde-2d0c" name="Reflex Armor (Eq)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="93">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="fead-bc73-7559-09fc" targetId="18c0-c86d-0b2c-23af" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="03c2-174e-8617-cf04" name="Reflex Armor/ Impact Cloak (Eq)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="93">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="a445-3a2a-b5dc-dff6" targetId="18c0-c86d-0b2c-23af" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="abe2-ce1e-271f-5a85" name="Scourer Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="73">
-      <entries>
-        <entry id="ccbf-d756-25d7-40f4" name="Scourer Cannon - Dispersed" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true" book="BtGoA" page="73">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
           <rules/>
-          <profiles>
-            <profile id="03b8-44da-840d-df59" profileTypeId="ecae-8ac8-2c13-0dd3" name="Scourer Cannon - Dispersed" hidden="false" book="BtGoA" page="73">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3, Standard Weapon"/>
-              </characteristics>
+          <infoLinks>
+            <infoLink id="393a-a871-9061-745a" hidden="false" targetId="ca96-58c9-9551-d4fe" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="6631-7298-fd9d-ce64" targetId="97d4-67cb-2671-ca29" linkType="rule">
+            </infoLink>
+            <infoLink id="dee2-529a-c466-8b1e" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="713c-944f-32ee-fe55" name="Scourer Cannon - Concentrated" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="73">
-          <entries/>
-          <entryGroups/>
+            </infoLink>
+            <infoLink id="1a7e-03a3-9055-86c1" hidden="false" targetId="6305-72fa-da02-235b" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b145-19b3-baae-ff39" name="Shield Drone" book="BtGoA" page="114" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="65a3-4c38-417c-cc9f" hidden="false" targetId="b08d-74dd-1a32-8bdc" type="rule">
+          <profiles/>
           <rules/>
-          <profiles>
-            <profile id="0f28-d6ef-0f10-6e8f" profileTypeId="ecae-8ac8-2c13-0dd3" name="Scourer Cannon - Concentrated" hidden="false" book="BtGoA" page="73">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="40"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="4"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-        <entry id="9a2e-529c-2e81-0d99" name="Scourer Cannon - Disruptor" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="73">
-          <entries/>
-          <entryGroups/>
+          <infoLinks/>
           <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1707-586b-01df-0f80" name="Shield Drone (2)" book="BtGoA" page="114" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="b2fa-ba86-d0d2-1a30" hidden="false" targetId="b08d-74dd-1a32-8bdc" type="rule">
+          <profiles/>
           <rules/>
-          <profiles>
-            <profile id="1b2e-f75a-2b45-9cde" profileTypeId="ecae-8ac8-2c13-0dd3" name="Scourer Cannon - Disruptor" hidden="false" book="BtGoA" page="73">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D4, No Cover, Disruptor, Standard Weapon"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="393a-a871-9061-745a" targetId="ca96-58c9-9551-d4fe" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="dee2-529a-c466-8b1e" targetId="a41d-d55e-6d97-049d" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="1a7e-03a3-9055-86c1" targetId="6305-72fa-da02-235b" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="b145-19b3-baae-ff39" name="Shield Drone" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="114">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="65a3-4c38-417c-cc9f" targetId="b08d-74dd-1a32-8bdc" linkType="rule">
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="1707-586b-01df-0f80" name="Shield Drone (2)" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="114">
-      <entries/>
-      <entryGroups/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1e33-99fa-00fc-0a32" name="Skark" book="BtGoA" page="131" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="b2fa-ba86-d0d2-1a30" targetId="b08d-74dd-1a32-8bdc" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="1e33-99fa-00fc-0a32" name="Skark" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="131">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules>
-        <rule id="3983-4050-5e06-8fd3" name="Skark" hidden="false" book="BtGoA" page="131">
-          <description>Three attacks at SV1.</description>
+        <rule id="3983-4050-5e06-8fd3" name="Skark" book="BtGoA" page="131" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <description>Three attacks at SV1.</description>
         </rule>
       </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a1a8-ba0b-2e45-8020" name="Skyraider" book="BtGoA" page="192" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="a1a8-ba0b-2e45-8020" name="Skyraider" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="192">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="d918-4412-0ae1-6f74" name="Weapon" defaultEntryId="467e-1407-3119-60ef" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="d918-4412-0ae1-6f74" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="467e-1407-3119-60ef">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="467e-1407-3119-60ef" targetId="f31c-6e5c-19c0-ada7" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="467e-1407-3119-60ef" hidden="false" targetId="f31c-6e5c-19c0-ada7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8de3-1e72-72ef-e7a3" name="SlingNet Ammo" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="8de3-1e72-72ef-e7a3" name="SlingNet Ammo" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles/>
-      <links>
-        <link id="27d6-5dd8-337d-1005" targetId="5bd0-9ab2-0523-cbc8" linkType="rule">
+      <infoLinks>
+        <infoLink id="27d6-5dd8-337d-1005" hidden="false" targetId="5bd0-9ab2-0523-cbc8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="db03-7794-daeb-fef6" name="Solar Charges" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="85">
-      <entries/>
-      <entryGroups/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="db03-7794-daeb-fef6" name="Solar Charges" book="BtGoA" page="85" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="457b-abde-ffd5-bb14" profileTypeId="ecae-8ac8-2c13-0dd3" name="Solar Charges" hidden="false" book="BtGoA" page="85">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D3, Hazardhous H2H, Grenade"/>
-          </characteristics>
+        <profile id="457b-abde-ffd5-bb14" name="Solar Charges" book="BtGoA" page="85" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D3, Hazardhous H2H, Grenade"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="7a23-290e-0678-0165" targetId="1acd-39d3-94e7-48e1" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="7cdc-f9ef-85bc-947a" targetId="1c2c-6574-0a17-f90c" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="3878-9363-1705-9eda" name="Soma Graft" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="121">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="7a23-290e-0678-0165" hidden="false" targetId="1acd-39d3-94e7-48e1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7cdc-f9ef-85bc-947a" hidden="false" targetId="1c2c-6574-0a17-f90c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3878-9363-1705-9eda" name="Soma Graft" book="BtGoA" page="121" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="3d50-6009-476b-2dd3" targetId="1253-ef5b-67d4-3e18" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="f3aa-148a-0460-c7e5" name="Spotter Drone" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="114">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="3d50-6009-476b-2dd3" hidden="false" targetId="1253-ef5b-67d4-3e18" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f3aa-148a-0460-c7e5" name="Spotter Drone" book="BtGoA" page="114" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="b096-0158-02cc-ad91" targetId="fdbd-254f-8dd7-b658" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="a1c9-551b-1532-ef5a" name="Spotter Drone (2)" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="114">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="b096-0158-02cc-ad91" hidden="false" targetId="fdbd-254f-8dd7-b658" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a1c9-551b-1532-ef5a" name="Spotter Drone (2)" book="BtGoA" page="114" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="af19-89d3-df23-32fc" targetId="fdbd-254f-8dd7-b658" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="e329-9443-6cb2-bc53" name="Spotter Drone (Eq)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="114">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="af19-89d3-df23-32fc" hidden="false" targetId="fdbd-254f-8dd7-b658" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e329-9443-6cb2-bc53" name="Spotter Drone (Eq)" book="BtGoA" page="114" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="65b9-8262-6f60-281e" targetId="fdbd-254f-8dd7-b658" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="6bfe-ff47-b61c-afd2" name="Sub-mounted X-Sling" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="65b9-8262-6f60-281e" hidden="false" targetId="fdbd-254f-8dd7-b658" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6bfe-ff47-b61c-afd2" name="Sub-mounted X-Sling" book="BtGoA" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="a9af-f28d-4e65-6d1b" targetId="b08e-548a-fda7-0a4e" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="fb8b-7402-c5a9-8644" name="Subverter Matrix" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="122">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="a9af-f28d-4e65-6d1b" hidden="false" targetId="b08e-548a-fda7-0a4e" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fb8b-7402-c5a9-8644" name="Subverter Matrix" book="BtGoA" page="122" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="24bd-bd70-2f6b-0434" targetId="cd8d-624c-ed86-e310" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="059e-3ead-10ef-9fd5" name="Synchroniser Drone" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Battle for Xilos" page="79">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="24bd-bd70-2f6b-0434" hidden="false" targetId="cd8d-624c-ed86-e310" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="059e-3ead-10ef-9fd5" name="Synchroniser Drone" book="Battle for Xilos" page="79" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="f848-9ddf-c5b7-7291" targetId="c526-9fd9-f1c5-6893" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="02f1-fd15-ca9d-ad79" name="Tractor Maul" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="65">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="f848-9ddf-c5b7-7291" hidden="false" targetId="c526-9fd9-f1c5-6893" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="02f1-fd15-ca9d-ad79" name="Tractor Maul" book="BtGoA" page="65" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="0f4d-9895-e878-29ea" profileTypeId="ecae-8ac8-2c13-0dd3" name="Tractor Maul" hidden="false" book="BtGoA" page="65">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks, Hand Weapon"/>
-          </characteristics>
+        <profile id="0f4d-9895-e878-29ea" name="Tractor Maul" book="BtGoA" page="65" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks, Hand Weapon"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="311e-56e1-d1bc-36a1" targetId="2cbd-47c9-de87-ec2a" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="ac1e-a740-57b7-cc64" name="Twin Mag Light Support" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="75">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="25d4-13e2-3977-4bd4" name="Mag Light Support" defaultEntryId="d17e-2eae-cc33-8d46" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="d17e-2eae-cc33-8d46" targetId="a00c-0542-f2a5-8124" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="c10e-6e9c-dabb-e6f1" name="Mag Light Support" defaultEntryId="b385-bf67-9722-e7f9" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="b385-bf67-9722-e7f9" targetId="a00c-0542-f2a5-8124" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="311e-56e1-d1bc-36a1" hidden="false" targetId="2cbd-47c9-de87-ec2a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ac1e-a740-57b7-cc64" name="Twin Mag Light Support" book="BtGoA" page="75" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="f31c-6e5c-19c0-ada7" name="Twin Mag Repeaters" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="69">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="4e5a-4594-d2da-527c" name="Mag Repeater" defaultEntryId="513b-6ec0-e655-02cd" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="513b-6ec0-e655-02cd" targetId="790a-6841-6372-870b" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="273a-5de1-c9e1-5310" name="Mag Repeater" defaultEntryId="6e82-7e87-0e72-610f" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="6e82-7e87-0e72-610f" targetId="790a-6841-6372-870b" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="25d4-13e2-3977-4bd4" name="Mag Light Support" hidden="false" collective="false" defaultSelectionEntryId="d17e-2eae-cc33-8d46">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="d17e-2eae-cc33-8d46" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="c10e-6e9c-dabb-e6f1" name="Mag Light Support" hidden="false" collective="false" defaultSelectionEntryId="b385-bf67-9722-e7f9">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="b385-bf67-9722-e7f9" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f31c-6e5c-19c0-ada7" name="Twin Mag Repeaters" book="BtGoA" page="69" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="78dd-7840-1210-fb35" name="Twin Plasma Carbines" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="306b-df6b-34af-a65f" name="Plasma Carbine" defaultEntryId="50f5-f0eb-d9cb-a569" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="50f5-f0eb-d9cb-a569" targetId="b018-6101-d2e3-b4ea" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="4e5a-4594-d2da-527c" name="Mag Repeater" hidden="false" collective="false" defaultSelectionEntryId="513b-6ec0-e655-02cd">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="513b-6ec0-e655-02cd" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="273a-5de1-c9e1-5310" name="Mag Repeater" hidden="false" collective="false" defaultSelectionEntryId="6e82-7e87-0e72-610f">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="6e82-7e87-0e72-610f" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="78dd-7840-1210-fb35" name="Twin Plasma Carbines" book="BtGoA" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="b9f1-a313-3e59-57ab" name="X-Howitzer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="82">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="acf4-2a5f-e9a1-6d3c" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Howitzer" hidden="false" book="BtGoA" page="82">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-50"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="250"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D10, No Cover, Heavy Weapon"/>
-          </characteristics>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="306b-df6b-34af-a65f" name="Plasma Carbine" hidden="false" collective="false" defaultSelectionEntryId="50f5-f0eb-d9cb-a569">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="50f5-f0eb-d9cb-a569" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b9f1-a313-3e59-57ab" name="X-Howitzer" book="BtGoA" page="82" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="acf4-2a5f-e9a1-6d3c" name="X-Howitzer" book="BtGoA" page="82" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-50"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="250"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D10, No Cover, Heavy Weapon"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="6f40-42de-4957-1df4" targetId="c3bc-87fd-fa5d-5055" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="b631-2638-986b-4611" targetId="04d9-a48d-7b25-4dd3" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="7c8b-6880-8593-4b52" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="92e5-9a8f-2921-8280" targetId="bc4e-7cd8-4017-d911" linkType="entry group">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="eed0-b68f-b5fb-92c7" name="X-Launcher" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="78">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="2489-100b-d116-96c6" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Launcher" hidden="false" book="BtGoA" page="78">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="60"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="120"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D5, No Cover,  Light Support Weapon"/>
-          </characteristics>
+      <infoLinks>
+        <infoLink id="6f40-42de-4957-1df4" hidden="false" targetId="c3bc-87fd-fa5d-5055" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+        </infoLink>
+        <infoLink id="b631-2638-986b-4611" hidden="false" targetId="04d9-a48d-7b25-4dd3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7c8b-6880-8593-4b52" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="92e5-9a8f-2921-8280" hidden="false" targetId="bc4e-7cd8-4017-d911" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eed0-b68f-b5fb-92c7" name="X-Launcher" book="BtGoA" page="78" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="2489-100b-d116-96c6" name="X-Launcher" book="BtGoA" page="78" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D5, No Cover,  Light Support Weapon"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="cbba-ff32-112c-3173" targetId="c3bc-87fd-fa5d-5055" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="57ac-1f50-9d13-b33b" targetId="b050-496a-ed16-2b2a" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="613e-43c3-a036-e997" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="7bb9-56de-ae51-c52b" targetId="bc4e-7cd8-4017-d911" linkType="entry group">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="b08e-548a-fda7-0a4e" name="X-Sling" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="68">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="3cec-d2e0-b0ed-7856" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Sling" hidden="false" book="BtGoA" page="68">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D3, Hand Weapon"/>
-          </characteristics>
+      <infoLinks>
+        <infoLink id="cbba-ff32-112c-3173" hidden="false" targetId="c3bc-87fd-fa5d-5055" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+        </infoLink>
+        <infoLink id="57ac-1f50-9d13-b33b" hidden="false" targetId="b050-496a-ed16-2b2a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="613e-43c3-a036-e997" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="7bb9-56de-ae51-c52b" hidden="false" targetId="bc4e-7cd8-4017-d911" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b08e-548a-fda7-0a4e" name="X-Sling" book="BtGoA" page="68" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="3cec-d2e0-b0ed-7856" name="X-Sling" book="BtGoA" page="68" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D3, Hand Weapon"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="ff22-4293-45d6-b483" targetId="1acd-39d3-94e7-48e1" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="179a-c0cc-49cc-c946" name="X-Sling (Eq)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="68">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="8977-826a-5f65-6907" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Sling" hidden="false" book="BtGoA" page="68">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D3, Hand Weapon"/>
-          </characteristics>
+      <infoLinks>
+        <infoLink id="ff22-4293-45d6-b483" hidden="false" targetId="1acd-39d3-94e7-48e1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="179a-c0cc-49cc-c946" name="X-Sling (Eq)" book="BtGoA" page="68" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="8977-826a-5f65-6907" name="X-Sling" book="BtGoA" page="68" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D3, Hand Weapon"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="f51f-aab5-2da1-d5d0" targetId="1acd-39d3-94e7-48e1" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-  </sharedEntries>
-  <sharedEntryGroups>
-    <entryGroup id="bc4e-7cd8-4017-d911" name="Munitions" minSelections="0" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="c816-58ed-3726-86b5" name="Scrambler" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="f51f-aab5-2da1-d5d0" hidden="false" targetId="1acd-39d3-94e7-48e1" type="rule">
           <profiles/>
-          <links>
-            <link id="55f1-0e9f-4b69-56c1" targetId="7a3b-74a5-3ced-dd88" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="69e5-ef01-7a5e-3f24" targetId="b996-131f-b84a-4724" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="e0bc-ff63-7ed9-9768" name="Arc" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
           <rules/>
-          <profiles/>
-          <links>
-            <link id="6614-fd6d-aecf-1070" targetId="c1ba-c745-22a8-e2d7" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="6979-177c-42e8-27bf" targetId="b996-131f-b84a-4724" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="d6cb-2428-f1b5-0f11" name="Blur" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-          <entries/>
-          <entryGroups/>
+          <infoLinks/>
           <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="a019-91dd-3b84-e72e" targetId="117a-a2aa-4be7-dffe" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="b4a9-0df0-5149-5785" targetId="b996-131f-b84a-4724" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="bbac-d335-536a-e63d" name="Scoot" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="0e1e-3e34-5c36-4bbf" targetId="28a0-7151-a0c5-9495" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="cc03-4929-b882-43a6" targetId="b996-131f-b84a-4724" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="2a9e-c888-1e5a-ea11" name="Net" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="f4bd-099a-19ab-8138" targetId="ac33-af99-2d76-c981" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="b932-f489-37e5-e6b4" name="Grip" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="eee1-31e1-599c-0bd8" targetId="1045-95cb-5504-9050" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="df1a-7d7c-9316-5794" targetId="b996-131f-b84a-4724" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="f766-367d-f5c0-fc59" name="All" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="1874-10fd-bc26-7005" targetId="c1ba-c745-22a8-e2d7" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="0234-4b9e-9342-68f7" targetId="117a-a2aa-4be7-dffe" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="6234-ec86-062c-0073" targetId="1045-95cb-5504-9050" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="a285-cf7f-7fac-f9ab" targetId="ac33-af99-2d76-c981" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="11d8-fdb9-76ff-2c4c" targetId="28a0-7151-a0c5-9495" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="9abb-2789-75c0-d3a8" targetId="7a3b-74a5-3ced-dd88" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="1492-b598-eb64-0ea0" targetId="b996-131f-b84a-4724" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <links/>
-    </entryGroup>
-  </sharedEntryGroups>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="bc4e-7cd8-4017-d911" name="Munitions" hidden="false" collective="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="c816-58ed-3726-86b5" name="Scrambler" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="55f1-0e9f-4b69-56c1" hidden="false" targetId="7a3b-74a5-3ced-dd88" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="69e5-ef01-7a5e-3f24" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e0bc-ff63-7ed9-9768" name="Arc" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="6614-fd6d-aecf-1070" hidden="false" targetId="c1ba-c745-22a8-e2d7" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="6979-177c-42e8-27bf" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d6cb-2428-f1b5-0f11" name="Blur" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="a019-91dd-3b84-e72e" hidden="false" targetId="117a-a2aa-4be7-dffe" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="b4a9-0df0-5149-5785" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="bbac-d335-536a-e63d" name="Scoot" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="0e1e-3e34-5c36-4bbf" hidden="false" targetId="28a0-7151-a0c5-9495" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="cc03-4929-b882-43a6" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2a9e-c888-1e5a-ea11" name="Net" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="f4bd-099a-19ab-8138" hidden="false" targetId="ac33-af99-2d76-c981" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b932-f489-37e5-e6b4" name="Grip" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="eee1-31e1-599c-0bd8" hidden="false" targetId="1045-95cb-5504-9050" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="df1a-7d7c-9316-5794" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f766-367d-f5c0-fc59" name="All" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="1874-10fd-bc26-7005" hidden="false" targetId="c1ba-c745-22a8-e2d7" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="0234-4b9e-9342-68f7" hidden="false" targetId="117a-a2aa-4be7-dffe" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="6234-ec86-062c-0073" hidden="false" targetId="1045-95cb-5504-9050" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="a285-cf7f-7fac-f9ab" hidden="false" targetId="ac33-af99-2d76-c981" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="11d8-fdb9-76ff-2c4c" hidden="false" targetId="28a0-7151-a0c5-9495" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="9abb-2789-75c0-d3a8" hidden="false" targetId="7a3b-74a5-3ced-dd88" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="1492-b598-eb64-0ea0" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
   <sharedRules>
-    <rule id="2cbd-47c9-de87-ec2a" name="2 Attacks" hidden="false" book="BtGoA" page="133">
+    <rule id="2cbd-47c9-de87-ec2a" name="2 Attacks" book="BtGoA" page="133" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Two attacks in close combat.</description>
-      <modifiers/>
     </rule>
-    <rule id="61e2-3707-ade3-c9ad" name="3 Attacks" hidden="false" book="BtGoA" page="133">
+    <rule id="61e2-3707-ade3-c9ad" name="3 Attacks" book="BtGoA" page="133" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Three attacks in close combat.</description>
-      <modifiers/>
     </rule>
-    <rule id="7daf-414b-c030-7626" name="AG Chute" hidden="false" book="BtGoA" page="120">
+    <rule id="7daf-414b-c030-7626" name="AG Chute" book="BtGoA" page="120" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May make 2M move and shoot when given advance order. +1 Ag. Treat difficult ground as suspensored vehicle. </description>
-      <modifiers/>
     </rule>
-    <rule id="c1ba-c745-22a8-e2d7" name="Arc" hidden="false" book="BtGoA" page="88">
+    <rule id="c1ba-c745-22a8-e2d7" name="Arc" book="BtGoA" page="88" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Creates 3&quot; sink area. Affects any shooter attemping to draw LOS and shoot through the arc. Roll a D10 if LOS goes through - 1-5 the shot is normal, 6-10 the shot automatically misses. Make test before rolling Acc to hit. 
 
 OH shots are affected if the target is within 3&quot; of the marker. </description>
-      <modifiers/>
     </rule>
-    <rule id="b7c6-fc7c-d48b-aae4" name="Auto-Workshop" hidden="false" book="BtGoA" page="121">
+    <rule id="b7c6-fc7c-d48b-aae4" name="Auto-Workshop" book="BtGoA" page="121" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Activated from any order to the unit. Affects every vehicle, weapon drone, weapon team, and machine mounted unit within 5&quot; of the unit, and itself. Roll D10 - on 1-5, nothing happens, 6-10 each unit removes a pin.</description>
-      <modifiers/>
     </rule>
-    <rule id="f0d9-1e5a-ec20-b27c" name="Batter Drone" hidden="false" book="BtGoA" page="110">
+    <rule id="f0d9-1e5a-ec20-b27c" name="Batter Drone" book="BtGoA" page="110" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Projects curved shield as template - must be positioned with outer side facing away from drone, no part of template more than 5&quot; from drone base. Template may be repositioned any time unit receives an order die.
 
 Enemy units shooting through shield suffer -2 ACC. Models positioned inside the shield do not receive the -2 ACC protection. Troops shooting from the inside convex side of the shield do not suffer the ACC penalty. 
 
 No protection is offered for OH shots.</description>
-      <modifiers/>
     </rule>
-    <rule id="04d9-a48d-7b25-4dd3" name="Blast D10" hidden="false" book="BtGoA">
+    <rule id="04d9-a48d-7b25-4dd3" name="Blast D10" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Inflicts D10 hits on a successful shooting attack.</description>
-      <modifiers/>
     </rule>
-    <rule id="1acd-39d3-94e7-48e1" name="Blast D3" hidden="false" book="BtGoA">
+    <rule id="1acd-39d3-94e7-48e1" name="Blast D3" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Inflicts D3 hits on a successful shooting attack.</description>
-      <modifiers/>
     </rule>
-    <rule id="ca96-58c9-9551-d4fe" name="Blast D4" hidden="false" book="BtGoA">
+    <rule id="ca96-58c9-9551-d4fe" name="Blast D4" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Inflicts D4 hits on a successful shooting attack.</description>
-      <modifiers/>
     </rule>
-    <rule id="b050-496a-ed16-2b2a" name="Blast D5" hidden="false" book="BtGoA">
+    <rule id="b050-496a-ed16-2b2a" name="Blast D5" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Inflicts D5 hits on a successful shooting attack.</description>
-      <modifiers/>
     </rule>
-    <rule id="5d2e-45d2-1707-87db" name="Block!" hidden="false" page="159">
+    <rule id="5d2e-45d2-1707-87db" name="Block!" page="159" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>The Order Die drawn from the bag is returned and another random die is drawn. This dice stands and cannot be blocked. Use once and discard. You can buy as many Blocks as you are allowed Auxiliary choices in your Army</description>
-      <modifiers/>
     </rule>
-    <rule id="117a-a2aa-4be7-dffe" name="Blur" hidden="false" book="BtGoA" page="89">
+    <rule id="117a-a2aa-4be7-dffe" name="Blur" book="BtGoA" page="89" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Any unit within 3&quot; reduces Acc by D3 each time it shoots. If within two or more blur markers, roll a D3 for each and take highest.</description>
-      <modifiers/>
     </rule>
-    <rule id="c3e6-4e9b-858c-80d3" name="Booster Drone" hidden="false" book="BtGoA" page="92">
+    <rule id="c3e6-4e9b-858c-80d3" name="Booster Drone" book="BtGoA" page="92" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Infantry, Weapon Team, or Command unit gains +1 armor bonus from reflex, hyperlight, and phase armor. Cannot benefit units with HL boosters.</description>
-      <modifiers/>
     </rule>
-    <rule id="4e34-753f-b082-2e00" name="Borer Drone" hidden="false" book="BtGoA" page="111">
+    <rule id="4e34-753f-b082-2e00" name="Borer Drone" book="BtGoA" page="111" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Every model in the owning unit gains +1 Str for all Strength tests and H2H. 
 
 Unit may put up temporary cover by making any action without a move. May result from order or reaction and can include a down action from failed order check. Unit benefits from 2+ Res as long as it does not move. Is not cumulative with other cover bonuses.</description>
-      <modifiers/>
     </rule>
-    <rule id="5f48-f41c-fd96-6a1a" name="Camo Drone" hidden="false" book="BtGoA" page="111">
+    <rule id="5f48-f41c-fd96-6a1a" name="Camo Drone" book="BtGoA" page="111" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>If unit goes down it cannot be targeted at ranges of more than 10&quot;. If a unit with the drone goes down as reaction to enemy shooting from more than 10&quot; away then the unit can no longer be targeted. OH shots will miss and have no effect. Scout probes can compromise this effect within 10&quot;.
 
 </description>
-      <modifiers/>
     </rule>
-    <rule id="fd72-d48c-e8af-4883" name="Choose Target" hidden="false" book="BtGoA" page="70">
+    <rule id="fd72-d48c-e8af-4883" name="Choose Target" book="BtGoA" page="70" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May fire at a different target from the test of the unit. If more than one model has a weapon with Choose Target, all weapons with Choose Target must shoot at same target.</description>
-      <modifiers/>
     </rule>
-    <rule id="5c9b-1bde-ee01-04a4" name="Command" hidden="false" book="BtGoA" page="133">
+    <rule id="5c9b-1bde-ee01-04a4" name="Command" book="BtGoA" page="133" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Friendly units within 10&quot; can use this model&apos;s Co value for any Co based test instead of their own. Pins still affect this Co value.</description>
-      <modifiers/>
     </rule>
-    <rule id="3995-c066-c957-5ffe" name="Compactor Drone" hidden="false" book="BtGoA" page="112">
+    <rule id="3995-c066-c957-5ffe" name="Compactor Drone" book="BtGoA" page="112" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May carry one of the following: all of a mounted unit&apos;s bikes, a unit&apos;s support weapon, an entire weapon drone unit complete with any associated buddy drones other than compactor drones, or an entire probe shard.
 
 May load or unload when their unit makes an action, even down order following failed order test. </description>
-      <modifiers/>
     </rule>
-    <rule id="7db4-2d14-3984-37d9" name="Compressor" hidden="false" book="BtGoA" page="71">
+    <rule id="7db4-2d14-3984-37d9" name="Compressor" book="BtGoA" page="71" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>SV value varies with range band.</description>
-      <modifiers/>
     </rule>
-    <rule id="5fb8-4f09-d496-4ea9" name="Concentrated Fire" hidden="false" book="BtGoA" page="72">
+    <rule id="5fb8-4f09-d496-4ea9" name="Concentrated Fire" book="BtGoA" page="72" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Any lucky hits can be allocated to the same model, do not have to be distributed evenly.</description>
-      <modifiers/>
     </rule>
-    <rule id="c34f-bbca-9bfc-6874" name="Crawler" hidden="false" book="BtGoA" page="133">
+    <rule id="c34f-bbca-9bfc-6874" name="Crawler" book="BtGoA" page="133" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Crawlers are restricted when moving over certain terrain types as described in the terrain section. They cross obstacles in the same manner as a heavy weapon team. They cannot cross at a run and must test to cross at advance rate. Crossing obstacles, p22</description>
-      <modifiers/>
     </rule>
-    <rule id="cf7f-6f85-e64e-0363" name="Cycle" hidden="false" book="BtGoA" page="78">
+    <rule id="cf7f-6f85-e64e-0363" name="Cycle" book="BtGoA" page="78" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>On the Acc roll of a 10 shot misses and weapon team goes down.</description>
-      <modifiers/>
     </rule>
-    <rule id="6305-72fa-da02-235b" name="Disruptor" hidden="false" book="BtGoA" page="79">
+    <rule id="6305-72fa-da02-235b" name="Disruptor" book="BtGoA" page="79" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>A target hit by a disruptor weapon gets no cover bonus to its Res roll against the hit.
 
 A non-Ghar target hit by a disruptor weapon takes 2 pins rather than the usual 1 pin. If the target has Res &gt; 10, it takes these pins even if the hit is successfully resisted. Ghar do not suffer these pins. 
@@ -6094,140 +10823,236 @@ A non-Ghar target hit by a disruptor weapon takes 2 pins rather than the usual 1
 Buddy drones can be allocated hits from this weapon by the shooter from any hits, not just lucky hits.
 
 If the target is a probe it only passes Res tests on a 1.</description>
-      <modifiers/>
     </rule>
-    <rule id="9444-e2a0-8048-5ce9" name="Down" hidden="false" book="BtGoA" page="74">
+    <rule id="9444-e2a0-8048-5ce9" name="Down" book="BtGoA" page="74" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Unit hit automatically goes down after shooting has been worked out whether casualties are caused or not. </description>
-      <modifiers/>
     </rule>
-    <rule id="4232-2801-36cf-704c" name="Exhausted" hidden="false" book="BtGoA" page="67">
+    <rule id="4232-2801-36cf-704c" name="Exhausted" book="BtGoA" page="67" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Rolls of 10 on Str or Acc to-hit rolls cannot be re-rolled and stave has become exhausted. Make a test at the turn end phase - 1-5 it is still exhausted, 6-10 it is replenished.</description>
-      <modifiers/>
     </rule>
-    <rule id="e77b-02da-5143-229e" name="Extra Shot" hidden="false" page="159">
+    <rule id="e77b-02da-5143-229e" name="Extra Shot" page="159" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>If you score a Lucky Hit with any shot you can make one more shot with that model using the same weapon with exactly the same score required to hit the same target. Roll one more shot to score a hit. Use once and discard. You can buy as many Extra Shots as you are allowed Auxiliary choices in your Army.</description>
-      <modifiers/>
     </rule>
-    <rule id="b0ca-8e7d-d03f-f027" name="Fast" hidden="false" book="BtGoA" page="133">
+    <rule id="b0ca-8e7d-d03f-f027" name="Fast" book="BtGoA" page="133" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Move at double pace - 10&quot; per advance, 20&quot; for run. Shots fired at fast targets with a run order must re-roll hits. 
 Fast units may break off of assault after point blank shooting has been conducted. They may move through the enemy during this move.</description>
-      <modifiers/>
     </rule>
-    <rule id="7bc9-5e98-2914-5abd" name="Follow" hidden="false" book="BtGoA" page="13">
+    <rule id="7bc9-5e98-2914-5abd" name="Follow" book="BtGoA" page="13" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>When a leader with follow gives his unit an order, any other friendly units within 5&quot; may make the same action as long as they have no pins and are otherwise able to make the action.</description>
-      <modifiers/>
     </rule>
-    <rule id="d50c-3bbe-c62d-34c3" name="Fractal Lock" hidden="false" book="BtGoA" page="83">
+    <rule id="d50c-3bbe-c62d-34c3" name="Fractal Lock" book="BtGoA" page="83" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>If the weapon hits, it locks on. If the target does not move and the unit receives a fire order it automatically hits. Each time it auto-hits the SV value goes up by 2.</description>
-      <modifiers/>
     </rule>
-    <rule id="2afe-05bf-268b-84c2" name="Get Up!" hidden="false" page="159">
+    <rule id="2afe-05bf-268b-84c2" name="Get Up!" page="159" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>When making a Recovery Test (to recover a Down order die) you will succeed on a roll of anything but a 10 regardless of the value you would normally test against. A roll of a 10 is still a failure, and no pin markers are removed, as standard. Use once and discard. You can buy as many Get Up!(s) as you are allowed Auxiliary choices in your Army.</description>
-      <modifiers/>
     </rule>
-    <rule id="b466-7990-db34-55b1" name="Grenade" hidden="false" book="BtGoA" page="85">
+    <rule id="b466-7990-db34-55b1" name="Grenade" book="BtGoA" page="85" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>In H2H counts as hand weapon +1 Str bonus. Grenade hits compound in H2H - if a model takes suffers two or more hits from grenades, add all SVs together and take one Res test.</description>
-      <modifiers/>
     </rule>
-    <rule id="1045-95cb-5504-9050" name="Grip" hidden="false" book="BtGoA" page="87">
+    <rule id="1045-95cb-5504-9050" name="Grip" book="BtGoA" page="87" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Unit beginning its move within 3&quot; must take and pass an Ag test. If failed it may not move, if passed it can move half rate, failed on a 10 it takes a pin and cannot move.
 
 If a unit moves within 3&quot; it must take the Ag test as above. </description>
-      <modifiers/>
     </rule>
-    <rule id="5f6c-7c20-3cbc-bcc8" name="Gun Drone" hidden="false" book="BtGoA" page="112">
+    <rule id="5f6c-7c20-3cbc-bcc8" name="Gun Drone" book="BtGoA" page="112" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Shoots as if it were an ordinary member of its unit with the same Acc value. Draw LOS in the same way as other models in the unit.</description>
-      <modifiers/>
     </rule>
-    <rule id="1c2c-6574-0a17-f90c" name="Hazardous H2H" hidden="false" book="BtGoA" page="85">
+    <rule id="1c2c-6574-0a17-f90c" name="Hazardous H2H" book="BtGoA" page="85" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Any H2H Str roll of 10 hits the user, not enemy.</description>
-      <modifiers/>
     </rule>
-    <rule id="a846-6829-3398-bac1" name="Heavy" hidden="false" book="BtGoA" page="134">
+    <rule id="a846-6829-3398-bac1" name="Heavy" book="BtGoA" page="134" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Movement restricted across obstacles per p22. Cannot cross obstacles at a run. Agility test required to cross at advance. When rolling resistance checks only fail on a 10, roll on damage chart p37.</description>
-      <modifiers/>
     </rule>
-    <rule id="3c64-6022-a5f1-9c04" name="Hero" hidden="false" book="BtGoA" page="134">
+    <rule id="3c64-6022-a5f1-9c04" name="Hero" book="BtGoA" page="134" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Friendly units within 10&quot; may use this model&apos;s Init stat. </description>
-      <modifiers/>
     </rule>
-    <rule id="34e0-c5a3-3998-5d0b" name="High Commander" hidden="false" book="BtGoA" page="134">
+    <rule id="34e0-c5a3-3998-5d0b" name="High Commander" book="BtGoA" page="134" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May re-roll every failed resist test once. May use command, hero, and follow special rules on any units.</description>
-      <modifiers/>
     </rule>
-    <rule id="b436-1f8a-5d3a-2d7d" name="HL Armor" hidden="false" book="BtGoA" page="93">
+    <rule id="b436-1f8a-5d3a-2d7d" name="HL Armor" book="BtGoA" page="93" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Ranges of 10&quot; or less, +1 to Res. Ranges of greater than 10&quot; +2 Res. Against any Blast hits, +3 Res. </description>
-      <modifiers/>
     </rule>
-    <rule id="56ab-52fc-9557-2586" name="HL Booster" hidden="false" book="BtGoA" page="93">
+    <rule id="56ab-52fc-9557-2586" name="HL Booster" book="BtGoA" page="93" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>+1 Res on top of all other bonuses.</description>
-      <modifiers/>
     </rule>
-    <rule id="ca2b-9550-eb1e-77c8" name="Homer Drone" hidden="false" book="BtGoA" page="112">
+    <rule id="ca2b-9550-eb1e-77c8" name="Homer Drone" book="BtGoA" page="112" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Unit may be transported off the table by using a Run order. If taking an order test and failed on a 10, homer drone is destroyed. Once removed from the battlefield unit cannot return. Only the unit and equipment may be transported - not objectives.</description>
-      <modifiers/>
     </rule>
-    <rule id="3b84-9d0e-a3c1-6c1f" name="Inaccurate" hidden="false" book="BtGoA" page="70">
+    <rule id="3b84-9d0e-a3c1-6c1f" name="Inaccurate" book="BtGoA" page="70" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Additional -1 Acc penalty.</description>
-      <modifiers/>
     </rule>
-    <rule id="96c4-7a43-2a4c-d7d3" name="Infiltrator" hidden="false" book="BtGoA" page="134">
+    <rule id="96c4-7a43-2a4c-d7d3" name="Infiltrator" book="BtGoA" page="134" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May make a special pre-game run action. May sprint, test for exhaustion. May not move within 10&quot; of enemy. May lay a minefield before game starts.</description>
-      <modifiers/>
     </rule>
-    <rule id="a221-d53c-b4bd-b52c" name="Large" hidden="false" book="BtGoA" page="134">
+    <rule id="a221-d53c-b4bd-b52c" name="Large" book="BtGoA" page="134" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Cannot sprint unless also fast. Passes when testing Ag to move through dense terrain reduce movement to half. Passes on a one mean unit can move at full rate. Failure means unit cannot move, failure on a 10 gains one pin. 
 
 Units may fire over regular sized units at no penalty. Large targets never gain cover bonuses to their Res stat. May not enter buildings. </description>
-      <modifiers/>
     </rule>
-    <rule id="7cfb-9874-dfe0-b136" name="Lava Spit" hidden="false" book="BtGoA" page="135">
+    <rule id="7cfb-9874-dfe0-b136" name="Lava Spit" book="BtGoA" page="135" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Lavamites may shoot during point blank shooting at SV 2.</description>
-      <modifiers/>
     </rule>
-    <rule id="e441-c3a6-7d61-2c63" name="Leader" hidden="false" book="BtGoA" page="135">
+    <rule id="e441-c3a6-7d61-2c63" name="Leader" book="BtGoA" page="135" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May re-roll one failed res test per leader level. </description>
-      <modifiers/>
     </rule>
-    <rule id="7850-89e7-bab8-86e9" name="Leader 2" hidden="false" book="BtGoA">
+    <rule id="7850-89e7-bab8-86e9" name="Leader 2" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May re-roll one failed res test per leader level.</description>
-      <modifiers/>
     </rule>
-    <rule id="05bb-4d34-70cd-25d2" name="Leader 3" hidden="false" book="BtGoA">
+    <rule id="05bb-4d34-70cd-25d2" name="Leader 3" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May re-roll one failed res test per leader level.</description>
-      <modifiers/>
     </rule>
-    <rule id="5efa-64a9-bbc9-3dba" name="Limited Ammo" hidden="false" book="BtGoA" page="73,77">
+    <rule id="5efa-64a9-bbc9-3dba" name="Limited Ammo" book="BtGoA" page="73,77" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Risks running out of ammunition.</description>
-      <modifiers/>
     </rule>
-    <rule id="d8dc-cf25-ef95-c94b" name="Limited Choice" hidden="false" book="BtGoA">
+    <rule id="d8dc-cf25-ef95-c94b" name="Limited Choice" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May only be taken as 1 in 4 choices of entire force.</description>
-      <modifiers/>
     </rule>
-    <rule id="5741-af68-9dc0-519f" name="Marksman" hidden="false" page="159">
+    <rule id="5741-af68-9dc0-519f" name="Marksman" page="159" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>When rolling to-hit against a unit with a shooting attack, you may re-roll all of the shots. If you choose to do this you must take ALL of the shots again regardless of whether they hit or miss, and whatever result you roll the second time stands, with no further re-rolls allowed. You can only buy ONE Marksman regardless of Army size.</description>
-      <modifiers/>
     </rule>
-    <rule id="c863-510b-e239-be92" name="Massive Damage" hidden="false" book="BtGoA" page="75">
+    <rule id="c863-510b-e239-be92" name="Massive Damage" book="BtGoA" page="75" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>If the mag cannon&apos;s target rolls for damage on a damage table it suffers Massive Damage - page 37.</description>
-      <modifiers/>
     </rule>
-    <rule id="4039-88e8-9f6d-bfb3" name="Medi-Drone" hidden="false" book="BtGoA" page="113">
+    <rule id="4039-88e8-9f6d-bfb3" name="Medi-Drone" book="BtGoA" page="113" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Can only attend humans - not machines or Skarks. Any friendly unit within 5&quot; may re-roll one failed Res test each time it is shot at, fights H2H, or otherwise suffers damage. Units within 5&quot; of more than one medi-drone may re-roll one failed Res test for each medi-drone. </description>
-      <modifiers/>
     </rule>
-    <rule id="137e-c2b6-65b7-ecc3" name="Medic" hidden="false" book="BtGoA" page="135">
+    <rule id="137e-c2b6-65b7-ecc3" name="Medic" book="BtGoA" page="135" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Units within 5&quot; of a medic unit may re-roll one failed Res test each time it is shot at. Medi-probes and drones may add their re-rolls to total number of re-rolls.
 
 Cannot be used on non-humans. </description>
-      <modifiers/>
     </rule>
-    <rule id="a97f-4540-de7b-5734" name="Meld" hidden="false" book="BtGoA" page="128">
+    <rule id="a97f-4540-de7b-5734" name="Meld" book="BtGoA" page="128" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Single unit of two NuHu but only has one Res value. If a Res test is failed, roll on Meld Damage Chart. </description>
-      <modifiers/>
     </rule>
-    <rule id="5e3d-6905-2b14-8cd1" name="Meld Damage" hidden="false" book="BtGoA" page="128">
+    <rule id="5e3d-6905-2b14-8cd1" name="Meld Damage" book="BtGoA" page="128" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>D10 Result
 1	No effect
 2-3 	Take one additional pin and Go Down
@@ -6235,9 +11060,12 @@ Cannot be used on non-humans. </description>
 6-8 	Take D3 additional pins and Go Down, MOD units lose one order die
 9 	One of the NuHu falls casualty, breaking the meld. Remaining model reverts to normal NuHu stats. MOD 	is lost. Surviving NuHu takes D3 additional pins and goes down.
 10 	Destroyed. The unit is destroyed, and both NuHu are removed as casualties.</description>
-      <modifiers/>
     </rule>
-    <rule id="db7a-5bd4-6400-f6d1" name="Misgenic Abilities" hidden="false" book="BtGoA" page="196">
+    <rule id="db7a-5bd4-6400-f6d1" name="Misgenic Abilities" book="BtGoA" page="196" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Set after deployment. May choose one of the following before the game and pay 10 points to gain any further qualities on a D10 roll. Duplicates may be added together or treated as a 10 roll.
 
 D10 Result:
@@ -6251,21 +11079,33 @@ D10 Result:
 8 Mesmerising: any enemy unit within 5&quot; must pass command test at -1 to do anything, even with no pins.
 9 Cunning Leader: unit leader gains command and Init 8. If unit has no leader, it gains a leader with base Co and Init.
 10 Choose one of the above qualities.</description>
-      <modifiers/>
     </rule>
-    <rule id="5565-ce10-1c78-1ee7" name="MOD2" hidden="false" book="BtGoA" page="136">
+    <rule id="5565-ce10-1c78-1ee7" name="MOD2" book="BtGoA" page="136" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Unit contributes two die to the dice pool and may act twice per turn. Always treated as having used the most recent action.</description>
-      <modifiers/>
     </rule>
-    <rule id="8151-2e24-94ee-0477" name="MOD3" hidden="false" book="BtGoA">
+    <rule id="8151-2e24-94ee-0477" name="MOD3" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Unit contributes three die to the dice pool and may act thrice per turn. Always treated as having used the most recent action.</description>
-      <modifiers/>
     </rule>
-    <rule id="c1c6-f9c7-c84f-d57d" name="Nano Drone" hidden="false" book="BtGoA" page="113">
+    <rule id="c1c6-f9c7-c84f-d57d" name="Nano Drone" book="BtGoA" page="113" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Shots against the unit suffer -2 Acc. Cannot be combined with a Batter drone. Unit counts as having HL armor. IMtel stave may be boosted by Nano Drone.</description>
-      <modifiers/>
     </rule>
-    <rule id="ac33-af99-2d76-c981" name="Net" hidden="false" book="BtGoA" page="88">
+    <rule id="ac33-af99-2d76-c981" name="Net" book="BtGoA" page="88" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Roll to hit as normal for a blast weapon. Target does not suffer blast damage, rather suffers pins:
 
 X-Launcher: D3+1 pin
@@ -6273,114 +11113,192 @@ X-Howitzer: D5+1 pin
 Mag Mortar: D10+1 pin
 
 Targets that would normally force an Acc re-roll suffer half the number of pins rounded down. Divide pins equally between two or more units as normal.</description>
-      <modifiers/>
     </rule>
-    <rule id="a41d-d55e-6d97-049d" name="No Cover" hidden="false" book="BtGoA" page="71">
+    <rule id="a41d-d55e-6d97-049d" name="No Cover" book="BtGoA" page="71" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>No cover bonus to Res roll.</description>
-      <modifiers/>
     </rule>
-    <rule id="f502-611e-9704-97bb" name="No Crew" hidden="false" book="BtGoA" page="7">
+    <rule id="f502-611e-9704-97bb" name="No Crew" book="BtGoA" page="7" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>When carried by a model in battle armor it counts as having full crew.</description>
-      <modifiers/>
     </rule>
-    <rule id="c3bc-87fd-fa5d-5055" name="OH" hidden="false" book="BtGoA" page="34">
+    <rule id="c3bc-87fd-fa5d-5055" name="OH" book="BtGoA" page="34" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Fires as an Overhead weapon.</description>
+    </rule>
+    <rule id="aef6-6934-1dee-6fa0" name="OHx2" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="aef6-6934-1dee-6fa0" name="OHx2" hidden="false" book="BtGoA">
+    <rule id="7db4-6bd3-fb59-706d" name="Outcast" book="BtGoA" page="136" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </rule>
-    <rule id="7db4-6bd3-fb59-706d" name="Outcast" hidden="false" book="BtGoA" page="136">
       <description>Command, hero, and follow rules only work on Outcast units. Cannot benefit from command, hero, or follow from non-Outcast unless it is a High Commander.</description>
-      <modifiers/>
     </rule>
-    <rule id="3559-4b87-980d-f90d" name="Overload Ammo" hidden="false" book="BtGoA" page="89">
+    <rule id="3559-4b87-980d-f90d" name="Overload Ammo" book="BtGoA" page="89" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Can only be used with direct fire. SV = 3, single hit. If a 10 is rolled on Acc roll, shot misses, cannot be re-rolled, and overload ammo cannot be used again.</description>
-      <modifiers/>
     </rule>
-    <rule id="b28d-571e-af69-4582" name="Phase Armor" hidden="false" book="BtGoA" page="93">
+    <rule id="b28d-571e-af69-4582" name="Phase Armor" book="BtGoA" page="93" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>10&quot; or less, +1 Res. Greater than 10&quot;, +2 Res. May make a down reaction even if it already has order die - flip to down if so. </description>
-      <modifiers/>
     </rule>
-    <rule id="6b03-2ad4-34c1-7f73" name="Plasma Fade" hidden="false" book="BtGoA" page="76">
+    <rule id="6b03-2ad4-34c1-7f73" name="Plasma Fade" book="BtGoA" page="76" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>On the Acc roll of a 10 to hit the shot is a miss and the unit goes down.</description>
-      <modifiers/>
     </rule>
-    <rule id="0f12-545e-1c86-f482" name="Plasma Reactor" hidden="false" book="BtGoA" page="1367">
+    <rule id="0f12-545e-1c86-f482" name="Plasma Reactor" book="BtGoA" page="1367" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Lucky hits are allocated by shooter and hit plasma reactor. On a Res failure of 10, roll for every other model in unit and on a 10 they are removed as well.</description>
-      <modifiers/>
     </rule>
-    <rule id="5d64-4bf5-e947-95d1" name="Point Blank Shooting Only" hidden="false" book="BtGoA" page="86">
+    <rule id="5d64-4bf5-e947-95d1" name="Point Blank Shooting Only" book="BtGoA" page="86" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May only be used for point blank shooting. Cannot be used for H2H.</description>
-      <modifiers/>
     </rule>
-    <rule id="8056-104a-5a5d-2089" name="Pull Yourself Together!" hidden="false" page="159">
+    <rule id="8056-104a-5a5d-2089" name="Pull Yourself Together!" page="159" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>At the end of any turn you can expend a &quot;Pull Yourself Together!&quot; to remove one pin from one unit. Use once and discard. You can buy as many as you are allowed Auxiliary choices in your Army but can only use ONE per turn.</description>
-      <modifiers/>
     </rule>
-    <rule id="b6e3-9cf0-1a9f-a941" name="Random SV" hidden="false" book="BtGoA" page="66">
+    <rule id="b6e3-9cf0-1a9f-a941" name="Random SV" book="BtGoA" page="66" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Roll every round for entire unit to determine SV. </description>
-      <modifiers/>
     </rule>
-    <rule id="9ad5-9fc3-726e-852a" name="Rapid Sprint" hidden="false" book="BtGoA" page="136">
+    <rule id="9ad5-9fc3-726e-852a" name="Rapid Sprint" book="BtGoA" page="136" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May sprint at 4M. </description>
-      <modifiers/>
     </rule>
-    <rule id="18c0-c86d-0b2c-23af" name="Reflex Armour" hidden="false" book="BtGoA" page="93">
+    <rule id="18c0-c86d-0b2c-23af" name="Reflex Armour" book="BtGoA" page="93" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>-Troops with Reflex Armour Shield add +1 to their Res value.
 -Troops with Reflex Armour and Impact Cloaks add +2 to their Res value, in hand to hand fighting.
 -Troops mounted on bikes with Reflex Armour and HL Boosters add +2 to their Res value.
 </description>
-      <modifiers/>
     </rule>
-    <rule id="1863-c041-6dc4-c62d" name="RF D6 Fire Only" hidden="false" book="BtGoA" page="72">
+    <rule id="1863-c041-6dc4-c62d" name="RF D6 Fire Only" book="BtGoA" page="72" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Rapid Fire D6 when making a fire action. When shooting with advance action weapon has one shot. If issued in multiples, roll D6 for all weapons in unit.</description>
-      <modifiers/>
     </rule>
-    <rule id="0cb1-ea91-e5bc-4f75" name="RF2" hidden="false" book="BtGoA">
+    <rule id="0cb1-ea91-e5bc-4f75" name="RF2" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May fire two shots at rapid fire. Suffers additional -1 ACC at Long or Extreme Ranges.</description>
-      <modifiers/>
     </rule>
-    <rule id="97d4-67cb-2671-ca29" name="RF3" hidden="false" book="BtGoA">
+    <rule id="97d4-67cb-2671-ca29" name="RF3" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May fire three shots at rapid fire. Suffers additional -1 ACC at Long or Extreme Ranges.</description>
-      <modifiers/>
     </rule>
-    <rule id="b0cb-c022-0531-4852" name="RF5" hidden="false" book="BtGoA">
+    <rule id="b0cb-c022-0531-4852" name="RF5" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May fire five shots at rapid fire. Suffers additional -1 ACC at Long or Extreme Ranges.</description>
-      <modifiers/>
     </rule>
-    <rule id="f7af-59ec-acde-2f75" name="Savage Strike" hidden="false" book="BtGoA" page="136">
+    <rule id="f7af-59ec-acde-2f75" name="Savage Strike" book="BtGoA" page="136" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Passes order check to assault on any roll except a 10, regardless of modifiers.</description>
-      <modifiers/>
     </rule>
-    <rule id="28a0-7151-a0c5-9495" name="Scoot" hidden="false" book="BtGoA" page="88">
+    <rule id="28a0-7151-a0c5-9495" name="Scoot" book="BtGoA" page="88" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Only affects infantry, mounted, weapon team, beast, and humongous beast, command, and bike mounted units with living crew. Affects scramble proof units. Any affected unit within 3&quot; canno tbe given any order except run or down. Cannot make any reaction apart from go down.</description>
-      <modifiers/>
     </rule>
-    <rule id="94f5-4a4c-92ad-94f9" name="Scramble Proof" hidden="false" book="BtGoA" page="137">
+    <rule id="94f5-4a4c-92ad-94f9" name="Scramble Proof" book="BtGoA" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Not affected by scrambler munitions. Vehicles may be affected by scoot. Subverter matrixes cannot affect model.</description>
-      <modifiers/>
     </rule>
-    <rule id="7a3b-74a5-3ced-dd88" name="Scrambler" hidden="false" book="BtGoA" page="88">
+    <rule id="7a3b-74a5-3ced-dd88" name="Scrambler" book="BtGoA" page="88" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Enemy units within 3&quot; that are not scramble proof it loses Reflex Armor, Hyperlight Armor, and Phase Armor along with any bonuses. Units in Phase Armor cannot use their armor to go down.
 
 Weapon Drone and vehicles have Res reduced by 2 within 3&quot;. Buddy drones cease to function if the unit is within 3&quot;. Probes can do nothing at all while marker is within 3&quot;. Penalties are not cumulative.</description>
-      <modifiers/>
     </rule>
-    <rule id="3377-9408-33bb-6a02" name="Self Repair" hidden="false" book="BtGoA" page="137">
+    <rule id="3377-9408-33bb-6a02" name="Self Repair" book="BtGoA" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Give unit rally order. If no pins exist after order, may attempt one repair on  immobilisation or weapon. 1-5 = success, 6-10 failure. Success = that function is working again.</description>
-      <modifiers/>
     </rule>
-    <rule id="00b8-b49c-4c61-2943" name="Shard" hidden="false" book="BtGoA" page="137">
+    <rule id="00b8-b49c-4c61-2943" name="Shard" book="BtGoA" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Every individual unit in the shard makes same action from order. Probes always run.
 
 Shard units never take pins. Always assumed to pass order tests. </description>
+    </rule>
+    <rule id="0c20-4983-db8a-0d56" name="Shared SV" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="0c20-4983-db8a-0d56" name="Shared SV" hidden="false" book="BtGoA">
+    <rule id="b08d-74dd-1a32-8bdc" name="Shield Drone" book="BtGoA" page="114" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </rule>
-    <rule id="b08d-74dd-1a32-8bdc" name="Shield Drone" hidden="false" book="BtGoA" page="114">
       <description>When unit is hit, shield drones may nullify one hit. Roll D10 on drone chart - 
 
 D10 Roll:
@@ -6389,54 +11307,90 @@ D10 Roll:
 10: Drone does not nullify the hit but is not removed.
 
 Shield drones may attempt to intercept lucky hits. Lucky hits can be allocated to them just like other drones - in that case the drone is removed with no roll. </description>
-      <modifiers/>
     </rule>
-    <rule id="5bd0-9ab2-0523-cbc8" name="Slingnet Ammo" hidden="false" book="BtGoA" page="112">
+    <rule id="5bd0-9ab2-0523-cbc8" name="Slingnet Ammo" book="BtGoA" page="112" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Fired direct unless from Micro X Launcher. Targets hit suffer no damage but take +1 additional pin. Cannot affect units that cannot be pinned when hit.</description>
-      <modifiers/>
     </rule>
-    <rule id="7c88-64d4-50ad-2313" name="Slow" hidden="false" book="BtGoA" page="137">
+    <rule id="7c88-64d4-50ad-2313" name="Slow" book="BtGoA" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Move at half pace.</description>
-      <modifiers/>
     </rule>
-    <rule id="6f47-5038-573a-b225" name="Sniper" hidden="false" book="BtGoA" page="137">
+    <rule id="6f47-5038-573a-b225" name="Sniper" book="BtGoA" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Deploy anywhere within player&apos;s half. Snipers may not be deployed within 20&quot; of other snipers, enemy may not deploy within 10&quot;. </description>
-      <modifiers/>
     </rule>
-    <rule id="1253-ef5b-67d4-3e18" name="Soma Graft" hidden="false" book="BtGoA" page="121">
+    <rule id="1253-ef5b-67d4-3e18" name="Soma Graft" book="BtGoA" page="121" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May activate when a unit takes a Co test. Will past any Co test on any score other than 10. If a 10 is rolled, unit goes out of control and must roll the order die to generate an order. The unit does not have to comply, but if it does an order that is the only one it can do.</description>
-      <modifiers/>
     </rule>
-    <rule id="b996-131f-b84a-4724" name="Special Munition" hidden="false" book="BtGoA" page="87">
+    <rule id="b996-131f-b84a-4724" name="Special Munition" book="BtGoA" page="87" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Stays on the battlefield until it ceases to work p87. Use a marker to locate where shot lands.</description>
-      <modifiers/>
     </rule>
-    <rule id="fdbd-254f-8dd7-b658" name="Spotter Drone" hidden="false" book="BtGoA" page="114">
+    <rule id="fdbd-254f-8dd7-b658" name="Spotter Drone" book="BtGoA" page="114" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Unit may re-roll one miss each time it shoots as long as drone has LOS to target. Units may fire OH using drone as spotter as long as it has LOS to target. 
 
 Spotter drones may spot through another spotter drone (within 20&quot;) with LOS to the target. Unit does not receive spotter re-roll as their spotter does not have LOS to target.</description>
+    </rule>
+    <rule id="cd8d-624c-ed86-e310" name="Subverter Matrix" book="BtGoA" page="122" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="cd8d-624c-ed86-e310" name="Subverter Matrix" hidden="false" book="BtGoA" page="122">
+    <rule id="d4f5-697e-dbf0-ced2" name="Superior Shard" page="159" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </rule>
-    <rule id="d4f5-697e-dbf0-ced2" name="Superior Shard" hidden="false" page="159">
       <description>At the start of the turn you can remove 1 of your opponent&apos;s Order Dice from the bag. This die isn&apos;t used that turn, and is returned to the dice bag at the start of the following turn. This means your opponent will have to fight without one of his dice that turn. Use once and discard. You can only buy ONE Superior Shard regardless of the eize of your army.</description>
-      <modifiers/>
     </rule>
-    <rule id="c526-9fd9-f1c5-6893" name="Synchroniser Drone" hidden="false" book="Battle for Xilos" page="79">
+    <rule id="c526-9fd9-f1c5-6893" name="Synchroniser Drone" book="Battle for Xilos" page="79" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>If a unit with a synchroniser drone is successfully issued an order, after it has completed all actions in that order it may attempt to synchronise with one other unit within 10&quot;. The unit nominated must take and pass a Command test made in the standard fashion. If successful, it may draw an Order Die and issue the same command as the Synchronising unit, treating the die as if it were drawn randomly for all game effects. If the Synchronising unit also has the Follow ability, the Drone extends the range of Follow to 10&quot; rather than 5&quot;. CANNOT be chained from one unit to another.</description>
-      <modifiers/>
     </rule>
-    <rule id="ab37-33d8-41f3-7532" name="Transport 10" hidden="false" book="BtGoA" page="137">
+    <rule id="ab37-33d8-41f3-7532" name="Transport 10" book="BtGoA" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May transport 10 human sized models.</description>
-      <modifiers/>
     </rule>
-    <rule id="99fd-f354-1703-5941" name="Variable Res/Strike" hidden="false" book="BtGoA" page="66">
+    <rule id="99fd-f354-1703-5941" name="Variable Res/Strike" book="BtGoA" page="66" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Use to boost Res +2 or give a SV +2 each round of fighting. If used as +2 SV, counts as Grenade. </description>
-      <modifiers/>
     </rule>
-    <rule id="e167-a8e4-c26a-cafd" name="Weapon Drone" hidden="false" book="BtGoA" page="115">
+    <rule id="e167-a8e4-c26a-cafd" name="Weapon Drone" book="BtGoA" page="115" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Always measure to model, not base. Not allowed to assault. Never take a break test, however auto-break if suffer pins equal to their Co stat. If drone fails a Res test, roll on Weapon Drone Damage Chart.
 
 D10 Result:
@@ -6446,581 +11400,736 @@ D10 Result:
 4: Take D3 additional pins and go down. Weapon malfunction.
 5: Take D6 additional pins and take a break test - destroyed if failed, go down if passed.
 6-10: Destroyed</description>
-      <modifiers/>
     </rule>
-    <rule id="75d2-6efa-9640-61df" name="Well Prepared" hidden="false" page="159">
-      <description>If you take any single re-roll, you can add plus one to the value tested against. For example instead of testing against a res of 7 you would test against a res of 8. Use once and discard. You can buy as many Well Prepared as you are allowed Auxiliary choices in your Army.</description>
+    <rule id="75d2-6efa-9640-61df" name="Well Prepared" page="159" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>If you take any single re-roll, you can add plus one to the value tested against. For example instead of testing against a res of 7 you would test against a res of 8. Use once and discard. You can buy as many Well Prepared as you are allowed Auxiliary choices in your Army.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>
-    <profile id="2da6-e419-5126-a73b" profileTypeId="1650-77b3-10d1-6406" name="Attack Skimmer" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="11"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="MOD2, Large"/>
-      </characteristics>
+    <profile id="2da6-e419-5126-a73b" name="Attack Skimmer" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="11"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="MOD2, Large"/>
+      </characteristics>
     </profile>
-    <profile id="9fba-d6b7-c66d-99f0" profileTypeId="1650-77b3-10d1-6406" name="Bodyguard" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="-"/>
-      </characteristics>
+    <profile id="9fba-d6b7-c66d-99f0" name="Bodyguard" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
+      </characteristics>
     </profile>
-    <profile id="eb0f-0718-35d7-1a00" profileTypeId="1650-77b3-10d1-6406" name="Combat Drone" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="13"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="MOD2, Large"/>
-      </characteristics>
+    <profile id="eb0f-0718-35d7-1a00" name="Combat Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="13"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="MOD2, Large"/>
+      </characteristics>
     </profile>
-    <profile id="b390-0002-e1ef-3999" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Bombard" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-50"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="150"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="9/7/5"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Cycle"/>
-      </characteristics>
+    <profile id="b390-0002-e1ef-3999" name="Compression Bombard" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-50"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="150"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="9/7/5"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Cycle"/>
+      </characteristics>
     </profile>
-    <profile id="2e88-78bb-e1ba-bf5c" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Cannon" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="7/4/2"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Cycle"/>
-      </characteristics>
+    <profile id="2e88-78bb-e1ba-bf5c" name="Compression Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="7/4/2"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Cycle"/>
+      </characteristics>
     </profile>
-    <profile id="75cb-cf9b-dd3d-9177" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Carbine" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2/5/0"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover"/>
-      </characteristics>
+    <profile id="75cb-cf9b-dd3d-9177" name="Compression Carbine" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2/5/0"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover"/>
+      </characteristics>
     </profile>
-    <profile id="2ae1-18d0-fbc8-21ad" profileTypeId="1650-77b3-10d1-6406" name="Feral Fighter" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="7"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="-"/>
-      </characteristics>
+    <profile id="2ae1-18d0-fbc8-21ad" name="Feral Fighter" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
+      </characteristics>
     </profile>
-    <profile id="f23b-60da-348a-e6db" profileTypeId="1650-77b3-10d1-6406" name="Feral Leader" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="7"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Leader"/>
-      </characteristics>
+    <profile id="f23b-60da-348a-e6db" name="Feral Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader"/>
+      </characteristics>
     </profile>
-    <profile id="1069-6287-7c2a-af01" profileTypeId="1650-77b3-10d1-6406" name="Ferel Skark Fighter" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Large, Fast, Skark3 Attacks SV1"/>
-      </characteristics>
+    <profile id="1069-6287-7c2a-af01" name="Ferel Skark Fighter" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Large, Fast, Skark3 Attacks SV1"/>
+      </characteristics>
     </profile>
-    <profile id="41f2-0f61-9758-5e8d" profileTypeId="1650-77b3-10d1-6406" name="Ferel Skark Leader" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Large, Fast, Skark3 Attacks SV1, Leader"/>
-      </characteristics>
+    <profile id="41f2-0f61-9758-5e8d" name="Ferel Skark Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Large, Fast, Skark3 Attacks SV1, Leader"/>
+      </characteristics>
     </profile>
-    <profile id="bc52-cc32-73de-da9d" profileTypeId="ecae-8ac8-2c13-0dd3" name="Fractal Bombard" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="50"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="200"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3 +2 max 10"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock"/>
-      </characteristics>
+    <profile id="bc52-cc32-73de-da9d" name="Fractal Bombard" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="50"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="200"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3 +2 max 10"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock"/>
+      </characteristics>
     </profile>
-    <profile id="4c7f-3ba3-d703-1255" profileTypeId="ecae-8ac8-2c13-0dd3" name="Fractal Cannon" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2 +1 max 10"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock"/>
-      </characteristics>
+    <profile id="4c7f-3ba3-d703-1255" name="Fractal Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2 +1 max 10"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock"/>
+      </characteristics>
     </profile>
-    <profile id="2d89-bcdb-b942-b900" profileTypeId="1650-77b3-10d1-6406" name="Freeborn Captain" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Command, Hero, Follow, Leader 2"/>
-      </characteristics>
+    <profile id="2d89-bcdb-b942-b900" name="Freeborn Captain" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Hero, Follow, Leader 2"/>
+      </characteristics>
     </profile>
-    <profile id="c245-fa49-1569-2f23" profileTypeId="1650-77b3-10d1-6406" name="Freeborn Crew" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="-"/>
-      </characteristics>
+    <profile id="c245-fa49-1569-2f23" name="Freeborn Crew" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
+      </characteristics>
     </profile>
-    <profile id="a770-8327-b96d-b92e" profileTypeId="1650-77b3-10d1-6406" name="Freeborn Crew Leader" hidden="true">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Leader"/>
-      </characteristics>
+    <profile id="a770-8327-b96d-b92e" name="Freeborn Crew Leader" hidden="true" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader"/>
+      </characteristics>
     </profile>
-    <profile id="7267-3051-f1b4-0a88" profileTypeId="1650-77b3-10d1-6406" name="Freeborn Heavy Crew" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Large, Slow"/>
-      </characteristics>
+    <profile id="7267-3051-f1b4-0a88" name="Freeborn Heavy Crew" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Large, Slow"/>
+      </characteristics>
     </profile>
-    <profile id="87a3-460d-879a-92a5" profileTypeId="1650-77b3-10d1-6406" name="Freeborn Heavy Crew Leader" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Large, Slow"/>
-      </characteristics>
+    <profile id="87a3-460d-879a-92a5" name="Freeborn Heavy Crew Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Large, Slow"/>
+      </characteristics>
     </profile>
-    <profile id="0c03-96a3-4833-bc67" profileTypeId="1650-77b3-10d1-6406" name="Freeborn NuHu Renegade" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="4"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="4(7)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="9"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Command, Hero, Follow, Leader 3"/>
-      </characteristics>
+    <profile id="0c03-96a3-4833-bc67" name="Freeborn NuHu Renegade" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="4"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(7)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="9"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Hero, Follow, Leader 3"/>
+      </characteristics>
     </profile>
-    <profile id="68fe-17c2-2841-2cde" profileTypeId="1650-77b3-10d1-6406" name="Freeborn NuHu Renegade Meld" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="4"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="8(11)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="9"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Command, Hero, Follow, Meld, Meld Damage, MOD2, Leader 3"/>
-      </characteristics>
+    <profile id="68fe-17c2-2841-2cde" name="Freeborn NuHu Renegade Meld" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="4"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="8(11)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="9"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Hero, Follow, Meld, Meld Damage, MOD2, Leader 3"/>
+      </characteristics>
     </profile>
-    <profile id="2dbd-14c5-219e-d37d" profileTypeId="1650-77b3-10d1-6406" name="GP Drone" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="7"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="0"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="8"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="-"/>
-      </characteristics>
+    <profile id="2dbd-14c5-219e-d37d" name="GP Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="7"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="0"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="8"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
+      </characteristics>
     </profile>
-    <profile id="9e2a-f076-d4df-b60a" profileTypeId="1650-77b3-10d1-6406" name="Heavy Combat Drone" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="15"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="MOD3, Slow, Large"/>
-      </characteristics>
+    <profile id="9e2a-f076-d4df-b60a" name="Heavy Combat Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="15"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="MOD3, Slow, Large"/>
+      </characteristics>
     </profile>
-    <profile id="d0a1-129b-f8e5-b1ad" profileTypeId="1650-77b3-10d1-6406" name="Hound Probe " hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="-"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="-"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="-"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="-"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Shard"/>
-      </characteristics>
+    <profile id="d0a1-129b-f8e5-b1ad" name="Hound Probe " hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Shard"/>
+      </characteristics>
     </profile>
-    <profile id="ed77-e875-0302-9bf4" profileTypeId="1650-77b3-10d1-6406" name="Household Leader" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Leader"/>
-      </characteristics>
+    <profile id="ed77-e875-0302-9bf4" name="Household Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader"/>
+      </characteristics>
     </profile>
-    <profile id="45dd-c1c8-46d5-0107" profileTypeId="1650-77b3-10d1-6406" name="Household Trooper" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="-"/>
-      </characteristics>
+    <profile id="45dd-c1c8-46d5-0107" name="Household Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
+      </characteristics>
     </profile>
-    <profile id="12c4-12f3-a601-7547" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Lash" hidden="false" book="BtGoA" page="67">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks"/>
-      </characteristics>
+    <profile id="12c4-12f3-a601-7547" name="Mag Lash" book="BtGoA" page="67" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks"/>
+      </characteristics>
     </profile>
-    <profile id="12fe-ec68-d3e2-79b9" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Mortar" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OHx2, Blast D10, No Cover"/>
-      </characteristics>
+    <profile id="12fe-ec68-d3e2-79b9" name="Mag Mortar" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OHx2, Blast D10, No Cover"/>
+      </characteristics>
     </profile>
-    <profile id="79c6-8556-6040-e975" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Pistol" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="30"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
-      </characteristics>
+    <profile id="79c6-8556-6040-e975" name="Mag Pistol" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
+      </characteristics>
     </profile>
-    <profile id="ac6c-7fd0-193a-7751" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Repeater" hidden="false" book="BtGoA" page="69">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2"/>
-      </characteristics>
+    <profile id="ac6c-7fd0-193a-7751" name="Mag Repeater" book="BtGoA" page="69" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2"/>
+      </characteristics>
     </profile>
-    <profile id="3bc6-2260-1caa-db1c" profileTypeId="1650-77b3-10d1-6406" name="Meld Skark" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="8"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="7(8)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Fast, Large, Savage Strike, Meld Skark 6 SV2, Leader"/>
-      </characteristics>
+    <profile id="3bc6-2260-1caa-db1c" name="Meld Skark" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="8"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="7(8)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Fast, Large, Savage Strike, Meld Skark 6 SV2, Leader"/>
+      </characteristics>
     </profile>
-    <profile id="f504-4de7-23b9-2bad" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Bombard" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="50"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="200"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="7"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Plasma Fade"/>
-      </characteristics>
+    <profile id="f504-4de7-23b9-2bad" name="Plasma Bombard" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="50"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="200"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="7"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Plasma Fade"/>
+      </characteristics>
     </profile>
-    <profile id="ed5d-2e1d-e51a-1f6a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Cannon" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="6"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Plasma Fade"/>
-      </characteristics>
+    <profile id="ed5d-2e1d-e51a-1f6a" name="Plasma Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Plasma Fade"/>
+      </characteristics>
     </profile>
-    <profile id="ee9c-ada6-953a-b774" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Carbine - Scatter" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2"/>
-      </characteristics>
+    <profile id="ee9c-ada6-953a-b774" name="Plasma Carbine - Scatter" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2"/>
+      </characteristics>
     </profile>
-    <profile id="b56d-0f1d-de00-62c4" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Carbine - Single Shot" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
-      </characteristics>
+    <profile id="b56d-0f1d-de00-62c4" name="Plasma Carbine - Single Shot" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
+      </characteristics>
     </profile>
-    <profile id="8b37-5912-a988-22e9" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Grenade Bandolier" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="-"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="-"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D4, Hazardous H2H"/>
-      </characteristics>
+    <profile id="8b37-5912-a988-22e9" name="Plasma Grenade Bandolier" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="-"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, Hazardous H2H"/>
+      </characteristics>
     </profile>
-    <profile id="96f9-325b-69f7-13b4" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Grenades" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
-      </characteristics>
+    <profile id="96f9-325b-69f7-13b4" name="Plasma Grenades" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
+      </characteristics>
     </profile>
-    <profile id="cc3a-cc3a-5a9e-616b" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Lance" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="4"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Choose Target, Inaccurate"/>
-      </characteristics>
+    <profile id="cc3a-cc3a-5a9e-616b" name="Plasma Lance - Lance" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="4"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Choose Target, Inaccurate"/>
+      </characteristics>
     </profile>
-    <profile id="5463-10c1-cf72-c3f8" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Scatter" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2"/>
-      </characteristics>
+    <profile id="5463-10c1-cf72-c3f8" name="Plasma Lance - Scatter" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2"/>
+      </characteristics>
     </profile>
-    <profile id="1112-0824-87c5-ae27" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Single Shot" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
-      </characteristics>
+    <profile id="1112-0824-87c5-ae27" name="Plasma Lance - Single Shot" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
+      </characteristics>
     </profile>
-    <profile id="e44d-e4f0-3ad5-6528" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Light Support Gun" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3"/>
-      </characteristics>
+    <profile id="e44d-e4f0-3ad5-6528" name="Plasma Light Support Gun" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3"/>
+      </characteristics>
     </profile>
-    <profile id="2e7c-b5f9-e3e5-9125" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Pistol" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="30"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
-      </characteristics>
+    <profile id="2e7c-b5f9-e3e5-9125" name="Plasma Pistol" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
+      </characteristics>
     </profile>
-    <profile id="04ae-2947-a8ea-2c08" profileTypeId="1650-77b3-10d1-6406" name="Probe" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="-"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="-"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="-"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="-"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Shard"/>
-      </characteristics>
+    <profile id="04ae-2947-a8ea-2c08" name="Probe" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Shard"/>
+      </characteristics>
     </profile>
-    <profile id="45af-eec1-b29d-273f" profileTypeId="1650-77b3-10d1-6406" name="Rejects" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="7"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Misgenic Abilities"/>
-      </characteristics>
+    <profile id="45af-eec1-b29d-273f" name="Rejects" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Misgenic Abilities"/>
+      </characteristics>
     </profile>
-    <profile id="74dc-b388-dc1d-fb61" profileTypeId="1650-77b3-10d1-6406" name="Skyraider Captain" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(7)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Command, Hero, Follow, Large, Fast, Leader 2"/>
-      </characteristics>
+    <profile id="74dc-b388-dc1d-fb61" name="Skyraider Captain" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Hero, Follow, Large, Fast, Leader 2"/>
+      </characteristics>
     </profile>
-    <profile id="e18f-34de-2624-4133" profileTypeId="1650-77b3-10d1-6406" name="Skyraider Leader" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(7)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Large, Fast, Leader "/>
-      </characteristics>
+    <profile id="e18f-34de-2624-4133" name="Skyraider Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Large, Fast, Leader "/>
+      </characteristics>
     </profile>
-    <profile id="a654-5213-64f2-703a" profileTypeId="1650-77b3-10d1-6406" name="Skyraider Trooper" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(7)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Large, Fast"/>
-      </characteristics>
+    <profile id="a654-5213-64f2-703a" name="Skyraider Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Large, Fast"/>
+      </characteristics>
     </profile>
-    <profile id="4d5f-ccb4-75c2-cbf2" profileTypeId="1650-77b3-10d1-6406" name="Targeter Probe" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="-"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="-"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="-"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="-"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Shard"/>
-      </characteristics>
+    <profile id="4d5f-ccb4-75c2-cbf2" name="Targeter Probe" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Shard"/>
+      </characteristics>
     </profile>
-    <profile id="5425-1edf-f536-d5a1" profileTypeId="1650-77b3-10d1-6406" name="Transport Drone" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="13"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="MOD2, Transport 10, Large"/>
-      </characteristics>
+    <profile id="5425-1edf-f536-d5a1" name="Transport Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="13"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="MOD2, Transport 10, Large"/>
+      </characteristics>
     </profile>
-    <profile id="702f-c8a7-d8cf-01c1" profileTypeId="1650-77b3-10d1-6406" name="Vardanari Gaurd Trooper" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="-"/>
-      </characteristics>
+    <profile id="702f-c8a7-d8cf-01c1" name="Vardanari Gaurd Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
+      </characteristics>
     </profile>
-    <profile id="62fc-1d76-c6fd-a3eb" profileTypeId="1650-77b3-10d1-6406" name="Vardanari Leader" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Leader"/>
-      </characteristics>
+    <profile id="62fc-1d76-c6fd-a3eb" name="Vardanari Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader"/>
+      </characteristics>
     </profile>
-    <profile id="27c9-718e-cee7-599d" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Launcher" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="60"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="120"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D5, No Cover"/>
-      </characteristics>
+    <profile id="27c9-718e-cee7-599d" name="X-Launcher" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D5, No Cover"/>
+      </characteristics>
     </profile>
-    <profile id="1298-3867-ea1e-c04c" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Sling" hidden="false" book="BtGoA" page="68">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D3, Hand Weapon"/>
-      </characteristics>
+    <profile id="1298-3867-ea1e-c04c" name="X-Sling" book="BtGoA" page="68" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D3, Hand Weapon"/>
+      </characteristics>
     </profile>
   </sharedProfiles>
 </catalogue>

--- a/Freeborn_Adventurers.cat
+++ b/Freeborn_Adventurers.cat
@@ -1,4802 +1,8479 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="5e8e-3fa7-98ab-9b96" revision="2" gameSystemId="c339-677a-60db-4060" gameSystemRevision="0" battleScribeVersion="1.15" name="Freeborn Adventurers" books="Battle for Xilos" authorName="Christopher Wailes" authorContact="email" authorUrl="http://cwailes1987@gmail.com" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
-  <entries>
-    <entry id="66a7-b2ec-cfcc-8359" name="&lt; Command Squad Options - Must choose first" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="c017-7f96-06bd-fd6b" name="Select one of the following option and the relevent selection will appear" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="3933-5e9f-f85c-ba75" name="1&lt; Add 2 extra bodygaurds" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
+<catalogue id="5e8e-3fa7-98ab-9b96" name="Freeborn Adventurers" book="Battle for Xilos" revision="3" battleScribeVersion="2.00" authorName="Christopher Wailes" authorContact="email" authorUrl="http://cwailes1987@gmail.com" gameSystemId="c339-677a-60db-4060" gameSystemRevision="0" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <profiles/>
+  <rules/>
+  <infoLinks/>
+  <costTypes/>
+  <profileTypes/>
+  <forceEntries/>
+  <selectionEntries>
+    <selectionEntry id="66a7-b2ec-cfcc-8359" name="&lt; Command Squad Options - Must choose first" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c017-7f96-06bd-fd6b" name="Select one of the following option and the relevent selection will appear" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3933-5e9f-f85c-ba75" name="1&lt; Add 2 extra bodygaurds" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links/>
-            </entry>
-            <entry id="a400-34cd-f726-fbf6" name="9&lt; Add Batter Drone" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
               <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-            <entry id="ad0d-a741-67ad-5d5c" name="7&lt; Add up to 2 Gun Drones" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+              <infoLinks/>
               <modifiers/>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a400-34cd-f726-fbf6" name="9&lt; Add Batter Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links/>
-            </entry>
-            <entry id="d17a-ef4d-2148-25e8" name="8&lt; Add up to 2 shield Drones" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ad0d-a741-67ad-5d5c" name="7&lt; Add up to 2 Gun Drones" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links/>
-            </entry>
-            <entry id="6559-a8ba-d266-7c27" name="2&lt; HL Armour for unit" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d17a-ef4d-2148-25e8" name="8&lt; Add up to 2 shield Drones" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links/>
-            </entry>
-            <entry id="1ef5-d006-6a32-fddb" name="3&lt; Phase Armour for unit" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6559-a8ba-d266-7c27" name="2&lt; HL Armour for unit" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links/>
-            </entry>
-            <entry id="a04c-3029-b790-0cdb" name="4&lt; Give Captain plasma Carbine" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1ef5-d006-6a32-fddb" name="3&lt; Phase Armour for unit" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links/>
-            </entry>
-            <entry id="a90a-cec1-cd13-3c17" name="5&lt; Give Captain Compression Carbine" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a04c-3029-b790-0cdb" name="4&lt; Give Captain plasma Carbine" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links/>
-            </entry>
-            <entry id="7f96-ddf7-af5d-958a" name="6&lt; Give Bodygaurds Compression carbines" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a90a-cec1-cd13-3c17" name="5&lt; Give Captain Compression Carbine" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links/>
-            </entry>
-            <entry id="39a7-bedc-c912-a9f0" name="0&lt; None" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7f96-ddf7-af5d-958a" name="6&lt; Give Bodygaurds Compression carbines" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="39a7-bedc-c912-a9f0" name="0&lt; None" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="set" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="minSelections" value="0.0">
+                  <repeats/>
                   <conditions>
-                    <condition parentId="direct parent" childId="39a7-bedc-c912-a9f0" field="selections" type="equal to" value="0.0"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="39a7-bedc-c912-a9f0" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3596-fdfb-c997-4a56" name="Replace with Amano Harran and Bodyguards" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links/>
-            </entry>
-            <entry id="3596-fdfb-c997-4a56" name="Replace with Amano Harran and Bodyguards" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f2dd-4a37-dae9-7560" name="Amano Harran and Bodyguards" book="Battle for Xilos" page="115" hidden="true" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="f2dd-4a37-dae9-7560" name="Amano Harran and Bodyguards" points="126.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true" book="Battle for Xilos" page="115">
-      <entries>
-        <entry id="cf2e-47f5-d441-4c5b" name="Amano Harran, Oszoni Freeborn Mercenary Captain" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="6082-fc71-a6e3-336d" name="&lt;Weapons&gt;" defaultEntryId="153b-99ce-0100-4c2a" minSelections="1" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="153b-99ce-0100-4c2a" name="Zantu Plasma Duelling Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Battle for Xilos" page="115">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules>
-                    <rule id="b823-4c67-cf88-a220" name="Dead Eye" hidden="false" book="Battle for Xilos" page="115">
-                      <description>When shooting with a Fire order, add +2 to Acc value rather than standard +1</description>
-                      <modifiers/>
-                    </rule>
-                    <rule id="9b94-bef6-d917-df02" name="Duellist" hidden="false" book="Battle for Xilos" page="115">
-                      <description>When shooting simultaenously with an enemy unit, both sides roll 1d10. If the controlling player rolls higher, he shoots first and any result is applied to the target before it can fire back, including casualty removal and pinning.</description>
-                      <modifiers/>
-                    </rule>
-                  </rules>
-                  <profiles>
-                    <profile id="7069-1178-686a-c24b" profileTypeId="ecae-8ac8-2c13-0dd3" name="Zantu Plasma Duelling Pistol" hidden="false" book="Battle for Xilos" page="115">
-                      <characteristics>
-                        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="40"/>
-                        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-                        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Dead Eye, Duellist"/>
-                      </characteristics>
-                      <modifiers/>
-                    </profile>
-                  </profiles>
-                  <links/>
-                </entry>
-                <entry id="4728-6094-f78e-8dab" name="Xilos Stasis Key" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Battle for Xilos" page="57">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules>
-                    <rule id="077e-ef13-fe7a-c8f2" name="Stasis" hidden="false" book="Battle for Xilos" page="57">
-                      <description>Weapon can ONLY be fired with a Fire order, applying normal +1 Acc bonus. If target unit is hit, either switch its current Order Die to a Down order, or if it does not yet have an order, retrieve an Order Die from the bag and issue it a down order. Then, add a Stasis marker to the unit.			If a unit is in stasis at the turn end phase, then instead of making a recovery test to recover the Down Order Die, make a recovery test to remove the Stasis marker. The unit then remains Down until the next chance to make a recovery test, at which point the test applies to the Down Order Die.</description>
-                      <modifiers/>
-                    </rule>
-                  </rules>
-                  <profiles>
-                    <profile id="c619-651a-cd68-d3c3" profileTypeId="ecae-8ac8-2c13-0dd3" name="Xilos Stasis Key" hidden="false" book="Battle for Xilos" page="57">
-                      <characteristics>
-                        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-                        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long"/>
-                        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme"/>
-                        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value"/>
-                        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Stasis"/>
-                      </characteristics>
-                      <modifiers/>
-                    </profile>
-                  </profiles>
-                  <links/>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules>
-            <rule id="ba35-82b3-795b-a95e" name="Fast Shot" hidden="false" book="Battle for Xilos" page="115">
-              <description>With any hand or standard weapon, this model shoots twice instead of once using the same weapon at the same target. This ability CAN be used with the Xilos Stasis Key, but the key can still only fire with a Fire order.</description>
-              <modifiers/>
-            </rule>
-            <rule id="7766-534c-a0a0-f7a6" name="Charismatic Aura" hidden="false" book="Battle for Xilos" page="115">
-              <description>If any enemy unit is within 10&quot; of the Amano Harran model then it cannot be given an order without taking an Order test against its Command, even if it has no pins, and both its Command and Initiative stat are reduced by -1 when making order and/or reaction tests.</description>
-              <modifiers/>
-            </rule>
-            <rule id="d457-7703-7346-887a" name="Wound" hidden="false" book="Battle for Xilos" page="115">
-              <description>If Amano Harran fails a Res test then instead of falling casualty he is wounded. Once wounded, if any further Res test is failed he is removed as a casualty. If Amano Harran is wounded then the unit cannot lose its last 1 pin. It can lose other pins as normal, but will always retain at least one.</description>
-              <modifiers/>
-            </rule>
-          </rules>
-          <profiles>
-            <profile id="0eda-1ed2-bfd0-68a3" profileTypeId="1650-77b3-10d1-6406" name="Amano Harran, Oszoni Freeborn Mercenary Captain" hidden="false" book="Battle for Xilos" page="115">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="6"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="10"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="10"/>
-                <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Command, Follow, Hero, Leader 3, Wound, Fast Shot, Charismatic Aura"/>
-              </characteristics>
-              <modifiers>
-                <modifier type="append" field="f214-abe8-c922-c51b" value="(7)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups>
-                    <conditionGroup type="or">
-                      <conditions>
-                        <condition parentId="f2dd-4a37-dae9-7560" childId="de28-9c93-9e3b-423a" field="selections" type="equal to" value="1.0"/>
-                        <condition parentId="f2dd-4a37-dae9-7560" childId="6654-8778-3ce4-7d00" field="selections" type="equal to" value="1.0"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-            </profile>
-          </profiles>
-          <links>
-            <link id="bc60-6cb8-2374-2d48" targetId="7bc9-5e98-2914-5abd" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="07b2-ecf8-7e7b-20b7" targetId="5c9b-1bde-ee01-04a4" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="cbbd-0195-b557-797b" targetId="3c64-6022-a5f1-9c04" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="0f40-5212-3cdf-2660" targetId="05bb-4d34-70cd-25d2" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="c172-9fe8-32cc-31d8" name="Bodyguard" points="21.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="dcf3-de46-e285-3509" targetId="9fba-d6b7-c66d-99f0" linkType="profile">
-              <modifiers>
-                <modifier type="append" field="f214-abe8-c922-c51b" value="(7)" repeat="false" numRepeats="1" incrementParentId="f2dd-4a37-dae9-7560" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups>
-                    <conditionGroup type="or">
-                      <conditions>
-                        <condition parentId="f2dd-4a37-dae9-7560" childId="de28-9c93-9e3b-423a" field="selections" type="equal to" value="1.0"/>
-                        <condition parentId="f2dd-4a37-dae9-7560" childId="6654-8778-3ce4-7d00" field="selections" type="equal to" value="1.0"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="e34f-0193-f3d5-05b5" targetId="b018-6101-d2e3-b4ea" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="8641-2ea1-91ce-ae8c" name="&lt;Unit Armor&gt;" defaultEntryId="d04c-28a8-87bc-e4fa" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="6654-8778-3ce4-7d00" targetId="eff8-bb0e-1b1d-bbb2" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="f2dd-4a37-dae9-7560" incrementChildId="cf2e-47f5-d441-4c5b" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="f2dd-4a37-dae9-7560" incrementChildId="c172-9fe8-32cc-31d8" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="de28-9c93-9e3b-423a" targetId="eb94-d1e8-1084-71b3" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="f2dd-4a37-dae9-7560" incrementChildId="c172-9fe8-32cc-31d8" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="f2dd-4a37-dae9-7560" incrementChildId="cf2e-47f5-d441-4c5b" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="d04c-28a8-87bc-e4fa" targetId="03c2-174e-8617-cf04" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="fdfe-37b2-dfb0-ef51" name="&lt;Unit Options&gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="2405-c5e8-d084-eeb6" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="1e1c-7799-d134-decf" targetId="502c-9855-7269-eaa2" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="c0cb-693a-2299-dec1" targetId="573b-88bc-97d7-d890" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="a33a-ce01-82ea-fc79" targetId="d571-d584-85fc-9110" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="d60b-ae7d-77fa-7b80" targetId="eefe-f70d-db8e-9414" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="7769-8a46-248d-2c2c" targetId="4b9d-a0bf-396e-384b" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="5683-6bd8-299e-056e" targetId="1707-586b-01df-0f80" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="a03d-71ee-1dcc-633a" targetId="d118-8115-df5f-2402" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="f2dd-4a37-dae9-7560" incrementChildId="c172-9fe8-32cc-31d8" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="f2dd-4a37-dae9-7560" incrementChildId="cf2e-47f5-d441-4c5b" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+      <rules/>
+      <infoLinks/>
       <modifiers>
-        <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+        <modifier type="set" field="hidden" value="false">
+          <repeats/>
           <conditions>
-            <condition parentId="roster" childId="3596-fdfb-c997-4a56" field="selections" type="equal to" value="1.0"/>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3596-fdfb-c997-4a56" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
       </modifiers>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="1871-8acd-7ec8-8700" name="Block!" points="5.0" categoryId="50ba-cf77-3941-189c" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="aadf-c739-5770-7605" targetId="5d2e-45d2-1707-87db" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="e721-0203-824e-8706" name="D1 Light Support Drone" points="59.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="13d2-5f57-94d2-90e5" name="D1 Light Support Drone" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="6da1-8ffb-5eb3-635a" targetId="fb67-43bf-9dc2-5218" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="83dc-8bf9-be97-22d7" targetId="0f97-9dbe-566a-5ab0" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="cc9d-27fa-54b7-8e44" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="00ed-fa82-cf24-e7bd" name="Spotter Drone" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="cf2e-47f5-d441-4c5b" name="Amano Harran, Oszoni Freeborn Mercenary Captain" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="0eda-1ed2-bfd0-68a3" name="Amano Harran, Oszoni Freeborn Mercenary Captain" book="Battle for Xilos" page="115" hidden="false" profileTypeId="1650-77b3-10d1-6406">
               <profiles/>
-              <links>
-                <link id="d571-c80d-d95e-07ef" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="321b-f095-c38c-1214" name="Batter Drone" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
               <rules/>
-              <profiles/>
-              <links>
-                <link id="5a96-d505-70e8-bbae" targetId="d571-d584-85fc-9110" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="97d0-e012-2c95-593e" name="Self Repair" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="9516-1172-da42-22f9" targetId="3377-9408-33bb-6a02" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="f389-99b2-4ec1-2d24" name="Synchroniser Drone" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="8ad6-d4a5-4f51-9839" targetId="d91f-8426-3ab2-f06c" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="e6a9-73dd-85cd-2520" targetId="1707-586b-01df-0f80" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="a44f-4447-aff2-0dcd" name="Domari Squad (Household Troops)" points="22.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="192">
-      <entries>
-        <entry id="c61f-6de1-069d-821f" name="&lt; Household Leader" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="191">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="eeeb-14fc-3015-51fc" name="&lt; Leader Level &gt;" defaultEntryId="af81-32d2-905d-4525" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="5b49-8a4d-07d2-fb89" targetId="02f3-3134-ae39-afed" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="af81-32d2-905d-4525" targetId="fc7e-7c0e-65e0-8c33" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="614f-b64a-4c29-8d4f" name="&lt; Ranged Weapon &gt;" defaultEntryId="2bc1-4f6e-02ba-7d1c" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="2bc1-4f6e-02ba-7d1c" targetId="8690-3ab7-9fef-06ee" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="48df-d58e-e0d1-d8df" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-                <link id="526a-3475-ccc6-063a" targetId="9cd6-dbb8-bdcb-0299" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-                <link id="052b-0bbe-d078-8a35" targetId="1631-5857-2139-960a" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="6.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="c976-a3c2-48e7-a65d" targetId="ed77-e875-0302-9bf4" linkType="profile">
+              <infoLinks/>
               <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="c61f-6de1-069d-821f" childId="5b49-8a4d-07d2-fb89" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
+                <modifier type="append" field="f214-abe8-c922-c51b" value="(7)">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="f2dd-4a37-dae9-7560" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="de28-9c93-9e3b-423a" type="equalTo"/>
+                        <condition field="selections" scope="f2dd-4a37-dae9-7560" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6654-8778-3ce4-7d00" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="d441-f08b-6ae0-3ce1" name="Household Trooper" points="15.0" categoryId="(No Category)" type="model" minSelections="5" maxSelections="7" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="192">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="9c0c-e485-c447-84fb" name="Ranged Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="20d8-1c96-d87e-6005" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="f4de-742c-31aa-3973" targetId="45dd-c1c8-46d5-0107" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="a960-249c-ef1d-5e8c" name="Micro-X Launcher" points="0.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="a9e5-f8a1-aadd-0667" name="SlingNet Ammo for Micro-X Launcher" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="6"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="10"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="10"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Follow, Hero, Leader 3, Wound, Fast Shot, Charismatic Aura"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="ba35-82b3-795b-a95e" name="Fast Shot" book="Battle for Xilos" page="115" hidden="false">
               <profiles/>
-              <links/>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="eb51-606e-6b9f-6c33" targetId="e7b0-651a-cc7c-f27e" linkType="entry">
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="678a-8f30-acb7-0053" name="&lt; Unit Armor &gt;" defaultEntryId="a03c-46bd-0028-b43e" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="a03c-46bd-0028-b43e" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
+              <description>With any hand or standard weapon, this model shoots twice instead of once using the same weapon at the same target. This ability CAN be used with the Xilos Stasis Key, but the key can still only fire with a Fire order.</description>
+            </rule>
+            <rule id="7766-534c-a0a0-f7a6" name="Charismatic Aura" book="Battle for Xilos" page="115" hidden="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="e31c-0032-c416-8471" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="606b-c5e6-d436-9d3c" targetId="f3aa-148a-0460-c7e5" linkType="entry">
+              <description>If any enemy unit is within 10&quot; of the Amano Harran model then it cannot be given an order without taking an Order test against its Command, even if it has no pins, and both its Command and Initiative stat are reduced by -1 when making order and/or reaction tests.</description>
+            </rule>
+            <rule id="d457-7703-7346-887a" name="Wound" book="Battle for Xilos" page="115" hidden="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="5163-e03b-fc25-9afe" targetId="d118-8115-df5f-2402" linkType="entry">
-              <modifiers>
-                <modifier type="set" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="a44f-4447-aff2-0dcd" incrementChildId="d441-f08b-6ae0-3ce1" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="a44f-4447-aff2-0dcd" incrementChildId="a960-249c-ef1d-5e8c" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="307c-9503-74f9-f4b3" name="Extra Shot" points="10.0" categoryId="50ba-cf77-3941-189c" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="4864-9551-d5ab-0fd1" targetId="e77b-02da-5143-229e" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="b73b-6140-e2ca-f0c1" name="Freeborn Command Squad" points="69.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true">
-      <entries>
-        <entry id="b36d-f9f6-80eb-6f8a" name="&lt; Freeborn Captain" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="ee93-85a8-a748-3858" name="&lt; Leader Level &gt;" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+              <description>If Amano Harran fails a Res test then instead of falling casualty he is wounded. Once wounded, if any further Res test is failed he is removed as a casualty. If Amano Harran is wounded then the unit cannot lose its last 1 pin. It can lose other pins as normal, but will always retain at least one.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="bc60-6cb8-2374-2d48" hidden="false" targetId="7bc9-5e98-2914-5abd" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <links>
-                <link id="3a47-103d-769c-3d59" targetId="5a4c-2f5e-40a2-91d4" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="0c11-a12d-3376-0b4b" name="&lt;Freeborn Captain Equipment &gt;" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups>
-                <entryGroup id="d72b-f17d-2842-5908" name="&lt; Armour &gt;" defaultEntryId="d821-bfad-6e70-be4a" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="d821-bfad-6e70-be4a" targetId="03c2-174e-8617-cf04" linkType="entry">
+            </infoLink>
+            <infoLink id="07b2-ecf8-7e7b-20b7" hidden="false" targetId="5c9b-1bde-ee01-04a4" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="cbbd-0195-b557-797b" hidden="false" targetId="3c64-6022-a5f1-9c04" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="0f40-5212-3cdf-2660" hidden="false" targetId="05bb-4d34-70cd-25d2" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="6082-fc71-a6e3-336d" name="&lt;Weapons&gt;" hidden="false" collective="false" defaultSelectionEntryId="153b-99ce-0100-4c2a">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="153b-99ce-0100-4c2a" name="Zantu Plasma Duelling Pistol" book="Battle for Xilos" page="115" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles>
+                    <profile id="7069-1178-686a-c24b" name="Zantu Plasma Duelling Pistol" book="Battle for Xilos" page="115" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
                       <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-                <entryGroup id="6343-7996-c9c2-e583" name="&lt; Weapons &gt;" defaultEntryId="c38c-46e0-0457-f57d" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="c38c-46e0-0457-f57d" targetId="e6db-6ed3-1a26-ea56" linkType="entry">
+                      <characteristics>
+                        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="40"/>
+                        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+                        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Dead Eye, Duellist"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules>
+                    <rule id="b823-4c67-cf88-a220" name="Dead Eye" book="Battle for Xilos" page="115" hidden="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
                       <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-              </entryGroups>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="75cc-7baf-4390-4597" targetId="2d89-bcdb-b942-b900" linkType="profile">
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="b73b-6140-e2ca-f0c1" childId="3a47-103d-769c-3d59" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="6b48-ec12-ab6c-2063" name="Bodyguards" points="21.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="c9a4-5ee7-f187-8235" name="&lt; Armour &gt;" defaultEntryId="5b9a-d663-bb0e-6480" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="5b9a-d663-bb0e-6480" targetId="03c2-174e-8617-cf04" linkType="entry">
+                      <description>When shooting with a Fire order, add +2 to Acc value rather than standard +1</description>
+                    </rule>
+                    <rule id="9b94-bef6-d917-df02" name="Duellist" book="Battle for Xilos" page="115" hidden="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <description>When shooting simultaenously with an enemy unit, both sides roll 1d10. If the controlling player rolls higher, he shoots first and any result is applied to the target before it can fire back, including casualty removal and pinning.</description>
+                    </rule>
+                  </rules>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="ce36-0f86-ad2b-2de0" name="&lt; Weapons &gt;" defaultEntryId="ffe5-b36e-981d-67c8" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="ffe5-b36e-981d-67c8" targetId="b018-6101-d2e3-b4ea" linkType="entry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="4728-6094-f78e-8dab" name="Xilos Stasis Key" book="Battle for Xilos" page="57" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles>
+                    <profile id="c619-651a-cd68-d3c3" name="Xilos Stasis Key" book="Battle for Xilos" page="57" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+                        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa"/>
+                        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9"/>
+                        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a"/>
+                        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Stasis"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules>
+                    <rule id="077e-ef13-fe7a-c8f2" name="Stasis" book="Battle for Xilos" page="57" hidden="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <description>Weapon can ONLY be fired with a Fire order, applying normal +1 Acc bonus. If target unit is hit, either switch its current Order Die to a Down order, or if it does not yet have an order, retrieve an Order Die from the bag and issue it a down order. Then, add a Stasis marker to the unit.			If a unit is in stasis at the turn end phase, then instead of making a recovery test to recover the Down Order Die, make a recovery test to remove the Stasis marker. The unit then remains Down until the next chance to make a recovery test, at which point the test applies to the Down Order Die.</description>
+                    </rule>
+                  </rules>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers>
-            <modifier type="increment" field="maxSelections" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions>
-                <condition parentId="roster" childId="3933-5e9f-f85c-ba75" field="selections" type="equal to" value="1.0"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="25.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c172-9fe8-32cc-31d8" name="Bodyguard" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles/>
-          <links>
-            <link id="16f3-2f8c-3e35-5557" targetId="9fba-d6b7-c66d-99f0" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="87b2-db05-700b-2ce2" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="dcf3-de46-e285-3509" hidden="false" targetId="9fba-d6b7-c66d-99f0" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="append" field="f214-abe8-c922-c51b" value="(7)">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="f2dd-4a37-dae9-7560" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="de28-9c93-9e3b-423a" type="equalTo"/>
+                        <condition field="selections" scope="f2dd-4a37-dae9-7560" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6654-8778-3ce4-7d00" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-          <links>
-            <link id="4e48-b0be-38f0-fb84" targetId="f3aa-148a-0460-c7e5" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="e34f-0193-f3d5-05b5" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="25ec-bc01-1917-42a1" targetId="502c-9855-7269-eaa2" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="e804-8e7c-7660-6271" targetId="573b-88bc-97d7-d890" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="19db-d0e1-8415-81fa" targetId="d118-8115-df5f-2402" linkType="entry">
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="21.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="8641-2ea1-91ce-ae8c" name="&lt;Unit Armor&gt;" hidden="false" collective="false" defaultSelectionEntryId="d04c-28a8-87bc-e4fa">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="6654-8778-3ce4-7d00" hidden="false" targetId="eff8-bb0e-1b1d-bbb2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="set" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="f2dd-4a37-dae9-7560" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cf2e-47f5-d441-4c5b" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="b73b-6140-e2ca-f0c1" incrementChildId="6b48-ec12-ab6c-2063" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="f2dd-4a37-dae9-7560" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c172-9fe8-32cc-31d8" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-            <link id="3b4d-27c4-5549-02cb" targetId="4b9d-a0bf-396e-384b" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="de28-9c93-9e3b-423a" hidden="false" targetId="eb94-d1e8-1084-71b3" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="f2dd-4a37-dae9-7560" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c172-9fe8-32cc-31d8" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="f2dd-4a37-dae9-7560" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cf2e-47f5-d441-4c5b" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="d04c-28a8-87bc-e4fa" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="fdfe-37b2-dfb0-ef51" name="&lt;Unit Options&gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="2405-c5e8-d084-eeb6" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="1e1c-7799-d134-decf" hidden="false" targetId="502c-9855-7269-eaa2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="c0cb-693a-2299-dec1" hidden="false" targetId="573b-88bc-97d7-d890" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="a33a-ce01-82ea-fc79" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="d60b-ae7d-77fa-7b80" hidden="false" targetId="eefe-f70d-db8e-9414" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="7769-8a46-248d-2c2c" hidden="false" targetId="4b9d-a0bf-396e-384b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="5683-6bd8-299e-056e" hidden="false" targetId="1707-586b-01df-0f80" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="a03d-71ee-1dcc-633a" hidden="false" targetId="d118-8115-df5f-2402" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="f2dd-4a37-dae9-7560" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c172-9fe8-32cc-31d8" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="f2dd-4a37-dae9-7560" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cf2e-47f5-d441-4c5b" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="126.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1871-8acd-7ec8-8700" name="Block!" hidden="false" collective="false" categoryEntryId="50ba-cf77-3941-189c" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="aadf-c739-5770-7605" hidden="false" targetId="5d2e-45d2-1707-87db" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e721-0203-824e-8706" name="D1 Light Support Drone" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="13d2-5f57-94d2-90e5" name="D1 Light Support Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="6da1-8ffb-5eb3-635a" hidden="false" targetId="fb67-43bf-9dc2-5218" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="83dc-8bf9-be97-22d7" hidden="false" targetId="0f97-9dbe-566a-5ab0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="cc9d-27fa-54b7-8e44" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="00ed-fa82-cf24-e7bd" name="Spotter Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="d571-c80d-d95e-07ef" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="321b-f095-c38c-1214" name="Batter Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="5a96-d505-70e8-bbae" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="97d0-e012-2c95-593e" name="Self Repair" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="9516-1172-da42-22f9" hidden="false" targetId="3377-9408-33bb-6a02" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f389-99b2-4ec1-2d24" name="Synchroniser Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="8ad6-d4a5-4f51-9839" hidden="false" targetId="d91f-8426-3ab2-f06c" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="e6a9-73dd-85cd-2520" hidden="false" targetId="1707-586b-01df-0f80" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="59.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a44f-4447-aff2-0dcd" name="Domari Squad (Household Troops)" book="BtGoA" page="192" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="c61f-6de1-069d-821f" name="&lt; Household Leader" book="BtGoA" page="191" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="c976-a3c2-48e7-a65d" hidden="false" targetId="ed77-e875-0302-9bf4" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2">
+                  <repeats/>
                   <conditions>
-                    <condition parentId="roster" childId="ad0d-a741-67ad-5d5c" field="selections" type="equal to" value="1.0"/>
+                    <condition field="selections" scope="c61f-6de1-069d-821f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5b49-8a4d-07d2-fb89" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-            <link id="2c36-464a-243b-0e55" targetId="1707-586b-01df-0f80" linkType="entry">
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="eeeb-14fc-3015-51fc" name="&lt; Leader Level &gt;" hidden="false" collective="false" defaultSelectionEntryId="af81-32d2-905d-4525">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="5b49-8a4d-07d2-fb89" hidden="false" targetId="02f3-3134-ae39-afed" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="af81-32d2-905d-4525" hidden="false" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="614f-b64a-4c29-8d4f" name="&lt; Ranged Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="2bc1-4f6e-02ba-7d1c">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="2bc1-4f6e-02ba-7d1c" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="48df-d58e-e0d1-d8df" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="3.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="526a-3475-ccc6-063a" hidden="false" targetId="9cd6-dbb8-bdcb-0299" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="1.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="052b-0bbe-d078-8a35" hidden="false" targetId="1631-5857-2139-960a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="6.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d441-f08b-6ae0-3ce1" name="Household Trooper" book="BtGoA" page="192" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="f4de-742c-31aa-3973" hidden="false" targetId="45dd-c1c8-46d5-0107" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="9c0c-e485-c447-84fb" name="Ranged Weapon" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="20d8-1c96-d87e-6005" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a960-249c-ef1d-5e8c" name="Micro-X Launcher" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="a9e5-f8a1-aadd-0667" name="SlingNet Ammo for Micro-X Launcher" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="eb51-606e-6b9f-6c33" hidden="false" targetId="e7b0-651a-cc7c-f27e" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="678a-8f30-acb7-0053" name="&lt; Unit Armor &gt;" hidden="false" collective="false" defaultSelectionEntryId="a03c-46bd-0028-b43e">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="a03c-46bd-0028-b43e" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e31c-0032-c416-8471" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="606b-c5e6-d436-9d3c" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="5163-e03b-fc25-9afe" hidden="false" targetId="d118-8115-df5f-2402" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="points" value="2.0">
+                  <repeats/>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="roster" childId="d17a-ef4d-2148-25e8" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="8de0-52be-784c-00ce" targetId="d571-d584-85fc-9110" linkType="entry">
-              <modifiers>
-                <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="a44f-4447-aff2-0dcd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d441-f08b-6ae0-3ce1" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="roster" childId="a400-34cd-f726-fbf6" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="a44f-4447-aff2-0dcd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a960-249c-ef1d-5e8c" repeats="1"/>
+                  </repeats>
+                  <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="22.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="307c-9503-74f9-f4b3" name="Extra Shot" hidden="false" collective="false" categoryEntryId="50ba-cf77-3941-189c" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="4864-9551-d5ab-0fd1" hidden="false" targetId="e77b-02da-5143-229e" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b73b-6140-e2ca-f0c1" name="Freeborn Command Squad" hidden="true" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers>
-        <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+        <modifier type="set" field="hidden" value="false">
+          <repeats/>
           <conditions/>
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition parentId="roster" childId="3933-5e9f-f85c-ba75" field="selections" type="equal to" value="1.0"/>
-                <condition parentId="roster" childId="a400-34cd-f726-fbf6" field="selections" type="equal to" value="1.0"/>
-                <condition parentId="roster" childId="ad0d-a741-67ad-5d5c" field="selections" type="equal to" value="1.0"/>
-                <condition parentId="roster" childId="d17a-ef4d-2148-25e8" field="selections" type="equal to" value="1.0"/>
-                <condition parentId="roster" childId="39a7-bedc-c912-a9f0" field="selections" type="equal to" value="1.0"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3933-5e9f-f85c-ba75" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a400-34cd-f726-fbf6" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad0d-a741-67ad-5d5c" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d17a-ef4d-2148-25e8" type="equalTo"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="39a7-bedc-c912-a9f0" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </conditionGroup>
           </conditionGroups>
         </modifier>
       </modifiers>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="15e4-e4af-15f1-94c3" name="Freeborn Command Squad" points="70.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true">
-      <entries>
-        <entry id="8b00-b972-e10d-1390" name="&lt; Freeborn Captain" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="b997-071f-1f47-aee8" name="&lt; Leader Level &gt;" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="ed96-be90-06f3-0beb" targetId="5a4c-2f5e-40a2-91d4" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="992a-ced2-9419-513c" name="&lt;Freeborn Captain Equipment &gt;" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups>
-                <entryGroup id="f80a-cee4-23df-5b8d" name="&lt; Armour &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="0ca1-9662-209b-eb0d" targetId="03c2-174e-8617-cf04" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-                <entryGroup id="a5f8-02a4-689a-510f" name="&lt; Weapons &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="c1d9-84de-92d6-cb72" targetId="e6db-6ed3-1a26-ea56" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-              </entryGroups>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="b36d-f9f6-80eb-6f8a" name="&lt; Freeborn Captain" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles/>
-          <links>
-            <link id="5545-8414-45f3-4c97" targetId="2d89-bcdb-b942-b900" linkType="profile">
+          <rules/>
+          <infoLinks>
+            <infoLink id="75cc-7baf-4390-4597" hidden="false" targetId="2d89-bcdb-b942-b900" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
+                  <repeats/>
                   <conditions>
-                    <condition parentId="15e4-e4af-15f1-94c3" childId="ed96-be90-06f3-0beb" field="selections" type="equal to" value="1.0"/>
+                    <condition field="selections" scope="b73b-6140-e2ca-f0c1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3a47-103d-769c-3d59" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="16e2-4b59-8a36-351a" name="Bodygaurds" points="26.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="70fa-1e75-d60b-2e16" name="&lt; Armour &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="ee93-85a8-a748-3858" name="&lt; Leader Level &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <links>
-                <link id="f41b-1c7d-c117-325d" targetId="03c2-174e-8617-cf04" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="3a47-103d-769c-3d59" hidden="false" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="05c5-0dc8-f360-2012" name="&lt; Weapons &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="0c11-a12d-3376-0b4b" name="&lt;Freeborn Captain Equipment &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <links>
-                <link id="b106-d8e7-67b5-3daf" targetId="059b-38f7-0313-5ae4" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="d72b-f17d-2842-5908" name="&lt; Armour &gt;" hidden="false" collective="false" defaultSelectionEntryId="d821-bfad-6e70-be4a">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="d821-bfad-6e70-be4a" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="6343-7996-c9c2-e583" name="&lt; Weapons &gt;" hidden="false" collective="false" defaultSelectionEntryId="c38c-46e0-0457-f57d">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="c38c-46e0-0457-f57d" hidden="false" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6b48-ec12-ab6c-2063" name="Bodyguards" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="16f3-2f8c-3e35-5557" hidden="false" targetId="9fba-d6b7-c66d-99f0" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers>
-            <modifier type="increment" field="maxSelections" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+            <modifier type="increment" field="maxSelections" value="2.0">
+              <repeats/>
               <conditions>
-                <condition parentId="roster" childId="3933-5e9f-f85c-ba75" field="selections" type="equal to" value="1.0"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3933-5e9f-f85c-ba75" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
           </modifiers>
-          <rules/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="c9a4-5ee7-f187-8235" name="&lt; Armour &gt;" hidden="false" collective="false" defaultSelectionEntryId="5b9a-d663-bb0e-6480">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="5b9a-d663-bb0e-6480" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="ce36-0f86-ad2b-2de0" name="&lt; Weapons &gt;" hidden="false" collective="false" defaultSelectionEntryId="ffe5-b36e-981d-67c8">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="ffe5-b36e-981d-67c8" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="21.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="87b2-db05-700b-2ce2" name="&lt; Unit Options &gt;" hidden="false" collective="false">
           <profiles/>
-          <links>
-            <link id="5e80-a56f-41a7-b337" targetId="9fba-d6b7-c66d-99f0" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="4fd9-336f-cb2a-74cb" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="5c84-6fcb-23cb-c531" targetId="f3aa-148a-0460-c7e5" linkType="entry">
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="4e48-b0be-38f0-fb84" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="0534-209c-6e63-b751" targetId="502c-9855-7269-eaa2" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="25ec-bc01-1917-42a1" hidden="false" targetId="502c-9855-7269-eaa2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="3cc5-bd4f-f987-bb96" targetId="573b-88bc-97d7-d890" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="e804-8e7c-7660-6271" hidden="false" targetId="573b-88bc-97d7-d890" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="9289-3ce8-ce3b-c398" targetId="d118-8115-df5f-2402" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="19db-d0e1-8415-81fa" hidden="false" targetId="d118-8115-df5f-2402" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="set" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="points" value="2.0">
+                  <repeats/>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="15e4-e4af-15f1-94c3" incrementChildId="16e2-4b59-8a36-351a" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="b73b-6140-e2ca-f0c1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6b48-ec12-ab6c-2063" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers>
-        <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-          <conditions>
-            <condition parentId="roster" childId="7f96-ddf7-af5d-958a" field="selections" type="equal to" value="1.0"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="4224-b512-8e27-a7ae" name="Freeborn Command Squad" points="70.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true">
-      <entries>
-        <entry id="8166-8ae2-85a7-d508" name="&lt; Freeborn Captain" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="ec55-a3a6-79d2-3d8d" name="&lt; Leader Level &gt;" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="7539-56fe-d7c4-3436" targetId="5a4c-2f5e-40a2-91d4" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="bc83-ae90-8685-ec61" name="&lt;Freeborn Captain Equipment &gt;" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups>
-                <entryGroup id="8610-880b-d363-2842" name="&lt; Armour &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="9413-43f9-5e3c-0e39" targetId="03c2-174e-8617-cf04" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-                <entryGroup id="b05f-e970-7acf-b5c2" name="&lt; Weapons &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="dc7e-0219-458d-80af" targetId="e6db-6ed3-1a26-ea56" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-              </entryGroups>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="74c9-0721-edb2-fe31" targetId="2d89-bcdb-b942-b900" linkType="profile">
+              <constraints/>
+            </entryLink>
+            <entryLink id="3b4d-27c4-5549-02cb" hidden="false" targetId="4b9d-a0bf-396e-384b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="hidden" value="false">
+                  <repeats/>
                   <conditions>
-                    <condition parentId="4224-b512-8e27-a7ae" childId="ec55-a3a6-79d2-3d8d" field="selections" type="equal to" value="1.0"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad0d-a741-67ad-5d5c" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="733f-d5cf-9ed2-cd37" name="Bodygaurds" points="26.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="2a25-debf-a112-08f8" name="&lt; Armour &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="94d8-34e0-0bd0-2f8f" targetId="03c2-174e-8617-cf04" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="64e2-25c4-0a20-fd6f" name="&lt; Weapons &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="f2d1-fbb0-ae51-637a" targetId="059b-38f7-0313-5ae4" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers>
-            <modifier type="increment" field="maxSelections" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions>
-                <condition parentId="roster" childId="3933-5e9f-f85c-ba75" field="selections" type="equal to" value="1.0"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="433d-17af-98e2-e708" targetId="9fba-d6b7-c66d-99f0" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="01c0-de81-eb4f-6520" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="2313-6b51-b6fc-4334" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="55b3-8e97-1f9f-99c1" targetId="502c-9855-7269-eaa2" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="6334-02c5-fe28-46b2" targetId="573b-88bc-97d7-d890" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="94a7-abc4-e849-288a" targetId="d118-8115-df5f-2402" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="2c36-464a-243b-0e55" hidden="false" targetId="1707-586b-01df-0f80" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="set" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="4224-b512-8e27-a7ae" incrementChildId="733f-d5cf-9ed2-cd37" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
+                <modifier type="set" field="hidden" value="false">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d17a-ef4d-2148-25e8" type="equalTo"/>
+                  </conditions>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+              <constraints/>
+            </entryLink>
+            <entryLink id="8de0-52be-784c-00ce" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="hidden" value="false">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a400-34cd-f726-fbf6" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="69.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="15e4-e4af-15f1-94c3" name="Freeborn Command Squad" hidden="true" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers>
-        <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+        <modifier type="set" field="hidden" value="false">
+          <repeats/>
           <conditions>
-            <condition parentId="roster" childId="a90a-cec1-cd13-3c17" field="selections" type="equal to" value="1.0"/>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f96-ddf7-af5d-958a" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
       </modifiers>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="0f65-b8ed-b8b2-294a" name="Freeborn Command Squad" points="70.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true">
-      <entries>
-        <entry id="6f3f-e7de-8b1f-9a45" name="&lt; Freeborn Captain" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="3f21-c5d0-9056-3513" name="&lt; Leader Level &gt;" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="8b00-b972-e10d-1390" name="&lt; Freeborn Captain" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="5545-8414-45f3-4c97" hidden="false" targetId="2d89-bcdb-b942-b900" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="15e4-e4af-15f1-94c3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ed96-be90-06f3-0beb" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="b997-071f-1f47-aee8" name="&lt; Leader Level &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <links>
-                <link id="6ef1-5f41-d717-8432" targetId="5a4c-2f5e-40a2-91d4" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="ed96-be90-06f3-0beb" hidden="false" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="eba6-42f4-e601-d9d4" name="&lt;Freeborn Captain Equipment &gt;" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups>
-                <entryGroup id="0c25-94d1-2ee1-8f97" name="&lt; Armour &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="992a-ced2-9419-513c" name="&lt;Freeborn Captain Equipment &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="f80a-cee4-23df-5b8d" name="&lt; Armour &gt;" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                  <links>
-                    <link id="fd6b-8d29-bb72-1f1a" targetId="03c2-174e-8617-cf04" linkType="entry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="0ca1-9662-209b-eb0d" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
                       <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-                <entryGroup id="1d89-7fac-a8ca-dea9" name="&lt; Weapons &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="a5f8-02a4-689a-510f" name="&lt; Weapons &gt;" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                  <links>
-                    <link id="bfcd-6dc1-7032-9eca" targetId="059b-38f7-0313-5ae4" linkType="entry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="c1d9-84de-92d6-cb72" hidden="false" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="16e2-4b59-8a36-351a" name="Bodygaurds" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="5e80-a56f-41a7-b337" hidden="false" targetId="9fba-d6b7-c66d-99f0" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="maxSelections" value="2.0">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3933-5e9f-f85c-ba75" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="70fa-1e75-d60b-2e16" name="&lt; Armour &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="f41b-1c7d-c117-325d" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="05c5-0dc8-f360-2012" name="&lt; Weapons &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="b106-d8e7-67b5-3daf" hidden="false" targetId="059b-38f7-0313-5ae4" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="26.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="4fd9-336f-cb2a-74cb" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="5c84-6fcb-23cb-c531" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="0534-209c-6e63-b751" hidden="false" targetId="502c-9855-7269-eaa2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="3cc5-bd4f-f987-bb96" hidden="false" targetId="573b-88bc-97d7-d890" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="9289-3ce8-ce3b-c398" hidden="false" targetId="d118-8115-df5f-2402" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="2.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="15e4-e4af-15f1-94c3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="16e2-4b59-8a36-351a" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="70.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4224-b512-8e27-a7ae" name="Freeborn Command Squad" hidden="true" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a90a-cec1-cd13-3c17" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="8166-8ae2-85a7-d508" name="&lt; Freeborn Captain" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="74c9-0721-edb2-fe31" hidden="false" targetId="2d89-bcdb-b942-b900" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="4224-b512-8e27-a7ae" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ec55-a3a6-79d2-3d8d" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="ec55-a3a6-79d2-3d8d" name="&lt; Leader Level &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="7539-56fe-d7c4-3436" hidden="false" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="bc83-ae90-8685-ec61" name="&lt;Freeborn Captain Equipment &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="8610-880b-d363-2842" name="&lt; Armour &gt;" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="9413-43f9-5e3c-0e39" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="b05f-e970-7acf-b5c2" name="&lt; Weapons &gt;" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="dc7e-0219-458d-80af" hidden="false" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="733f-d5cf-9ed2-cd37" name="Bodygaurds" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="433d-17af-98e2-e708" hidden="false" targetId="9fba-d6b7-c66d-99f0" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="maxSelections" value="2.0">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3933-5e9f-f85c-ba75" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="2a25-debf-a112-08f8" name="&lt; Armour &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="94d8-34e0-0bd0-2f8f" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="64e2-25c4-0a20-fd6f" name="&lt; Weapons &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="f2d1-fbb0-ae51-637a" hidden="false" targetId="059b-38f7-0313-5ae4" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="26.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="01c0-de81-eb4f-6520" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="2313-6b51-b6fc-4334" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="55b3-8e97-1f9f-99c1" hidden="false" targetId="502c-9855-7269-eaa2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="6334-02c5-fe28-46b2" hidden="false" targetId="573b-88bc-97d7-d890" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="94a7-abc4-e849-288a" hidden="false" targetId="d118-8115-df5f-2402" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="2.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="4224-b512-8e27-a7ae" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="733f-d5cf-9ed2-cd37" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="70.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0f65-b8ed-b8b2-294a" name="Freeborn Command Squad" hidden="true" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a04c-3029-b790-0cdb" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="6f3f-e7de-8b1f-9a45" name="&lt; Freeborn Captain" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="9559-7359-c187-35e7" hidden="false" targetId="2d89-bcdb-b942-b900" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="0f65-b8ed-b8b2-294a" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6ef1-5f41-d717-8432" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="3f21-c5d0-9056-3513" name="&lt; Leader Level &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="6ef1-5f41-d717-8432" hidden="false" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="eba6-42f4-e601-d9d4" name="&lt;Freeborn Captain Equipment &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="0c25-94d1-2ee1-8f97" name="&lt; Armour &gt;" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="fd6b-8d29-bb72-1f1a" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="1d89-7fac-a8ca-dea9" name="&lt; Weapons &gt;" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="bfcd-6dc1-7032-9eca" hidden="false" targetId="059b-38f7-0313-5ae4" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
                       <modifiers>
-                        <modifier type="set" field="points" value="8.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                        <modifier type="set" field="points" value="8.0">
+                          <repeats/>
                           <conditions/>
                           <conditionGroups/>
                         </modifier>
                       </modifiers>
-                    </link>
-                  </links>
-                </entryGroup>
-              </entryGroups>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f539-7c50-1fed-c0fe" name="Bodygaurds" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles/>
-          <links>
-            <link id="9559-7359-c187-35e7" targetId="2d89-bcdb-b942-b900" linkType="profile">
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="0f65-b8ed-b8b2-294a" childId="6ef1-5f41-d717-8432" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="f539-7c50-1fed-c0fe" name="Bodygaurds" points="26.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="db1b-d74c-4488-f114" name="&lt; Armour &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="c830-2ab1-3be7-3427" hidden="false" targetId="9fba-d6b7-c66d-99f0" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <links>
-                <link id="9dbd-a1b9-f7e2-b802" targetId="03c2-174e-8617-cf04" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="da8e-2b95-0031-818a" name="&lt; Weapons &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="bcc8-515f-8cbc-7a6c" targetId="b018-6101-d2e3-b4ea" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
+            </infoLink>
+          </infoLinks>
           <modifiers>
-            <modifier type="increment" field="maxSelections" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+            <modifier type="increment" field="maxSelections" value="2.0">
+              <repeats/>
               <conditions>
-                <condition parentId="roster" childId="3933-5e9f-f85c-ba75" field="selections" type="equal to" value="1.0"/>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3933-5e9f-f85c-ba75" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
           </modifiers>
-          <rules/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="db1b-d74c-4488-f114" name="&lt; Armour &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="9dbd-a1b9-f7e2-b802" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="da8e-2b95-0031-818a" name="&lt; Weapons &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="bcc8-515f-8cbc-7a6c" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="26.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6c4b-1586-3d8b-dbda" name="&lt; Unit Options &gt;" hidden="false" collective="false">
           <profiles/>
-          <links>
-            <link id="c830-2ab1-3be7-3427" targetId="9fba-d6b7-c66d-99f0" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="6c4b-1586-3d8b-dbda" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="712a-24b1-dd4d-c34e" targetId="f3aa-148a-0460-c7e5" linkType="entry">
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="712a-24b1-dd4d-c34e" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="7484-dc39-dbc9-ced2" targetId="502c-9855-7269-eaa2" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="7484-dc39-dbc9-ced2" hidden="false" targetId="502c-9855-7269-eaa2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="2981-4427-c93a-87d1" targetId="573b-88bc-97d7-d890" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="2981-4427-c93a-87d1" hidden="false" targetId="573b-88bc-97d7-d890" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="7113-0a49-238b-ccc3" targetId="d118-8115-df5f-2402" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="7113-0a49-238b-ccc3" hidden="false" targetId="d118-8115-df5f-2402" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="set" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="points" value="2.0">
+                  <repeats/>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="0f65-b8ed-b8b2-294a" incrementChildId="f539-7c50-1fed-c0fe" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="0f65-b8ed-b8b2-294a" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f539-7c50-1fed-c0fe" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="70.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ff83-951c-1523-67b4" name="Freeborn Command Squad" hidden="true" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers>
-        <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+        <modifier type="set" field="hidden" value="false">
+          <repeats/>
           <conditions>
-            <condition parentId="roster" childId="a04c-3029-b790-0cdb" field="selections" type="equal to" value="1.0"/>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6559-a8ba-d266-7c27" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
       </modifiers>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="ff83-951c-1523-67b4" name="Freeborn Command Squad" points="70.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true">
-      <entries>
-        <entry id="0b68-b15d-4f21-400d" name="&lt; Freeborn Captain" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="4f77-859f-d36f-3f51" name="&lt; Leader Level &gt;" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="0b68-b15d-4f21-400d" name="&lt; Freeborn Captain" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="865b-5fee-3347-eedb" hidden="false" targetId="2d89-bcdb-b942-b900" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="ff83-951c-1523-67b4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fab0-fb87-4db4-b758" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="4f77-859f-d36f-3f51" name="&lt; Leader Level &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <links>
-                <link id="fab0-fb87-4db4-b758" targetId="5a4c-2f5e-40a2-91d4" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="fab0-fb87-4db4-b758" hidden="false" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="534d-0cc6-dc8f-0e4a" name="&lt;Freeborn Captain Equipment &gt;" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups>
-                <entryGroup id="6168-628e-5ed2-eaa9" name="&lt; Armour &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="534d-0cc6-dc8f-0e4a" name="&lt;Freeborn Captain Equipment &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="6168-628e-5ed2-eaa9" name="&lt; Armour &gt;" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                  <links>
-                    <link id="be23-8e40-689c-4584" targetId="eff8-bb0e-1b1d-bbb2" linkType="entry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="be23-8e40-689c-4584" hidden="false" targetId="eff8-bb0e-1b1d-bbb2" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
                       <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-                <entryGroup id="5ec4-d224-e3cc-e5a6" name="&lt; Weapons &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="5ec4-d224-e3cc-e5a6" name="&lt; Weapons &gt;" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                  <links>
-                    <link id="bff1-9762-306f-171b" targetId="b018-6101-d2e3-b4ea" linkType="entry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="bff1-9762-306f-171b" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
                       <modifiers>
-                        <modifier type="set" field="points" value="8.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                        <modifier type="set" field="points" value="8.0">
+                          <repeats/>
                           <conditions/>
                           <conditionGroups/>
                         </modifier>
                       </modifiers>
-                    </link>
-                  </links>
-                </entryGroup>
-              </entryGroups>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b52c-6be6-7a76-ba77" name="Bodygaurds" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles/>
-          <links>
-            <link id="865b-5fee-3347-eedb" targetId="2d89-bcdb-b942-b900" linkType="profile">
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="ff83-951c-1523-67b4" childId="fab0-fb87-4db4-b758" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="b52c-6be6-7a76-ba77" name="Bodygaurds" points="26.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="48ac-19f4-04e6-2834" name="&lt; Armour &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="f1f4-b68d-48a0-6c7f" targetId="eff8-bb0e-1b1d-bbb2" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="1095-6dad-810d-ff4f" name="&lt; Weapons &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="dde5-232c-c035-35fa" targetId="b018-6101-d2e3-b4ea" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
           <rules/>
-          <profiles/>
-          <links>
-            <link id="248c-567b-902f-d5d5" targetId="9fba-d6b7-c66d-99f0" linkType="profile">
+          <infoLinks>
+            <infoLink id="248c-567b-902f-d5d5" hidden="false" targetId="9fba-d6b7-c66d-99f0" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="4329-ec3b-739b-0050" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-          <links>
-            <link id="9bc9-cab0-4841-6c2c" targetId="f3aa-148a-0460-c7e5" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="48ac-19f4-04e6-2834" name="&lt; Armour &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="c86a-f1fe-6d59-873f" targetId="502c-9855-7269-eaa2" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="f1f4-b68d-48a0-6c7f" hidden="false" targetId="eff8-bb0e-1b1d-bbb2" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="1095-6dad-810d-ff4f" name="&lt; Weapons &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="e0aa-ee5e-c24a-c338" targetId="573b-88bc-97d7-d890" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="dde5-232c-c035-35fa" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="26.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="4329-ec3b-739b-0050" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="9bc9-cab0-4841-6c2c" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="0aac-c5ca-badb-4434" targetId="d118-8115-df5f-2402" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="c86a-f1fe-6d59-873f" hidden="false" targetId="502c-9855-7269-eaa2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="e0aa-ee5e-c24a-c338" hidden="false" targetId="573b-88bc-97d7-d890" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="0aac-c5ca-badb-4434" hidden="false" targetId="d118-8115-df5f-2402" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="set" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="points" value="2.0">
+                  <repeats/>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="ff83-951c-1523-67b4" incrementChildId="b52c-6be6-7a76-ba77" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="ff83-951c-1523-67b4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b52c-6be6-7a76-ba77" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="70.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d603-36ff-a2eb-312f" name="Freeborn Command Squad" hidden="true" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers>
-        <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+        <modifier type="set" field="hidden" value="false">
+          <repeats/>
           <conditions>
-            <condition parentId="roster" childId="6559-a8ba-d266-7c27" field="selections" type="equal to" value="1.0"/>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1ef5-d006-6a32-fddb" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
       </modifiers>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="d603-36ff-a2eb-312f" name="Freeborn Command Squad" points="70.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true">
-      <entries>
-        <entry id="3c30-80dd-c936-7ccf" name="&lt; Freeborn Captain" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="6111-3b3b-a2ef-bdbc" name="&lt; Leader Level &gt;" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="7671-d1cb-8583-32f9" targetId="5a4c-2f5e-40a2-91d4" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="c091-1c08-a4c1-1e30" name="&lt;Freeborn Captain Equipment &gt;" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups>
-                <entryGroup id="90d1-c02b-6791-3678" name="&lt; Armour &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="ef1a-0b88-41e9-520f" targetId="eb94-d1e8-1084-71b3" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-                <entryGroup id="954d-9823-9e71-fdb2" name="&lt; Weapons &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="9620-1c29-bbc5-277d" targetId="e6db-6ed3-1a26-ea56" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-              </entryGroups>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="3c30-80dd-c936-7ccf" name="&lt; Freeborn Captain" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles/>
-          <links>
-            <link id="86ad-520b-f8d8-0b4d" targetId="2d89-bcdb-b942-b900" linkType="profile">
+          <rules/>
+          <infoLinks>
+            <infoLink id="86ad-520b-f8d8-0b4d" hidden="false" targetId="2d89-bcdb-b942-b900" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
+                  <repeats/>
                   <conditions>
-                    <condition parentId="d603-36ff-a2eb-312f" childId="7671-d1cb-8583-32f9" field="selections" type="equal to" value="1.0"/>
+                    <condition field="selections" scope="d603-36ff-a2eb-312f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7671-d1cb-8583-32f9" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="70ef-17b0-4cc6-59d6" name="Bodygaurds" points="26.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="b2b0-8472-6f6f-b03b" name="&lt; Armour &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="4966-a136-1d34-1648" targetId="eb94-d1e8-1084-71b3" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="cd16-bf68-6808-737f" name="&lt; Weapons &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="7c24-c3ed-edef-f97d" targetId="b018-6101-d2e3-b4ea" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-          <rules/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="6111-3b3b-a2ef-bdbc" name="&lt; Leader Level &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="7671-d1cb-8583-32f9" hidden="false" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="c091-1c08-a4c1-1e30" name="&lt;Freeborn Captain Equipment &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="90d1-c02b-6791-3678" name="&lt; Armour &gt;" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="ef1a-0b88-41e9-520f" hidden="false" targetId="eb94-d1e8-1084-71b3" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+                <selectionEntryGroup id="954d-9823-9e71-fdb2" name="&lt; Weapons &gt;" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="9620-1c29-bbc5-277d" hidden="false" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="70ef-17b0-4cc6-59d6" name="Bodygaurds" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles/>
-          <links>
-            <link id="8523-7e21-40bd-02f6" targetId="9fba-d6b7-c66d-99f0" linkType="profile">
+          <rules/>
+          <infoLinks>
+            <infoLink id="8523-7e21-40bd-02f6" hidden="false" targetId="9fba-d6b7-c66d-99f0" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="1359-b8c0-aedb-1bbe" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-          <links>
-            <link id="3c36-c80e-c93c-f6a4" targetId="f3aa-148a-0460-c7e5" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="b2b0-8472-6f6f-b03b" name="&lt; Armour &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="9092-1d24-81d4-4b37" targetId="502c-9855-7269-eaa2" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="4966-a136-1d34-1648" hidden="false" targetId="eb94-d1e8-1084-71b3" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="cd16-bf68-6808-737f" name="&lt; Weapons &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="e184-cee5-0fd5-9e41" targetId="573b-88bc-97d7-d890" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="7c24-c3ed-edef-f97d" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="26.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="1359-b8c0-aedb-1bbe" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="3c36-c80e-c93c-f6a4" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="6f0c-0da4-1e67-2635" targetId="d118-8115-df5f-2402" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="9092-1d24-81d4-4b37" hidden="false" targetId="502c-9855-7269-eaa2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="e184-cee5-0fd5-9e41" hidden="false" targetId="573b-88bc-97d7-d890" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="6f0c-0da4-1e67-2635" hidden="false" targetId="d118-8115-df5f-2402" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="set" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="points" value="2.0">
+                  <repeats/>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="d603-36ff-a2eb-312f" incrementChildId="70ef-17b0-4cc6-59d6" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="d603-36ff-a2eb-312f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70ef-17b0-4cc6-59d6" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers>
-        <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-          <conditions>
-            <condition parentId="roster" childId="1ef5-d006-6a32-fddb" field="selections" type="equal to" value="1.0"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <rules/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="70.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6a1d-c668-c7e8-ed9f" name="Freeborn Heavy Support Team" book="BtGoA" page="194" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="6a1d-c668-c7e8-ed9f" name="Freeborn Heavy Support Team" points="25.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="194">
-      <entries>
-        <entry id="d45c-a6e2-b912-4bcd" name="Freeborn Crew" points="12.0" categoryId="(No Category)" type="upgrade" minSelections="3" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="193">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="8b71-ca9c-1ca2-0abc" name="&lt; Unit Weapon &gt;" defaultEntryId="42ad-31e5-60a7-9e01" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="42ad-31e5-60a7-9e01" targetId="8690-3ab7-9fef-06ee" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="d718-d349-ce44-fe7e" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="9dd0-b9bb-59a6-5f05" name="&lt; Unit Armor &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="7632-f6c2-622d-6f3a" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="4d7b-6ff6-c6f1-e988" targetId="7267-3051-f1b4-0a88" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="e688-49e6-a2dd-5f3f" targetId="87a3-460d-879a-92a5" linkType="profile">
-              <modifiers>
-                <modifier type="show" field="None" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="6a1d-c668-c7e8-ed9f" childId="5afb-493a-f716-72df" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="a4e6-016c-c52f-4548" name="&lt; Support Weapon &gt;" defaultEntryId="f434-b021-4e80-826a" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="f434-b021-4e80-826a" targetId="cea7-8511-2208-1b1f" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="a076-8dc7-3360-7f97" targetId="b9f1-a313-3e59-57ab" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="9d3d-0bdc-592a-8e5a" targetId="9733-7039-e306-26b5" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="a2ac-6dfc-f14e-fcab" targetId="5149-5183-64d5-feaf" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="16f8-cbcf-1527-66e2" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="5afb-493a-f716-72df" name="Promote Crew Member to Leader" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="fb3e-d593-1cf1-ad9d" targetId="fc7e-7c0e-65e0-8c33" linkType="entry">
-                  <modifiers>
-                    <modifier type="set" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <links>
-            <link id="b8ea-0f50-8af5-3fec" targetId="d571-d584-85fc-9110" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="97c0-d505-6d11-a769" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="b771-d383-4d92-ea6b" targetId="4364-45ee-ee83-ca30" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="6a1d-c668-c7e8-ed9f" incrementChildId="d45c-a6e2-b912-4bcd" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
       <rules>
         <rule id="99d8-ad33-bc0e-0a91" name="Weapon Team Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="b8d9-62b2-a114-98f3" targetId="e329-9443-6cb2-bc53" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="0223-7d39-0a7c-f8a9" name="Freeborn Skyraider Squad" points="121.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="174">
-      <entries>
-        <entry id="cffa-15d6-0631-ed32" name="&lt; Skyraider Leader" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="192">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="6fb4-5cba-7e48-83e2" name="Leader Level" defaultEntryId="e5fb-0118-831e-f517" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="86cc-1a90-418d-75d5" targetId="02f3-3134-ae39-afed" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="e5fb-0118-831e-f517" targetId="fc7e-7c0e-65e0-8c33" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="d45c-a6e2-b912-4bcd" name="Freeborn Crew" book="BtGoA" page="193" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles/>
-          <links>
-            <link id="7e77-cac2-feab-67d6" targetId="5c9b-1bde-ee01-04a4" linkType="rule">
+          <rules/>
+          <infoLinks>
+            <infoLink id="4d7b-6ff6-c6f1-e988" hidden="false" targetId="7267-3051-f1b4-0a88" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="a17a-173b-6907-b7ee" targetId="7bc9-5e98-2914-5abd" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="1491-1d08-a7c9-d0f4" targetId="e18f-34de-2624-4133" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="212a-5750-9cf2-9c7a" targetId="e18f-34de-2624-4133" linkType="profile">
+            </infoLink>
+            <infoLink id="e688-49e6-a2dd-5f3f" hidden="false" targetId="87a3-460d-879a-92a5" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Large, Fast, Leader 2" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="hidden" value="false">
+                  <repeats/>
                   <conditions>
-                    <condition parentId="cffa-15d6-0631-ed32" childId="86cc-1a90-418d-75d5" field="selections" type="equal to" value="1.0"/>
+                    <condition field="selections" scope="6a1d-c668-c7e8-ed9f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5afb-493a-f716-72df" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="b5b1-72ee-b28c-ed4a" name="Skyraider Trooper" points="0.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="192">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="d042-54cc-962c-5c4e" name="&lt; Ranged Weapon &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="8b71-ca9c-1ca2-0abc" name="&lt; Unit Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="42ad-31e5-60a7-9e01">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <links>
-                <link id="60da-034a-d954-5cfc" targetId="84ac-0f31-c388-d0bd" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="42ad-31e5-60a7-9e01" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="d718-d349-ce44-fe7e" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="3.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="9dd0-b9bb-59a6-5f05" name="&lt; Unit Armor &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="7632-f6c2-622d-6f3a" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="12.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="a4e6-016c-c52f-4548" name="&lt; Support Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="f434-b021-4e80-826a">
           <profiles/>
-          <links>
-            <link id="7303-1648-6de4-25ea" targetId="a654-5213-64f2-703a" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="84fe-b5cd-ab19-23e4" name="&lt; Skyraider &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="87a0-db4c-17e6-d240" targetId="a1a8-ba0b-2e45-8020" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="f434-b021-4e80-826a" hidden="false" targetId="cea7-8511-2208-1b1f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="46d3-88f8-ecac-204c" name="&lt; Special Weapon Option &gt;" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="a076-8dc7-3360-7f97" hidden="false" targetId="b9f1-a313-3e59-57ab" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="9d3d-0bdc-592a-8e5a" hidden="false" targetId="9733-7039-e306-26b5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="a2ac-6dfc-f14e-fcab" hidden="false" targetId="5149-5183-64d5-feaf" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="16f8-cbcf-1527-66e2" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="e34a-7c57-c72d-b20e" targetId="47d9-8149-9744-9849" linkType="entry">
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="5afb-493a-f716-72df" name="Promote Crew Member to Leader" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="8a5a-b8d3-b9f7-cffb" targetId="a00c-0542-f2a5-8124" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="fb3e-d593-1cf1-ad9d" hidden="false" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="10.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="b8ea-0f50-8af5-3fec" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="f5d5-4b78-eab5-56a2" name="&lt; Unit Armor &gt;" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="97c0-d505-6d11-a769" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="b771-d383-4d92-ea6b" hidden="false" targetId="4364-45ee-ee83-ca30" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="6a1d-c668-c7e8-ed9f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d45c-a6e2-b912-4bcd" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="b8d9-62b2-a114-98f3" hidden="false" targetId="e329-9443-6cb2-bc53" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="3304-35c1-b35b-5a16" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="41f4-516b-6edc-fa24" targetId="2e3d-bbaa-3f5c-ac53" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="d56e-be22-258f-698c" name="&lt; Unit Options &gt; " minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="a434-7a9b-75cb-d4be" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0223-7d39-0a7c-f8a9" name="Freeborn Skyraider Squad" book="BtGoA" page="174" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
       <rules>
         <rule id="a61b-d8b1-c4a3-6102" name="Mounted Command Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
         <rule id="572f-a685-c7aa-3d42" name="Limited Choice" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="c8b0-00c2-4509-d681" targetId="b0ca-8e7d-d03f-f027" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="3fb0-934a-d1a8-ed1e" targetId="a221-d53c-b4bd-b52c" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="0f2b-5fd2-86c3-563b" name="Freeborn Support Team" points="10.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="193">
-      <entries>
-        <entry id="3b68-a4c9-03bb-dd68" name="Freeborn Crew" points="12.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="193">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="09ce-fa1f-63c6-0dee" name="&lt; Unit Weapon &gt;" defaultEntryId="e022-953c-7321-fa34" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="e022-953c-7321-fa34" targetId="8690-3ab7-9fef-06ee" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="af1b-11cd-5a0f-d758" name="&lt; Unit Armor &gt;" defaultEntryId="20cd-dacc-9c25-5545" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="20cd-dacc-9c25-5545" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+      <infoLinks>
+        <infoLink id="c8b0-00c2-4509-d681" hidden="false" targetId="b0ca-8e7d-d03f-f027" type="rule">
           <profiles/>
-          <links>
-            <link id="6f07-d1a0-a27b-5ab4" targetId="c245-fa49-1569-2f23" linkType="profile">
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3fb0-934a-d1a8-ed1e" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="cffa-15d6-0631-ed32" name="&lt; Skyraider Leader" book="BtGoA" page="192" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="7e77-cac2-feab-67d6" hidden="false" targetId="5c9b-1bde-ee01-04a4" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="0ced-d327-0411-d442" targetId="a770-8327-b96d-b92e" linkType="profile">
+            </infoLink>
+            <infoLink id="a17a-173b-6907-b7ee" hidden="false" targetId="7bc9-5e98-2914-5abd" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="1491-1d08-a7c9-d0f4" hidden="false" targetId="e18f-34de-2624-4133" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="212a-5750-9cf2-9c7a" hidden="false" targetId="e18f-34de-2624-4133" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="show" field="None" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Large, Fast, Leader 2">
+                  <repeats/>
                   <conditions>
-                    <condition parentId="0f2b-5fd2-86c3-563b" childId="8943-c8c6-eaa4-c959" field="selections" type="equal to" value="1.0"/>
+                    <condition field="selections" scope="cffa-15d6-0631-ed32" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="86cc-1a90-418d-75d5" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="85a1-9aa5-986c-0134" name="Weapon" defaultEntryId="5764-6087-e7b6-4c73" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-          <links>
-            <link id="7198-55af-d564-f2fd" targetId="6a2b-50c5-9a33-b756" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="4711-a1d0-8193-4ddf" targetId="eed0-b68f-b5fb-92c7" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="6fb4-5cba-7e48-83e2" name="Leader Level" hidden="false" collective="false" defaultSelectionEntryId="e5fb-0118-831e-f517">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="5764-6087-e7b6-4c73" targetId="a00c-0542-f2a5-8124" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="86cc-1a90-418d-75d5" hidden="false" targetId="02f3-3134-ae39-afed" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="e5fb-0118-831e-f517" hidden="false" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b5b1-72ee-b28c-ed4a" name="Skyraider Trooper" book="BtGoA" page="192" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="7303-1648-6de4-25ea" hidden="false" targetId="a654-5213-64f2-703a" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="8c57-5f05-54c3-3b50" targetId="93db-3751-fdd4-08f9" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="40.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="0bef-09de-cda1-001e" targetId="c2bf-0272-30c6-dd20" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="35.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="3f8a-3a73-e583-707c" targetId="cf3a-e6a9-bdc0-e0ae" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="30.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="a7eb-103f-f984-c4f9" targetId="71c9-4382-01cf-c737" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="52c4-3f29-7cff-341f" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="3860-7352-2507-b377" name="Promote Crew Member to Leader" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="d042-54cc-962c-5c4e" name="&lt; Ranged Weapon &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <links>
-                <link id="8943-c8c6-eaa4-c959" targetId="fc7e-7c0e-65e0-8c33" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="60da-034a-d954-5cfc" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="84fe-b5cd-ab19-23e4" name="&lt; Skyraider &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="87a0-db4c-17e6-d240" hidden="false" targetId="a1a8-ba0b-2e45-8020" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="46d3-88f8-ecac-204c" name="&lt; Special Weapon Option &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="e34a-7c57-c72d-b20e" hidden="false" targetId="47d9-8149-9744-9849" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="8a5a-b8d3-b9f7-cffb" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="f5d5-4b78-eab5-56a2" name="&lt; Unit Armor &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="3304-35c1-b35b-5a16" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="41f4-516b-6edc-fa24" hidden="false" targetId="2e3d-bbaa-3f5c-ac53" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d56e-be22-258f-698c" name="&lt; Unit Options &gt; " hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="a434-7a9b-75cb-d4be" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="121.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0f2b-5fd2-86c3-563b" name="Freeborn Support Team" book="BtGoA" page="193" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="a6d0-fc64-ad5d-674a" name="Weapon Team Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="3b68-a4c9-03bb-dd68" name="Freeborn Crew" book="BtGoA" page="193" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="6f07-d1a0-a27b-5ab4" hidden="false" targetId="c245-fa49-1569-2f23" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="0ced-d327-0411-d442" hidden="false" targetId="a770-8327-b96d-b92e" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="0f2b-5fd2-86c3-563b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8943-c8c6-eaa4-c959" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="09ce-fa1f-63c6-0dee" name="&lt; Unit Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="e022-953c-7321-fa34">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="e022-953c-7321-fa34" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="af1b-11cd-5a0f-d758" name="&lt; Unit Armor &gt;" hidden="false" collective="false" defaultSelectionEntryId="20cd-dacc-9c25-5545">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="20cd-dacc-9c25-5545" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="12.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="85a1-9aa5-986c-0134" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="5764-6087-e7b6-4c73">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="7198-55af-d564-f2fd" hidden="false" targetId="6a2b-50c5-9a33-b756" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="4711-a1d0-8193-4ddf" hidden="false" targetId="eed0-b68f-b5fb-92c7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="5764-6087-e7b6-4c73" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="8c57-5f05-54c3-3b50" hidden="false" targetId="93db-3751-fdd4-08f9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="40.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="0bef-09de-cda1-001e" hidden="false" targetId="c2bf-0272-30c6-dd20" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="35.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="3f8a-3a73-e583-707c" hidden="false" targetId="cf3a-e6a9-bdc0-e0ae" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="30.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="a7eb-103f-f984-c4f9" hidden="false" targetId="71c9-4382-01cf-c737" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="52c4-3f29-7cff-341f" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="3860-7352-2507-b377" name="Promote Crew Member to Leader" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="8943-c8c6-eaa4-c959" hidden="false" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers>
-                    <modifier type="set" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                    <modifier type="set" field="points" value="10.0">
+                      <repeats/>
                       <conditions/>
                       <conditionGroups/>
                     </modifier>
                   </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <links>
-            <link id="d6e9-f088-ecba-53b8" targetId="d571-d584-85fc-9110" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="e4a1-35cb-9989-c083" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="22d3-07af-fc6e-749c" targetId="4364-45ee-ee83-ca30" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="0f2b-5fd2-86c3-563b" incrementChildId="3b68-a4c9-03bb-dd68" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="a6d0-fc64-ad5d-674a" name="Weapon Team Unit" hidden="false">
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="cff3-e0da-411a-cbd9" name="Get Up!" points="10.0" categoryId="50ba-cf77-3941-189c" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="8563-f338-4ece-a2d7" targetId="2afe-05bf-268b-84c2" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="bd58-a73b-e17b-89ae" name="Light General Purpose Drone" points="20.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="196">
-      <entries>
-        <entry id="136e-670b-fde8-eb08" name="GP Drone" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="ee6d-c97a-5f05-6da2" targetId="2dbd-14c5-219e-d37d" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="3dc6-b2b7-80a4-d6db" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="7189-205b-e43f-4b47" name="Self Repair" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <rules/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="d6e9-f088-ecba-53b8" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
               <profiles/>
-              <links>
-                <link id="4f3f-a904-dfd8-30e0" targetId="3377-9408-33bb-6a02" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="e4a1-35cb-9989-c083" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="22d3-07af-fc6e-749c" hidden="false" targetId="4364-45ee-ee83-ca30" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="0f2b-5fd2-86c3-563b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3b68-a4c9-03bb-dd68" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cff3-e0da-411a-cbd9" name="Get Up!" hidden="false" collective="false" categoryEntryId="50ba-cf77-3941-189c" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="8563-f338-4ece-a2d7" hidden="false" targetId="2afe-05bf-268b-84c2" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="9c14-af40-c4a6-8c01" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="8fc1-59dc-574d-d478" targetId="d571-d584-85fc-9110" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="b30a-6adc-e0b9-35b5" targetId="1707-586b-01df-0f80" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="ee36-d310-391a-5a23" targetId="fb8b-7402-c5a9-8644" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bd58-a73b-e17b-89ae" name="Light General Purpose Drone" book="BtGoA" page="196" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit">
+      <profiles/>
       <rules>
-        <rule id="ae83-e15b-aca4-e246" name="Weapon Drone Unit" hidden="false" book="BtGoA">
+        <rule id="ae83-e15b-aca4-e246" name="Weapon Drone Unit" book="BtGoA" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="bd92-cca5-ea64-865d" targetId="e167-a8e4-c26a-cafd" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="68e5-824d-8e72-1018" name="Marksman" points="15.0" categoryId="50ba-cf77-3941-189c" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="1054-eaa0-48d3-3dfa" targetId="5741-af68-9dc0-519f" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="e1f2-aa77-1cf5-d89f" name="Pull Yourself Together!" points="15.0" categoryId="50ba-cf77-3941-189c" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="96ff-949d-ec39-33e0" targetId="8056-104a-5a5d-2089" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="969a-8139-9654-9cdf" name="Skyraider Command Squad" points="164.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="174">
-      <entries>
-        <entry id="d40e-0a4d-13fa-863b" name="&lt; Skyraider Captain" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="192">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="e0b2-8c3a-7575-9736" name="Leader Level" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="4ac0-b84e-687f-e73b" targetId="5a4c-2f5e-40a2-91d4" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+      <infoLinks>
+        <infoLink id="bd92-cca5-ea64-865d" hidden="false" targetId="e167-a8e4-c26a-cafd" type="rule">
           <profiles/>
-          <links>
-            <link id="0b4f-18e9-64d4-1bc8" targetId="5c9b-1bde-ee01-04a4" linkType="rule">
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="136e-670b-fde8-eb08" name="GP Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="ee6d-c97a-5f05-6da2" hidden="false" targetId="2dbd-14c5-219e-d37d" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="7780-1ba7-1b1c-b4c2" targetId="7bc9-5e98-2914-5abd" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="f186-3a30-6680-477f" targetId="e18f-34de-2624-4133" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="8ac3-35e0-d064-d5b0" targetId="74dc-b388-dc1d-fb61" linkType="profile">
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="3dc6-b2b7-80a4-d6db" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="7189-205b-e43f-4b47" name="Self Repair" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="4f3f-a904-dfd8-30e0" hidden="false" targetId="3377-9408-33bb-6a02" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
               <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command, Hero, Follow, Large, Fast, Leader 3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="9c14-af40-c4a6-8c01" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="8fc1-59dc-574d-d478" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="b30a-6adc-e0b9-35b5" hidden="false" targetId="1707-586b-01df-0f80" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="ee36-d310-391a-5a23" hidden="false" targetId="fb8b-7402-c5a9-8644" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="68e5-824d-8e72-1018" name="Marksman" hidden="false" collective="false" categoryEntryId="50ba-cf77-3941-189c" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="1054-eaa0-48d3-3dfa" hidden="false" targetId="5741-af68-9dc0-519f" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e1f2-aa77-1cf5-d89f" name="Pull Yourself Together!" hidden="false" collective="false" categoryEntryId="50ba-cf77-3941-189c" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="96ff-949d-ec39-33e0" hidden="false" targetId="8056-104a-5a5d-2089" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="969a-8139-9654-9cdf" name="Skyraider Command Squad" book="BtGoA" page="174" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="76be-d990-01b2-40b5" name="Mounted Command Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+        <rule id="801f-37d3-aeef-35ef" name="Limited Choice" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="8ada-48df-990a-b1c6" hidden="false" targetId="b0ca-8e7d-d03f-f027" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="0026-0fee-242b-f524" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="d40e-0a4d-13fa-863b" name="&lt; Skyraider Captain" book="BtGoA" page="192" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="0b4f-18e9-64d4-1bc8" hidden="false" targetId="5c9b-1bde-ee01-04a4" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="7780-1ba7-1b1c-b4c2" hidden="false" targetId="7bc9-5e98-2914-5abd" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="f186-3a30-6680-477f" hidden="false" targetId="e18f-34de-2624-4133" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="8ac3-35e0-d064-d5b0" hidden="false" targetId="74dc-b388-dc1d-fb61" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command, Hero, Follow, Large, Fast, Leader 3">
+                  <repeats/>
                   <conditions>
-                    <condition parentId="d40e-0a4d-13fa-863b" childId="4ac0-b84e-687f-e73b" field="selections" type="equal to" value="1.0"/>
+                    <condition field="selections" scope="d40e-0a4d-13fa-863b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4ac0-b84e-687f-e73b" type="equalTo"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="2c42-d94f-83c4-fb4f" name="Skyraider Trooper" points="0.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="192">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="62da-827c-1a4c-bfef" name="&lt; Ranged Weapon &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="e0b2-8c3a-7575-9736" name="Leader Level" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <links>
-                <link id="5c2c-6873-9857-0546" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="a18a-ce88-b9af-89e7" targetId="a654-5213-64f2-703a" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="2996-96fd-31e3-fe8c" name="&lt; Skyraider &gt;" defaultEntryId="92a3-2543-174e-504b" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="92a3-2543-174e-504b" targetId="a1a8-ba0b-2e45-8020" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="5f94-8423-056d-5f54" name="&lt; Special Weapon Option &gt;" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="b3cb-790e-d4ae-710a" targetId="47d9-8149-9744-9849" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="0f9b-216d-3f08-d82e" targetId="a00c-0542-f2a5-8124" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="2d2f-4f61-9b31-50b5" name="&lt; Unit Armor &gt;" defaultEntryId="6df8-de07-b4b9-201f" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="6df8-de07-b4b9-201f" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="0eff-479f-05c9-7f65" targetId="2e3d-bbaa-3f5c-ac53" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="1858-3233-777b-6a0f" name="&lt; Unit Options &gt; " minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="8350-a307-4835-3176" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="76be-d990-01b2-40b5" name="Mounted Command Unit" hidden="false">
-          <modifiers/>
-        </rule>
-        <rule id="801f-37d3-aeef-35ef" name="Limited Choice" hidden="false">
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links>
-        <link id="8ada-48df-990a-b1c6" targetId="b0ca-8e7d-d03f-f027" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="0026-0fee-242b-f524" targetId="a221-d53c-b4bd-b52c" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="1fc7-db89-4652-3c98" name="Superior Shard" points="15.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="661d-86ab-a747-8bb5" targetId="d4f5-697e-dbf0-ced2" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="aa6c-67b7-3d3b-2a61" name="Targeter Probe Shard" points="0.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="196">
-      <entries>
-        <entry id="31ff-3d6d-2a30-3b5a" name="&gt; Targeter Probe" points="5.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="58b0-e470-5c3a-0e30" targetId="00b8-b49c-4c61-2943" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="6620-e65c-9afa-7ed9" targetId="4d5f-ccb4-75c2-cbf2" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules>
-        <rule id="8104-2eac-f495-21f9" name="Probe Unit" hidden="false" book="">
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="40ad-08b6-fa6a-0171" name="Vardanari Squad (Guards)" points="42.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="191">
-      <entries>
-        <entry id="c3fa-7787-a4d1-50f8" name="&lt; Vardanari Leader" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="191">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="189f-239f-cc54-f496" name="&lt; Leader Level &gt;" defaultEntryId="7ea8-bf13-37df-8acf" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="6cd8-052e-b9da-e94e" name="Leader 2" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="4ac0-b84e-687f-e73b" hidden="false" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
                   <profiles/>
-                  <links>
-                    <link id="f2ac-6316-75a8-0504" targetId="7850-89e7-bab8-86e9" linkType="rule">
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2c42-d94f-83c4-fb4f" name="Skyraider Trooper" book="BtGoA" page="192" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="a18a-ce88-b9af-89e7" hidden="false" targetId="a654-5213-64f2-703a" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="62da-827c-1a4c-bfef" name="&lt; Ranged Weapon &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="5c2c-6873-9857-0546" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2996-96fd-31e3-fe8c" name="&lt; Skyraider &gt;" hidden="false" collective="false" defaultSelectionEntryId="92a3-2543-174e-504b">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="92a3-2543-174e-504b" hidden="false" targetId="a1a8-ba0b-2e45-8020" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="5f94-8423-056d-5f54" name="&lt; Special Weapon Option &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="b3cb-790e-d4ae-710a" hidden="false" targetId="47d9-8149-9744-9849" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="0f9b-216d-3f08-d82e" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="2d2f-4f61-9b31-50b5" name="&lt; Unit Armor &gt;" hidden="false" collective="false" defaultSelectionEntryId="6df8-de07-b4b9-201f">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="6df8-de07-b4b9-201f" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="0eff-479f-05c9-7f65" hidden="false" targetId="2e3d-bbaa-3f5c-ac53" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1858-3233-777b-6a0f" name="&lt; Unit Options &gt; " hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="8350-a307-4835-3176" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="164.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1fc7-db89-4652-3c98" name="Superior Shard" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="661d-86ab-a747-8bb5" hidden="false" targetId="d4f5-697e-dbf0-ced2" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="aa6c-67b7-3d3b-2a61" name="Targeter Probe Shard" book="BtGoA" page="196" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="8104-2eac-f495-21f9" name="Probe Unit" book="" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="31ff-3d6d-2a30-3b5a" name="&gt; Targeter Probe" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="58b0-e470-5c3a-0e30" hidden="false" targetId="00b8-b49c-4c61-2943" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="6620-e65c-9afa-7ed9" hidden="false" targetId="4d5f-ccb4-75c2-cbf2" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="40ad-08b6-fa6a-0171" name="Vardanari Squad (Guards)" book="BtGoA" page="191" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="c3fa-7787-a4d1-50f8" name="&lt; Vardanari Leader" book="BtGoA" page="191" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="1a89-bc54-c850-a7a0" hidden="false" targetId="62fc-1d76-c6fd-a3eb" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="189f-239f-cc54-f496" name="&lt; Leader Level &gt;" hidden="false" collective="false" defaultSelectionEntryId="7ea8-bf13-37df-8acf">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="6cd8-052e-b9da-e94e" name="Leader 2" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="f2ac-6316-75a8-0504" hidden="false" targetId="7850-89e7-bab8-86e9" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
                       <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="7ea8-bf13-37df-8acf" targetId="fc7e-7c0e-65e0-8c33" linkType="entry">
+                    </infoLink>
+                  </infoLinks>
                   <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="f5ed-8cd5-154e-1987" name="&lt; Ranged Weapon &gt;" defaultEntryId="c12f-a100-2c77-940b" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="c12f-a100-2c77-940b" targetId="b018-6101-d2e3-b4ea" linkType="entry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="7ea8-bf13-37df-8acf" hidden="false" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-                <link id="02d9-18d6-822b-c297" targetId="179a-c0cc-49cc-c946" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="dbcb-5feb-24da-acaf" targetId="8de3-1e72-72ef-e7a3" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="1a89-bc54-c850-a7a0" targetId="62fc-1d76-c6fd-a3eb" linkType="profile">
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="97e8-d8ef-1bec-906d" name="Vardanari Guard" points="19.0" categoryId="(No Category)" type="model" minSelections="5" maxSelections="7" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="191">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="4ca6-7e89-8b59-f1d5" targetId="702f-c8a7-d8cf-01c1" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="fff7-d85d-7713-194d" name="Ranged Weapon" defaultEntryId="1b32-6cc9-8dc9-64b3" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="1b32-6cc9-8dc9-64b3" targetId="b018-6101-d2e3-b4ea" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="8836-8c4d-3a4f-5d40" name="Armor" defaultEntryId="a575-c942-e1b2-0d29" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="a575-c942-e1b2-0d29" targetId="03c2-174e-8617-cf04" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="7876-6071-860a-2b8f" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="a7b4-9779-24e9-b2a7" targetId="573b-88bc-97d7-d890" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="4e0f-95bb-f4f1-6030" name="Well Prepared" points="5.0" categoryId="50ba-cf77-3941-189c" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="69f3-3470-5212-8eaa" targetId="75d2-6efa-9640-61df" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-  </entries>
-  <rules/>
-  <links/>
-  <sharedEntries>
-    <entry id="e9dd-1dc6-3c92-4305" name="AG Chute" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="120">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="54c4-0df3-268c-9fe1" targetId="7daf-414b-c030-7626" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="828e-3aa2-3dbf-f2cb" name="Auto-Workshop" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="120">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="2aa0-3909-ff3b-5bfe" targetId="b7c6-fc7c-d48b-aae4" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="d571-d584-85fc-9110" name="Batter Drone" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="11">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="2686-6df4-4601-e99f" targetId="f0d9-1e5a-ec20-b27c" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="8f68-d09d-6e26-c6ea" name="Batter Drone (2)" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="11">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="0a02-46cc-7e6f-28b0" targetId="f0d9-1e5a-ec20-b27c" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="af35-43cb-665c-f896" name="Booster Drone" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="111">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="77b8-dc0d-36ff-0f1d" name="Borer Drone" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="111">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="f67e-b103-c5e0-7d92" targetId="4e34-753f-b082-2e00" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="4933-25f0-2896-ac60" name="Camo Drone" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="0235-7440-f324-d8e9" targetId="5f48-f41c-fd96-6a1a" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="babd-f951-933b-1254" name="Compactor Drone" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="d5b5-2649-62fd-e305" targetId="3995-c066-c957-5ffe" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="666e-aa69-6e72-f168" name="Compactor Drone with Mag Cannon" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="9c4f-f6de-c09c-eab2" targetId="6a2b-50c5-9a33-b756" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="663f-33f4-57b5-7a11" targetId="3995-c066-c957-5ffe" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="2144-e450-c8f2-af26" name="Compactor Drone with Mag Light Support" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="d525-3a93-38f1-7e4e" targetId="a00c-0542-f2a5-8124" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="4e01-7b13-2e6c-0f97" targetId="3995-c066-c957-5ffe" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="0299-39fc-32bd-8ac2" name="Compactor Drone with Plasma Cannon" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="e506-bd0d-b513-7050" targetId="c2bf-0272-30c6-dd20" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="ae6e-0698-5ad9-8d26" targetId="3995-c066-c957-5ffe" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="af24-45f9-4669-bf98" name="Compression Bombard" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="84">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="f3f6-794b-82b3-a39a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Bombard" hidden="false" book="BtGoA" page="84">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-50"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="150"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="9/7/5"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Cycle, Heavy Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="d318-c320-5b7c-b089" targetId="7db4-2d14-3984-37d9" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="a2f7-528d-dd59-9d00" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="b53d-32d6-c4fc-cefc" targetId="cf7f-6f85-e64e-0363" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="71c9-4382-01cf-c737" name="Compression Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="78">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="b626-3a7f-ecf5-ea69" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Cannon" hidden="false" book="BtGoA" page="78">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="7/4/2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Cycle,  Light Support Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="a6f9-23ce-e99d-7c15" targetId="7db4-2d14-3984-37d9" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="3003-31fb-fb6c-3084" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="70d5-a230-ba57-ead0" targetId="cf7f-6f85-e64e-0363" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="059b-38f7-0313-5ae4" name="Compression Carbine" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="72">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="e580-6389-7ec6-d445" targetId="7db4-2d14-3984-37d9" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="b230-6dc2-fc21-9332" targetId="75cb-cf9b-dd3d-9177" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="72ba-15e7-dbf7-816c" name="D-Spinner" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="66">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="bc08-23ff-215d-d442" profileTypeId="ecae-8ac8-2c13-0dd3" name="D-Spinner" hidden="false" book="BtGoA" page="66">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="Varies"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks, Variable Res/Strike, Grenade, Hand Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="bf1e-fb77-9e71-f9fe" targetId="2cbd-47c9-de87-ec2a" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="363c-73f0-41ad-dfb8" targetId="99fd-f354-1703-5941" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="91a4-fa2b-910b-b8f8" targetId="b466-7990-db34-55b1" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="ff6c-f8d8-94e6-57bc" name="Disruptor Bomber" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="77">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="c100-99b7-2ff6-24a0" profileTypeId="ecae-8ac8-2c13-0dd3" name="Disruptor Bomber" hidden="false" book="BtGoA" page="77">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="60"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="120"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D5, No Crew, Limited Ammo, No Cover, Disruptor,  Light Support Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="5bfd-e568-cff9-ff1b" targetId="c3bc-87fd-fa5d-5055" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="ada8-a0a5-d314-27a6" targetId="b050-496a-ed16-2b2a" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="c9a5-e124-997c-44ea" targetId="f502-611e-9704-97bb" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="b3e6-5aa3-ef1f-f7b1" targetId="5efa-64a9-bbc9-3dba" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="df53-3436-c62e-c73e" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="7fb2-1ffe-610d-7f33" targetId="6305-72fa-da02-235b" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="f771-f4b5-0047-de53" name="Disruptor Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="79">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="17db-4b84-9d1b-122d" profileTypeId="ecae-8ac8-2c13-0dd3" name="Disruptor Cannon" hidden="false" book="BtGoA" page="79">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D4, No Cover, Disruptor, Light Support Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="48bb-4c87-e0f2-08b4" targetId="ca96-58c9-9551-d4fe" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="3b06-bc9e-4002-8aeb" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="8e03-d6b4-1fab-5cd2" targetId="6305-72fa-da02-235b" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="396e-b157-b3bb-a5e7" name="Disruptor Discharger" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="86">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="de01-ba7b-11ee-55ca" profileTypeId="ecae-8ac8-2c13-0dd3" name="Disruptor Discharger" hidden="false" book="BtGoA" page="86">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="Point blank shooting only"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="Point blank shooting only"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="Point blank shooting only"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D4, No Cover, Disruptor, Grenade"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="e755-a7a2-1343-d27a" targetId="5d64-4bf5-e947-95d1" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="b2cb-0542-2c44-9f1b" targetId="ca96-58c9-9551-d4fe" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="049f-1e26-3f5d-a4f9" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="adad-ebe2-3953-6510" targetId="6305-72fa-da02-235b" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="2cec-e1d7-c680-7ca0" name="Fractal Bombard" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="83">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="279b-22b3-c3ff-1320" profileTypeId="ecae-8ac8-2c13-0dd3" name="Fractal Bombard" hidden="false" book="BtGoA" page="83">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="50"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="200"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3 + 2 Max 10"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock, Heavy Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="fe6a-32a9-1211-b766" targetId="d50c-3bbe-c62d-34c3" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="93db-3751-fdd4-08f9" name="Fractal Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="76">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="cb47-aad3-9a1b-1266" profileTypeId="ecae-8ac8-2c13-0dd3" name="Fractal Cannon" hidden="false" book="BtGoA" page="76">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2 + 1 Max 10"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock,  Light Support Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="b7b4-01fa-5f1f-ebee" targetId="d50c-3bbe-c62d-34c3" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="aac7-43b0-4a5c-05bb" name="Frag Borer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="77">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="5cb2-9abf-ed28-03ff" profileTypeId="ecae-8ac8-2c13-0dd3" name="Frag Borer" hidden="false" book="BtGoA" page="77">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="60"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3 + 1 Max 10"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock,  Light Support Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="eac9-8b04-b66c-5db6" targetId="d50c-3bbe-c62d-34c3" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="3975-3892-22f2-0c8e" name="Ghar Plasma Claw" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="66">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="57de-9415-94c2-a9cd" profileTypeId="ecae-8ac8-2c13-0dd3" name="Ghar Plasma Claw" hidden="false" book="BtGoA" page="66">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="D4"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Random SV,  Hand Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="7eb4-a0e1-1e61-3d82" targetId="b6e3-9cf0-1a9f-a941" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="f319-5d36-f853-9d45" name="Gouger Gun" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="74">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="5caa-0eb3-a2c8-d79c" profileTypeId="ecae-8ac8-2c13-0dd3" name="Gouger Gun" hidden="false" book="BtGoA" page="74">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Down, Inaccurate, Standard Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="6c43-9149-1b89-35e5" targetId="9444-e2a0-8048-5ce9" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="aa66-a1ad-73f1-8bd2" targetId="3b84-9d0e-a3c1-6c1f" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="b8d1-46be-c623-ad68" name="Gun Drone" points="14.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="4b9d-a0bf-396e-384b" name="Gun Drone (2)" points="14.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="f9cf-568d-998b-c3ca" name="Heavy Disruptor Bomber" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="80">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="a9a7-e90e-e54a-e37c" profileTypeId="ecae-8ac8-2c13-0dd3" name="Heavy Disruptor Bomber" hidden="false" book="BtGoA" page="80">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="60"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="120"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH x2, Blast D10, Limited Ammo, No Cover, Disruptor, Heavy Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="baaa-0b37-7581-545a" targetId="aef6-6934-1dee-6fa0" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="ad5f-454c-b4ec-0b29" targetId="04d9-a48d-7b25-4dd3" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="3dc5-ce4c-aaf4-7bc4" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="1d69-8270-126c-b660" targetId="6305-72fa-da02-235b" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="564d-3561-f5e4-783d" name="Heavy Frag Borer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="83">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="4001-9da2-86d1-6b80" profileTypeId="ecae-8ac8-2c13-0dd3" name="Heavy Frag Borer" hidden="false" book="BtGoA" page="83">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="60"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="6 + 1 Max 10"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock, Heavy Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="174d-fb91-0ee1-de89" targetId="d50c-3bbe-c62d-34c3" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="5149-5183-64d5-feaf" name="Heavy Mag Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="81">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="49f7-05c7-8536-e088" profileTypeId="ecae-8ac8-2c13-0dd3" name="Heavy Mag Cannon" hidden="false" book="BtGoA" page="81">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="50"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="10"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="250"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="6"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Massive Damage, Heavy Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="2226-327b-9cef-5629" targetId="c863-510b-e239-be92" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="4fbe-feab-de05-5312" name="Heavy Tractor Maul" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="65">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="05cc-6d3b-93d8-0b0e" profileTypeId="ecae-8ac8-2c13-0dd3" name="Heavy Tractor Maul" hidden="false" book="BtGoA" page="65">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks, Hand Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="c401-a6db-93c9-69e0" targetId="2cbd-47c9-de87-ec2a" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="eff8-bb0e-1b1d-bbb2" name="HL armor" points="0.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="93">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="2a6f-a102-e7b6-54c7" targetId="b436-1f8a-5d3a-2d7d" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="2e3d-bbaa-3f5c-ac53" name="HL Booster (Eq)" points="1.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="b458-ac53-f980-4960" targetId="56ab-52fc-9557-2586" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="573b-88bc-97d7-d890" name="HL Booster Drone" points="20.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="121">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="68d9-bb11-1862-acca" targetId="56ab-52fc-9557-2586" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="1b16-412b-662a-5467" name="Homer Drone" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="e015-e1a0-3cd3-a350" targetId="ca2b-9550-eb1e-77c8" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="4364-45ee-ee83-ca30" name="Impact Cloak " points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="93">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules>
-        <rule id="5da7-d6db-a841-0ff0" name="Impact Cloak" hidden="false" book="BtGoA" page="93">
-          <description>Add +2 to Res in hand to hand combat.</description>
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="74e7-3e15-6b19-94e8" name="Impact Cloak (Eq)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="93">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules>
-        <rule id="a94d-f3ac-90df-d53a" name="Impact Cloak" hidden="false" book="BtGoA" page="93">
-          <description>Add +2 to Res in hand to hand combat.</description>
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="f99c-daab-b3d7-9c61" name="Implosion Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="85">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="50ac-e85f-6480-9e2e" profileTypeId="ecae-8ac8-2c13-0dd3" name="Implosion Grenades" hidden="false" book="BtGoA" page="85">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Hazardous H2H, Grenade"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="9868-0703-9743-d4b5" targetId="1c2c-6574-0a17-f90c" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="b357-a997-60e5-053e" name="IMTel Stave" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="67">
-      <entries>
-        <entry id="d6be-b9a8-1ea3-d1ee" name="IMTel Stave - Standard" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="9cc5-5341-3598-a655" profileTypeId="ecae-8ac8-2c13-0dd3" name="IMTel Stave - Standard" hidden="false" book="BtGoA" page="67">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="3 Attacks, Hand Weapon"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="051e-0412-fe0f-16d2" targetId="61e2-3707-ade3-c9ad" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="da2f-6bd2-fb0e-5e5e" name="IMTel Stave - Nano Drone Boost" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="cf0b-c836-c681-d9c0" profileTypeId="ecae-8ac8-2c13-0dd3" name="IMTel Stave - Nano Drone Boost" hidden="false" book="BtGoA" page="67">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="6"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="3 Attacks, Blast D3, Exhausted, Hand Weapon"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="8918-00b1-258e-5005" targetId="61e2-3707-ade3-c9ad" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="a14f-0f5e-7b8f-63f5" targetId="1acd-39d3-94e7-48e1" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="e461-67a4-a88e-a136" targetId="4232-2801-36cf-704c" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="5346-a420-8994-c5ed" name="Interceptor Bike" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="100">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="c7d2-5723-e428-dd5a" name="Ranged Weapon" minSelections="3" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="fa7c-b456-730f-167f" targetId="47d9-8149-9744-9849" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="ec8f-9506-26e0-53ec" targetId="78dd-7840-1210-fb35" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="d3a3-d3e0-1480-e349" name="Intruder Skimmer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="9">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="e102-2c84-66f5-fba9" name="Ranged Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="ed95-b0bc-1c54-77ce" name="Twin Mag Repeaters" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="f5ed-8cd5-154e-1987" name="&lt; Ranged Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="c12f-a100-2c77-940b">
               <profiles/>
-              <links/>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="3aa7-ded4-1810-f136" targetId="f31c-6e5c-19c0-ada7" linkType="entry">
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="c12f-a100-2c77-940b" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="02d9-18d6-822b-c297" hidden="false" targetId="179a-c0cc-49cc-c946" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="dbcb-5feb-24da-acaf" hidden="false" targetId="8de3-1e72-72ef-e7a3" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="97e8-d8ef-1bec-906d" name="Vardanari Guard" book="BtGoA" page="191" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="4ca6-7e89-8b59-f1d5" hidden="false" targetId="702f-c8a7-d8cf-01c1" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="19.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="fff7-d85d-7713-194d" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="1b32-6cc9-8dc9-64b3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="1b32-6cc9-8dc9-64b3" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="8836-8c4d-3a4f-5d40" name="Armor" hidden="false" collective="false" defaultSelectionEntryId="a575-c942-e1b2-0d29">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="a575-c942-e1b2-0d29" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="7876-6071-860a-2b8f" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="a7b4-9779-24e9-b2a7" hidden="false" targetId="573b-88bc-97d7-d890" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="42.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4e0f-95bb-f4f1-6030" name="Well Prepared" hidden="false" collective="false" categoryEntryId="50ba-cf77-3941-189c" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="fc7e-7c0e-65e0-8c33" name="Leader" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="69f3-3470-5212-8eaa" hidden="false" targetId="75d2-6efa-9640-61df" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <entryLinks>
+    <entryLink id="5a89-9dad-479c-0ce2" name="Army Options" hidden="false" targetId="529a-3e2a-4bd5-5e5f" type="selectionEntry" categoryEntryId="50ba-cf77-3941-189c">
       <profiles/>
-      <links>
-        <link id="b121-6dcc-8053-c5a2" targetId="e441-c3a6-7d61-2c63" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="02f3-3134-ae39-afed" name="Leader 2" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="135">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </entryLink>
+  </entryLinks>
+  <sharedSelectionEntries>
+    <selectionEntry id="e9dd-1dc6-3c92-4305" name="AG Chute" book="BtGoA" page="120" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="0240-940c-2896-fe6d" targetId="7850-89e7-bab8-86e9" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="5a4c-2f5e-40a2-91d4" name="Leader 3" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="135">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="54c4-0df3-268c-9fe1" hidden="false" targetId="7daf-414b-c030-7626" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="828e-3aa2-3dbf-f2cb" name="Auto-Workshop" book="BtGoA" page="120" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="0722-f7c8-1f58-524e" targetId="05bb-4d34-70cd-25d2" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="222a-c399-636e-c285" name="Lectro Lance" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="66">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="1194-e016-79d8-8f37" profileTypeId="ecae-8ac8-2c13-0dd3" name="Lectro Lance" hidden="false" book="BtGoA" page="66">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Hand Weapon"/>
-          </characteristics>
+      <infoLinks>
+        <infoLink id="2aa0-3909-ff3b-5bfe" hidden="false" targetId="b7c6-fc7c-d48b-aae4" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="10e4-842d-bb66-6204" name="Lectro Lash" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="65">
-      <entries/>
-      <entryGroups/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="0e1a-a803-d9c9-9f0a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Lectro Lash" hidden="false" book="BtGoA" page="65">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="3 Attacks, Hand Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="485e-5cd5-458a-5b01" targetId="61e2-3707-ade3-c9ad" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="3ad3-bfdd-6120-7c29" name="Lugger Gun" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="73">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="5c6f-c4ef-b4a1-32eb" profileTypeId="ecae-8ac8-2c13-0dd3" name="Lugger Gun" hidden="false" book="BtGoA" page="73">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2, Limited Ammo, Standard Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="a5ed-7915-9221-076b" targetId="0cb1-ea91-e5bc-4f75" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="cc2c-1225-57ca-f1ed" targetId="5efa-64a9-bbc9-3dba" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="6a2b-50c5-9a33-b756" name="Mag Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="75">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="295a-d623-e2d2-c684" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Cannon" hidden="false" book="BtGoA" page="75">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="5"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="5"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Massive Damage, Light Support Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="ba14-c26b-33c6-8283" targetId="c863-510b-e239-be92" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="84ac-0f31-c388-d0bd" name="Mag Gun" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="69">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="d809-b3af-7007-a7b3" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Gun" hidden="false" book="BtGoA" page="69">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="60"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="8f47-408e-cc6e-7a19" name="Mag Gun (Eq)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="69">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="33ca-cc05-d33e-3d00" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Gun" hidden="false" book="BtGoA" page="69">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="60"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="cea7-8511-2208-1b1f" name="Mag Heavy Support" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="81">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="c318-2375-d610-2950" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Heavy Support" hidden="false" book="BtGoA" page="81">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="5"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF5, Heavy Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="d752-3c59-1096-f66d" targetId="b0cb-c022-0531-4852" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="b5e9-5297-04d2-2bf8" name="Mag Lash" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="67">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="f404-2eda-272f-57cf" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Lash" hidden="false" book="BtGoA" page="67">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="a97e-ddef-2a97-6023" targetId="2cbd-47c9-de87-ec2a" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="a00c-0542-f2a5-8124" name="Mag Light Support" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="75">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="df5b-35ce-669c-6aee" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Light Support" hidden="false" book="BtGoA" page="75">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="50"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3, Light Support Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="1edc-0547-c0b3-df09" targetId="97d4-67cb-2671-ca29" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="9733-7039-e306-26b5" name="Mag Mortar" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="81">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="d461-69b8-c506-322a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Mortar" hidden="false" book="BtGoA" page="81">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH x2, Blast D10, No Cover, Heavy Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="f42c-7e9e-5b27-6658" targetId="aef6-6934-1dee-6fa0" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="bfd1-e214-1717-c121" targetId="04d9-a48d-7b25-4dd3" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="f78e-6fd2-fff5-58e2" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="3203-24a2-4083-bc0d" targetId="bc4e-7cd8-4017-d911" linkType="entry group">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="8690-3ab7-9fef-06ee" name="Mag Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="68">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="57f9-ac99-e46c-2757" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Pistol" hidden="false" book="BtGoA" page="68">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="30"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Hand Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="790a-6841-6372-870b" name="Mag Repeater" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="69">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="1c20-93a8-d402-9d61" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Repeater" hidden="false" book="BtGoA" page="69">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2, Standard Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="af4a-bed9-243c-993e" targetId="0cb1-ea91-e5bc-4f75" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="3ecf-d559-4559-c1bb" name="Mass Compactor" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="71">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="b468-06b2-1a5d-2ec0" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mass Compactor" hidden="false" book="BtGoA" page="71">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="30"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3/2/1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Standard Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="068c-0048-aa5f-9906" targetId="7db4-2d14-3984-37d9" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="af50-5808-cb3e-2ec9" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="502c-9855-7269-eaa2" name="Medi-Drone" points="20.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="113">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d571-d584-85fc-9110" name="Batter Drone" book="BtGoA" page="11" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="a034-e97d-eddd-d272" targetId="4039-88e8-9f6d-bfb3" linkType="rule">
+      <rules/>
+      <infoLinks>
+        <infoLink id="2686-6df4-4601-e99f" hidden="false" targetId="f0d9-1e5a-ec20-b27c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="eafe-29d5-1222-4155" name="Meld Skark" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8f68-d09d-6e26-c6ea" name="Batter Drone (2)" book="BtGoA" page="11" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0a02-46cc-7e6f-28b0" hidden="false" targetId="f0d9-1e5a-ec20-b27c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="af35-43cb-665c-f896" name="Booster Drone" book="BtGoA" page="111" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="77b8-dc0d-36ff-0f1d" name="Borer Drone" book="BtGoA" page="111" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="f67e-b103-c5e0-7d92" hidden="false" targetId="4e34-753f-b082-2e00" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4933-25f0-2896-ac60" name="Camo Drone" book="BtGoA" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0235-7440-f324-d8e9" hidden="false" targetId="5f48-f41c-fd96-6a1a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="babd-f951-933b-1254" name="Compactor Drone" book="BtGoA" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d5b5-2649-62fd-e305" hidden="false" targetId="3995-c066-c957-5ffe" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="666e-aa69-6e72-f168" name="Compactor Drone with Mag Cannon" book="BtGoA" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="663f-33f4-57b5-7a11" hidden="false" targetId="3995-c066-c957-5ffe" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="9c4f-f6de-c09c-eab2" hidden="false" targetId="6a2b-50c5-9a33-b756" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2144-e450-c8f2-af26" name="Compactor Drone with Mag Light Support" book="BtGoA" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="4e01-7b13-2e6c-0f97" hidden="false" targetId="3995-c066-c957-5ffe" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="d525-3a93-38f1-7e4e" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0299-39fc-32bd-8ac2" name="Compactor Drone with Plasma Cannon" book="BtGoA" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="ae6e-0698-5ad9-8d26" hidden="false" targetId="3995-c066-c957-5ffe" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="e506-bd0d-b513-7050" hidden="false" targetId="c2bf-0272-30c6-dd20" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="af24-45f9-4669-bf98" name="Compression Bombard" book="BtGoA" page="84" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="f3f6-794b-82b3-a39a" name="Compression Bombard" book="BtGoA" page="84" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-50"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="150"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="9/7/5"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Cycle, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d318-c320-5b7c-b089" hidden="false" targetId="7db4-2d14-3984-37d9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="a2f7-528d-dd59-9d00" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b53d-32d6-c4fc-cefc" hidden="false" targetId="cf7f-6f85-e64e-0363" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="71c9-4382-01cf-c737" name="Compression Cannon" book="BtGoA" page="78" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="b626-3a7f-ecf5-ea69" name="Compression Cannon" book="BtGoA" page="78" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="7/4/2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Cycle,  Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a6f9-23ce-e99d-7c15" hidden="false" targetId="7db4-2d14-3984-37d9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3003-31fb-fb6c-3084" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="70d5-a230-ba57-ead0" hidden="false" targetId="cf7f-6f85-e64e-0363" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="059b-38f7-0313-5ae4" name="Compression Carbine" book="BtGoA" page="72" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="e580-6389-7ec6-d445" hidden="false" targetId="7db4-2d14-3984-37d9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b230-6dc2-fc21-9332" hidden="false" targetId="75cb-cf9b-dd3d-9177" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="72ba-15e7-dbf7-816c" name="D-Spinner" book="BtGoA" page="66" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="bc08-23ff-215d-d442" name="D-Spinner" book="BtGoA" page="66" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="Varies"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks, Variable Res/Strike, Grenade, Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="bf1e-fb77-9e71-f9fe" hidden="false" targetId="2cbd-47c9-de87-ec2a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="363c-73f0-41ad-dfb8" hidden="false" targetId="99fd-f354-1703-5941" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="91a4-fa2b-910b-b8f8" hidden="false" targetId="b466-7990-db34-55b1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ff6c-f8d8-94e6-57bc" name="Disruptor Bomber" book="BtGoA" page="77" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="c100-99b7-2ff6-24a0" name="Disruptor Bomber" book="BtGoA" page="77" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D5, No Crew, Limited Ammo, No Cover, Disruptor,  Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="5bfd-e568-cff9-ff1b" hidden="false" targetId="c3bc-87fd-fa5d-5055" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ada8-a0a5-d314-27a6" hidden="false" targetId="b050-496a-ed16-2b2a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="c9a5-e124-997c-44ea" hidden="false" targetId="f502-611e-9704-97bb" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b3e6-5aa3-ef1f-f7b1" hidden="false" targetId="5efa-64a9-bbc9-3dba" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="df53-3436-c62e-c73e" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7fb2-1ffe-610d-7f33" hidden="false" targetId="6305-72fa-da02-235b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f771-f4b5-0047-de53" name="Disruptor Cannon" book="BtGoA" page="79" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="17db-4b84-9d1b-122d" name="Disruptor Cannon" book="BtGoA" page="79" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, No Cover, Disruptor, Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="48bb-4c87-e0f2-08b4" hidden="false" targetId="ca96-58c9-9551-d4fe" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3b06-bc9e-4002-8aeb" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="8e03-d6b4-1fab-5cd2" hidden="false" targetId="6305-72fa-da02-235b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="396e-b157-b3bb-a5e7" name="Disruptor Discharger" book="BtGoA" page="86" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="de01-ba7b-11ee-55ca" name="Disruptor Discharger" book="BtGoA" page="86" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="Point blank shooting only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="Point blank shooting only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="Point blank shooting only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, No Cover, Disruptor, Grenade"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="e755-a7a2-1343-d27a" hidden="false" targetId="5d64-4bf5-e947-95d1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b2cb-0542-2c44-9f1b" hidden="false" targetId="ca96-58c9-9551-d4fe" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="049f-1e26-3f5d-a4f9" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="adad-ebe2-3953-6510" hidden="false" targetId="6305-72fa-da02-235b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2cec-e1d7-c680-7ca0" name="Fractal Bombard" book="BtGoA" page="83" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="279b-22b3-c3ff-1320" name="Fractal Bombard" book="BtGoA" page="83" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="50"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="200"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3 + 2 Max 10"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="fe6a-32a9-1211-b766" hidden="false" targetId="d50c-3bbe-c62d-34c3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="93db-3751-fdd4-08f9" name="Fractal Cannon" book="BtGoA" page="76" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="cb47-aad3-9a1b-1266" name="Fractal Cannon" book="BtGoA" page="76" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2 + 1 Max 10"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock,  Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="b7b4-01fa-5f1f-ebee" hidden="false" targetId="d50c-3bbe-c62d-34c3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="aac7-43b0-4a5c-05bb" name="Frag Borer" book="BtGoA" page="77" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="5cb2-9abf-ed28-03ff" name="Frag Borer" book="BtGoA" page="77" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3 + 1 Max 10"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock,  Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="eac9-8b04-b66c-5db6" hidden="false" targetId="d50c-3bbe-c62d-34c3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3975-3892-22f2-0c8e" name="Ghar Plasma Claw" book="BtGoA" page="66" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="57de-9415-94c2-a9cd" name="Ghar Plasma Claw" book="BtGoA" page="66" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="D4"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Random SV,  Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="7eb4-a0e1-1e61-3d82" hidden="false" targetId="b6e3-9cf0-1a9f-a941" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f319-5d36-f853-9d45" name="Gouger Gun" book="BtGoA" page="74" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="5caa-0eb3-a2c8-d79c" name="Gouger Gun" book="BtGoA" page="74" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Down, Inaccurate, Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="6c43-9149-1b89-35e5" hidden="false" targetId="9444-e2a0-8048-5ce9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="aa66-a1ad-73f1-8bd2" hidden="false" targetId="3b84-9d0e-a3c1-6c1f" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b8d1-46be-c623-ad68" name="Gun Drone" book="BtGoA" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="14.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4b9d-a0bf-396e-384b" name="Gun Drone (2)" book="BtGoA" page="112" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="14.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f9cf-568d-998b-c3ca" name="Heavy Disruptor Bomber" book="BtGoA" page="80" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="a9a7-e90e-e54a-e37c" name="Heavy Disruptor Bomber" book="BtGoA" page="80" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH x2, Blast D10, Limited Ammo, No Cover, Disruptor, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="baaa-0b37-7581-545a" hidden="false" targetId="aef6-6934-1dee-6fa0" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ad5f-454c-b4ec-0b29" hidden="false" targetId="04d9-a48d-7b25-4dd3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3dc5-ce4c-aaf4-7bc4" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="1d69-8270-126c-b660" hidden="false" targetId="6305-72fa-da02-235b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="564d-3561-f5e4-783d" name="Heavy Frag Borer" book="BtGoA" page="83" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="4001-9da2-86d1-6b80" name="Heavy Frag Borer" book="BtGoA" page="83" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6 + 1 Max 10"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="174d-fb91-0ee1-de89" hidden="false" targetId="d50c-3bbe-c62d-34c3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5149-5183-64d5-feaf" name="Heavy Mag Cannon" book="BtGoA" page="81" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="49f7-05c7-8536-e088" name="Heavy Mag Cannon" book="BtGoA" page="81" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="50"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="10"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="250"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Massive Damage, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="2226-327b-9cef-5629" hidden="false" targetId="c863-510b-e239-be92" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4fbe-feab-de05-5312" name="Heavy Tractor Maul" book="BtGoA" page="65" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="05cc-6d3b-93d8-0b0e" name="Heavy Tractor Maul" book="BtGoA" page="65" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks, Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="c401-a6db-93c9-69e0" hidden="false" targetId="2cbd-47c9-de87-ec2a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eff8-bb0e-1b1d-bbb2" name="HL armor" book="BtGoA" page="93" hidden="false" collective="true" categoryEntryId="(No Category)" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="2a6f-a102-e7b6-54c7" hidden="false" targetId="b436-1f8a-5d3a-2d7d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2e3d-bbaa-3f5c-ac53" name="HL Booster (Eq)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="b458-ac53-f980-4960" hidden="false" targetId="56ab-52fc-9557-2586" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="1.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="573b-88bc-97d7-d890" name="HL Booster Drone" book="BtGoA" page="121" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="68d9-bb11-1862-acca" hidden="false" targetId="56ab-52fc-9557-2586" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1b16-412b-662a-5467" name="Homer Drone" book="BtGoA" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="e015-e1a0-3cd3-a350" hidden="false" targetId="ca2b-9550-eb1e-77c8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4364-45ee-ee83-ca30" name="Impact Cloak " book="BtGoA" page="93" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
       <rules>
-        <rule id="68b7-72bd-610b-2ae3" name="Meld Skark" hidden="false" book="BtGoA" page="194">
+        <rule id="5da7-d6db-a841-0ff0" name="Impact Cloak" book="BtGoA" page="93" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>Add +2 to Res in hand to hand combat.</description>
+        </rule>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="74e7-3e15-6b19-94e8" name="Impact Cloak (Eq)" book="BtGoA" page="93" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules>
+        <rule id="a94d-f3ac-90df-d53a" name="Impact Cloak" book="BtGoA" page="93" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>Add +2 to Res in hand to hand combat.</description>
+        </rule>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f99c-daab-b3d7-9c61" name="Implosion Grenades" book="BtGoA" page="85" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="50ac-e85f-6480-9e2e" name="Implosion Grenades" book="BtGoA" page="85" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Hazardous H2H, Grenade"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="9868-0703-9743-d4b5" hidden="false" targetId="1c2c-6574-0a17-f90c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b357-a997-60e5-053e" name="IMTel Stave" book="BtGoA" page="67" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="d6be-b9a8-1ea3-d1ee" name="IMTel Stave - Standard" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="9cc5-5341-3598-a655" name="IMTel Stave - Standard" book="BtGoA" page="67" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="3 Attacks, Hand Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="051e-0412-fe0f-16d2" hidden="false" targetId="61e2-3707-ade3-c9ad" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="da2f-6bd2-fb0e-5e5e" name="IMTel Stave - Nano Drone Boost" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="cf0b-c836-c681-d9c0" name="IMTel Stave - Nano Drone Boost" book="BtGoA" page="67" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="3 Attacks, Blast D3, Exhausted, Hand Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="8918-00b1-258e-5005" hidden="false" targetId="61e2-3707-ade3-c9ad" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="a14f-0f5e-7b8f-63f5" hidden="false" targetId="1acd-39d3-94e7-48e1" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="e461-67a4-a88e-a136" hidden="false" targetId="4232-2801-36cf-704c" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5346-a420-8994-c5ed" name="Interceptor Bike" book="BtGoA" page="100" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c7d2-5723-e428-dd5a" name="Ranged Weapon" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="fa7c-b456-730f-167f" hidden="false" targetId="47d9-8149-9744-9849" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="ec8f-9506-26e0-53ec" hidden="false" targetId="78dd-7840-1210-fb35" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d3a3-d3e0-1480-e349" name="Intruder Skimmer" book="BtGoA" page="9" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e102-2c84-66f5-fba9" name="Ranged Weapon" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="ed95-b0bc-1c54-77ce" name="Twin Mag Repeaters" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="3aa7-ded4-1810-f136" hidden="false" targetId="f31c-6e5c-19c0-ada7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fc7e-7c0e-65e0-8c33" name="Leader" book="" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="b121-6dcc-8053-c5a2" hidden="false" targetId="e441-c3a6-7d61-2c63" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="02f3-3134-ae39-afed" name="Leader 2" book="BtGoA" page="135" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0240-940c-2896-fe6d" hidden="false" targetId="7850-89e7-bab8-86e9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5a4c-2f5e-40a2-91d4" name="Leader 3" book="BtGoA" page="135" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0722-f7c8-1f58-524e" hidden="false" targetId="05bb-4d34-70cd-25d2" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="222a-c399-636e-c285" name="Lectro Lance" book="BtGoA" page="66" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="1194-e016-79d8-8f37" name="Lectro Lance" book="BtGoA" page="66" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="10e4-842d-bb66-6204" name="Lectro Lash" book="BtGoA" page="65" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="0e1a-a803-d9c9-9f0a" name="Lectro Lash" book="BtGoA" page="65" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="3 Attacks, Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="485e-5cd5-458a-5b01" hidden="false" targetId="61e2-3707-ade3-c9ad" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3ad3-bfdd-6120-7c29" name="Lugger Gun" book="BtGoA" page="73" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="5c6f-c4ef-b4a1-32eb" name="Lugger Gun" book="BtGoA" page="73" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Limited Ammo, Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a5ed-7915-9221-076b" hidden="false" targetId="0cb1-ea91-e5bc-4f75" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="cc2c-1225-57ca-f1ed" hidden="false" targetId="5efa-64a9-bbc9-3dba" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6a2b-50c5-9a33-b756" name="Mag Cannon" book="BtGoA" page="75" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="295a-d623-e2d2-c684" name="Mag Cannon" book="BtGoA" page="75" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="5"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="5"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Massive Damage, Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="ba14-c26b-33c6-8283" hidden="false" targetId="c863-510b-e239-be92" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="84ac-0f31-c388-d0bd" name="Mag Gun" book="BtGoA" page="69" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="d809-b3af-7007-a7b3" name="Mag Gun" book="BtGoA" page="69" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8f47-408e-cc6e-7a19" name="Mag Gun (Eq)" book="BtGoA" page="69" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="33ca-cc05-d33e-3d00" name="Mag Gun" book="BtGoA" page="69" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cea7-8511-2208-1b1f" name="Mag Heavy Support" book="BtGoA" page="81" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="c318-2375-d610-2950" name="Mag Heavy Support" book="BtGoA" page="81" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="5"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF5, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d752-3c59-1096-f66d" hidden="false" targetId="b0cb-c022-0531-4852" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b5e9-5297-04d2-2bf8" name="Mag Lash" book="BtGoA" page="67" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="f404-2eda-272f-57cf" name="Mag Lash" book="BtGoA" page="67" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a97e-ddef-2a97-6023" hidden="false" targetId="2cbd-47c9-de87-ec2a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a00c-0542-f2a5-8124" name="Mag Light Support" book="BtGoA" page="75" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="df5b-35ce-669c-6aee" name="Mag Light Support" book="BtGoA" page="75" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="50"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3, Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="1edc-0547-c0b3-df09" hidden="false" targetId="97d4-67cb-2671-ca29" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9733-7039-e306-26b5" name="Mag Mortar" book="BtGoA" page="81" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="d461-69b8-c506-322a" name="Mag Mortar" book="BtGoA" page="81" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH x2, Blast D10, No Cover, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="f42c-7e9e-5b27-6658" hidden="false" targetId="aef6-6934-1dee-6fa0" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="bfd1-e214-1717-c121" hidden="false" targetId="04d9-a48d-7b25-4dd3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f78e-6fd2-fff5-58e2" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="3203-24a2-4083-bc0d" hidden="false" targetId="bc4e-7cd8-4017-d911" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8690-3ab7-9fef-06ee" name="Mag Pistol" book="BtGoA" page="68" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="57f9-ac99-e46c-2757" name="Mag Pistol" book="BtGoA" page="68" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="790a-6841-6372-870b" name="Mag Repeater" book="BtGoA" page="69" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="1c20-93a8-d402-9d61" name="Mag Repeater" book="BtGoA" page="69" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="af4a-bed9-243c-993e" hidden="false" targetId="0cb1-ea91-e5bc-4f75" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3ecf-d559-4559-c1bb" name="Mass Compactor" book="BtGoA" page="71" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="b468-06b2-1a5d-2ec0" name="Mass Compactor" book="BtGoA" page="71" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3/2/1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="068c-0048-aa5f-9906" hidden="false" targetId="7db4-2d14-3984-37d9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="af50-5808-cb3e-2ec9" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="502c-9855-7269-eaa2" name="Medi-Drone" book="BtGoA" page="113" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a034-e97d-eddd-d272" hidden="false" targetId="4039-88e8-9f6d-bfb3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eafe-29d5-1222-4155" name="Meld Skark" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules>
+        <rule id="68b7-72bd-610b-2ae3" name="Meld Skark" book="BtGoA" page="194" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
           <description>6 Attacks, SV1</description>
-          <modifiers/>
         </rule>
       </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1a9d-01a2-ee09-883c" name="Micro-X Launcher" book="BtGoA" page="71" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="1a9d-01a2-ee09-883c" name="Micro-X Launcher" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="71">
-      <entries>
-        <entry id="756b-b4d4-8824-056b" name="Micro X-Launcher - Overhead" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="756b-b4d4-8824-056b" name="Micro X-Launcher - Overhead" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles>
-            <profile id="b067-87fe-65b4-6bd8" profileTypeId="ecae-8ac8-2c13-0dd3" name="Micro X-Launcher Overhead" hidden="false" book="BtGoA" page="71">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="5"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D4, No Cover, Standard Weapon"/>
-              </characteristics>
+            <profile id="b067-87fe-65b4-6bd8" name="Micro X-Launcher Overhead" book="BtGoA" page="71" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="5"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D4, No Cover, Standard Weapon"/>
+              </characteristics>
             </profile>
           </profiles>
-          <links>
-            <link id="29b1-77a8-eac1-dcb8" targetId="c3bc-87fd-fa5d-5055" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="5888-4d4d-b427-d1f3" targetId="ca96-58c9-9551-d4fe" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="de68-1314-0e93-bc44" targetId="a41d-d55e-6d97-049d" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="b484-5b5d-96fb-e628" name="Micro X-Launcher - Direct Fire" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
           <rules/>
-          <profiles>
-            <profile id="c0c1-ee5f-5c1f-77a0" profileTypeId="ecae-8ac8-2c13-0dd3" name="Micro X-Launcher - Direct Fire" hidden="false" book="BtGoA" page="71">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
-              </characteristics>
+          <infoLinks>
+            <infoLink id="29b1-77a8-eac1-dcb8" hidden="false" targetId="c3bc-87fd-fa5d-5055" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
+            </infoLink>
+            <infoLink id="5888-4d4d-b427-d1f3" hidden="false" targetId="ca96-58c9-9551-d4fe" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="de68-1314-0e93-bc44" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b484-5b5d-96fb-e628" name="Micro X-Launcher - Direct Fire" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="c0c1-ee5f-5c1f-77a0" name="Micro X-Launcher - Direct Fire" book="BtGoA" page="71" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+              </characteristics>
             </profile>
           </profiles>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="e7b0-651a-cc7c-f27e" name="Micro-X Launcher (Eq)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="71">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e7b0-651a-cc7c-f27e" name="Micro-X Launcher (Eq)" book="BtGoA" page="71" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="3bdc-c653-a2ab-de1c" profileTypeId="ecae-8ac8-2c13-0dd3" name="Micro X-Launcher - Direct Fire" hidden="false" book="BtGoA" page="71">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
-          </characteristics>
+        <profile id="3bdc-c653-a2ab-de1c" name="Micro X-Launcher - Direct Fire" book="BtGoA" page="71" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+          </characteristics>
         </profile>
-        <profile id="7649-e5a8-d706-0d24" profileTypeId="ecae-8ac8-2c13-0dd3" name="Micro X-Launcher Overhead" hidden="false" book="BtGoA" page="71">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="5"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D4, No Cover, Standard Weapon"/>
-          </characteristics>
+        <profile id="7649-e5a8-d706-0d24" name="Micro X-Launcher Overhead" book="BtGoA" page="71" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="5"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D4, No Cover, Standard Weapon"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="ede2-e3e5-c94d-4378" targetId="ca96-58c9-9551-d4fe" linkType="rule">
+      <rules/>
+      <infoLinks>
+        <infoLink id="ede2-e3e5-c94d-4378" hidden="false" targetId="ca96-58c9-9551-d4fe" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="c25b-badb-e157-f945" targetId="a41d-d55e-6d97-049d" linkType="rule">
+        </infoLink>
+        <infoLink id="c25b-badb-e157-f945" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="83cb-eec9-94c0-8fc1" targetId="c3bc-87fd-fa5d-5055" linkType="rule">
+        </infoLink>
+        <infoLink id="83cb-eec9-94c0-8fc1" hidden="false" targetId="c3bc-87fd-fa5d-5055" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="7849-7fc2-0006-8fbd" name="Munitions" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="cf32-46fd-cdce-80dd" name="Munitions" minSelections="0" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="2f9e-d8b5-f1a8-6e4c" name="Scrambler" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-              <entries/>
-              <entryGroups/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7849-7fc2-0006-8fbd" name="Munitions" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="cf32-46fd-cdce-80dd" name="Munitions" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="2f9e-d8b5-f1a8-6e4c" name="Scrambler" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="c2fb-c9db-5e9c-dcfe" hidden="false" targetId="7a3b-74a5-3ced-dd88" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="9622-01bf-0303-e5f7" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
               <modifiers>
-                <modifier type="hide" field="maxSelections" value="0.0" repeat="true" numRepeats="1" incrementParentId="cf32-46fd-cdce-80dd" incrementChildId="057c-a217-e792-8ef7" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="hidden" value="true">
+                  <repeats>
+                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="47c5-9ed0-b50a-45b7" name="Arc" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links>
-                <link id="c2fb-c9db-5e9c-dcfe" targetId="7a3b-74a5-3ced-dd88" linkType="rule">
+              <rules/>
+              <infoLinks>
+                <infoLink id="1838-cbe5-7c85-395d" hidden="false" targetId="c1ba-c745-22a8-e2d7" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-                <link id="9622-01bf-0303-e5f7" targetId="b996-131f-b84a-4724" linkType="rule">
+                </infoLink>
+                <infoLink id="6568-0044-8497-b002" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="47c5-9ed0-b50a-45b7" name="Arc" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-              <entries/>
-              <entryGroups/>
+                </infoLink>
+              </infoLinks>
               <modifiers>
-                <modifier type="hide" field="maxSelections" value="0.0" repeat="true" numRepeats="1" incrementParentId="cf32-46fd-cdce-80dd" incrementChildId="057c-a217-e792-8ef7" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="hidden" value="true">
+                  <repeats>
+                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="876b-029d-8c49-cf28" name="Blur" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links>
-                <link id="1838-cbe5-7c85-395d" targetId="c1ba-c745-22a8-e2d7" linkType="rule">
+              <rules/>
+              <infoLinks>
+                <infoLink id="8a68-f508-7c9e-1ee4" hidden="false" targetId="117a-a2aa-4be7-dffe" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-                <link id="6568-0044-8497-b002" targetId="b996-131f-b84a-4724" linkType="rule">
+                </infoLink>
+                <infoLink id="1fe7-d90c-fd8b-2777" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="876b-029d-8c49-cf28" name="Blur" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-              <entries/>
-              <entryGroups/>
+                </infoLink>
+              </infoLinks>
               <modifiers>
-                <modifier type="hide" field="maxSelections" value="0.0" repeat="true" numRepeats="1" incrementParentId="cf32-46fd-cdce-80dd" incrementChildId="057c-a217-e792-8ef7" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="hidden" value="true">
+                  <repeats>
+                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2f18-3173-0eea-f19f" name="Scoot" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links>
-                <link id="8a68-f508-7c9e-1ee4" targetId="117a-a2aa-4be7-dffe" linkType="rule">
+              <rules/>
+              <infoLinks>
+                <infoLink id="a787-c45e-8df6-7cdb" hidden="false" targetId="28a0-7151-a0c5-9495" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-                <link id="1fe7-d90c-fd8b-2777" targetId="b996-131f-b84a-4724" linkType="rule">
+                </infoLink>
+                <infoLink id="4acd-4d6e-c5ce-c202" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="2f18-3173-0eea-f19f" name="Scoot" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-              <entries/>
-              <entryGroups/>
+                </infoLink>
+              </infoLinks>
               <modifiers>
-                <modifier type="hide" field="maxSelections" value="0.0" repeat="true" numRepeats="1" incrementParentId="cf32-46fd-cdce-80dd" incrementChildId="057c-a217-e792-8ef7" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="hidden" value="true">
+                  <repeats>
+                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="99d6-3f14-a1e9-779b" name="Net" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links>
-                <link id="a787-c45e-8df6-7cdb" targetId="28a0-7151-a0c5-9495" linkType="rule">
+              <rules/>
+              <infoLinks>
+                <infoLink id="c8d2-16b3-5523-a9b1" hidden="false" targetId="ac33-af99-2d76-c981" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-                <link id="4acd-4d6e-c5ce-c202" targetId="b996-131f-b84a-4724" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="99d6-3f14-a1e9-779b" name="Net" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-              <entries/>
-              <entryGroups/>
+                </infoLink>
+              </infoLinks>
               <modifiers>
-                <modifier type="hide" field="maxSelections" value="0.0" repeat="true" numRepeats="1" incrementParentId="cf32-46fd-cdce-80dd" incrementChildId="057c-a217-e792-8ef7" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="hidden" value="true">
+                  <repeats>
+                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e014-fd16-bd43-6ead" name="Grip" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links>
-                <link id="c8d2-16b3-5523-a9b1" targetId="ac33-af99-2d76-c981" linkType="rule">
+              <rules/>
+              <infoLinks>
+                <infoLink id="6ffa-8857-9b93-35b5" hidden="false" targetId="1045-95cb-5504-9050" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="e014-fd16-bd43-6ead" name="Grip" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-              <entries/>
-              <entryGroups/>
+                </infoLink>
+                <infoLink id="3eba-9eb4-bf44-4b04" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
               <modifiers>
-                <modifier type="hide" field="maxSelections" value="0.0" repeat="true" numRepeats="1" incrementParentId="cf32-46fd-cdce-80dd" incrementChildId="057c-a217-e792-8ef7" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="hidden" value="true">
+                  <repeats>
+                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="057c-a217-e792-8ef7" name="All" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links>
-                <link id="6ffa-8857-9b93-35b5" targetId="1045-95cb-5504-9050" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="3eba-9eb4-bf44-4b04" targetId="b996-131f-b84a-4724" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="057c-a217-e792-8ef7" name="All" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
               <rules/>
+              <infoLinks>
+                <infoLink id="7fae-ff88-b94e-934e" hidden="false" targetId="c1ba-c745-22a8-e2d7" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="49a1-2fba-ff8f-c1b0" hidden="false" targetId="117a-a2aa-4be7-dffe" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="7acb-0144-9a6a-9840" hidden="false" targetId="1045-95cb-5504-9050" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="878e-a6f2-d2ce-4e02" hidden="false" targetId="ac33-af99-2d76-c981" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="ed06-0ab3-bc83-05de" hidden="false" targetId="28a0-7151-a0c5-9495" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="03ee-325f-d6f1-fd20" hidden="false" targetId="7a3b-74a5-3ced-dd88" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="8d63-0835-da60-a624" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bf0f-913b-e028-8891" name="Nano Drone" book="BtGoA" page="113" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="4173-19e8-aa99-3e22" hidden="false" targetId="c1c6-f9c7-c84f-d57d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cadc-e1ce-3615-ac4b" name="Nano Drones (2)" book="BtGoA" page="113" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="ce7f-8e3d-c50c-b636" hidden="false" targetId="c1c6-f9c7-c84f-d57d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6b54-c223-3c4a-5de7" name="Overload Ammo" book="BtGoA" page="89" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="6edf-03c1-417f-13e8" hidden="false" targetId="3559-4b87-980d-f90d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eb94-d1e8-1084-71b3" name="Phase Armor" book="BtGoA" page="93" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="3da3-80ac-dc11-6809" hidden="false" targetId="b28d-571e-af69-4582" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5725-5e4d-d4f2-1dd0" name="Phase Rifle" book="BtGoA" page="72" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="d2b1-2482-5f97-a4e4" name="Phase Rifle" book="BtGoA" page="72" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="No Cover, RF D6 Fire Only, Concentrated Fire, Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0d4d-4f3f-c86d-9dbe" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b46e-26ca-aad6-e64b" hidden="false" targetId="1863-c041-6dc4-c62d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6fea-ec6b-df33-2abe" hidden="false" targetId="5fb8-4f09-d496-4ea9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a18f-8d16-f879-e590" name="Phaseshift Shield" book="BtGoA" page="122" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="67b6-d6f5-5ba3-e50d" name="Plasma Bombard" book="BtGoA" page="82" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="a5d1-11c5-eb13-f676" name="Plasma Bombard" book="BtGoA" page="82" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="200"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="7"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Plasma Fade, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="7388-9f57-6e2a-eadb" hidden="false" targetId="6b03-2ad4-34c1-7f73" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c2bf-0272-30c6-dd20" name="Plasma Cannon" book="BtGoA" page="76" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="dce6-92d7-7812-820a" name="Plasma Cannon" book="BtGoA" page="76" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="4"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Plasma Fade, Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="3c39-3d6d-7a5a-f2f5" hidden="false" targetId="6b03-2ad4-34c1-7f73" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1631-5857-2139-960a" name="Plasma Carbine " book="BtGoA" page="70" hidden="false" collective="true" categoryEntryId="(No Category)" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0212-5213-7d18-d37f" hidden="false" targetId="ee9c-ada6-953a-b774" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="d572-ea69-f6bd-9b8f" hidden="false" targetId="b56d-0f1d-de00-62c4" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b55d-3878-89ca-fb86" hidden="false" targetId="0cb1-ea91-e5bc-4f75" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b018-6101-d2e3-b4ea" name="Plasma Carbine (Eq)" book="BtGoA" page="70" hidden="false" collective="true" categoryEntryId="(No Category)" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="7c09-db8c-68d9-485b" hidden="false" targetId="ee9c-ada6-953a-b774" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="8179-73ab-e5c7-065c" hidden="false" targetId="b56d-0f1d-de00-62c4" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f29e-ac68-7310-1db0" hidden="false" targetId="0cb1-ea91-e5bc-4f75" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d118-8115-df5f-2402" name="Plasma Grenades" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="8771-f173-82cd-3509" hidden="false" targetId="96f9-325b-69f7-13b4" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="47d9-8149-9744-9849" name="Plasma Lance" book="BtGoA" page="70" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="b6e9-addd-c005-4547" name="Plasma Lance - Single Shot" book="BtGoA" page="70" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="3799-96cf-d949-da4e" name="Plasma Lance - Single Shot" book="BtGoA" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
               <profiles/>
-              <links>
-                <link id="7fae-ff88-b94e-934e" targetId="c1ba-c745-22a8-e2d7" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="49a1-2fba-ff8f-c1b0" targetId="117a-a2aa-4be7-dffe" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="7acb-0144-9a6a-9840" targetId="1045-95cb-5504-9050" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="878e-a6f2-d2ce-4e02" targetId="ac33-af99-2d76-c981" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="ed06-0ab3-bc83-05de" targetId="28a0-7151-a0c5-9495" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="03ee-325f-d6f1-fd20" targetId="7a3b-74a5-3ced-dd88" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="8d63-0835-da60-a624" targetId="b996-131f-b84a-4724" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="bf0f-913b-e028-8891" name="Nano Drone" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="113">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="4173-19e8-aa99-3e22" targetId="c1c6-f9c7-c84f-d57d" linkType="rule">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="80ed-e766-57b1-3d2a" name="Plasma Lance - Scatter" book="BtGoA" page="70" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="9ad5-3648-6628-2caa" name="Plasma Lance - Scatter" book="BtGoA" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Standard Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="3f8e-ffa3-e1eb-fde7" hidden="false" targetId="0cb1-ea91-e5bc-4f75" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="cadc-e1ce-3615-ac4b" name="Nano Drones (2)" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="113">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="ce7f-8e3d-c50c-b636" targetId="c1c6-f9c7-c84f-d57d" linkType="rule">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4069-4420-c5b5-56af" name="Plasma Lance - Lance" book="BtGoA" page="70" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="f44f-9fdb-7e3c-bf9e" name="Plasma Lance - Lance" book="BtGoA" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="4"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Choose Target, Inaccurate, Standard Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="7213-775a-deac-dce8" hidden="false" targetId="fd72-d48c-e8af-4883" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="9752-310b-98a1-37af" hidden="false" targetId="3b84-9d0e-a3c1-6c1f" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="6b54-c223-3c4a-5de7" name="Overload Ammo" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="89">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="6edf-03c1-417f-13e8" targetId="3559-4b87-980d-f90d" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="eb94-d1e8-1084-71b3" name="Phase Armor" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="93">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="3da3-80ac-dc11-6809" targetId="b28d-571e-af69-4582" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="5725-5e4d-d4f2-1dd0" name="Phase Rifle" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="72">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cf3a-e6a9-bdc0-e0ae" name="Plasma Light Support" book="BtGoA" page="76" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="d2b1-2482-5f97-a4e4" profileTypeId="ecae-8ac8-2c13-0dd3" name="Phase Rifle" hidden="false" book="BtGoA" page="72">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="No Cover, RF D6 Fire Only, Concentrated Fire, Standard Weapon"/>
-          </characteristics>
+        <profile id="d429-b8cc-aca0-aac9" name="Plasma Light Support" book="BtGoA" page="76" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="4"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3, Light Support Weapon"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="0d4d-4f3f-c86d-9dbe" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="b46e-26ca-aad6-e64b" targetId="1863-c041-6dc4-c62d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="6fea-ec6b-df33-2abe" targetId="5fb8-4f09-d496-4ea9" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="a18f-8d16-f879-e590" name="Phaseshift Shield" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="122">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="67b6-d6f5-5ba3-e50d" name="Plasma Bombard" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="82">
-      <entries/>
-      <entryGroups/>
+      <infoLinks>
+        <infoLink id="9e8b-6ee9-56f0-aedf" hidden="false" targetId="97d4-67cb-2671-ca29" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0f97-9dbe-566a-5ab0" name="Plasma Light Support (Eq)" book="BtGoA" page="76" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="a5d1-11c5-eb13-f676" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Bombard" hidden="false" book="BtGoA" page="82">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="200"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="7"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Plasma Fade, Heavy Weapon"/>
-          </characteristics>
+        <profile id="4477-6aca-5fe1-2d03" name="Plasma Light Support" book="BtGoA" page="76" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="4"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3, Light Support Weapon"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="7388-9f57-6e2a-eadb" targetId="6b03-2ad4-34c1-7f73" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="c2bf-0272-30c6-dd20" name="Plasma Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="76">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="dce6-92d7-7812-820a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Cannon" hidden="false" book="BtGoA" page="76">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="4"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="6"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Plasma Fade, Light Support Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="3c39-3d6d-7a5a-f2f5" targetId="6b03-2ad4-34c1-7f73" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="1631-5857-2139-960a" name="Plasma Carbine " points="0.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="70">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="0212-5213-7d18-d37f" targetId="ee9c-ada6-953a-b774" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="d572-ea69-f6bd-9b8f" targetId="b56d-0f1d-de00-62c4" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="b55d-3878-89ca-fb86" targetId="0cb1-ea91-e5bc-4f75" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="b018-6101-d2e3-b4ea" name="Plasma Carbine (Eq)" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="70">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="7c09-db8c-68d9-485b" targetId="ee9c-ada6-953a-b774" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="8179-73ab-e5c7-065c" targetId="b56d-0f1d-de00-62c4" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="f29e-ac68-7310-1db0" targetId="0cb1-ea91-e5bc-4f75" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="d118-8115-df5f-2402" name="Plasma Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="8771-f173-82cd-3509" targetId="96f9-325b-69f7-13b4" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="47d9-8149-9744-9849" name="Plasma Lance" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="70">
-      <entries>
-        <entry id="b6e9-addd-c005-4547" name="Plasma Lance - Single Shot" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="70">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
+      <infoLinks>
+        <infoLink id="61c1-b16a-8335-9497" hidden="false" targetId="97d4-67cb-2671-ca29" type="rule">
+          <profiles/>
           <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9cd6-dbb8-bdcb-0299" name="Plasma Pistol" book="BtGoA" page="68" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="3d5e-ab8a-1859-49b2" hidden="false" targetId="2e7c-b5f9-e3e5-9125" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e6db-6ed3-1a26-ea56" name="Plasma Pistol (Eq)" book="BtGoA" page="68" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d7c4-2e9d-b85d-2cda" hidden="false" targetId="2e7c-b5f9-e3e5-9125" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2396-4159-e26c-6c42" name="Reflex Armor" book="BtGoA" page="93" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="6826-c718-8070-65a3" hidden="false" targetId="18c0-c86d-0b2c-23af" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9cdf-f068-bbde-2d0c" name="Reflex Armor (Eq)" book="BtGoA" page="93" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="fead-bc73-7559-09fc" hidden="false" targetId="18c0-c86d-0b2c-23af" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="03c2-174e-8617-cf04" name="Reflex Armor/ Impact Cloak (Eq)" book="BtGoA" page="93" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a445-3a2a-b5dc-dff6" hidden="false" targetId="18c0-c86d-0b2c-23af" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="abe2-ce1e-271f-5a85" name="Scourer Cannon" book="BtGoA" page="73" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="ccbf-d756-25d7-40f4" name="Scourer Cannon - Dispersed" book="BtGoA" page="73" hidden="true" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles>
-            <profile id="3799-96cf-d949-da4e" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Single Shot" hidden="false" book="BtGoA" page="70">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
-              </characteristics>
+            <profile id="03b8-44da-840d-df59" name="Scourer Cannon - Dispersed" book="BtGoA" page="73" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3, Standard Weapon"/>
+              </characteristics>
             </profile>
           </profiles>
-          <links/>
-        </entry>
-        <entry id="80ed-e766-57b1-3d2a" name="Plasma Lance - Scatter" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="70">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
           <rules/>
-          <profiles>
-            <profile id="9ad5-3648-6628-2caa" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Scatter" hidden="false" book="BtGoA" page="70">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2, Standard Weapon"/>
-              </characteristics>
+          <infoLinks>
+            <infoLink id="6631-7298-fd9d-ce64" hidden="false" targetId="97d4-67cb-2671-ca29" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="713c-944f-32ee-fe55" name="Scourer Cannon - Concentrated" book="BtGoA" page="73" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="0f28-d6ef-0f10-6e8f" name="Scourer Cannon - Concentrated" book="BtGoA" page="73" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="40"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="4"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+              </characteristics>
             </profile>
           </profiles>
-          <links>
-            <link id="3f8e-ffa3-e1eb-fde7" targetId="0cb1-ea91-e5bc-4f75" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="4069-4420-c5b5-56af" name="Plasma Lance - Lance" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="70">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
           <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9a2e-529c-2e81-0d99" name="Scourer Cannon - Disruptor" book="BtGoA" page="73" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles>
-            <profile id="f44f-9fdb-7e3c-bf9e" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Lance" hidden="false" book="BtGoA" page="70">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="4"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Choose Target, Inaccurate, Standard Weapon"/>
-              </characteristics>
+            <profile id="1b2e-f75a-2b45-9cde" name="Scourer Cannon - Disruptor" book="BtGoA" page="73" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, No Cover, Disruptor, Standard Weapon"/>
+              </characteristics>
             </profile>
           </profiles>
-          <links>
-            <link id="7213-775a-deac-dce8" targetId="fd72-d48c-e8af-4883" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="9752-310b-98a1-37af" targetId="3b84-9d0e-a3c1-6c1f" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="cf3a-e6a9-bdc0-e0ae" name="Plasma Light Support" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="76">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="d429-b8cc-aca0-aac9" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Light Support" hidden="false" book="BtGoA" page="76">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="4"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3, Light Support Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="9e8b-6ee9-56f0-aedf" targetId="97d4-67cb-2671-ca29" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="0f97-9dbe-566a-5ab0" name="Plasma Light Support (Eq)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="76">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="4477-6aca-5fe1-2d03" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Light Support" hidden="false" book="BtGoA" page="76">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="4"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3, Light Support Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links>
-        <link id="61c1-b16a-8335-9497" targetId="97d4-67cb-2671-ca29" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="9cd6-dbb8-bdcb-0299" name="Plasma Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="68">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="3d5e-ab8a-1859-49b2" targetId="2e7c-b5f9-e3e5-9125" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="e6db-6ed3-1a26-ea56" name="Plasma Pistol (Eq)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="68">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="d7c4-2e9d-b85d-2cda" targetId="2e7c-b5f9-e3e5-9125" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="2396-4159-e26c-6c42" name="Reflex Armor" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="93">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="6826-c718-8070-65a3" targetId="18c0-c86d-0b2c-23af" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="9cdf-f068-bbde-2d0c" name="Reflex Armor (Eq)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="93">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="fead-bc73-7559-09fc" targetId="18c0-c86d-0b2c-23af" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="03c2-174e-8617-cf04" name="Reflex Armor/ Impact Cloak (Eq)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="93">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="a445-3a2a-b5dc-dff6" targetId="18c0-c86d-0b2c-23af" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="abe2-ce1e-271f-5a85" name="Scourer Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="73">
-      <entries>
-        <entry id="ccbf-d756-25d7-40f4" name="Scourer Cannon - Dispersed" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true" book="BtGoA" page="73">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
           <rules/>
-          <profiles>
-            <profile id="03b8-44da-840d-df59" profileTypeId="ecae-8ac8-2c13-0dd3" name="Scourer Cannon - Dispersed" hidden="false" book="BtGoA" page="73">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3, Standard Weapon"/>
-              </characteristics>
+          <infoLinks>
+            <infoLink id="393a-a871-9061-745a" hidden="false" targetId="ca96-58c9-9551-d4fe" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="6631-7298-fd9d-ce64" targetId="97d4-67cb-2671-ca29" linkType="rule">
+            </infoLink>
+            <infoLink id="dee2-529a-c466-8b1e" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="713c-944f-32ee-fe55" name="Scourer Cannon - Concentrated" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="73">
-          <entries/>
-          <entryGroups/>
+            </infoLink>
+            <infoLink id="1a7e-03a3-9055-86c1" hidden="false" targetId="6305-72fa-da02-235b" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b145-19b3-baae-ff39" name="Shield Drone" book="BtGoA" page="114" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="65a3-4c38-417c-cc9f" hidden="false" targetId="b08d-74dd-1a32-8bdc" type="rule">
+          <profiles/>
           <rules/>
-          <profiles>
-            <profile id="0f28-d6ef-0f10-6e8f" profileTypeId="ecae-8ac8-2c13-0dd3" name="Scourer Cannon - Concentrated" hidden="false" book="BtGoA" page="73">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="40"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="4"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-        <entry id="9a2e-529c-2e81-0d99" name="Scourer Cannon - Disruptor" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="73">
-          <entries/>
-          <entryGroups/>
+          <infoLinks/>
           <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1707-586b-01df-0f80" name="Shield Drone (2)" book="BtGoA" page="114" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="b2fa-ba86-d0d2-1a30" hidden="false" targetId="b08d-74dd-1a32-8bdc" type="rule">
+          <profiles/>
           <rules/>
-          <profiles>
-            <profile id="1b2e-f75a-2b45-9cde" profileTypeId="ecae-8ac8-2c13-0dd3" name="Scourer Cannon - Disruptor" hidden="false" book="BtGoA" page="73">
-              <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D4, No Cover, Disruptor, Standard Weapon"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="393a-a871-9061-745a" targetId="ca96-58c9-9551-d4fe" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="dee2-529a-c466-8b1e" targetId="a41d-d55e-6d97-049d" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="1a7e-03a3-9055-86c1" targetId="6305-72fa-da02-235b" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="b145-19b3-baae-ff39" name="Shield Drone" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="114">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="65a3-4c38-417c-cc9f" targetId="b08d-74dd-1a32-8bdc" linkType="rule">
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="1707-586b-01df-0f80" name="Shield Drone (2)" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="114">
-      <entries/>
-      <entryGroups/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1e33-99fa-00fc-0a32" name="Skark" book="BtGoA" page="131" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="b2fa-ba86-d0d2-1a30" targetId="b08d-74dd-1a32-8bdc" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="1e33-99fa-00fc-0a32" name="Skark" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="131">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules>
-        <rule id="3983-4050-5e06-8fd3" name="Skark" hidden="false" book="BtGoA" page="131">
-          <description>Three attacks at SV1.</description>
+        <rule id="3983-4050-5e06-8fd3" name="Skark" book="BtGoA" page="131" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <description>Three attacks at SV1.</description>
         </rule>
       </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a1a8-ba0b-2e45-8020" name="Skyraider" book="BtGoA" page="192" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="a1a8-ba0b-2e45-8020" name="Skyraider" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="192">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="d918-4412-0ae1-6f74" name="Weapon" defaultEntryId="467e-1407-3119-60ef" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="d918-4412-0ae1-6f74" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="467e-1407-3119-60ef">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="467e-1407-3119-60ef" targetId="f31c-6e5c-19c0-ada7" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="467e-1407-3119-60ef" hidden="false" targetId="f31c-6e5c-19c0-ada7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8de3-1e72-72ef-e7a3" name="SlingNet Ammo" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="8de3-1e72-72ef-e7a3" name="SlingNet Ammo" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles/>
-      <links>
-        <link id="27d6-5dd8-337d-1005" targetId="5bd0-9ab2-0523-cbc8" linkType="rule">
+      <infoLinks>
+        <infoLink id="27d6-5dd8-337d-1005" hidden="false" targetId="5bd0-9ab2-0523-cbc8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="db03-7794-daeb-fef6" name="Solar Charges" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="85">
-      <entries/>
-      <entryGroups/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="db03-7794-daeb-fef6" name="Solar Charges" book="BtGoA" page="85" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="457b-abde-ffd5-bb14" profileTypeId="ecae-8ac8-2c13-0dd3" name="Solar Charges" hidden="false" book="BtGoA" page="85">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D3, Hazardhous H2H, Grenade"/>
-          </characteristics>
+        <profile id="457b-abde-ffd5-bb14" name="Solar Charges" book="BtGoA" page="85" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D3, Hazardhous H2H, Grenade"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="7a23-290e-0678-0165" targetId="1acd-39d3-94e7-48e1" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="7cdc-f9ef-85bc-947a" targetId="1c2c-6574-0a17-f90c" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="3878-9363-1705-9eda" name="Soma Graft" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="121">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="7a23-290e-0678-0165" hidden="false" targetId="1acd-39d3-94e7-48e1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7cdc-f9ef-85bc-947a" hidden="false" targetId="1c2c-6574-0a17-f90c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3878-9363-1705-9eda" name="Soma Graft" book="BtGoA" page="121" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="3d50-6009-476b-2dd3" targetId="1253-ef5b-67d4-3e18" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="f3aa-148a-0460-c7e5" name="Spotter Drone" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="114">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="3d50-6009-476b-2dd3" hidden="false" targetId="1253-ef5b-67d4-3e18" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f3aa-148a-0460-c7e5" name="Spotter Drone" book="BtGoA" page="114" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="b096-0158-02cc-ad91" targetId="fdbd-254f-8dd7-b658" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="a1c9-551b-1532-ef5a" name="Spotter Drone (2)" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="114">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="b096-0158-02cc-ad91" hidden="false" targetId="fdbd-254f-8dd7-b658" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a1c9-551b-1532-ef5a" name="Spotter Drone (2)" book="BtGoA" page="114" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="af19-89d3-df23-32fc" targetId="fdbd-254f-8dd7-b658" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="e329-9443-6cb2-bc53" name="Spotter Drone (Eq)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="114">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="af19-89d3-df23-32fc" hidden="false" targetId="fdbd-254f-8dd7-b658" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e329-9443-6cb2-bc53" name="Spotter Drone (Eq)" book="BtGoA" page="114" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="65b9-8262-6f60-281e" targetId="fdbd-254f-8dd7-b658" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="6bfe-ff47-b61c-afd2" name="Sub-mounted X-Sling" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="65b9-8262-6f60-281e" hidden="false" targetId="fdbd-254f-8dd7-b658" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6bfe-ff47-b61c-afd2" name="Sub-mounted X-Sling" book="BtGoA" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="a9af-f28d-4e65-6d1b" targetId="b08e-548a-fda7-0a4e" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="fb8b-7402-c5a9-8644" name="Subverter Matrix" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="122">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="a9af-f28d-4e65-6d1b" hidden="false" targetId="b08e-548a-fda7-0a4e" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fb8b-7402-c5a9-8644" name="Subverter Matrix" book="BtGoA" page="122" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="24bd-bd70-2f6b-0434" targetId="cd8d-624c-ed86-e310" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="eefe-f70d-db8e-9414" name="Synchroniser Drone" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Battle for Xilos" page="79">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="24bd-bd70-2f6b-0434" hidden="false" targetId="cd8d-624c-ed86-e310" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eefe-f70d-db8e-9414" name="Synchroniser Drone" book="Battle for Xilos" page="79" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="6931-4ce0-42bd-4c83" targetId="d91f-8426-3ab2-f06c" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="02f1-fd15-ca9d-ad79" name="Tractor Maul" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="65">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="6931-4ce0-42bd-4c83" hidden="false" targetId="d91f-8426-3ab2-f06c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="02f1-fd15-ca9d-ad79" name="Tractor Maul" book="BtGoA" page="65" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="0f4d-9895-e878-29ea" profileTypeId="ecae-8ac8-2c13-0dd3" name="Tractor Maul" hidden="false" book="BtGoA" page="65">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks, Hand Weapon"/>
-          </characteristics>
+        <profile id="0f4d-9895-e878-29ea" name="Tractor Maul" book="BtGoA" page="65" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks, Hand Weapon"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="311e-56e1-d1bc-36a1" targetId="2cbd-47c9-de87-ec2a" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="ac1e-a740-57b7-cc64" name="Twin Mag Light Support" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="75">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="25d4-13e2-3977-4bd4" name="Mag Light Support" defaultEntryId="d17e-2eae-cc33-8d46" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="d17e-2eae-cc33-8d46" targetId="a00c-0542-f2a5-8124" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="c10e-6e9c-dabb-e6f1" name="Mag Light Support" defaultEntryId="b385-bf67-9722-e7f9" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="b385-bf67-9722-e7f9" targetId="a00c-0542-f2a5-8124" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="311e-56e1-d1bc-36a1" hidden="false" targetId="2cbd-47c9-de87-ec2a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ac1e-a740-57b7-cc64" name="Twin Mag Light Support" book="BtGoA" page="75" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="f31c-6e5c-19c0-ada7" name="Twin Mag Repeaters" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="69">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="4e5a-4594-d2da-527c" name="Mag Repeater" defaultEntryId="513b-6ec0-e655-02cd" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="513b-6ec0-e655-02cd" targetId="790a-6841-6372-870b" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="273a-5de1-c9e1-5310" name="Mag Repeater" defaultEntryId="6e82-7e87-0e72-610f" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="6e82-7e87-0e72-610f" targetId="790a-6841-6372-870b" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="25d4-13e2-3977-4bd4" name="Mag Light Support" hidden="false" collective="false" defaultSelectionEntryId="d17e-2eae-cc33-8d46">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="d17e-2eae-cc33-8d46" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="c10e-6e9c-dabb-e6f1" name="Mag Light Support" hidden="false" collective="false" defaultSelectionEntryId="b385-bf67-9722-e7f9">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="b385-bf67-9722-e7f9" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f31c-6e5c-19c0-ada7" name="Twin Mag Repeaters" book="BtGoA" page="69" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="78dd-7840-1210-fb35" name="Twin Plasma Carbines" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="306b-df6b-34af-a65f" name="Plasma Carbine" defaultEntryId="50f5-f0eb-d9cb-a569" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="50f5-f0eb-d9cb-a569" targetId="b018-6101-d2e3-b4ea" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="4e5a-4594-d2da-527c" name="Mag Repeater" hidden="false" collective="false" defaultSelectionEntryId="513b-6ec0-e655-02cd">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="513b-6ec0-e655-02cd" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="273a-5de1-c9e1-5310" name="Mag Repeater" hidden="false" collective="false" defaultSelectionEntryId="6e82-7e87-0e72-610f">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="6e82-7e87-0e72-610f" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="78dd-7840-1210-fb35" name="Twin Plasma Carbines" book="BtGoA" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="b9f1-a313-3e59-57ab" name="X-Howitzer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="82">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="acf4-2a5f-e9a1-6d3c" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Howitzer" hidden="false" book="BtGoA" page="82">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-50"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="250"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D10, No Cover, Heavy Weapon"/>
-          </characteristics>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="306b-df6b-34af-a65f" name="Plasma Carbine" hidden="false" collective="false" defaultSelectionEntryId="50f5-f0eb-d9cb-a569">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="50f5-f0eb-d9cb-a569" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b9f1-a313-3e59-57ab" name="X-Howitzer" book="BtGoA" page="82" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="acf4-2a5f-e9a1-6d3c" name="X-Howitzer" book="BtGoA" page="82" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-50"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="250"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D10, No Cover, Heavy Weapon"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="6f40-42de-4957-1df4" targetId="c3bc-87fd-fa5d-5055" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="b631-2638-986b-4611" targetId="04d9-a48d-7b25-4dd3" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="7c8b-6880-8593-4b52" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="92e5-9a8f-2921-8280" targetId="bc4e-7cd8-4017-d911" linkType="entry group">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="eed0-b68f-b5fb-92c7" name="X-Launcher" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="78">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="2489-100b-d116-96c6" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Launcher" hidden="false" book="BtGoA" page="78">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="60"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="120"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D5, No Cover,  Light Support Weapon"/>
-          </characteristics>
+      <infoLinks>
+        <infoLink id="6f40-42de-4957-1df4" hidden="false" targetId="c3bc-87fd-fa5d-5055" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+        </infoLink>
+        <infoLink id="b631-2638-986b-4611" hidden="false" targetId="04d9-a48d-7b25-4dd3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7c8b-6880-8593-4b52" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="92e5-9a8f-2921-8280" hidden="false" targetId="bc4e-7cd8-4017-d911" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eed0-b68f-b5fb-92c7" name="X-Launcher" book="BtGoA" page="78" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="2489-100b-d116-96c6" name="X-Launcher" book="BtGoA" page="78" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D5, No Cover,  Light Support Weapon"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="cbba-ff32-112c-3173" targetId="c3bc-87fd-fa5d-5055" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="57ac-1f50-9d13-b33b" targetId="b050-496a-ed16-2b2a" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="613e-43c3-a036-e997" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="7bb9-56de-ae51-c52b" targetId="bc4e-7cd8-4017-d911" linkType="entry group">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="b08e-548a-fda7-0a4e" name="X-Sling" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="68">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="3cec-d2e0-b0ed-7856" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Sling" hidden="false" book="BtGoA" page="68">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D3, Hand Weapon"/>
-          </characteristics>
+      <infoLinks>
+        <infoLink id="cbba-ff32-112c-3173" hidden="false" targetId="c3bc-87fd-fa5d-5055" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+        </infoLink>
+        <infoLink id="57ac-1f50-9d13-b33b" hidden="false" targetId="b050-496a-ed16-2b2a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="613e-43c3-a036-e997" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="7bb9-56de-ae51-c52b" hidden="false" targetId="bc4e-7cd8-4017-d911" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b08e-548a-fda7-0a4e" name="X-Sling" book="BtGoA" page="68" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="3cec-d2e0-b0ed-7856" name="X-Sling" book="BtGoA" page="68" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D3, Hand Weapon"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="ff22-4293-45d6-b483" targetId="1acd-39d3-94e7-48e1" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="179a-c0cc-49cc-c946" name="X-Sling (Eq)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="68">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="8977-826a-5f65-6907" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Sling" hidden="false" book="BtGoA" page="68">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D3, Hand Weapon"/>
-          </characteristics>
+      <infoLinks>
+        <infoLink id="ff22-4293-45d6-b483" hidden="false" targetId="1acd-39d3-94e7-48e1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="179a-c0cc-49cc-c946" name="X-Sling (Eq)" book="BtGoA" page="68" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="8977-826a-5f65-6907" name="X-Sling" book="BtGoA" page="68" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D3, Hand Weapon"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="f51f-aab5-2da1-d5d0" targetId="1acd-39d3-94e7-48e1" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-  </sharedEntries>
-  <sharedEntryGroups>
-    <entryGroup id="bc4e-7cd8-4017-d911" name="Munitions" minSelections="0" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="c816-58ed-3726-86b5" name="Scrambler" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="f51f-aab5-2da1-d5d0" hidden="false" targetId="1acd-39d3-94e7-48e1" type="rule">
           <profiles/>
-          <links>
-            <link id="55f1-0e9f-4b69-56c1" targetId="7a3b-74a5-3ced-dd88" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="69e5-ef01-7a5e-3f24" targetId="b996-131f-b84a-4724" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="e0bc-ff63-7ed9-9768" name="Arc" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
           <rules/>
-          <profiles/>
-          <links>
-            <link id="6614-fd6d-aecf-1070" targetId="c1ba-c745-22a8-e2d7" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="6979-177c-42e8-27bf" targetId="b996-131f-b84a-4724" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="d6cb-2428-f1b5-0f11" name="Blur" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-          <entries/>
-          <entryGroups/>
+          <infoLinks/>
           <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="a019-91dd-3b84-e72e" targetId="117a-a2aa-4be7-dffe" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="b4a9-0df0-5149-5785" targetId="b996-131f-b84a-4724" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="bbac-d335-536a-e63d" name="Scoot" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="0e1e-3e34-5c36-4bbf" targetId="28a0-7151-a0c5-9495" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="cc03-4929-b882-43a6" targetId="b996-131f-b84a-4724" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="2a9e-c888-1e5a-ea11" name="Net" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="f4bd-099a-19ab-8138" targetId="ac33-af99-2d76-c981" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="b932-f489-37e5-e6b4" name="Grip" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="eee1-31e1-599c-0bd8" targetId="1045-95cb-5504-9050" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="df1a-7d7c-9316-5794" targetId="b996-131f-b84a-4724" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="f766-367d-f5c0-fc59" name="All" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="1874-10fd-bc26-7005" targetId="c1ba-c745-22a8-e2d7" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="0234-4b9e-9342-68f7" targetId="117a-a2aa-4be7-dffe" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="6234-ec86-062c-0073" targetId="1045-95cb-5504-9050" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="a285-cf7f-7fac-f9ab" targetId="ac33-af99-2d76-c981" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="11d8-fdb9-76ff-2c4c" targetId="28a0-7151-a0c5-9495" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="9abb-2789-75c0-d3a8" targetId="7a3b-74a5-3ced-dd88" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="1492-b598-eb64-0ea0" targetId="b996-131f-b84a-4724" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <links/>
-    </entryGroup>
-  </sharedEntryGroups>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="bc4e-7cd8-4017-d911" name="Munitions" hidden="false" collective="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="c816-58ed-3726-86b5" name="Scrambler" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="55f1-0e9f-4b69-56c1" hidden="false" targetId="7a3b-74a5-3ced-dd88" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="69e5-ef01-7a5e-3f24" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e0bc-ff63-7ed9-9768" name="Arc" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="6614-fd6d-aecf-1070" hidden="false" targetId="c1ba-c745-22a8-e2d7" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="6979-177c-42e8-27bf" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d6cb-2428-f1b5-0f11" name="Blur" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="a019-91dd-3b84-e72e" hidden="false" targetId="117a-a2aa-4be7-dffe" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="b4a9-0df0-5149-5785" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="bbac-d335-536a-e63d" name="Scoot" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="0e1e-3e34-5c36-4bbf" hidden="false" targetId="28a0-7151-a0c5-9495" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="cc03-4929-b882-43a6" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2a9e-c888-1e5a-ea11" name="Net" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="f4bd-099a-19ab-8138" hidden="false" targetId="ac33-af99-2d76-c981" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b932-f489-37e5-e6b4" name="Grip" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="eee1-31e1-599c-0bd8" hidden="false" targetId="1045-95cb-5504-9050" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="df1a-7d7c-9316-5794" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f766-367d-f5c0-fc59" name="All" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="1874-10fd-bc26-7005" hidden="false" targetId="c1ba-c745-22a8-e2d7" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="0234-4b9e-9342-68f7" hidden="false" targetId="117a-a2aa-4be7-dffe" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="6234-ec86-062c-0073" hidden="false" targetId="1045-95cb-5504-9050" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="a285-cf7f-7fac-f9ab" hidden="false" targetId="ac33-af99-2d76-c981" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="11d8-fdb9-76ff-2c4c" hidden="false" targetId="28a0-7151-a0c5-9495" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="9abb-2789-75c0-d3a8" hidden="false" targetId="7a3b-74a5-3ced-dd88" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="1492-b598-eb64-0ea0" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
   <sharedRules>
-    <rule id="2cbd-47c9-de87-ec2a" name="2 Attacks" hidden="false" book="BtGoA" page="133">
+    <rule id="2cbd-47c9-de87-ec2a" name="2 Attacks" book="BtGoA" page="133" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Two attacks in close combat.</description>
-      <modifiers/>
     </rule>
-    <rule id="61e2-3707-ade3-c9ad" name="3 Attacks" hidden="false" book="BtGoA" page="133">
+    <rule id="61e2-3707-ade3-c9ad" name="3 Attacks" book="BtGoA" page="133" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Three attacks in close combat.</description>
-      <modifiers/>
     </rule>
-    <rule id="7daf-414b-c030-7626" name="AG Chute" hidden="false" book="BtGoA" page="120">
+    <rule id="7daf-414b-c030-7626" name="AG Chute" book="BtGoA" page="120" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May make 2M move and shoot when given advance order. +1 Ag. Treat difficult ground as suspensored vehicle. </description>
-      <modifiers/>
     </rule>
-    <rule id="c1ba-c745-22a8-e2d7" name="Arc" hidden="false" book="BtGoA" page="88">
+    <rule id="c1ba-c745-22a8-e2d7" name="Arc" book="BtGoA" page="88" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Creates 3&quot; sink area. Affects any shooter attemping to draw LOS and shoot through the arc. Roll a D10 if LOS goes through - 1-5 the shot is normal, 6-10 the shot automatically misses. Make test before rolling Acc to hit. 
 
 OH shots are affected if the target is within 3&quot; of the marker. </description>
-      <modifiers/>
     </rule>
-    <rule id="b7c6-fc7c-d48b-aae4" name="Auto-Workshop" hidden="false" book="BtGoA" page="121">
+    <rule id="b7c6-fc7c-d48b-aae4" name="Auto-Workshop" book="BtGoA" page="121" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Activated from any order to the unit. Affects every vehicle, weapon drone, weapon team, and machine mounted unit within 5&quot; of the unit, and itself. Roll D10 - on 1-5, nothing happens, 6-10 each unit removes a pin.</description>
-      <modifiers/>
     </rule>
-    <rule id="f0d9-1e5a-ec20-b27c" name="Batter Drone" hidden="false" book="BtGoA" page="110">
+    <rule id="f0d9-1e5a-ec20-b27c" name="Batter Drone" book="BtGoA" page="110" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Projects curved shield as template - must be positioned with outer side facing away from drone, no part of template more than 5&quot; from drone base. Template may be repositioned any time unit receives an order die.
 
 Enemy units shooting through shield suffer -2 ACC. Models positioned inside the shield do not receive the -2 ACC protection. Troops shooting from the inside convex side of the shield do not suffer the ACC penalty. 
 
 No protection is offered for OH shots.</description>
-      <modifiers/>
     </rule>
-    <rule id="04d9-a48d-7b25-4dd3" name="Blast D10" hidden="false" book="BtGoA">
+    <rule id="04d9-a48d-7b25-4dd3" name="Blast D10" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Inflicts D10 hits on a successful shooting attack.</description>
-      <modifiers/>
     </rule>
-    <rule id="1acd-39d3-94e7-48e1" name="Blast D3" hidden="false" book="BtGoA">
+    <rule id="1acd-39d3-94e7-48e1" name="Blast D3" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Inflicts D3 hits on a successful shooting attack.</description>
-      <modifiers/>
     </rule>
-    <rule id="ca96-58c9-9551-d4fe" name="Blast D4" hidden="false" book="BtGoA">
+    <rule id="ca96-58c9-9551-d4fe" name="Blast D4" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Inflicts D4 hits on a successful shooting attack.</description>
-      <modifiers/>
     </rule>
-    <rule id="b050-496a-ed16-2b2a" name="Blast D5" hidden="false" book="BtGoA">
+    <rule id="b050-496a-ed16-2b2a" name="Blast D5" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Inflicts D5 hits on a successful shooting attack.</description>
-      <modifiers/>
     </rule>
-    <rule id="5d2e-45d2-1707-87db" name="Block!" hidden="false" page="159">
+    <rule id="5d2e-45d2-1707-87db" name="Block!" page="159" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>The Order Die drawn from the bag is returned and another random die is drawn. This dice stands and cannot be blocked. Use once and discard. You can buy as many Blocks as you are allowed Auxiliary choices in your Army</description>
-      <modifiers/>
     </rule>
-    <rule id="117a-a2aa-4be7-dffe" name="Blur" hidden="false" book="BtGoA" page="89">
+    <rule id="117a-a2aa-4be7-dffe" name="Blur" book="BtGoA" page="89" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Any unit within 3&quot; reduces Acc by D3 each time it shoots. If within two or more blur markers, roll a D3 for each and take highest.</description>
-      <modifiers/>
     </rule>
-    <rule id="c3e6-4e9b-858c-80d3" name="Booster Drone" hidden="false" book="BtGoA" page="92">
+    <rule id="c3e6-4e9b-858c-80d3" name="Booster Drone" book="BtGoA" page="92" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Infantry, Weapon Team, or Command unit gains +1 armor bonus from reflex, hyperlight, and phase armor. Cannot benefit units with HL boosters.</description>
-      <modifiers/>
     </rule>
-    <rule id="4e34-753f-b082-2e00" name="Borer Drone" hidden="false" book="BtGoA" page="111">
+    <rule id="4e34-753f-b082-2e00" name="Borer Drone" book="BtGoA" page="111" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Every model in the owning unit gains +1 Str for all Strength tests and H2H. 
 
 Unit may put up temporary cover by making any action without a move. May result from order or reaction and can include a down action from failed order check. Unit benefits from 2+ Res as long as it does not move. Is not cumulative with other cover bonuses.</description>
-      <modifiers/>
     </rule>
-    <rule id="5f48-f41c-fd96-6a1a" name="Camo Drone" hidden="false" book="BtGoA" page="111">
+    <rule id="5f48-f41c-fd96-6a1a" name="Camo Drone" book="BtGoA" page="111" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>If unit goes down it cannot be targeted at ranges of more than 10&quot;. If a unit with the drone goes down as reaction to enemy shooting from more than 10&quot; away then the unit can no longer be targeted. OH shots will miss and have no effect. Scout probes can compromise this effect within 10&quot;.
 
 </description>
-      <modifiers/>
     </rule>
-    <rule id="fd72-d48c-e8af-4883" name="Choose Target" hidden="false" book="BtGoA" page="70">
+    <rule id="fd72-d48c-e8af-4883" name="Choose Target" book="BtGoA" page="70" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May fire at a different target from the test of the unit. If more than one model has a weapon with Choose Target, all weapons with Choose Target must shoot at same target.</description>
-      <modifiers/>
     </rule>
-    <rule id="5c9b-1bde-ee01-04a4" name="Command" hidden="false" book="BtGoA" page="133">
+    <rule id="5c9b-1bde-ee01-04a4" name="Command" book="BtGoA" page="133" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Friendly units within 10&quot; can use this model&apos;s Co value for any Co based test instead of their own. Pins still affect this Co value.</description>
-      <modifiers/>
     </rule>
-    <rule id="3995-c066-c957-5ffe" name="Compactor Drone" hidden="false" book="BtGoA" page="112">
+    <rule id="3995-c066-c957-5ffe" name="Compactor Drone" book="BtGoA" page="112" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May carry one of the following: all of a mounted unit&apos;s bikes, a unit&apos;s support weapon, an entire weapon drone unit complete with any associated buddy drones other than compactor drones, or an entire probe shard.
 
 May load or unload when their unit makes an action, even down order following failed order test. </description>
-      <modifiers/>
     </rule>
-    <rule id="7db4-2d14-3984-37d9" name="Compressor" hidden="false" book="BtGoA" page="71">
+    <rule id="7db4-2d14-3984-37d9" name="Compressor" book="BtGoA" page="71" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>SV value varies with range band.</description>
-      <modifiers/>
     </rule>
-    <rule id="5fb8-4f09-d496-4ea9" name="Concentrated Fire" hidden="false" book="BtGoA" page="72">
+    <rule id="5fb8-4f09-d496-4ea9" name="Concentrated Fire" book="BtGoA" page="72" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Any lucky hits can be allocated to the same model, do not have to be distributed evenly.</description>
-      <modifiers/>
     </rule>
-    <rule id="c34f-bbca-9bfc-6874" name="Crawler" hidden="false" book="BtGoA" page="133">
+    <rule id="c34f-bbca-9bfc-6874" name="Crawler" book="BtGoA" page="133" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Crawlers are restricted when moving over certain terrain types as described in the terrain section. They cross obstacles in the same manner as a heavy weapon team. They cannot cross at a run and must test to cross at advance rate. Crossing obstacles, p22</description>
-      <modifiers/>
     </rule>
-    <rule id="cf7f-6f85-e64e-0363" name="Cycle" hidden="false" book="BtGoA" page="78">
+    <rule id="cf7f-6f85-e64e-0363" name="Cycle" book="BtGoA" page="78" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>On the Acc roll of a 10 shot misses and weapon team goes down.</description>
-      <modifiers/>
     </rule>
-    <rule id="6305-72fa-da02-235b" name="Disruptor" hidden="false" book="BtGoA" page="79">
+    <rule id="6305-72fa-da02-235b" name="Disruptor" book="BtGoA" page="79" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>A target hit by a disruptor weapon gets no cover bonus to its Res roll against the hit.
 
 A non-Ghar target hit by a disruptor weapon takes 2 pins rather than the usual 1 pin. If the target has Res &gt; 10, it takes these pins even if the hit is successfully resisted. Ghar do not suffer these pins. 
@@ -4804,140 +8481,236 @@ A non-Ghar target hit by a disruptor weapon takes 2 pins rather than the usual 1
 Buddy drones can be allocated hits from this weapon by the shooter from any hits, not just lucky hits.
 
 If the target is a probe it only passes Res tests on a 1.</description>
-      <modifiers/>
     </rule>
-    <rule id="9444-e2a0-8048-5ce9" name="Down" hidden="false" book="BtGoA" page="74">
+    <rule id="9444-e2a0-8048-5ce9" name="Down" book="BtGoA" page="74" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Unit hit automatically goes down after shooting has been worked out whether casualties are caused or not. </description>
-      <modifiers/>
     </rule>
-    <rule id="4232-2801-36cf-704c" name="Exhausted" hidden="false" book="BtGoA" page="67">
+    <rule id="4232-2801-36cf-704c" name="Exhausted" book="BtGoA" page="67" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Rolls of 10 on Str or Acc to-hit rolls cannot be re-rolled and stave has become exhausted. Make a test at the turn end phase - 1-5 it is still exhausted, 6-10 it is replenished.</description>
-      <modifiers/>
     </rule>
-    <rule id="e77b-02da-5143-229e" name="Extra Shot" hidden="false" page="159">
+    <rule id="e77b-02da-5143-229e" name="Extra Shot" page="159" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>If you score a Lucky Hit with any shot you can make one more shot with that model using the same weapon with exactly the same score required to hit the same target. Roll one more shot to score a hit. Use once and discard. You can buy as many Extra Shots as you are allowed Auxiliary choices in your Army.</description>
-      <modifiers/>
     </rule>
-    <rule id="b0ca-8e7d-d03f-f027" name="Fast" hidden="false" book="BtGoA" page="133">
+    <rule id="b0ca-8e7d-d03f-f027" name="Fast" book="BtGoA" page="133" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Move at double pace - 10&quot; per advance, 20&quot; for run. Shots fired at fast targets with a run order must re-roll hits. 
 Fast units may break off of assault after point blank shooting has been conducted. They may move through the enemy during this move.</description>
-      <modifiers/>
     </rule>
-    <rule id="7bc9-5e98-2914-5abd" name="Follow" hidden="false" book="BtGoA" page="13">
+    <rule id="7bc9-5e98-2914-5abd" name="Follow" book="BtGoA" page="13" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>When a leader with follow gives his unit an order, any other friendly units within 5&quot; may make the same action as long as they have no pins and are otherwise able to make the action.</description>
-      <modifiers/>
     </rule>
-    <rule id="d50c-3bbe-c62d-34c3" name="Fractal Lock" hidden="false" book="BtGoA" page="83">
+    <rule id="d50c-3bbe-c62d-34c3" name="Fractal Lock" book="BtGoA" page="83" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>If the weapon hits, it locks on. If the target does not move and the unit receives a fire order it automatically hits. Each time it auto-hits the SV value goes up by 2.</description>
-      <modifiers/>
     </rule>
-    <rule id="2afe-05bf-268b-84c2" name="Get Up!" hidden="false" page="159">
+    <rule id="2afe-05bf-268b-84c2" name="Get Up!" page="159" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>When making a Recovery Test (to recover a Down order die) you will succeed on a roll of anything but a 10 regardless of the value you would normally test against. A roll of a 10 is still a failure, and no pin markers are removed, as standard. Use once and discard. You can buy as many Get Up!(s) as you are allowed Auxiliary choices in your Army.</description>
-      <modifiers/>
     </rule>
-    <rule id="b466-7990-db34-55b1" name="Grenade" hidden="false" book="BtGoA" page="85">
+    <rule id="b466-7990-db34-55b1" name="Grenade" book="BtGoA" page="85" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>In H2H counts as hand weapon +1 Str bonus. Grenade hits compound in H2H - if a model takes suffers two or more hits from grenades, add all SVs together and take one Res test.</description>
-      <modifiers/>
     </rule>
-    <rule id="1045-95cb-5504-9050" name="Grip" hidden="false" book="BtGoA" page="87">
+    <rule id="1045-95cb-5504-9050" name="Grip" book="BtGoA" page="87" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Unit beginning its move within 3&quot; must take and pass an Ag test. If failed it may not move, if passed it can move half rate, failed on a 10 it takes a pin and cannot move.
 
 If a unit moves within 3&quot; it must take the Ag test as above. </description>
-      <modifiers/>
     </rule>
-    <rule id="5f6c-7c20-3cbc-bcc8" name="Gun Drone" hidden="false" book="BtGoA" page="112">
+    <rule id="5f6c-7c20-3cbc-bcc8" name="Gun Drone" book="BtGoA" page="112" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Shoots as if it were an ordinary member of its unit with the same Acc value. Draw LOS in the same way as other models in the unit.</description>
-      <modifiers/>
     </rule>
-    <rule id="1c2c-6574-0a17-f90c" name="Hazardous H2H" hidden="false" book="BtGoA" page="85">
+    <rule id="1c2c-6574-0a17-f90c" name="Hazardous H2H" book="BtGoA" page="85" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Any H2H Str roll of 10 hits the user, not enemy.</description>
-      <modifiers/>
     </rule>
-    <rule id="a846-6829-3398-bac1" name="Heavy" hidden="false" book="BtGoA" page="134">
+    <rule id="a846-6829-3398-bac1" name="Heavy" book="BtGoA" page="134" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Movement restricted across obstacles per p22. Cannot cross obstacles at a run. Agility test required to cross at advance. When rolling resistance checks only fail on a 10, roll on damage chart p37.</description>
-      <modifiers/>
     </rule>
-    <rule id="3c64-6022-a5f1-9c04" name="Hero" hidden="false" book="BtGoA" page="134">
+    <rule id="3c64-6022-a5f1-9c04" name="Hero" book="BtGoA" page="134" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Friendly units within 10&quot; may use this model&apos;s Init stat. </description>
-      <modifiers/>
     </rule>
-    <rule id="34e0-c5a3-3998-5d0b" name="High Commander" hidden="false" book="BtGoA" page="134">
+    <rule id="34e0-c5a3-3998-5d0b" name="High Commander" book="BtGoA" page="134" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May re-roll every failed resist test once. May use command, hero, and follow special rules on any units.</description>
-      <modifiers/>
     </rule>
-    <rule id="b436-1f8a-5d3a-2d7d" name="HL Armor" hidden="false" book="BtGoA" page="93">
+    <rule id="b436-1f8a-5d3a-2d7d" name="HL Armor" book="BtGoA" page="93" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Ranges of 10&quot; or less, +1 to Res. Ranges of greater than 10&quot; +2 Res. Against any Blast hits, +3 Res. </description>
-      <modifiers/>
     </rule>
-    <rule id="56ab-52fc-9557-2586" name="HL Booster" hidden="false" book="BtGoA" page="93">
+    <rule id="56ab-52fc-9557-2586" name="HL Booster" book="BtGoA" page="93" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>+1 Res on top of all other bonuses.</description>
-      <modifiers/>
     </rule>
-    <rule id="ca2b-9550-eb1e-77c8" name="Homer Drone" hidden="false" book="BtGoA" page="112">
+    <rule id="ca2b-9550-eb1e-77c8" name="Homer Drone" book="BtGoA" page="112" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Unit may be transported off the table by using a Run order. If taking an order test and failed on a 10, homer drone is destroyed. Once removed from the battlefield unit cannot return. Only the unit and equipment may be transported - not objectives.</description>
-      <modifiers/>
     </rule>
-    <rule id="3b84-9d0e-a3c1-6c1f" name="Inaccurate" hidden="false" book="BtGoA" page="70">
+    <rule id="3b84-9d0e-a3c1-6c1f" name="Inaccurate" book="BtGoA" page="70" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Additional -1 Acc penalty.</description>
-      <modifiers/>
     </rule>
-    <rule id="96c4-7a43-2a4c-d7d3" name="Infiltrator" hidden="false" book="BtGoA" page="134">
+    <rule id="96c4-7a43-2a4c-d7d3" name="Infiltrator" book="BtGoA" page="134" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May make a special pre-game run action. May sprint, test for exhaustion. May not move within 10&quot; of enemy. May lay a minefield before game starts.</description>
-      <modifiers/>
     </rule>
-    <rule id="a221-d53c-b4bd-b52c" name="Large" hidden="false" book="BtGoA" page="134">
+    <rule id="a221-d53c-b4bd-b52c" name="Large" book="BtGoA" page="134" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Cannot sprint unless also fast. Passes when testing Ag to move through dense terrain reduce movement to half. Passes on a one mean unit can move at full rate. Failure means unit cannot move, failure on a 10 gains one pin. 
 
 Units may fire over regular sized units at no penalty. Large targets never gain cover bonuses to their Res stat. May not enter buildings. </description>
-      <modifiers/>
     </rule>
-    <rule id="7cfb-9874-dfe0-b136" name="Lava Spit" hidden="false" book="BtGoA" page="135">
+    <rule id="7cfb-9874-dfe0-b136" name="Lava Spit" book="BtGoA" page="135" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Lavamites may shoot during point blank shooting at SV 2.</description>
-      <modifiers/>
     </rule>
-    <rule id="e441-c3a6-7d61-2c63" name="Leader" hidden="false" book="BtGoA" page="135">
+    <rule id="e441-c3a6-7d61-2c63" name="Leader" book="BtGoA" page="135" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May re-roll one failed res test per leader level. </description>
-      <modifiers/>
     </rule>
-    <rule id="7850-89e7-bab8-86e9" name="Leader 2" hidden="false" book="BtGoA">
+    <rule id="7850-89e7-bab8-86e9" name="Leader 2" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May re-roll one failed res test per leader level.</description>
-      <modifiers/>
     </rule>
-    <rule id="05bb-4d34-70cd-25d2" name="Leader 3" hidden="false" book="BtGoA">
+    <rule id="05bb-4d34-70cd-25d2" name="Leader 3" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May re-roll one failed res test per leader level.</description>
-      <modifiers/>
     </rule>
-    <rule id="5efa-64a9-bbc9-3dba" name="Limited Ammo" hidden="false" book="BtGoA" page="73,77">
+    <rule id="5efa-64a9-bbc9-3dba" name="Limited Ammo" book="BtGoA" page="73,77" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Risks running out of ammunition.</description>
-      <modifiers/>
     </rule>
-    <rule id="d8dc-cf25-ef95-c94b" name="Limited Choice" hidden="false" book="BtGoA">
+    <rule id="d8dc-cf25-ef95-c94b" name="Limited Choice" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May only be taken as 1 in 4 choices of entire force.</description>
-      <modifiers/>
     </rule>
-    <rule id="5741-af68-9dc0-519f" name="Marksman" hidden="false" page="159">
+    <rule id="5741-af68-9dc0-519f" name="Marksman" page="159" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>When rolling to-hit against a unit with a shooting attack, you may re-roll all of the shots. If you choose to do this you must take ALL of the shots again regardless of whether they hit or miss, and whatever result you roll the second time stands, with no further re-rolls allowed. You can only buy ONE Marksman regardless of Army size.</description>
-      <modifiers/>
     </rule>
-    <rule id="c863-510b-e239-be92" name="Massive Damage" hidden="false" book="BtGoA" page="75">
+    <rule id="c863-510b-e239-be92" name="Massive Damage" book="BtGoA" page="75" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>If the mag cannon&apos;s target rolls for damage on a damage table it suffers Massive Damage - page 37.</description>
-      <modifiers/>
     </rule>
-    <rule id="4039-88e8-9f6d-bfb3" name="Medi-Drone" hidden="false" book="BtGoA" page="113">
+    <rule id="4039-88e8-9f6d-bfb3" name="Medi-Drone" book="BtGoA" page="113" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Can only attend humans - not machines or Skarks. Any friendly unit within 5&quot; may re-roll one failed Res test each time it is shot at, fights H2H, or otherwise suffers damage. Units within 5&quot; of more than one medi-drone may re-roll one failed Res test for each medi-drone. </description>
-      <modifiers/>
     </rule>
-    <rule id="137e-c2b6-65b7-ecc3" name="Medic" hidden="false" book="BtGoA" page="135">
+    <rule id="137e-c2b6-65b7-ecc3" name="Medic" book="BtGoA" page="135" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Units within 5&quot; of a medic unit may re-roll one failed Res test each time it is shot at. Medi-probes and drones may add their re-rolls to total number of re-rolls.
 
 Cannot be used on non-humans. </description>
-      <modifiers/>
     </rule>
-    <rule id="a97f-4540-de7b-5734" name="Meld" hidden="false" book="BtGoA" page="128">
+    <rule id="a97f-4540-de7b-5734" name="Meld" book="BtGoA" page="128" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Single unit of two NuHu but only has one Res value. If a Res test is failed, roll on Meld Damage Chart. </description>
-      <modifiers/>
     </rule>
-    <rule id="5e3d-6905-2b14-8cd1" name="Meld Damage" hidden="false" book="BtGoA" page="128">
+    <rule id="5e3d-6905-2b14-8cd1" name="Meld Damage" book="BtGoA" page="128" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>D10 Result
 1	No effect
 2-3 	Take one additional pin and Go Down
@@ -4945,9 +8718,12 @@ Cannot be used on non-humans. </description>
 6-8 	Take D3 additional pins and Go Down, MOD units lose one order die
 9 	One of the NuHu falls casualty, breaking the meld. Remaining model reverts to normal NuHu stats. MOD 	is lost. Surviving NuHu takes D3 additional pins and goes down.
 10 	Destroyed. The unit is destroyed, and both NuHu are removed as casualties.</description>
-      <modifiers/>
     </rule>
-    <rule id="db7a-5bd4-6400-f6d1" name="Misgenic Abilities" hidden="false" book="BtGoA" page="196">
+    <rule id="db7a-5bd4-6400-f6d1" name="Misgenic Abilities" book="BtGoA" page="196" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Set after deployment. May choose one of the following before the game and pay 10 points to gain any further qualities on a D10 roll. Duplicates may be added together or treated as a 10 roll.
 
 D10 Result:
@@ -4961,21 +8737,33 @@ D10 Result:
 8 Mesmerising: any enemy unit within 5&quot; must pass command test at -1 to do anything, even with no pins.
 9 Cunning Leader: unit leader gains command and Init 8. If unit has no leader, it gains a leader with base Co and Init.
 10 Choose one of the above qualities.</description>
-      <modifiers/>
     </rule>
-    <rule id="5565-ce10-1c78-1ee7" name="MOD2" hidden="false" book="BtGoA" page="136">
+    <rule id="5565-ce10-1c78-1ee7" name="MOD2" book="BtGoA" page="136" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Unit contributes two die to the dice pool and may act twice per turn. Always treated as having used the most recent action.</description>
-      <modifiers/>
     </rule>
-    <rule id="8151-2e24-94ee-0477" name="MOD3" hidden="false" book="BtGoA">
+    <rule id="8151-2e24-94ee-0477" name="MOD3" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Unit contributes three die to the dice pool and may act thrice per turn. Always treated as having used the most recent action.</description>
-      <modifiers/>
     </rule>
-    <rule id="c1c6-f9c7-c84f-d57d" name="Nano Drone" hidden="false" book="BtGoA" page="113">
+    <rule id="c1c6-f9c7-c84f-d57d" name="Nano Drone" book="BtGoA" page="113" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Shots against the unit suffer -2 Acc. Cannot be combined with a Batter drone. Unit counts as having HL armor. IMtel stave may be boosted by Nano Drone.</description>
-      <modifiers/>
     </rule>
-    <rule id="ac33-af99-2d76-c981" name="Net" hidden="false" book="BtGoA" page="88">
+    <rule id="ac33-af99-2d76-c981" name="Net" book="BtGoA" page="88" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Roll to hit as normal for a blast weapon. Target does not suffer blast damage, rather suffers pins:
 
 X-Launcher: D3+1 pin
@@ -4983,114 +8771,192 @@ X-Howitzer: D5+1 pin
 Mag Mortar: D10+1 pin
 
 Targets that would normally force an Acc re-roll suffer half the number of pins rounded down. Divide pins equally between two or more units as normal.</description>
-      <modifiers/>
     </rule>
-    <rule id="a41d-d55e-6d97-049d" name="No Cover" hidden="false" book="BtGoA" page="71">
+    <rule id="a41d-d55e-6d97-049d" name="No Cover" book="BtGoA" page="71" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>No cover bonus to Res roll.</description>
-      <modifiers/>
     </rule>
-    <rule id="f502-611e-9704-97bb" name="No Crew" hidden="false" book="BtGoA" page="7">
+    <rule id="f502-611e-9704-97bb" name="No Crew" book="BtGoA" page="7" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>When carried by a model in battle armor it counts as having full crew.</description>
-      <modifiers/>
     </rule>
-    <rule id="c3bc-87fd-fa5d-5055" name="OH" hidden="false" book="BtGoA" page="34">
+    <rule id="c3bc-87fd-fa5d-5055" name="OH" book="BtGoA" page="34" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Fires as an Overhead weapon.</description>
+    </rule>
+    <rule id="aef6-6934-1dee-6fa0" name="OHx2" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="aef6-6934-1dee-6fa0" name="OHx2" hidden="false" book="BtGoA">
+    <rule id="7db4-6bd3-fb59-706d" name="Outcast" book="BtGoA" page="136" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </rule>
-    <rule id="7db4-6bd3-fb59-706d" name="Outcast" hidden="false" book="BtGoA" page="136">
       <description>Command, hero, and follow rules only work on Outcast units. Cannot benefit from command, hero, or follow from non-Outcast unless it is a High Commander.</description>
-      <modifiers/>
     </rule>
-    <rule id="3559-4b87-980d-f90d" name="Overload Ammo" hidden="false" book="BtGoA" page="89">
+    <rule id="3559-4b87-980d-f90d" name="Overload Ammo" book="BtGoA" page="89" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Can only be used with direct fire. SV = 3, single hit. If a 10 is rolled on Acc roll, shot misses, cannot be re-rolled, and overload ammo cannot be used again.</description>
-      <modifiers/>
     </rule>
-    <rule id="b28d-571e-af69-4582" name="Phase Armor" hidden="false" book="BtGoA" page="93">
+    <rule id="b28d-571e-af69-4582" name="Phase Armor" book="BtGoA" page="93" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>10&quot; or less, +1 Res. Greater than 10&quot;, +2 Res. May make a down reaction even if it already has order die - flip to down if so. </description>
-      <modifiers/>
     </rule>
-    <rule id="6b03-2ad4-34c1-7f73" name="Plasma Fade" hidden="false" book="BtGoA" page="76">
+    <rule id="6b03-2ad4-34c1-7f73" name="Plasma Fade" book="BtGoA" page="76" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>On the Acc roll of a 10 to hit the shot is a miss and the unit goes down.</description>
-      <modifiers/>
     </rule>
-    <rule id="0f12-545e-1c86-f482" name="Plasma Reactor" hidden="false" book="BtGoA" page="1367">
+    <rule id="0f12-545e-1c86-f482" name="Plasma Reactor" book="BtGoA" page="1367" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Lucky hits are allocated by shooter and hit plasma reactor. On a Res failure of 10, roll for every other model in unit and on a 10 they are removed as well.</description>
-      <modifiers/>
     </rule>
-    <rule id="5d64-4bf5-e947-95d1" name="Point Blank Shooting Only" hidden="false" book="BtGoA" page="86">
+    <rule id="5d64-4bf5-e947-95d1" name="Point Blank Shooting Only" book="BtGoA" page="86" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May only be used for point blank shooting. Cannot be used for H2H.</description>
-      <modifiers/>
     </rule>
-    <rule id="8056-104a-5a5d-2089" name="Pull Yourself Together!" hidden="false" page="159">
+    <rule id="8056-104a-5a5d-2089" name="Pull Yourself Together!" page="159" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>At the end of any turn you can expend a &quot;Pull Yourself Together!&quot; to remove one pin from one unit. Use once and discard. You can buy as many as you are allowed Auxiliary choices in your Army but can only use ONE per turn.</description>
-      <modifiers/>
     </rule>
-    <rule id="b6e3-9cf0-1a9f-a941" name="Random SV" hidden="false" book="BtGoA" page="66">
+    <rule id="b6e3-9cf0-1a9f-a941" name="Random SV" book="BtGoA" page="66" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Roll every round for entire unit to determine SV. </description>
-      <modifiers/>
     </rule>
-    <rule id="9ad5-9fc3-726e-852a" name="Rapid Sprint" hidden="false" book="BtGoA" page="136">
+    <rule id="9ad5-9fc3-726e-852a" name="Rapid Sprint" book="BtGoA" page="136" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May sprint at 4M. </description>
-      <modifiers/>
     </rule>
-    <rule id="18c0-c86d-0b2c-23af" name="Reflex Armour" hidden="false" book="BtGoA" page="93">
+    <rule id="18c0-c86d-0b2c-23af" name="Reflex Armour" book="BtGoA" page="93" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>-Troops with Reflex Armour Shield add +1 to their Res value.
 -Troops with Reflex Armour and Impact Cloaks add +2 to their Res value, in hand to hand fighting.
 -Troops mounted on bikes with Reflex Armour and HL Boosters add +2 to their Res value.
 </description>
-      <modifiers/>
     </rule>
-    <rule id="1863-c041-6dc4-c62d" name="RF D6 Fire Only" hidden="false" book="BtGoA" page="72">
+    <rule id="1863-c041-6dc4-c62d" name="RF D6 Fire Only" book="BtGoA" page="72" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Rapid Fire D6 when making a fire action. When shooting with advance action weapon has one shot. If issued in multiples, roll D6 for all weapons in unit.</description>
-      <modifiers/>
     </rule>
-    <rule id="0cb1-ea91-e5bc-4f75" name="RF2" hidden="false" book="BtGoA">
+    <rule id="0cb1-ea91-e5bc-4f75" name="RF2" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May fire two shots at rapid fire. Suffers additional -1 ACC at Long or Extreme Ranges.</description>
-      <modifiers/>
     </rule>
-    <rule id="97d4-67cb-2671-ca29" name="RF3" hidden="false" book="BtGoA">
+    <rule id="97d4-67cb-2671-ca29" name="RF3" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May fire three shots at rapid fire. Suffers additional -1 ACC at Long or Extreme Ranges.</description>
-      <modifiers/>
     </rule>
-    <rule id="b0cb-c022-0531-4852" name="RF5" hidden="false" book="BtGoA">
+    <rule id="b0cb-c022-0531-4852" name="RF5" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May fire five shots at rapid fire. Suffers additional -1 ACC at Long or Extreme Ranges.</description>
-      <modifiers/>
     </rule>
-    <rule id="f7af-59ec-acde-2f75" name="Savage Strike" hidden="false" book="BtGoA" page="136">
+    <rule id="f7af-59ec-acde-2f75" name="Savage Strike" book="BtGoA" page="136" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Passes order check to assault on any roll except a 10, regardless of modifiers.</description>
-      <modifiers/>
     </rule>
-    <rule id="28a0-7151-a0c5-9495" name="Scoot" hidden="false" book="BtGoA" page="88">
+    <rule id="28a0-7151-a0c5-9495" name="Scoot" book="BtGoA" page="88" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Only affects infantry, mounted, weapon team, beast, and humongous beast, command, and bike mounted units with living crew. Affects scramble proof units. Any affected unit within 3&quot; canno tbe given any order except run or down. Cannot make any reaction apart from go down.</description>
-      <modifiers/>
     </rule>
-    <rule id="94f5-4a4c-92ad-94f9" name="Scramble Proof" hidden="false" book="BtGoA" page="137">
+    <rule id="94f5-4a4c-92ad-94f9" name="Scramble Proof" book="BtGoA" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Not affected by scrambler munitions. Vehicles may be affected by scoot. Subverter matrixes cannot affect model.</description>
-      <modifiers/>
     </rule>
-    <rule id="7a3b-74a5-3ced-dd88" name="Scrambler" hidden="false" book="BtGoA" page="88">
+    <rule id="7a3b-74a5-3ced-dd88" name="Scrambler" book="BtGoA" page="88" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Enemy units within 3&quot; that are not scramble proof it loses Reflex Armor, Hyperlight Armor, and Phase Armor along with any bonuses. Units in Phase Armor cannot use their armor to go down.
 
 Weapon Drone and vehicles have Res reduced by 2 within 3&quot;. Buddy drones cease to function if the unit is within 3&quot;. Probes can do nothing at all while marker is within 3&quot;. Penalties are not cumulative.</description>
-      <modifiers/>
     </rule>
-    <rule id="3377-9408-33bb-6a02" name="Self Repair" hidden="false" book="BtGoA" page="137">
+    <rule id="3377-9408-33bb-6a02" name="Self Repair" book="BtGoA" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Give unit rally order. If no pins exist after order, may attempt one repair on  immobilisation or weapon. 1-5 = success, 6-10 failure. Success = that function is working again.</description>
-      <modifiers/>
     </rule>
-    <rule id="00b8-b49c-4c61-2943" name="Shard" hidden="false" book="BtGoA" page="137">
+    <rule id="00b8-b49c-4c61-2943" name="Shard" book="BtGoA" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Every individual unit in the shard makes same action from order. Probes always run.
 
 Shard units never take pins. Always assumed to pass order tests. </description>
+    </rule>
+    <rule id="0c20-4983-db8a-0d56" name="Shared SV" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="0c20-4983-db8a-0d56" name="Shared SV" hidden="false" book="BtGoA">
+    <rule id="b08d-74dd-1a32-8bdc" name="Shield Drone" book="BtGoA" page="114" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </rule>
-    <rule id="b08d-74dd-1a32-8bdc" name="Shield Drone" hidden="false" book="BtGoA" page="114">
       <description>When unit is hit, shield drones may nullify one hit. Roll D10 on drone chart - 
 
 D10 Roll:
@@ -5099,54 +8965,90 @@ D10 Roll:
 10: Drone does not nullify the hit but is not removed.
 
 Shield drones may attempt to intercept lucky hits. Lucky hits can be allocated to them just like other drones - in that case the drone is removed with no roll. </description>
-      <modifiers/>
     </rule>
-    <rule id="5bd0-9ab2-0523-cbc8" name="Slingnet Ammo" hidden="false" book="BtGoA" page="112">
+    <rule id="5bd0-9ab2-0523-cbc8" name="Slingnet Ammo" book="BtGoA" page="112" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Fired direct unless from Micro X Launcher. Targets hit suffer no damage but take +1 additional pin. Cannot affect units that cannot be pinned when hit.</description>
-      <modifiers/>
     </rule>
-    <rule id="7c88-64d4-50ad-2313" name="Slow" hidden="false" book="BtGoA" page="137">
+    <rule id="7c88-64d4-50ad-2313" name="Slow" book="BtGoA" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Move at half pace.</description>
-      <modifiers/>
     </rule>
-    <rule id="6f47-5038-573a-b225" name="Sniper" hidden="false" book="BtGoA" page="137">
+    <rule id="6f47-5038-573a-b225" name="Sniper" book="BtGoA" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Deploy anywhere within player&apos;s half. Snipers may not be deployed within 20&quot; of other snipers, enemy may not deploy within 10&quot;. </description>
-      <modifiers/>
     </rule>
-    <rule id="1253-ef5b-67d4-3e18" name="Soma Graft" hidden="false" book="BtGoA" page="121">
+    <rule id="1253-ef5b-67d4-3e18" name="Soma Graft" book="BtGoA" page="121" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May activate when a unit takes a Co test. Will past any Co test on any score other than 10. If a 10 is rolled, unit goes out of control and must roll the order die to generate an order. The unit does not have to comply, but if it does an order that is the only one it can do.</description>
-      <modifiers/>
     </rule>
-    <rule id="b996-131f-b84a-4724" name="Special Munition" hidden="false" book="BtGoA" page="87">
+    <rule id="b996-131f-b84a-4724" name="Special Munition" book="BtGoA" page="87" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Stays on the battlefield until it ceases to work p87. Use a marker to locate where shot lands.</description>
-      <modifiers/>
     </rule>
-    <rule id="fdbd-254f-8dd7-b658" name="Spotter Drone" hidden="false" book="BtGoA" page="114">
+    <rule id="fdbd-254f-8dd7-b658" name="Spotter Drone" book="BtGoA" page="114" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Unit may re-roll one miss each time it shoots as long as drone has LOS to target. Units may fire OH using drone as spotter as long as it has LOS to target. 
 
 Spotter drones may spot through another spotter drone (within 20&quot;) with LOS to the target. Unit does not receive spotter re-roll as their spotter does not have LOS to target.</description>
+    </rule>
+    <rule id="cd8d-624c-ed86-e310" name="Subverter Matrix" book="BtGoA" page="122" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="cd8d-624c-ed86-e310" name="Subverter Matrix" hidden="false" book="BtGoA" page="122">
+    <rule id="d4f5-697e-dbf0-ced2" name="Superior Shard" page="159" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </rule>
-    <rule id="d4f5-697e-dbf0-ced2" name="Superior Shard" hidden="false" page="159">
       <description>At the start of the turn you can remove 1 of your opponent&apos;s Order Dice from the bag. This die isn&apos;t used that turn, and is returned to the dice bag at the start of the following turn. This means your opponent will have to fight without one of his dice that turn. Use once and discard. You can only buy ONE Superior Shard regardless of the eize of your army.</description>
-      <modifiers/>
     </rule>
-    <rule id="d91f-8426-3ab2-f06c" name="Synchroniser Drone" hidden="false" book="Battle for Xilos" page="79">
+    <rule id="d91f-8426-3ab2-f06c" name="Synchroniser Drone" book="Battle for Xilos" page="79" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>If a unit with a synchroniser drone is successfully issued an order, after it has completed all actions in that order it may attempt to synchronise with one other unit within 10&quot;. The unit nominated must take and pass a Command test made in the standard fashion. If successful, it may draw an Order Die and issue the same command as the Synchronising unit, treating the die as if it were drawn randomly for all game effects. If the Synchronising unit also has the Follow ability, the Drone extends the range of Follow to 10&quot; rather than 5&quot;. CANNOT be chained from one unit to another.</description>
-      <modifiers/>
     </rule>
-    <rule id="ab37-33d8-41f3-7532" name="Transport 10" hidden="false" book="BtGoA" page="137">
+    <rule id="ab37-33d8-41f3-7532" name="Transport 10" book="BtGoA" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May transport 10 human sized models.</description>
-      <modifiers/>
     </rule>
-    <rule id="99fd-f354-1703-5941" name="Variable Res/Strike" hidden="false" book="BtGoA" page="66">
+    <rule id="99fd-f354-1703-5941" name="Variable Res/Strike" book="BtGoA" page="66" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Use to boost Res +2 or give a SV +2 each round of fighting. If used as +2 SV, counts as Grenade. </description>
-      <modifiers/>
     </rule>
-    <rule id="e167-a8e4-c26a-cafd" name="Weapon Drone" hidden="false" book="BtGoA" page="115">
+    <rule id="e167-a8e4-c26a-cafd" name="Weapon Drone" book="BtGoA" page="115" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Always measure to model, not base. Not allowed to assault. Never take a break test, however auto-break if suffer pins equal to their Co stat. If drone fails a Res test, roll on Weapon Drone Damage Chart.
 
 D10 Result:
@@ -5156,593 +9058,751 @@ D10 Result:
 4: Take D3 additional pins and go down. Weapon malfunction.
 5: Take D6 additional pins and take a break test - destroyed if failed, go down if passed.
 6-10: Destroyed</description>
-      <modifiers/>
     </rule>
-    <rule id="75d2-6efa-9640-61df" name="Well Prepared" hidden="false" page="159">
-      <description>If you take any single re-roll, you can add plus one to the value tested against. For example instead of testing against a res of 7 you would test against a res of 8. Use once and discard. You can buy as many Well Prepared as you are allowed Auxiliary choices in your Army.</description>
+    <rule id="75d2-6efa-9640-61df" name="Well Prepared" page="159" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>If you take any single re-roll, you can add plus one to the value tested against. For example instead of testing against a res of 7 you would test against a res of 8. Use once and discard. You can buy as many Well Prepared as you are allowed Auxiliary choices in your Army.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>
-    <profile id="2da6-e419-5126-a73b" profileTypeId="1650-77b3-10d1-6406" name="Attack Skimmer" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="11"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="MOD2, Large"/>
-      </characteristics>
+    <profile id="2da6-e419-5126-a73b" name="Attack Skimmer" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="11"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="MOD2, Large"/>
+      </characteristics>
     </profile>
-    <profile id="9fba-d6b7-c66d-99f0" profileTypeId="1650-77b3-10d1-6406" name="Bodyguard" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="-"/>
-      </characteristics>
+    <profile id="9fba-d6b7-c66d-99f0" name="Bodyguard" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
+      </characteristics>
     </profile>
-    <profile id="eb0f-0718-35d7-1a00" profileTypeId="1650-77b3-10d1-6406" name="Combat Drone" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="13"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="MOD2, Large"/>
-      </characteristics>
+    <profile id="eb0f-0718-35d7-1a00" name="Combat Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="13"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="MOD2, Large"/>
+      </characteristics>
     </profile>
-    <profile id="b390-0002-e1ef-3999" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Bombard" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-50"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="150"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="9/7/5"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Cycle"/>
-      </characteristics>
+    <profile id="b390-0002-e1ef-3999" name="Compression Bombard" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-50"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="150"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="9/7/5"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Cycle"/>
+      </characteristics>
     </profile>
-    <profile id="2e88-78bb-e1ba-bf5c" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Cannon" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="7/4/2"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Cycle"/>
-      </characteristics>
+    <profile id="2e88-78bb-e1ba-bf5c" name="Compression Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="7/4/2"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Cycle"/>
+      </characteristics>
     </profile>
-    <profile id="75cb-cf9b-dd3d-9177" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Carbine" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2/5/0"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover"/>
-      </characteristics>
+    <profile id="75cb-cf9b-dd3d-9177" name="Compression Carbine" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2/5/0"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover"/>
+      </characteristics>
     </profile>
-    <profile id="fb67-43bf-9dc2-5218" profileTypeId="1650-77b3-10d1-6406" name="D1 Light Support Drone" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="7"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="8"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special"/>
-      </characteristics>
+    <profile id="fb67-43bf-9dc2-5218" name="D1 Light Support Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="7"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="8"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+      </characteristics>
     </profile>
-    <profile id="2ae1-18d0-fbc8-21ad" profileTypeId="1650-77b3-10d1-6406" name="Feral Fighter" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="7"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="-"/>
-      </characteristics>
+    <profile id="2ae1-18d0-fbc8-21ad" name="Feral Fighter" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
+      </characteristics>
     </profile>
-    <profile id="f23b-60da-348a-e6db" profileTypeId="1650-77b3-10d1-6406" name="Feral Leader" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="7"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Leader"/>
-      </characteristics>
+    <profile id="f23b-60da-348a-e6db" name="Feral Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader"/>
+      </characteristics>
     </profile>
-    <profile id="1069-6287-7c2a-af01" profileTypeId="1650-77b3-10d1-6406" name="Ferel Skark Fighter" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Large, Fast, Skark3 Attacks SV1"/>
-      </characteristics>
+    <profile id="1069-6287-7c2a-af01" name="Ferel Skark Fighter" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Large, Fast, Skark3 Attacks SV1"/>
+      </characteristics>
     </profile>
-    <profile id="41f2-0f61-9758-5e8d" profileTypeId="1650-77b3-10d1-6406" name="Ferel Skark Leader" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Large, Fast, Skark3 Attacks SV1, Leader"/>
-      </characteristics>
+    <profile id="41f2-0f61-9758-5e8d" name="Ferel Skark Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Large, Fast, Skark3 Attacks SV1, Leader"/>
+      </characteristics>
     </profile>
-    <profile id="bc52-cc32-73de-da9d" profileTypeId="ecae-8ac8-2c13-0dd3" name="Fractal Bombard" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="50"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="200"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3 +2 max 10"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock"/>
-      </characteristics>
+    <profile id="bc52-cc32-73de-da9d" name="Fractal Bombard" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="50"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="200"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3 +2 max 10"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock"/>
+      </characteristics>
     </profile>
-    <profile id="4c7f-3ba3-d703-1255" profileTypeId="ecae-8ac8-2c13-0dd3" name="Fractal Cannon" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2 +1 max 10"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock"/>
-      </characteristics>
+    <profile id="4c7f-3ba3-d703-1255" name="Fractal Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2 +1 max 10"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock"/>
+      </characteristics>
     </profile>
-    <profile id="2d89-bcdb-b942-b900" profileTypeId="1650-77b3-10d1-6406" name="Freeborn Captain" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Command, Hero, Follow, Leader 2"/>
-      </characteristics>
+    <profile id="2d89-bcdb-b942-b900" name="Freeborn Captain" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Hero, Follow, Leader 2"/>
+      </characteristics>
     </profile>
-    <profile id="c245-fa49-1569-2f23" profileTypeId="1650-77b3-10d1-6406" name="Freeborn Crew" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="-"/>
-      </characteristics>
+    <profile id="c245-fa49-1569-2f23" name="Freeborn Crew" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
+      </characteristics>
     </profile>
-    <profile id="a770-8327-b96d-b92e" profileTypeId="1650-77b3-10d1-6406" name="Freeborn Crew Leader" hidden="true">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Leader"/>
-      </characteristics>
+    <profile id="a770-8327-b96d-b92e" name="Freeborn Crew Leader" hidden="true" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader"/>
+      </characteristics>
     </profile>
-    <profile id="7267-3051-f1b4-0a88" profileTypeId="1650-77b3-10d1-6406" name="Freeborn Heavy Crew" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Large, Slow"/>
-      </characteristics>
+    <profile id="7267-3051-f1b4-0a88" name="Freeborn Heavy Crew" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Large, Slow"/>
+      </characteristics>
     </profile>
-    <profile id="87a3-460d-879a-92a5" profileTypeId="1650-77b3-10d1-6406" name="Freeborn Heavy Crew Leader" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Large, Slow"/>
-      </characteristics>
+    <profile id="87a3-460d-879a-92a5" name="Freeborn Heavy Crew Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Large, Slow"/>
+      </characteristics>
     </profile>
-    <profile id="0c03-96a3-4833-bc67" profileTypeId="1650-77b3-10d1-6406" name="Freeborn NuHu Renegade" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="4"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="4(7)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="9"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Command, Hero, Follow, Leader 3"/>
-      </characteristics>
+    <profile id="0c03-96a3-4833-bc67" name="Freeborn NuHu Renegade" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="4"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(7)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="9"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Hero, Follow, Leader 3"/>
+      </characteristics>
     </profile>
-    <profile id="68fe-17c2-2841-2cde" profileTypeId="1650-77b3-10d1-6406" name="Freeborn NuHu Renegade Meld" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="4"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="8(11)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="9"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Command, Hero, Follow, Meld, Meld Damage, MOD2, Leader 3"/>
-      </characteristics>
+    <profile id="68fe-17c2-2841-2cde" name="Freeborn NuHu Renegade Meld" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="4"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="8(11)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="9"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Hero, Follow, Meld, Meld Damage, MOD2, Leader 3"/>
+      </characteristics>
     </profile>
-    <profile id="2dbd-14c5-219e-d37d" profileTypeId="1650-77b3-10d1-6406" name="GP Drone" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="7"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="0"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="8"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="-"/>
-      </characteristics>
+    <profile id="2dbd-14c5-219e-d37d" name="GP Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="7"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="0"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="8"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
+      </characteristics>
     </profile>
-    <profile id="9e2a-f076-d4df-b60a" profileTypeId="1650-77b3-10d1-6406" name="Heavy Combat Drone" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="15"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="MOD3, Slow, Large"/>
-      </characteristics>
+    <profile id="9e2a-f076-d4df-b60a" name="Heavy Combat Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="15"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="MOD3, Slow, Large"/>
+      </characteristics>
     </profile>
-    <profile id="d0a1-129b-f8e5-b1ad" profileTypeId="1650-77b3-10d1-6406" name="Hound Probe " hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="-"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="-"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="-"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="-"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Shard"/>
-      </characteristics>
+    <profile id="d0a1-129b-f8e5-b1ad" name="Hound Probe " hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Shard"/>
+      </characteristics>
     </profile>
-    <profile id="ed77-e875-0302-9bf4" profileTypeId="1650-77b3-10d1-6406" name="Household Leader" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Leader"/>
-      </characteristics>
+    <profile id="ed77-e875-0302-9bf4" name="Household Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader"/>
+      </characteristics>
     </profile>
-    <profile id="45dd-c1c8-46d5-0107" profileTypeId="1650-77b3-10d1-6406" name="Household Trooper" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="-"/>
-      </characteristics>
+    <profile id="45dd-c1c8-46d5-0107" name="Household Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
+      </characteristics>
     </profile>
-    <profile id="12c4-12f3-a601-7547" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Lash" hidden="false" book="BtGoA" page="67">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks"/>
-      </characteristics>
+    <profile id="12c4-12f3-a601-7547" name="Mag Lash" book="BtGoA" page="67" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks"/>
+      </characteristics>
     </profile>
-    <profile id="12fe-ec68-d3e2-79b9" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Mortar" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OHx2, Blast D10, No Cover"/>
-      </characteristics>
+    <profile id="12fe-ec68-d3e2-79b9" name="Mag Mortar" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OHx2, Blast D10, No Cover"/>
+      </characteristics>
     </profile>
-    <profile id="79c6-8556-6040-e975" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Pistol" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="30"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
-      </characteristics>
+    <profile id="79c6-8556-6040-e975" name="Mag Pistol" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
+      </characteristics>
     </profile>
-    <profile id="ac6c-7fd0-193a-7751" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Repeater" hidden="false" book="BtGoA" page="69">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2"/>
-      </characteristics>
+    <profile id="ac6c-7fd0-193a-7751" name="Mag Repeater" book="BtGoA" page="69" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2"/>
+      </characteristics>
     </profile>
-    <profile id="3bc6-2260-1caa-db1c" profileTypeId="1650-77b3-10d1-6406" name="Meld Skark" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="8"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="7(8)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Fast, Large, Savage Strike, Meld Skark 6 SV2, Leader"/>
-      </characteristics>
+    <profile id="3bc6-2260-1caa-db1c" name="Meld Skark" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="8"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="7(8)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Fast, Large, Savage Strike, Meld Skark 6 SV2, Leader"/>
+      </characteristics>
     </profile>
-    <profile id="f504-4de7-23b9-2bad" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Bombard" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="50"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="200"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="7"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Plasma Fade"/>
-      </characteristics>
+    <profile id="f504-4de7-23b9-2bad" name="Plasma Bombard" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="50"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="200"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="7"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Plasma Fade"/>
+      </characteristics>
     </profile>
-    <profile id="ed5d-2e1d-e51a-1f6a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Cannon" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="6"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Plasma Fade"/>
-      </characteristics>
+    <profile id="ed5d-2e1d-e51a-1f6a" name="Plasma Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Plasma Fade"/>
+      </characteristics>
     </profile>
-    <profile id="ee9c-ada6-953a-b774" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Carbine - Scatter" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2"/>
-      </characteristics>
+    <profile id="ee9c-ada6-953a-b774" name="Plasma Carbine - Scatter" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2"/>
+      </characteristics>
     </profile>
-    <profile id="b56d-0f1d-de00-62c4" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Carbine - Single Shot" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
-      </characteristics>
+    <profile id="b56d-0f1d-de00-62c4" name="Plasma Carbine - Single Shot" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
+      </characteristics>
     </profile>
-    <profile id="8b37-5912-a988-22e9" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Grenade Bandolier" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="-"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="-"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D4, Hazardous H2H"/>
-      </characteristics>
+    <profile id="8b37-5912-a988-22e9" name="Plasma Grenade Bandolier" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="-"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, Hazardous H2H"/>
+      </characteristics>
     </profile>
-    <profile id="96f9-325b-69f7-13b4" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Grenades" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
-      </characteristics>
+    <profile id="96f9-325b-69f7-13b4" name="Plasma Grenades" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
+      </characteristics>
     </profile>
-    <profile id="cc3a-cc3a-5a9e-616b" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Lance" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="4"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Choose Target, Inaccurate"/>
-      </characteristics>
+    <profile id="cc3a-cc3a-5a9e-616b" name="Plasma Lance - Lance" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="4"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Choose Target, Inaccurate"/>
+      </characteristics>
     </profile>
-    <profile id="5463-10c1-cf72-c3f8" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Scatter" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2"/>
-      </characteristics>
+    <profile id="5463-10c1-cf72-c3f8" name="Plasma Lance - Scatter" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2"/>
+      </characteristics>
     </profile>
-    <profile id="1112-0824-87c5-ae27" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Single Shot" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
-      </characteristics>
+    <profile id="1112-0824-87c5-ae27" name="Plasma Lance - Single Shot" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
+      </characteristics>
     </profile>
-    <profile id="e44d-e4f0-3ad5-6528" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Light Support Gun" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3"/>
-      </characteristics>
+    <profile id="e44d-e4f0-3ad5-6528" name="Plasma Light Support Gun" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3"/>
+      </characteristics>
     </profile>
-    <profile id="2e7c-b5f9-e3e5-9125" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Pistol" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="30"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
-      </characteristics>
+    <profile id="2e7c-b5f9-e3e5-9125" name="Plasma Pistol" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
+      </characteristics>
     </profile>
-    <profile id="04ae-2947-a8ea-2c08" profileTypeId="1650-77b3-10d1-6406" name="Probe" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="-"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="-"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="-"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="-"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Shard"/>
-      </characteristics>
+    <profile id="04ae-2947-a8ea-2c08" name="Probe" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Shard"/>
+      </characteristics>
     </profile>
-    <profile id="45af-eec1-b29d-273f" profileTypeId="1650-77b3-10d1-6406" name="Rejects" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="7"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Misgenic Abilities"/>
-      </characteristics>
+    <profile id="45af-eec1-b29d-273f" name="Rejects" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Misgenic Abilities"/>
+      </characteristics>
     </profile>
-    <profile id="74dc-b388-dc1d-fb61" profileTypeId="1650-77b3-10d1-6406" name="Skyraider Captain" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(7)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Command, Hero, Follow, Large, Fast, Leader 2"/>
-      </characteristics>
+    <profile id="74dc-b388-dc1d-fb61" name="Skyraider Captain" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Hero, Follow, Large, Fast, Leader 2"/>
+      </characteristics>
     </profile>
-    <profile id="e18f-34de-2624-4133" profileTypeId="1650-77b3-10d1-6406" name="Skyraider Leader" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(7)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Large, Fast, Leader "/>
-      </characteristics>
+    <profile id="e18f-34de-2624-4133" name="Skyraider Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Large, Fast, Leader "/>
+      </characteristics>
     </profile>
-    <profile id="a654-5213-64f2-703a" profileTypeId="1650-77b3-10d1-6406" name="Skyraider Trooper" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(7)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Large, Fast"/>
-      </characteristics>
+    <profile id="a654-5213-64f2-703a" name="Skyraider Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Large, Fast"/>
+      </characteristics>
     </profile>
-    <profile id="4d5f-ccb4-75c2-cbf2" profileTypeId="1650-77b3-10d1-6406" name="Targeter Probe" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="-"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="-"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="-"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="-"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Shard"/>
-      </characteristics>
+    <profile id="4d5f-ccb4-75c2-cbf2" name="Targeter Probe" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Shard"/>
+      </characteristics>
     </profile>
-    <profile id="5425-1edf-f536-d5a1" profileTypeId="1650-77b3-10d1-6406" name="Transport Drone" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="13"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="MOD2, Transport 10, Large"/>
-      </characteristics>
+    <profile id="5425-1edf-f536-d5a1" name="Transport Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="13"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="MOD2, Transport 10, Large"/>
+      </characteristics>
     </profile>
-    <profile id="702f-c8a7-d8cf-01c1" profileTypeId="1650-77b3-10d1-6406" name="Vardanari Gaurd Trooper" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="-"/>
-      </characteristics>
+    <profile id="702f-c8a7-d8cf-01c1" name="Vardanari Gaurd Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
+      </characteristics>
     </profile>
-    <profile id="62fc-1d76-c6fd-a3eb" profileTypeId="1650-77b3-10d1-6406" name="Vardanari Leader" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Leader"/>
-      </characteristics>
+    <profile id="62fc-1d76-c6fd-a3eb" name="Vardanari Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader"/>
+      </characteristics>
     </profile>
-    <profile id="27c9-718e-cee7-599d" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Launcher" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="60"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="120"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D5, No Cover"/>
-      </characteristics>
+    <profile id="27c9-718e-cee7-599d" name="X-Launcher" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D5, No Cover"/>
+      </characteristics>
     </profile>
-    <profile id="1298-3867-ea1e-c04c" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Sling" hidden="false" book="BtGoA" page="68">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D3, Hand Weapon"/>
-      </characteristics>
+    <profile id="1298-3867-ea1e-c04c" name="X-Sling" book="BtGoA" page="68" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D3, Hand Weapon"/>
+      </characteristics>
     </profile>
   </sharedProfiles>
 </catalogue>

--- a/Ghar.cat
+++ b/Ghar.cat
@@ -1,1713 +1,3063 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="0f2e-f338-5620-a215" revision="12" gameSystemId="c339-677a-60db-4060" gameSystemRevision="4" battleScribeVersion="1.15" name="Ghar" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
-  <entries>
-    <entry id="3d57-162c-00ab-4c84" name="Fartok, Outcast High Commander" points="132.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="0392-cdb8-e66c-08f6" name="Fartok" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
+<catalogue id="0f2e-f338-5620-a215" name="Ghar" revision="13" battleScribeVersion="2.00" gameSystemId="c339-677a-60db-4060" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <profiles/>
+  <rules/>
+  <infoLinks/>
+  <costTypes/>
+  <profileTypes/>
+  <forceEntries/>
+  <selectionEntries>
+    <selectionEntry id="3d57-162c-00ab-4c84" name="Fartok, Outcast High Commander" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="0392-cdb8-e66c-08f6" name="Fartok" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles>
-            <profile id="2503-767b-452a-9f0d" profileTypeId="1650-77b3-10d1-6406" name="Fartok" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="3"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="10"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="4(12)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="9"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-              </characteristics>
+            <profile id="2503-767b-452a-9f0d" name="Fartok" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="3"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="10"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(12)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="9"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
             </profile>
           </profiles>
-          <links>
-            <link id="c652-7377-38e9-59a0" targetId="3fde-b133-beb3-43d7" linkType="entry">
+          <rules/>
+          <infoLinks>
+            <infoLink id="68f3-6a1c-7ab2-188e" hidden="false" targetId="1d76-267d-696a-2e8a" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="68f3-6a1c-7ab2-188e" targetId="1d76-267d-696a-2e8a" linkType="rule">
+            </infoLink>
+            <infoLink id="ec4f-5ee3-cc36-a034" hidden="false" targetId="ae1d-2212-b0ef-48b6" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="ec4f-5ee3-cc36-a034" targetId="ae1d-2212-b0ef-48b6" linkType="rule">
+            </infoLink>
+            <infoLink id="b5de-d4c1-099f-d22f" hidden="false" targetId="48e7-7b6b-328c-29fe" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="b5de-d4c1-099f-d22f" targetId="48e7-7b6b-328c-29fe" linkType="rule">
+            </infoLink>
+            <infoLink id="5f62-26e1-d3c2-aeb0" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="5f62-26e1-d3c2-aeb0" targetId="931b-a54d-a846-cb74" linkType="rule">
+            </infoLink>
+            <infoLink id="a9a4-fa90-7757-39b9" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="a9a4-fa90-7757-39b9" targetId="a985-d1e1-a15f-c261" linkType="rule">
+            </infoLink>
+            <infoLink id="e03a-20fa-abf5-1274" hidden="false" targetId="f5cb-d1fc-6b00-39f5" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="e03a-20fa-abf5-1274" targetId="f5cb-d1fc-6b00-39f5" linkType="rule">
+            </infoLink>
+            <infoLink id="ac75-b6bf-fee9-58e0" hidden="false" targetId="2ed7-3d50-bea9-5f27" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="ac75-b6bf-fee9-58e0" targetId="2ed7-3d50-bea9-5f27" linkType="rule">
+            </infoLink>
+            <infoLink id="ca4e-8c82-0775-2425" hidden="false" targetId="57d1-980d-ee47-f717" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="ca4e-8c82-0775-2425" targetId="57d1-980d-ee47-f717" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="a0d2-a464-576a-d53f" name="Flitters" points="0.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="0d74-51f5-cdef-1da6" name="Flitter" points="5.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="c652-7377-38e9-59a0" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="132.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a0d2-a464-576a-d53f" name="Flitters" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="0d74-51f5-cdef-1da6" name="Flitter" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="e0b7-4216-5e20-71c4" name="Flitter" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="3"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
           <rules>
             <rule id="88cb-8269-0777-b47e" name="Probe Unit" hidden="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
             </rule>
           </rules>
-          <profiles>
-            <profile id="e0b7-4216-5e20-71c4" profileTypeId="1650-77b3-10d1-6406" name="Flitter" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="-"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="-"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="3"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="-"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="-"/>
-              </characteristics>
+          <infoLinks>
+            <infoLink id="2ab9-ffed-3ff2-6498" hidden="false" targetId="485f-1f8e-7808-4a17" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="2ab9-ffed-3ff2-6498" targetId="485f-1f8e-7808-4a17" linkType="rule">
+            </infoLink>
+            <infoLink id="0a47-9677-96a8-9f0a" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="0a47-9677-96a8-9f0a" targetId="a985-d1e1-a15f-c261" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9030-9dea-f00b-e2ed" name="Ghar Assault Squad" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="9030-9dea-f00b-e2ed" name="Ghar Assault Squad" points="0.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="c8dc-aa17-3f85-1a20" name="Ghar Leader" points="64.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="da1d-e454-1800-044b" name="Leader Rank" defaultEntryId="0d25-cce8-cf4b-478d" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="bb13-ff27-bf60-82ef" targetId="0e9b-9aae-bd16-d30f" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="a28d-5daa-1acf-caa1" targetId="da65-5109-5f5f-0f9a" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="0d25-cce8-cf4b-478d" targetId="05af-fc97-7a19-cf8d" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="0af9-d07a-2fca-4caf" targetId="562d-6cd9-4b4a-7019" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="4850-1a32-f160-03dc" name="Ghar Trooper" points="60.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="d0f1-7c67-3951-8631" targetId="de07-7287-f4d3-bf98" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="7db0-3bc8-ba66-2437" name="Plasma Dumps" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="9030-9dea-f00b-e2ed" incrementChildId="c8dc-aa17-3f85-1a20" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="9030-9dea-f00b-e2ed" incrementChildId="4850-1a32-f160-03dc" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="8608-c223-4acd-7e72" targetId="4280-96f3-aa68-8d6e" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="3b0a-3a3a-9ba0-4a01" name="Plasma Amplifiers" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="9030-9dea-f00b-e2ed" incrementChildId="4850-1a32-f160-03dc" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="9030-9dea-f00b-e2ed" incrementChildId="c8dc-aa17-3f85-1a20" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="18c8-9dff-9749-1130" targetId="0448-a629-3df9-73c0" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
       <rules>
         <rule id="fef7-39df-2b98-1c66" name="Infantry Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="85ac-ff6e-0649-05db" targetId="931b-a54d-a846-cb74" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="9666-60fb-6002-9667" targetId="a985-d1e1-a15f-c261" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="2c0c-fe84-bfff-3841" targetId="f5cb-d1fc-6b00-39f5" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="cadd-7f5d-ed2e-aba9" targetId="3cfd-07d8-f685-fa34" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="0b52-400d-e2fa-6607" targetId="36a7-e564-c80c-2a7e" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="46f3-8791-7cb4-e161" targetId="ff6d-c9e5-a6c4-f336" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="c27a-aa4f-97c0-ebef" name="Ghar Attack Scutter Squad" points="0.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="8974-5164-823a-fe6c" name="Ghar Attack Scutter Leader" points="36.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Beyond the Gates of Antares" page="170">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="e731-c0ab-0ba9-c676" name="Leader Rank" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="0133-88f6-fa5e-13f5" name="Leader 2" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="6564-66f8-98cb-f112" targetId="9d03-08db-93a6-4f05" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="f0a7-09f6-37c9-02f2" name="Leader 3" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="ffe5-44c2-bced-defa" targetId="e048-25d9-af17-bdf0" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="c559-421a-a988-dbfc" name="Leader" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="5b39-2a49-3a77-c370" targetId="24a5-60f8-93fc-7dff" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="98cb-1e8a-385f-e77e" profileTypeId="1650-77b3-10d1-6406" name="Ghar Attack Scutter Leader" hidden="false" book="Beyond the Gates of Antares" page="170">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="4(10)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-        <entry id="7fdb-3754-be08-c953" name="Ghar Attack Scutter" points="26.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Beyond the Gates of Antares" page="170">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="011c-3842-decf-b59b" profileTypeId="1650-77b3-10d1-6406" name="Ghar Attack Scutter" hidden="false" book="Beyond the Gates of Antares" page="170">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="4(10)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="7"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-        <entry id="1e0c-2244-a076-556e" name="Plasma Amplifiers" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="c27a-aa4f-97c0-ebef" incrementChildId="8974-5164-823a-fe6c" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="c27a-aa4f-97c0-ebef" incrementChildId="7fdb-3754-be08-c953" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
+      <infoLinks>
+        <infoLink id="85ac-ff6e-0649-05db" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
           <profiles/>
-          <links/>
-        </entry>
-        <entry id="af71-451e-6e05-d0c7" name="Plasma Dumps" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="c27a-aa4f-97c0-ebef" incrementChildId="7fdb-3754-be08-c953" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="c27a-aa4f-97c0-ebef" incrementChildId="8974-5164-823a-fe6c" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
           <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="9666-60fb-6002-9667" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
           <profiles/>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="2c0c-fe84-bfff-3841" hidden="false" targetId="f5cb-d1fc-6b00-39f5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="c8dc-aa17-3f85-1a20" name="Ghar Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="0af9-d07a-2fca-4caf" hidden="false" targetId="562d-6cd9-4b4a-7019" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="da1d-e454-1800-044b" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="0d25-cce8-cf4b-478d">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="bb13-ff27-bf60-82ef" hidden="false" targetId="0e9b-9aae-bd16-d30f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="a28d-5daa-1acf-caa1" hidden="false" targetId="da65-5109-5f5f-0f9a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="0d25-cce8-cf4b-478d" hidden="false" targetId="05af-fc97-7a19-cf8d" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="64.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4850-1a32-f160-03dc" name="Ghar Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="d0f1-7c67-3951-8631" hidden="false" targetId="de07-7287-f4d3-bf98" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="60.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7db0-3bc8-ba66-2437" name="Plasma Dumps" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="8608-c223-4acd-7e72" hidden="false" targetId="4280-96f3-aa68-8d6e" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="9030-9dea-f00b-e2ed" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c8dc-aa17-3f85-1a20" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="9030-9dea-f00b-e2ed" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4850-1a32-f160-03dc" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3b0a-3a3a-9ba0-4a01" name="Plasma Amplifiers" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="18c8-9dff-9749-1130" hidden="false" targetId="0448-a629-3df9-73c0" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="9030-9dea-f00b-e2ed" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4850-1a32-f160-03dc" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="9030-9dea-f00b-e2ed" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c8dc-aa17-3f85-1a20" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="cadd-7f5d-ed2e-aba9" hidden="false" targetId="3cfd-07d8-f685-fa34" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="0b52-400d-e2fa-6607" hidden="false" targetId="36a7-e564-c80c-2a7e" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="46f3-8791-7cb4-e161" hidden="false" targetId="ff6d-c9e5-a6c4-f336" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c27a-aa4f-97c0-ebef" name="Ghar Attack Scutter Squad" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
       <rules>
-        <rule id="0702-c8f1-8d5b-8900" name="Mounted Unit" hidden="false" book="Beyond the Gates of Antares" page="95">
+        <rule id="0702-c8f1-8d5b-8900" name="Mounted Unit" book="Beyond the Gates of Antares" page="95" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="10fb-a495-0f52-b962" targetId="f5cb-d1fc-6b00-39f5" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="a984-6534-8962-0067" targetId="a985-d1e1-a15f-c261" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="4ae7-9649-084d-3397" targetId="931b-a54d-a846-cb74" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="055a-0fdc-4575-9e60" targetId="23c8-9405-75ca-7f03" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="5670-d9f9-4779-7a23" name="Ghar Battle Squad" points="0.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="1" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="169">
-      <entries>
-        <entry id="c899-96c3-90ae-a7a9" name="Ghar Leader" points="64.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="ed36-f6c6-fac2-472f" name="Leader Rank" defaultEntryId="413a-de59-87e5-7423" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="7e9e-abc2-6eda-189c" targetId="0e9b-9aae-bd16-d30f" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="8dd1-7f91-54f6-3404" targetId="da65-5109-5f5f-0f9a" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="413a-de59-87e5-7423" targetId="05af-fc97-7a19-cf8d" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+      <infoLinks>
+        <infoLink id="10fb-a495-0f52-b962" hidden="false" targetId="f5cb-d1fc-6b00-39f5" type="rule">
           <profiles/>
-          <links>
-            <link id="6dfb-a1b6-be58-5fc1" targetId="562d-6cd9-4b4a-7019" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="d842-422d-f043-b735" name="Ghar Trooper" points="60.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <rules/>
+        </infoLink>
+        <infoLink id="a984-6534-8962-0067" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
           <profiles/>
-          <links>
-            <link id="307d-b360-e3d6-b2ea" targetId="de07-7287-f4d3-bf98" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="b8b4-04a9-1ee9-228b" name="Plasma Dumps" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="5670-d9f9-4779-7a23" incrementChildId="c899-96c3-90ae-a7a9" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="5670-d9f9-4779-7a23" incrementChildId="d842-422d-f043-b735" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
           <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="4ae7-9649-084d-3397" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
           <profiles/>
-          <links>
-            <link id="4065-1ed9-2939-5b44" targetId="4280-96f3-aa68-8d6e" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="ef06-9064-c307-e665" name="Plasma Amplifiers" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="5670-d9f9-4779-7a23" incrementChildId="d842-422d-f043-b735" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="5670-d9f9-4779-7a23" incrementChildId="c899-96c3-90ae-a7a9" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
           <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="055a-0fdc-4575-9e60" hidden="false" targetId="23c8-9405-75ca-7f03" type="rule">
           <profiles/>
-          <links>
-            <link id="b8e3-5e41-cdf0-30e5" targetId="0448-a629-3df9-73c0" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="8974-5164-823a-fe6c" name="Ghar Attack Scutter Leader" book="Beyond the Gates of Antares" page="170" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="98cb-1e8a-385f-e77e" name="Ghar Attack Scutter Leader" book="Beyond the Gates of Antares" page="170" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(10)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="e731-c0ab-0ba9-c676" name="Leader Rank" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="0133-88f6-fa5e-13f5" name="Leader 2" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="6564-66f8-98cb-f112" hidden="false" targetId="9d03-08db-93a6-4f05" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="f0a7-09f6-37c9-02f2" name="Leader 3" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="ffe5-44c2-bced-defa" hidden="false" targetId="e048-25d9-af17-bdf0" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="20.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="c559-421a-a988-dbfc" name="Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="5b39-2a49-3a77-c370" hidden="false" targetId="24a5-60f8-93fc-7dff" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="36.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7fdb-3754-be08-c953" name="Ghar Attack Scutter" book="Beyond the Gates of Antares" page="170" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="011c-3842-decf-b59b" name="Ghar Attack Scutter" book="Beyond the Gates of Antares" page="170" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(10)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="26.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1e0c-2244-a076-556e" name="Plasma Amplifiers" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="c27a-aa4f-97c0-ebef" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8974-5164-823a-fe6c" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="c27a-aa4f-97c0-ebef" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7fdb-3754-be08-c953" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="af71-451e-6e05-d0c7" name="Plasma Dumps" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="c27a-aa4f-97c0-ebef" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7fdb-3754-be08-c953" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="c27a-aa4f-97c0-ebef" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8974-5164-823a-fe6c" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5670-d9f9-4779-7a23" name="Ghar Battle Squad" page="169" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
       <rules>
         <rule id="54a7-9a44-ddc3-e465" name="Infantry Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="5337-8aa7-11e4-24e8" targetId="931b-a54d-a846-cb74" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="96af-24be-477b-617d" targetId="a985-d1e1-a15f-c261" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="4e88-7e17-35a9-efdb" targetId="f5cb-d1fc-6b00-39f5" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="cf73-74f7-d7bd-e099" targetId="3fde-b133-beb3-43d7" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="f21b-beb2-224e-5e3f" name="Ghar Bombardment Crawler" points="256.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="170">
-      <entries>
-        <entry id="1a33-1125-41be-a84c" name="Ghar Bombardment Crawler" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="9eb2-f76c-73b5-402f" profileTypeId="1650-77b3-10d1-6406" name="Ghar Bombardment Crawler" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="3"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="10"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="13"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="13e6-878c-c923-5a97" targetId="5a09-7c98-31f2-0b1b" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="e938-8434-70f7-d9c7" targetId="3fde-b133-beb3-43d7" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="0019-d8b6-f4b8-fe36" targetId="3fde-b133-beb3-43d7" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="0e62-9dd3-f8d6-58e5" targetId="09d0-48ed-82d2-38b5" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="a8a2-a078-6edf-978b" name="Plasma Amplifiers" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="f21b-beb2-224e-5e3f" incrementChildId="1a33-1125-41be-a84c" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="f21b-beb2-224e-5e3f" incrementChildId="ef3d-dcd6-70ae-c6c6" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
+      <infoLinks>
+        <infoLink id="5337-8aa7-11e4-24e8" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
           <profiles/>
-          <links>
-            <link id="8580-c966-a7b2-e3b0" targetId="0448-a629-3df9-73c0" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="6a4c-fdb7-ebdb-0a84" name="Plasma Dumps" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="f21b-beb2-224e-5e3f" incrementChildId="1a33-1125-41be-a84c" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="f21b-beb2-224e-5e3f" incrementChildId="ef3d-dcd6-70ae-c6c6" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
           <rules/>
-          <profiles/>
-          <links>
-            <link id="bb80-60c6-c83a-a75d" targetId="4280-96f3-aa68-8d6e" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="ef3d-dcd6-70ae-c6c6" name="Ghar Scutter" points="26.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <infoLinks/>
           <modifiers/>
+        </infoLink>
+        <infoLink id="96af-24be-477b-617d" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
+          <profiles/>
           <rules/>
-          <profiles>
-            <profile id="ba55-480e-906f-39ce" profileTypeId="1650-77b3-10d1-6406" name="Ghar Scutter" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="3"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="10"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="0b1b-0a86-07ce-c5ec" targetId="562c-13be-8455-d77b" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="5805-0b73-8f17-f572" targetId="3fde-b133-beb3-43d7" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="4e88-7e17-35a9-efdb" hidden="false" targetId="f5cb-d1fc-6b00-39f5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="c899-96c3-90ae-a7a9" name="Ghar Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="6dfb-a1b6-be58-5fc1" hidden="false" targetId="562d-6cd9-4b4a-7019" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="ed36-f6c6-fac2-472f" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="413a-de59-87e5-7423">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="7e9e-abc2-6eda-189c" hidden="false" targetId="0e9b-9aae-bd16-d30f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="8dd1-7f91-54f6-3404" hidden="false" targetId="da65-5109-5f5f-0f9a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="413a-de59-87e5-7423" hidden="false" targetId="05af-fc97-7a19-cf8d" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="64.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d842-422d-f043-b735" name="Ghar Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="307d-b360-e3d6-b2ea" hidden="false" targetId="de07-7287-f4d3-bf98" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="60.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b8b4-04a9-1ee9-228b" name="Plasma Dumps" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="4065-1ed9-2939-5b44" hidden="false" targetId="4280-96f3-aa68-8d6e" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="5670-d9f9-4779-7a23" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c899-96c3-90ae-a7a9" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="5670-d9f9-4779-7a23" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d842-422d-f043-b735" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ef06-9064-c307-e665" name="Plasma Amplifiers" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="b8e3-5e41-cdf0-30e5" hidden="false" targetId="0448-a629-3df9-73c0" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="5670-d9f9-4779-7a23" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d842-422d-f043-b735" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="5670-d9f9-4779-7a23" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c899-96c3-90ae-a7a9" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="cf73-74f7-d7bd-e099" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f21b-beb2-224e-5e3f" name="Ghar Bombardment Crawler" page="170" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
       <rules>
-        <rule id="d6a3-4bb5-e5d9-3659" name="Vehicle Unit / Mixed Vehicle + Mounts" hidden="false" book="">
+        <rule id="d6a3-4bb5-e5d9-3659" name="Vehicle Unit / Mixed Vehicle + Mounts" book="" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="82e8-1e97-c543-e349" targetId="a985-d1e1-a15f-c261" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="a66d-463b-3e43-e86e" targetId="f5cb-d1fc-6b00-39f5" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="2645-00c7-46ac-40eb" targetId="23c8-9405-75ca-7f03" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="f118-b292-ee30-0032" targetId="931b-a54d-a846-cb74" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="8b5a-d5f0-e539-a0ee" name="Ghar Bomber Squad" points="0.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="4a98-4c68-15aa-a072" name="Ghar Leader" points="64.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="1801-be82-bad9-46b6" name="Leader Rank" defaultEntryId="1133-61fa-0a8e-be9c" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="e148-d3dc-c579-ecba" name="Leader 2" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="206a-a126-a295-7465" targetId="9d03-08db-93a6-4f05" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="5d73-1f5e-0487-13e2" name="Leader 3" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="f30e-8b02-26ec-f5a4" targetId="e048-25d9-af17-bdf0" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="1133-61fa-0a8e-be9c" name="Leader" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="fbc6-19e6-ecb2-afe8" targetId="24a5-60f8-93fc-7dff" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="c216-69a9-3e8a-0f02" profileTypeId="1650-77b3-10d1-6406" name="Ghar Leader" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="3"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="10"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="4 (12)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="9f8b-ab48-0d2d-e501" targetId="3fde-b133-beb3-43d7" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="a18c-40ae-d918-8109" name="Ghar Trooper" points="60.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="be58-28f6-c6ca-323c" profileTypeId="1650-77b3-10d1-6406" name="Ghar Trooper" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="3"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="10"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="4 (12)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value=""/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value=""/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="0e80-ade2-0809-2392" targetId="3fde-b133-beb3-43d7" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="3a43-be53-21c6-bb37" name="Plasma Dumps" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="8b5a-d5f0-e539-a0ee" incrementChildId="0d6e-d1da-4558-5a99" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="8b5a-d5f0-e539-a0ee" incrementChildId="4a98-4c68-15aa-a072" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="8b5a-d5f0-e539-a0ee" incrementChildId="90ee-0a6f-9336-975d" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="8b5a-d5f0-e539-a0ee" incrementChildId="a18c-40ae-d918-8109" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
+      <infoLinks>
+        <infoLink id="82e8-1e97-c543-e349" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
           <profiles/>
-          <links/>
-        </entry>
-        <entry id="28a7-4a00-8b9f-618b" name="Plasma Amplifiers" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="8b5a-d5f0-e539-a0ee" incrementChildId="a18c-40ae-d918-8109" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="8b5a-d5f0-e539-a0ee" incrementChildId="4a98-4c68-15aa-a072" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="8b5a-d5f0-e539-a0ee" incrementChildId="0d6e-d1da-4558-5a99" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="8b5a-d5f0-e539-a0ee" incrementChildId="90ee-0a6f-9336-975d" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
           <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-        <entry id="0d6e-d1da-4558-5a99" name="Ghar Bomb Trooper" points="63.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <infoLinks/>
           <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="952f-9f4c-cbc4-2ebc" profileTypeId="1650-77b3-10d1-6406" name="Ghar Bomb Trooper" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="3"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="10"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="4 (12)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="7"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="39b2-7138-f2dd-425b" targetId="e376-d612-25ff-b855" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="90ee-0a6f-9336-975d" name="Ghar Scutter" points="47.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
+        </infoLink>
+        <infoLink id="a66d-463b-3e43-e86e" hidden="false" targetId="f5cb-d1fc-6b00-39f5" type="rule">
           <profiles/>
-          <links>
-            <link id="6790-53e2-2efa-2be5" targetId="562c-13be-8455-d77b" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="e66e-6adf-a0cd-5f9c" targetId="3fde-b133-beb3-43d7" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="2645-00c7-46ac-40eb" hidden="false" targetId="23c8-9405-75ca-7f03" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f118-b292-ee30-0032" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="1a33-1125-41be-a84c" name="Ghar Bombardment Crawler" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="9eb2-f76c-73b5-402f" name="Ghar Bombardment Crawler" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="3"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="10"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="13"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="0e62-9dd3-f8d6-58e5" hidden="false" targetId="09d0-48ed-82d2-38b5" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="13e6-878c-c923-5a97" hidden="false" targetId="5a09-7c98-31f2-0b1b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="e938-8434-70f7-d9c7" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="0019-d8b6-f4b8-fe36" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a8a2-a078-6edf-978b" name="Plasma Amplifiers" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="8580-c966-a7b2-e3b0" hidden="false" targetId="0448-a629-3df9-73c0" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="f21b-beb2-224e-5e3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1a33-1125-41be-a84c" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="f21b-beb2-224e-5e3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ef3d-dcd6-70ae-c6c6" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6a4c-fdb7-ebdb-0a84" name="Plasma Dumps" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="bb80-60c6-c83a-a75d" hidden="false" targetId="4280-96f3-aa68-8d6e" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="f21b-beb2-224e-5e3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1a33-1125-41be-a84c" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="f21b-beb2-224e-5e3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ef3d-dcd6-70ae-c6c6" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ef3d-dcd6-70ae-c6c6" name="Ghar Scutter" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="ba55-480e-906f-39ce" name="Ghar Scutter" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="3"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="10"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="0b1b-0a86-07ce-c5ec" hidden="false" targetId="562c-13be-8455-d77b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="5805-0b73-8f17-f572" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="26.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="256.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8b5a-d5f0-e539-a0ee" name="Ghar Bomber Squad" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
       <rules>
         <rule id="ca5c-7445-3e1f-4676" name="Infantry Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="2b2a-cf47-51fe-1daf" targetId="931b-a54d-a846-cb74" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="016f-eaf3-dbd7-ac1e" targetId="a985-d1e1-a15f-c261" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="7729-636d-e51e-d6f7" targetId="f5cb-d1fc-6b00-39f5" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="8a8c-71c0-d041-09a6" name="Ghar Command Crawler" points="243.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="170">
-      <entries>
-        <entry id="cc54-51ee-9a73-2c3f" name="Ghar Commander" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="a1eb-a7e9-0ba1-9166" name="Leader Rank" defaultEntryId="4f80-8e2f-3425-932a" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="4f80-8e2f-3425-932a" name="Leader 2" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="6243-126a-8498-6540" targetId="9d03-08db-93a6-4f05" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="bbd9-af80-b959-dbe0" name="Leader 3" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="585f-d49e-dc61-d4ba" targetId="e048-25d9-af17-bdf0" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="4351-2a97-c5fa-68de" name="High Commander" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="6df5-d261-e1a6-cc51" targetId="48e7-7b6b-328c-29fe" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
+      <infoLinks>
+        <infoLink id="2b2a-cf47-51fe-1daf" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
+          <profiles/>
           <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="016f-eaf3-dbd7-ac1e" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7729-636d-e51e-d6f7" hidden="false" targetId="f5cb-d1fc-6b00-39f5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="4a98-4c68-15aa-a072" name="Ghar Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles>
-            <profile id="e177-ef68-f56f-fd00" profileTypeId="f9a2-eeae-3284-75fd" name="Ghar Commander" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="18c1-4764-7d08-708d" name="Ag" value="5"/>
-                <characteristic characteristicId="e39c-d7a4-86a8-d23d" name="Acc" value="5"/>
-                <characteristic characteristicId="0790-bfd5-1273-fe12" name="Str" value="10"/>
-                <characteristic characteristicId="5b77-3595-2819-675c" name="Res" value="13"/>
-                <characteristic characteristicId="c0d8-f6fd-a474-1385" name="Init" value="8"/>
-                <characteristic characteristicId="135d-efc3-5039-b6e6" name="Co" value="9"/>
-              </characteristics>
+            <profile id="c216-69a9-3e8a-0f02" name="Ghar Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="3"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="10"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4 (12)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
             </profile>
           </profiles>
-          <links>
-            <link id="bb84-7c0e-852e-ef11" targetId="3fde-b133-beb3-43d7" linkType="entry">
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="1801-be82-bad9-46b6" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="1133-61fa-0a8e-be9c">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="66d8-4c57-7b8f-aa81" targetId="3fde-b133-beb3-43d7" linkType="entry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="e148-d3dc-c579-ecba" name="Leader 2" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="206a-a126-a295-7465" hidden="false" targetId="9d03-08db-93a6-4f05" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="5d73-1f5e-0487-13e2" name="Leader 3" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="f30e-8b02-26ec-f5a4" hidden="false" targetId="e048-25d9-af17-bdf0" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="20.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="1133-61fa-0a8e-be9c" name="Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="fbc6-19e6-ecb2-afe8" hidden="false" targetId="24a5-60f8-93fc-7dff" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="9f8b-ab48-0d2d-e501" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="a403-8e75-3775-b0a9" name="Plasma Amplifiers" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="64.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a18c-40ae-d918-8109" name="Ghar Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="be58-28f6-c6ca-323c" name="Ghar Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="3"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="10"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4 (12)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value=""/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value=""/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="0e80-ade2-0809-2392" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="60.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3a43-be53-21c6-bb37" name="Plasma Dumps" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="8a8c-71c0-d041-09a6" incrementChildId="cc54-51ee-9a73-2c3f" incrementField="selections" incrementValue="1.0">
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0d6e-d1da-4558-5a99" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4a98-4c68-15aa-a072" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="90ee-0a6f-9336-975d" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a18c-40ae-d918-8109" repeats="1"/>
+              </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
           </modifiers>
-          <rules/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="28a7-4a00-8b9f-618b" name="Plasma Amplifiers" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles/>
-          <links/>
-        </entry>
-        <entry id="6675-7341-53d3-7e85" name="Plasma Dumps" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <rules/>
+          <infoLinks/>
           <modifiers>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="8a8c-71c0-d041-09a6" incrementChildId="8a8c-71c0-d041-09a6" incrementField="selections" incrementValue="1.0">
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a18c-40ae-d918-8109" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4a98-4c68-15aa-a072" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0d6e-d1da-4558-5a99" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="90ee-0a6f-9336-975d" repeats="1"/>
+              </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
           </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0d6e-d1da-4558-5a99" name="Ghar Bomb Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="952f-9f4c-cbc4-2ebc" name="Ghar Bomb Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="3"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="10"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4 (12)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
           <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="39b2-7138-f2dd-425b" hidden="false" targetId="e376-d612-25ff-b855" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="63.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="90ee-0a6f-9336-975d" name="Ghar Scutter" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles/>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="6790-53e2-2efa-2be5" hidden="false" targetId="562c-13be-8455-d77b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="e66e-6adf-a0cd-5f9c" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="47.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8a8c-71c0-d041-09a6" name="Ghar Command Crawler" page="170" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
       <rules>
         <rule id="0436-9fe8-9e6b-50a5" name="Vehicle Command Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="6467-0c52-2d03-3bf8" targetId="1d76-267d-696a-2e8a" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="8915-9dfa-3860-1897" targetId="ae1d-2212-b0ef-48b6" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="340c-1a14-abeb-546e" targetId="931b-a54d-a846-cb74" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="c4ce-ab60-efd6-a256" targetId="23c8-9405-75ca-7f03" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="6212-fa71-4521-332a" targetId="09d0-48ed-82d2-38b5" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="d54c-a9c9-6971-285c" targetId="a985-d1e1-a15f-c261" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="6ac4-7768-08a8-a64f" targetId="f5cb-d1fc-6b00-39f5" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="52ba-dd45-2ef8-eb63" name="Outcast Command Squad" points="0.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="0" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="b7fa-60d2-b829-a7be" name="Ghar Outcast Slave Driver" points="32.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="d3b2-1969-407b-c61f" name="Leader Rank" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="d2d6-30be-8bdb-e811" targetId="0e9b-9aae-bd16-d30f" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="8dae-6f58-6727-960d" targetId="da65-5109-5f5f-0f9a" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="86da-277a-ba37-4410" targetId="05af-fc97-7a19-cf8d" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+      <infoLinks>
+        <infoLink id="6467-0c52-2d03-3bf8" hidden="false" targetId="1d76-267d-696a-2e8a" type="rule">
           <profiles/>
-          <links>
-            <link id="71f3-5c76-98db-4716" targetId="4a94-ffc8-8d46-6869" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="2eb4-601c-fb91-f555" targetId="1d76-267d-696a-2e8a" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="051d-ccd9-1c23-6d4a" targetId="ae1d-2212-b0ef-48b6" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="9f80-e19b-ca95-07f7" targetId="7a11-cc52-4a61-59a6" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="c451-d195-16f0-bc4d" name="Outcast" points="4.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
           <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="8915-9dfa-3860-1897" hidden="false" targetId="ae1d-2212-b0ef-48b6" type="rule">
           <profiles/>
-          <links>
-            <link id="7e9a-de9f-8205-ae42" targetId="b292-161d-d26f-b5e9" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers>
-        <modifier type="increment" field="maxInForce" value="1.0" repeat="true" numRepeats="1" incrementParentId="force type" incrementChildId="6cfb-8ee0-4610-646d" incrementField="selections" incrementValue="1.0">
-          <conditions/>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <rules>
-        <rule id="dcc1-0cf8-5b64-89eb" name="Infantry Command Unit" hidden="false">
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links>
-        <link id="2c06-feb9-7429-4b91" targetId="dc72-b0e2-b8cb-2d5c" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="2d17-14ce-3721-d6c7" targetId="ccca-f1e8-512c-ade7" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="cb3e-e577-5ce4-de30" name="Outcast Disruptor Cannon" points="0.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="de51-23ed-0173-ba47" name="Outcast Crew" points="12.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
           <rules/>
-          <profiles/>
-          <links>
-            <link id="691c-03e3-c741-b67f" targetId="4d36-a47c-487c-f893" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="16d6-88ef-a262-a931" targetId="b292-161d-d26f-b5e9" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="cc71-0ba4-2876-cc38" name="Outcast Leader" points="9.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="d3c3-c5ff-1552-7d0b" name="Leader Rank" defaultEntryId="d813-a45b-705e-5144" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="99a0-ce67-06df-5518" name="Leader 2" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="cb31-6745-fde4-599b" targetId="9d03-08db-93a6-4f05" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="d813-a45b-705e-5144" name="Leader" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="aa5f-bdb7-15d1-83ac" targetId="24a5-60f8-93fc-7dff" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
+          <infoLinks/>
           <modifiers/>
+        </infoLink>
+        <infoLink id="340c-1a14-abeb-546e" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
+          <profiles/>
           <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="c4ce-ab60-efd6-a256" hidden="false" targetId="23c8-9405-75ca-7f03" type="rule">
           <profiles/>
-          <links>
-            <link id="2387-ed4c-8c83-472f" targetId="dc72-b0e2-b8cb-2d5c" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="0875-519b-be7b-8626" targetId="9770-5f42-fa8c-247c" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers>
-        <modifier type="set" field="maxInForce" value="99.0" repeat="true" numRepeats="1" incrementParentId="force type" incrementChildId="52ba-dd45-2ef8-eb63" incrementField="selections" incrementValue="1.0">
-          <conditions/>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <rules>
-        <rule id="45cb-83a8-6ea1-a8b5" name="Weapon Team Unit" hidden="false">
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="6cfb-8ee0-4610-646d" name="Outcast Squad" points="0.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="0c5f-a39d-f318-124e" name="Ghar Outcast Leader" points="18.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="f3c1-a4fd-77c7-1ad3" name="Leader Rank" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="246c-fea3-dfb5-693c" targetId="0e9b-9aae-bd16-d30f" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="15bd-449b-fa72-2c5f" targetId="da65-5109-5f5f-0f9a" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="fb25-afca-e693-0a27" targetId="05af-fc97-7a19-cf8d" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
           <rules/>
-          <profiles/>
-          <links>
-            <link id="7b56-0416-c6ba-a4c6" targetId="4d36-a47c-487c-f893" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="7e56-6dae-2924-222d" targetId="9770-5f42-fa8c-247c" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="f22f-86cd-4a95-b370" name="Ghar Outcast" points="5.0" categoryId="(No Category)" type="model" minSelections="5" maxSelections="11" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <infoLinks/>
           <modifiers/>
-          <rules/>
+        </infoLink>
+        <infoLink id="6212-fa71-4521-332a" hidden="false" targetId="09d0-48ed-82d2-38b5" type="rule">
           <profiles/>
-          <links>
-            <link id="6e24-74a4-80af-9ca3" targetId="4d36-a47c-487c-f893" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="efc3-4fa1-890c-d8c1" targetId="b292-161d-d26f-b5e9" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="770f-0ac0-8238-7bfc" name="Outcast Weapon Team of Two" points="24.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <rules/>
+        </infoLink>
+        <infoLink id="d54c-a9c9-6971-285c" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
           <profiles/>
-          <links>
-            <link id="47a4-e76a-0c78-f0f8" targetId="a975-754b-83c3-802b" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="9212-637f-32c3-029a" targetId="b292-161d-d26f-b5e9" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6ac4-7768-08a8-a64f" hidden="false" targetId="f5cb-d1fc-6b00-39f5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules>
-        <rule id="e266-7204-4b62-9954" name="Infantry Unit" hidden="false">
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="cc54-51ee-9a73-2c3f" name="Ghar Commander" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="e177-ef68-f56f-fd00" name="Ghar Commander" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="10"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="13"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="8"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="9"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links>
-        <link id="438c-b342-0622-0896" targetId="c429-23e1-056e-cfd3" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="a1eb-a7e9-0ba1-9166" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="4f80-8e2f-3425-932a">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="4f80-8e2f-3425-932a" name="Leader 2" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="6243-126a-8498-6540" hidden="false" targetId="9d03-08db-93a6-4f05" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="bbd9-af80-b959-dbe0" name="Leader 3" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="585f-d49e-dc61-d4ba" hidden="false" targetId="e048-25d9-af17-bdf0" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="4351-2a97-c5fa-68de" name="High Commander" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="6df5-d261-e1a6-cc51" hidden="false" targetId="48e7-7b6b-328c-29fe" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="20.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="bb84-7c0e-852e-ef11" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="66d8-4c57-7b8f-aa81" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a403-8e75-3775-b0a9" name="Plasma Amplifiers" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="6cfb-8ee0-4610-646d" incrementChildId="0c5f-a39d-f318-124e" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="6cfb-8ee0-4610-646d" incrementChildId="f22f-86cd-4a95-b370" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="4.0" repeat="true" numRepeats="1" incrementParentId="6cfb-8ee0-4610-646d" incrementChildId="770f-0ac0-8238-7bfc" incrementField="selections" incrementValue="1.0">
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="8a8c-71c0-d041-09a6" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cc54-51ee-9a73-2c3f" repeats="1"/>
+              </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
           </modifiers>
-        </link>
-        <link id="d5e2-d48c-821b-8519" targetId="ccca-f1e8-512c-ade7" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="fd3a-9dc3-6585-6d3e" name="Tectorist Scouts" points="0.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="b572-c2ed-763c-a0a4" name="Tectorist Scout" points="5.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6675-7341-53d3-7e85" name="Plasma Dumps" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
           <rules/>
-          <profiles>
-            <profile id="d0e9-50a7-5823-cc89" profileTypeId="1650-77b3-10d1-6406" name="Tectorist Scouts" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="6"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="3"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="4"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="7"/>
-              </characteristics>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="8a8c-71c0-d041-09a6" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6675-7341-53d3-7e85" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="243.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="52ba-dd45-2ef8-eb63" name="Outcast Command Squad" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="dcc1-0cf8-5b64-89eb" name="Infantry Command Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="2d17-14ce-3721-d6c7" hidden="false" targetId="ccca-f1e8-512c-ade7" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers>
+        <modifier type="increment" field="maxInForce" value="1.0">
+          <repeats>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6cfb-8ee0-4610-646d" repeats="1"/>
+          </repeats>
+          <conditions/>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="b7fa-60d2-b829-a7be" name="Ghar Outcast Slave Driver" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="71f3-5c76-98db-4716" hidden="false" targetId="4a94-ffc8-8d46-6869" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="9d42-7e5f-bbf0-acd4" targetId="ccca-f1e8-512c-ade7" linkType="rule">
+            </infoLink>
+            <infoLink id="2eb4-601c-fb91-f555" hidden="false" targetId="1d76-267d-696a-2e8a" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="f6a8-13c6-b9ac-c035" targetId="24a5-60f8-93fc-7dff" linkType="rule">
+            </infoLink>
+            <infoLink id="051d-ccd9-1c23-6d4a" hidden="false" targetId="ae1d-2212-b0ef-48b6" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="8061-c0ee-f0f9-6958" targetId="485f-1f8e-7808-4a17" linkType="rule">
+            </infoLink>
+            <infoLink id="9f80-e19b-ca95-07f7" hidden="false" targetId="7a11-cc52-4a61-59a6" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="d3b2-1969-407b-c61f" name="Leader Rank" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="d2d6-30be-8bdb-e811" hidden="false" targetId="0e9b-9aae-bd16-d30f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="8dae-6f58-6727-960d" hidden="false" targetId="da65-5109-5f5f-0f9a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="86da-277a-ba37-4410" hidden="false" targetId="05af-fc97-7a19-cf8d" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="32.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c451-d195-16f0-bc4d" name="Outcast" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="7e9a-de9f-8205-ae42" hidden="false" targetId="b292-161d-d26f-b5e9" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="4.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="2c06-feb9-7429-4b91" hidden="false" targetId="dc72-b0e2-b8cb-2d5c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cb3e-e577-5ce4-de30" name="Outcast Disruptor Cannon" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="45cb-83a8-6ea1-a8b5" name="Weapon Team Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="maxInForce" value="99.0">
+          <repeats>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="52ba-dd45-2ef8-eb63" repeats="1"/>
+          </repeats>
+          <conditions/>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="de51-23ed-0173-ba47" name="Outcast Crew" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="16d6-88ef-a262-a931" hidden="false" targetId="b292-161d-d26f-b5e9" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="691c-03e3-c741-b67f" hidden="false" targetId="4d36-a47c-487c-f893" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="12.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="cc71-0ba4-2876-cc38" name="Outcast Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="0875-519b-be7b-8626" hidden="false" targetId="9770-5f42-fa8c-247c" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="d3c3-c5ff-1552-7d0b" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="d813-a45b-705e-5144">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="99a0-ce67-06df-5518" name="Leader 2" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="cb31-6745-fde4-599b" hidden="false" targetId="9d03-08db-93a6-4f05" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="d813-a45b-705e-5144" name="Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="aa5f-bdb7-15d1-83ac" hidden="false" targetId="24a5-60f8-93fc-7dff" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="2387-ed4c-8c83-472f" hidden="false" targetId="dc72-b0e2-b8cb-2d5c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="9.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6cfb-8ee0-4610-646d" name="Outcast Squad" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="e266-7204-4b62-9954" name="Infantry Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="d5e2-d48c-821b-8519" hidden="false" targetId="ccca-f1e8-512c-ade7" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="0c5f-a39d-f318-124e" name="Ghar Outcast Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="7e56-6dae-2924-222d" hidden="false" targetId="9770-5f42-fa8c-247c" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="f3c1-a4fd-77c7-1ad3" name="Leader Rank" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="246c-fea3-dfb5-693c" hidden="false" targetId="0e9b-9aae-bd16-d30f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="15bd-449b-fa72-2c5f" hidden="false" targetId="da65-5109-5f5f-0f9a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="fb25-afca-e693-0a27" hidden="false" targetId="05af-fc97-7a19-cf8d" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="7b56-0416-c6ba-a4c6" hidden="false" targetId="4d36-a47c-487c-f893" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="18.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f22f-86cd-4a95-b370" name="Ghar Outcast" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="efc3-4fa1-890c-d8c1" hidden="false" targetId="b292-161d-d26f-b5e9" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="11.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="6e24-74a4-80af-9ca3" hidden="false" targetId="4d36-a47c-487c-f893" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="770f-0ac0-8238-7bfc" name="Outcast Weapon Team of Two" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="9212-637f-32c3-029a" hidden="false" targetId="b292-161d-d26f-b5e9" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="47a4-e76a-0c78-f0f8" hidden="false" targetId="a975-754b-83c3-802b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="24.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="438c-b342-0622-0896" hidden="false" targetId="c429-23e1-056e-cfd3" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="6cfb-8ee0-4610-646d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0c5f-a39d-f318-124e" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="6cfb-8ee0-4610-646d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f22f-86cd-4a95-b370" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="4.0">
+              <repeats>
+                <repeat field="selections" scope="6cfb-8ee0-4610-646d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="770f-0ac0-8238-7bfc" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fd3a-9dc3-6585-6d3e" name="Tectorist Scouts" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit">
+      <profiles/>
       <rules>
         <rule id="0361-c2bf-5185-8a0b" name="Special: Sharded Infantry Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="bee5-b458-d288-7e29" targetId="3b86-3198-ef3c-030e" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="1de0-bc86-9c78-0a15" name="Wrecker" points="30.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
+      <infoLinks/>
       <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="b572-c2ed-763c-a0a4" name="Tectorist Scout" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="d0e9-50a7-5823-cc89" name="Tectorist Scouts" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="6"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="3"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="9d42-7e5f-bbf0-acd4" hidden="false" targetId="ccca-f1e8-512c-ade7" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="f6a8-13c6-b9ac-c035" hidden="false" targetId="24a5-60f8-93fc-7dff" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="8061-c0ee-f0f9-6958" hidden="false" targetId="485f-1f8e-7808-4a17" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="bee5-b458-d288-7e29" hidden="false" targetId="3b86-3198-ef3c-030e" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1de0-bc86-9c78-0a15" name="Wrecker" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit">
+      <profiles>
+        <profile id="3660-6724-8c24-7b00" name="Ghar Wrecker" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="7"/>
+            <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+            <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="7"/>
+            <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4 (10)"/>
+            <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+            <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+            <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+          </characteristics>
+        </profile>
+      </profiles>
       <rules>
         <rule id="4f33-d4dd-0d5d-5d25" name="Mounted Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles>
-        <profile id="3660-6724-8c24-7b00" profileTypeId="1650-77b3-10d1-6406" name="Ghar Wrecker" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="7"/>
-            <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
-            <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="7"/>
-            <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="4 (10)"/>
-            <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-            <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-          </characteristics>
+      <infoLinks>
+        <infoLink id="6134-f048-10c3-6377" hidden="false" targetId="23c8-9405-75ca-7f03" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+        </infoLink>
+        <infoLink id="89a5-d8cb-d79c-c1c1" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="1036-b394-2250-91f0" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b602-7148-7417-d812" hidden="false" targetId="f5cb-d1fc-6b00-39f5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="29a1-79f1-cc3e-bf8a" hidden="false" targetId="ac9f-9690-ac50-3e99" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="30.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <entryLinks>
+    <entryLink id="fec8-09b0-facd-aa88" name="Army Options" hidden="false" targetId="529a-3e2a-4bd5-5e5f" type="selectionEntry" categoryEntryId="50ba-cf77-3941-189c">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </entryLink>
+  </entryLinks>
+  <sharedSelectionEntries>
+    <selectionEntry id="562c-13be-8455-d77b" name="Bomb Feeder" book="Main Rulebook" page="124" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e376-d612-25ff-b855" name="Disruptor Bomber" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a975-754b-83c3-802b" name="Disruptor Cannon" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ff6d-c9e5-a6c4-f336" name="Disruptor Discharger" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="72a8-99cd-7759-5303" name="Disruptor Discharger" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="-"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="-"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Point Blank Shooting Only, Grenade, Blast D4, Disruptor"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="29a1-79f1-cc3e-bf8a" targetId="ac9f-9690-ac50-3e99" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="6134-f048-10c3-6377" targetId="23c8-9405-75ca-7f03" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="89a5-d8cb-d79c-c1c1" targetId="931b-a54d-a846-cb74" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="1036-b394-2250-91f0" targetId="a985-d1e1-a15f-c261" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="b602-7148-7417-d812" targetId="f5cb-d1fc-6b00-39f5" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-  </entries>
-  <rules/>
-  <links/>
-  <sharedEntries>
-    <entry id="562c-13be-8455-d77b" name="Bomb Feeder" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="Main Rulebook" page="124">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="e376-d612-25ff-b855" name="Disruptor Bomber" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
+      <infoLinks>
+        <infoLink id="84fd-8f52-305f-f304" hidden="false" targetId="0bb9-6368-6b0e-0c1c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="76d1-263c-00e2-7e8d" hidden="false" targetId="5344-3037-5451-66d9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7452-3046-3f4b-7e77" hidden="false" targetId="e650-ca8a-00be-3fd1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="5f8c-16cb-14c1-dbd1" hidden="false" targetId="e140-2d88-ec8d-28a8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="a975-754b-83c3-802b" name="Disruptor Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="ff6d-c9e5-a6c4-f336" name="Disruptor Discharger" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3cfd-07d8-f685-fa34" name="Gouger" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="72a8-99cd-7759-5303" profileTypeId="ecae-8ac8-2c13-0dd3" name="Disruptor Discharger" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="-"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="-"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="-"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Point Blank Shooting Only, Grenade, Blast D4, Disruptor"/>
-          </characteristics>
+        <profile id="9983-0148-efd4-e87b" name="Gouger" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Down, Inaccurate"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="84fd-8f52-305f-f304" targetId="0bb9-6368-6b0e-0c1c" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="76d1-263c-00e2-7e8d" targetId="5344-3037-5451-66d9" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="7452-3046-3f4b-7e77" targetId="e650-ca8a-00be-3fd1" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="5f8c-16cb-14c1-dbd1" targetId="e140-2d88-ec8d-28a8" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="3cfd-07d8-f685-fa34" name="Gouger" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="9983-0148-efd4-e87b" profileTypeId="ecae-8ac8-2c13-0dd3" name="Gouger" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="-"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Down, Inaccurate"/>
-          </characteristics>
+      <infoLinks>
+        <infoLink id="dc53-88cf-67b6-f50c" hidden="false" targetId="4cb3-1c82-5192-1a7a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+        </infoLink>
+        <infoLink id="f96a-f7aa-7dff-a92d" hidden="false" targetId="c524-47f2-d062-eed0" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ac9f-9690-ac50-3e99" name="Grabber" book="Main Rulebook" page="124" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5a09-7c98-31f2-0b1b" name="Heavy Disruptor Bomber" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="6829-9a72-421b-cfd5" name="Heavy Disruptor Bomber" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OHx2, Blast D10, No Crew, Limited Ammo, No Cover, Disruptor"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="dc53-88cf-67b6-f50c" targetId="4cb3-1c82-5192-1a7a" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="f96a-f7aa-7dff-a92d" targetId="c524-47f2-d062-eed0" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="ac9f-9690-ac50-3e99" name="Grabber" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="Main Rulebook" page="124">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="05af-fc97-7a19-cf8d" name="Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="5a09-7c98-31f2-0b1b" name="Heavy Disruptor Bomber" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="6829-9a72-421b-cfd5" profileTypeId="ecae-8ac8-2c13-0dd3" name="Heavy Disruptor Bomber" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="60"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="120"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OHx2, Blast D10, No Crew, Limited Ammo, No Cover, Disruptor"/>
-          </characteristics>
+      <infoLinks>
+        <infoLink id="6ed0-d806-e77d-98d7" hidden="false" targetId="24a5-60f8-93fc-7dff" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0e9b-9aae-bd16-d30f" name="Leader 2" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="94ea-cf78-4b71-6d44" hidden="false" targetId="9d03-08db-93a6-4f05" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="da65-5109-5f5f-0f9a" name="Leader 3" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="35f6-4a4a-f299-e85f" hidden="false" targetId="e048-25d9-af17-bdf0" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4d36-a47c-487c-f893" name="Lugger Gun" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="98d1-3d6d-debb-e8f0" name="Lugger Gun" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Limited Ammo"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links/>
-    </entry>
-    <entry id="05af-fc97-7a19-cf8d" name="Leader" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles/>
-      <links>
-        <link id="6ed0-d806-e77d-98d7" targetId="24a5-60f8-93fc-7dff" linkType="rule">
+      <infoLinks>
+        <infoLink id="7b96-6226-be5a-13d9" hidden="false" targetId="0dab-4247-3f70-96e7" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="0e9b-9aae-bd16-d30f" name="Leader 2" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="94ea-cf78-4b71-6d44" targetId="9d03-08db-93a6-4f05" linkType="rule">
+        </infoLink>
+        <infoLink id="8fbb-fa4e-9d17-e664" hidden="false" targetId="a9b4-063d-b7f2-c577" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="da65-5109-5f5f-0f9a" name="Leader 3" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="35f6-4a4a-f299-e85f" targetId="e048-25d9-af17-bdf0" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="4d36-a47c-487c-f893" name="Lugger Gun" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="dc72-b0e2-b8cb-2d5c" name="Maglash" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="98d1-3d6d-debb-e8f0" profileTypeId="ecae-8ac8-2c13-0dd3" name="Lugger Gun" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="-"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2, Limited Ammo"/>
-          </characteristics>
+        <profile id="66ab-8aa6-0aad-7137" name="Maglash" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="-"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="7b96-6226-be5a-13d9" targetId="0dab-4247-3f70-96e7" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="8fbb-fa4e-9d17-e664" targetId="a9b4-063d-b7f2-c577" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="dc72-b0e2-b8cb-2d5c" name="Maglash" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="66ab-8aa6-0aad-7137" profileTypeId="ecae-8ac8-2c13-0dd3" name="Maglash" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="-"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="-"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks"/>
-          </characteristics>
+      <infoLinks>
+        <infoLink id="a742-ea4f-8be3-471b" hidden="false" targetId="3d3d-094e-e819-bbc6" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0924-6883-4fd0-7896" name="Plasma Amplifier" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="36a7-e564-c80c-2a7e" name="Plasma Claw" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="7b7f-6710-a8ca-13a0" name="Plasma Claw" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="-"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="-"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="D4"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Random SV, Hand to Hand Only"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="a742-ea4f-8be3-471b" targetId="3d3d-094e-e819-bbc6" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="0924-6883-4fd0-7896" name="Plasma Amplifier" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="552b-e451-f468-5bc2" hidden="false" targetId="30d6-c6b7-e415-04b6" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="4e02-a4cc-a3ca-5602" hidden="false" targetId="34b7-4d0d-35b3-8ebe" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6e7f-8fb9-1596-4ab8" name="Plasma Dump" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="36a7-e564-c80c-2a7e" name="Plasma Claw" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c429-23e1-056e-cfd3" name="Plasma Grenades" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3fde-b133-beb3-43d7" name="Scourer Cannon" book="" hidden="false" collective="true" categoryEntryId="(No Category)" type="model">
       <profiles>
-        <profile id="7b7f-6710-a8ca-13a0" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Claw" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="-"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="-"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="-"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="D4"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Random SV, Hand to Hand Only"/>
-          </characteristics>
+        <profile id="3a17-075b-0005-da30" name="Scourer Cannon - Dispersed" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3"/>
+          </characteristics>
+        </profile>
+        <profile id="f1bd-dc3c-6c69-200a" name="Scourer Cannon - Concentrated" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="40"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="4"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec"/>
+          </characteristics>
+        </profile>
+        <profile id="386e-981d-4010-4c7c" name="Scourer Cannon - Disruptor" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, No Cover, Disruptor"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="552b-e451-f468-5bc2" targetId="30d6-c6b7-e415-04b6" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="4e02-a4cc-a3ca-5602" targetId="34b7-4d0d-35b3-8ebe" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="6e7f-8fb9-1596-4ab8" name="Plasma Dump" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3b86-3198-ef3c-030e" name="Tector Rods" book="Main Rulebook" page="124" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="c429-23e1-056e-cfd3" name="Plasma Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="3fde-b133-beb3-43d7" name="Scourer Cannon" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="">
-      <entries/>
-      <entryGroups/>
+      <infoLinks/>
       <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="3a17-075b-0005-da30" profileTypeId="ecae-8ac8-2c13-0dd3" name="Scourer Cannon - Dispersed" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="-"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-        <profile id="f1bd-dc3c-6c69-200a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Scourer Cannon - Concentrated" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="40"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="4"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-        <profile id="386e-981d-4010-4c7c" profileTypeId="ecae-8ac8-2c13-0dd3" name="Scourer Cannon - Disruptor" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="-"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D4, No Cover, Disruptor"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="3b86-3198-ef3c-030e" name="Tector Rods" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="Main Rulebook" page="124">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-  </sharedEntries>
-  <sharedEntryGroups/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups/>
   <sharedRules>
     <rule id="0bb9-6368-6b0e-0c1c" name="Blast" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="1d76-267d-696a-2e8a" name="Command" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="23c8-9405-75ca-7f03" name="Crawler" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="e140-2d88-ec8d-28a8" name="Disruptor" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="4cb3-1c82-5192-1a7a" name="Down" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="ae1d-2212-b0ef-48b6" name="Follow" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="e650-ca8a-00be-3fd1" name="Grenade" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="34b7-4d0d-35b3-8ebe" name="Hand to Hand Only" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="4a94-ffc8-8d46-6869" name="Hero" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="48e7-7b6b-328c-29fe" name="High Commander" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="c524-47f2-d062-eed0" name="Inaccurate" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="931b-a54d-a846-cb74" name="Large" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="24a5-60f8-93fc-7dff" name="Leader" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="9d03-08db-93a6-4f05" name="Leader 2" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="e048-25d9-af17-bdf0" name="Leader 3" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="0dab-4247-3f70-96e7" name="Limited Ammo" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="09d0-48ed-82d2-38b5" name="MOD2" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="3d3d-094e-e819-bbc6" name="Multiple Attacks" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="5344-3037-5451-66d9" name="No Cover" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="2ed7-3d50-bea9-5f27" name="Outcast Champion" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="ccca-f1e8-512c-ade7" name="Outcasts" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="0448-a629-3df9-73c0" name="Plasma Amplifier" hidden="false" book="Main Rulebook" page="125">
+    <rule id="0448-a629-3df9-73c0" name="Plasma Amplifier" book="Main Rulebook" page="125" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="4280-96f3-aa68-8d6e" name="Plasma Dump" hidden="false" book="Main Rulebook" page="124">
+    <rule id="4280-96f3-aa68-8d6e" name="Plasma Dump" book="Main Rulebook" page="124" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="f5cb-d1fc-6b00-39f5" name="Plasma Reactor" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="30d6-c6b7-e415-04b6" name="Random SV" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="a9b4-063d-b7f2-c577" name="Rapid Fire (RF)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="a985-d1e1-a15f-c261" name="Scramble Proof" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="485f-1f8e-7808-4a17" name="Shard" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="57d1-980d-ee47-f717" name="Wound" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
   </sharedRules>
   <sharedProfiles>
-    <profile id="562d-6cd9-4b4a-7019" profileTypeId="1650-77b3-10d1-6406" name="Ghar Leader" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="3"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="10"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="4(12)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-      </characteristics>
+    <profile id="562d-6cd9-4b4a-7019" name="Ghar Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="3"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="10"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(12)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+      </characteristics>
     </profile>
-    <profile id="de07-7287-f4d3-bf98" profileTypeId="1650-77b3-10d1-6406" name="Ghar Trooper" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="3"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="10"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="4(12)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="7"/>
-      </characteristics>
+    <profile id="de07-7287-f4d3-bf98" name="Ghar Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="3"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="10"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(12)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+      </characteristics>
     </profile>
-    <profile id="b292-161d-d26f-b5e9" profileTypeId="1650-77b3-10d1-6406" name="Outcast" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="6"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="3"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="4"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="6"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="6"/>
-      </characteristics>
+    <profile id="b292-161d-d26f-b5e9" name="Outcast" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="6"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="3"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="6"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="6"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+      </characteristics>
     </profile>
-    <profile id="9770-5f42-fa8c-247c" profileTypeId="1650-77b3-10d1-6406" name="Outcast Leader" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="6"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="3"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="4"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="7"/>
-      </characteristics>
+    <profile id="9770-5f42-fa8c-247c" name="Outcast Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="6"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="3"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+      </characteristics>
     </profile>
-    <profile id="7a11-cc52-4a61-59a6" profileTypeId="1650-77b3-10d1-6406" name="Outcast Slave Driver" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="6"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="3"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="4"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="7"/>
-      </characteristics>
+    <profile id="7a11-cc52-4a61-59a6" name="Outcast Slave Driver" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="6"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="3"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+      </characteristics>
     </profile>
   </sharedProfiles>
 </catalogue>

--- a/Ghar_Rebels.cat
+++ b/Ghar_Rebels.cat
@@ -1,3330 +1,5846 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="2165-1159-f3ed-3ea5" revision="2" gameSystemId="c339-677a-60db-4060" gameSystemRevision="4" battleScribeVersion="1.15" name="Rebel" books="BFX" authorName="Maye Gelt" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
-  <entries>
-    <entry id="4ddf-247a-fd1d-2264" name="Army Options" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="brb" page="159">
-      <entries>
-        <entry id="f7ce-75c3-2997-6921" name="Block!" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="brb" page="159">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-        <entry id="915e-f2eb-da32-24f6" name="Get Up!" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="brb" page="159">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-        <entry id="3534-7fce-4a95-7c1e" name="Extra Shot" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="brb" page="159">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-        <entry id="1f63-b2ca-1245-db01" name="Pull Yourself Together" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="brb" page="159">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-        <entry id="c18c-a602-3036-dd57" name="Superior Shard" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="brb" page="159">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-        <entry id="9d50-659a-cb95-a5f3" name="Marksman" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="brb" page="159">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-        <entry id="63bf-d255-762d-7445" name="Well Prepared" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="brb" page="159">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
+<catalogue id="2165-1159-f3ed-3ea5" name="Rebel" book="BFX" revision="3" battleScribeVersion="2.00" authorName="Maye Gelt" gameSystemId="c339-677a-60db-4060" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <profiles/>
+  <rules/>
+  <infoLinks/>
+  <costTypes/>
+  <profileTypes/>
+  <forceEntries/>
+  <selectionEntries>
+    <selectionEntry id="4ddf-247a-fd1d-2264" name="Army Options" book="brb" page="159" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="3d57-162c-00ab-4c84" name="Fartok, Leader Of The Outcast Revolt" points="179.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BFX" page="107">
-      <entries>
-        <entry id="0392-cdb8-e66c-08f6" name="Fartok" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="2503-767b-452a-9f0d" profileTypeId="1650-77b3-10d1-6406" name="Fartok" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="3"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="10"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="4(12)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="9"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-                <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Command, Follow, High Command, Wound, Large, Hybrid Plasma Reactor"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="68f3-6a1c-7ab2-188e" targetId="1d76-267d-696a-2e8a" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="ec4f-5ee3-cc36-a034" targetId="ae1d-2212-b0ef-48b6" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="b5de-d4c1-099f-d22f" targetId="48e7-7b6b-328c-29fe" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="5f62-26e1-d3c2-aeb0" targetId="931b-a54d-a846-cb74" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="a9a4-fa90-7757-39b9" targetId="a985-d1e1-a15f-c261" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="ca4e-8c82-0775-2425" targetId="57d1-980d-ee47-f717" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="dd24-7c10-4a67-30df" targetId="f2a0-778f-5fa4-20af" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="036d-d495-7f37-864f" name="Ghar Trooper 1" points="85.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="5149-8785-472f-ec8c" name="Plasma Claws" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="3d57-162c-00ab-4c84" incrementChildId="036d-d495-7f37-864f" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="38db-0f51-f87c-f8e4" targetId="0a8d-432b-4cb0-6b78" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="456f-9eeb-4ec2-0879" profileTypeId="1650-77b3-10d1-6406" name="Ghar Trooper" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="3"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="10"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="4(12)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="9"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-                <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Large, Scramble Proof, Hybrid Plasma Reactor"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-        <entry id="1c5f-6e05-0634-9598" name="Plasma Dumps" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="3d57-162c-00ab-4c84" incrementChildId="0392-cdb8-e66c-08f6" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="3d57-162c-00ab-4c84" incrementChildId="036d-d495-7f37-864f" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="3d57-162c-00ab-4c84" incrementChildId="5c66-1eb0-17c5-71e7" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="aba5-9159-ad1f-9d95" targetId="4280-96f3-aa68-8d6e" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="5c66-1eb0-17c5-71e7" name="Ghar Trooper 2" points="85.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="e4c4-e2f4-1333-2473" name="Plasma Claws" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="3d57-162c-00ab-4c84" incrementChildId="5c66-1eb0-17c5-71e7" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="3dd6-23d6-b8d6-db5d" targetId="0a8d-432b-4cb0-6b78" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="0fe7-c74b-d600-df56" profileTypeId="1650-77b3-10d1-6406" name="Ghar Trooper" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="3"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="10"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="4(12)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="9"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value=""/>
-                <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Large, Scramble Proof, Hybrid Plasma Reactor"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="f7ce-75c3-2997-6921" name="Block!" book="brb" page="159" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="915e-f2eb-da32-24f6" name="Get Up!" book="brb" page="159" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3534-7fce-4a95-7c1e" name="Extra Shot" book="brb" page="159" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1f63-b2ca-1245-db01" name="Pull Yourself Together" book="brb" page="159" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c18c-a602-3036-dd57" name="Superior Shard" book="brb" page="159" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9d50-659a-cb95-a5f3" name="Marksman" book="brb" page="159" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="63bf-d255-762d-7445" name="Well Prepared" book="brb" page="159" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3d57-162c-00ab-4c84" name="Fartok, Leader Of The Outcast Revolt" book="BFX" page="107" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
       <rules>
         <rule id="cc41-d1a4-756b-8db5" name="Infantry Command Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
+      <infoLinks>
+        <infoLink id="0457-88a3-946a-21eb" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="910d-0a3a-9847-e4e5" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="0392-cdb8-e66c-08f6" name="Fartok" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="2503-767b-452a-9f0d" name="Fartok" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="3"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="10"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(12)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="9"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Follow, High Command, Wound, Large, Hybrid Plasma Reactor"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="68f3-6a1c-7ab2-188e" hidden="false" targetId="1d76-267d-696a-2e8a" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="ec4f-5ee3-cc36-a034" hidden="false" targetId="ae1d-2212-b0ef-48b6" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="b5de-d4c1-099f-d22f" hidden="false" targetId="48e7-7b6b-328c-29fe" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="5f62-26e1-d3c2-aeb0" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="a9a4-fa90-7757-39b9" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="ca4e-8c82-0775-2425" hidden="false" targetId="57d1-980d-ee47-f717" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="dd24-7c10-4a67-30df" hidden="false" targetId="f2a0-778f-5fa4-20af" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="036d-d495-7f37-864f" name="Ghar Trooper 1" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="456f-9eeb-4ec2-0879" name="Ghar Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="3"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="10"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(12)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="9"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Large, Scramble Proof, Hybrid Plasma Reactor"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="5149-8785-472f-ec8c" name="Plasma Claws" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats>
+                    <repeat field="selections" scope="3d57-162c-00ab-4c84" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="036d-d495-7f37-864f" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="38db-0f51-f87c-f8e4" hidden="false" targetId="0a8d-432b-4cb0-6b78" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="85.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1c5f-6e05-0634-9598" name="Plasma Dumps" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="aba5-9159-ad1f-9d95" hidden="false" targetId="4280-96f3-aa68-8d6e" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="3d57-162c-00ab-4c84" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0392-cdb8-e66c-08f6" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="3d57-162c-00ab-4c84" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="036d-d495-7f37-864f" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="3d57-162c-00ab-4c84" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5c66-1eb0-17c5-71e7" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5c66-1eb0-17c5-71e7" name="Ghar Trooper 2" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="0fe7-c74b-d600-df56" name="Ghar Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="3"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="10"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(12)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="9"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value=""/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Large, Scramble Proof, Hybrid Plasma Reactor"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="e4c4-e2f4-1333-2473" name="Plasma Claws" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats>
+                    <repeat field="selections" scope="3d57-162c-00ab-4c84" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5c66-1eb0-17c5-71e7" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="3dd6-23d6-b8d6-db5d" hidden="false" targetId="0a8d-432b-4cb0-6b78" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="85.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="a496-4a76-0557-8ff1" hidden="false" targetId="8592-5404-f9d1-f93b" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="179.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ba8c-4fea-3a3d-51af" name="Flitter Bombs" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit">
       <profiles/>
-      <links>
-        <link id="0457-88a3-946a-21eb" targetId="931b-a54d-a846-cb74" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="910d-0a3a-9847-e4e5" targetId="a985-d1e1-a15f-c261" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="a496-4a76-0557-8ff1" targetId="8592-5404-f9d1-f93b" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="ba8c-4fea-3a3d-51af" name="Flitter Bombs" points="0.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="5de7-d08d-e15d-7ce9" name="Flitter Bombs" points="10.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="5de7-d08d-e15d-7ce9" name="Flitter Bombs" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="cd10-ac71-475b-4f57" name="Flitter Bomb" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="3"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Shard, Scramble Proof"/>
+              </characteristics>
+            </profile>
+          </profiles>
           <rules>
             <rule id="c2ec-750c-4e06-7cc2" name="Probe Unit" hidden="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
             </rule>
           </rules>
-          <profiles>
-            <profile id="cd10-ac71-475b-4f57" profileTypeId="1650-77b3-10d1-6406" name="Flitter Bomb" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="-"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="-"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="3"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="-"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="-"/>
-                <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Shard, Scramble Proof"/>
-              </characteristics>
+          <infoLinks>
+            <infoLink id="f145-4aa1-65bd-dca3" hidden="false" targetId="485f-1f8e-7808-4a17" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
+            </infoLink>
+            <infoLink id="c480-5649-1e89-904a" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="785e-2c45-97b6-5467" hidden="false" targetId="6d5c-d6f2-3426-e11c" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="b103-2dc9-6fe1-6a00" hidden="false" targetId="2bb1-783e-8a6e-5970" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a0d2-a464-576a-d53f" name="Flitters" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="0d74-51f5-cdef-1da6" name="Flitter" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="e0b7-4216-5e20-71c4" name="Flitter" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="3"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Shard, Scramble Proof"/>
+              </characteristics>
             </profile>
           </profiles>
-          <links>
-            <link id="f145-4aa1-65bd-dca3" targetId="485f-1f8e-7808-4a17" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="c480-5649-1e89-904a" targetId="a985-d1e1-a15f-c261" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="785e-2c45-97b6-5467" targetId="6d5c-d6f2-3426-e11c" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="b103-2dc9-6fe1-6a00" targetId="2bb1-783e-8a6e-5970" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="a0d2-a464-576a-d53f" name="Flitters" points="0.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="0d74-51f5-cdef-1da6" name="Flitter" points="5.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
           <rules>
             <rule id="88cb-8269-0777-b47e" name="Probe Unit" hidden="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
             </rule>
           </rules>
-          <profiles>
-            <profile id="e0b7-4216-5e20-71c4" profileTypeId="1650-77b3-10d1-6406" name="Flitter" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="-"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="-"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="3"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="-"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="-"/>
-                <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Shard, Scramble Proof"/>
-              </characteristics>
+          <infoLinks>
+            <infoLink id="2ab9-ffed-3ff2-6498" hidden="false" targetId="485f-1f8e-7808-4a17" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="2ab9-ffed-3ff2-6498" targetId="485f-1f8e-7808-4a17" linkType="rule">
+            </infoLink>
+            <infoLink id="0a47-9677-96a8-9f0a" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="0a47-9677-96a8-9f0a" targetId="a985-d1e1-a15f-c261" linkType="rule">
+            </infoLink>
+            <infoLink id="5000-2d94-0c7a-5ec5" hidden="false" targetId="2dca-9d1f-0a96-e2d2" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="5000-2d94-0c7a-5ec5" targetId="2dca-9d1f-0a96-e2d2" linkType="rule">
+            </infoLink>
+            <infoLink id="7987-7ea4-3ee6-2b31" hidden="false" targetId="2bb1-783e-8a6e-5970" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="7987-7ea4-3ee6-2b31" targetId="2bb1-783e-8a6e-5970" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8b5a-d5f0-e539-a0ee" name="Ghar Rebel Bomber Squad" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="8b5a-d5f0-e539-a0ee" name="Ghar Rebel Bomber Squad" points="0.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="4a98-4c68-15aa-a072" name="Ghar Leader" points="64.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="1801-be82-bad9-46b6" name="Leader Rank" defaultEntryId="1133-61fa-0a8e-be9c" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="e148-d3dc-c579-ecba" name="Leader 2" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="206a-a126-a295-7465" targetId="9d03-08db-93a6-4f05" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="5d73-1f5e-0487-13e2" name="Leader 3" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="f30e-8b02-26ec-f5a4" targetId="e048-25d9-af17-bdf0" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="1133-61fa-0a8e-be9c" name="Leader" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="fbc6-19e6-ecb2-afe8" targetId="24a5-60f8-93fc-7dff" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="c216-69a9-3e8a-0f02" profileTypeId="f9a2-eeae-3284-75fd" name="Ghar Leader" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="18c1-4764-7d08-708d" name="Ag" value="3"/>
-                <characteristic characteristicId="e39c-d7a4-86a8-d23d" name="Acc" value="5"/>
-                <characteristic characteristicId="0790-bfd5-1273-fe12" name="Str" value="10"/>
-                <characteristic characteristicId="5b77-3595-2819-675c" name="Res" value="4(12)"/>
-                <characteristic characteristicId="c0d8-f6fd-a474-1385" name="Init" value="8"/>
-                <characteristic characteristicId="135d-efc3-5039-b6e6" name="Co" value="8"/>
-                <characteristic characteristicId="ab43-4d1c-4651-b424" name="Special" value="Leader, Large, Scramble Proof, Plasma Reactor"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="9f8b-ab48-0d2d-e501" targetId="3fde-b133-beb3-43d7" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="85b9-2e1c-9874-a211" targetId="f2a0-778f-5fa4-20af" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="a18c-40ae-d918-8109" name="Ghar Trooper" points="60.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="0e80-ade2-0809-2392" targetId="3fde-b133-beb3-43d7" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="4ba9-443d-2f8c-e499" targetId="de07-7287-f4d3-bf98" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="3a43-be53-21c6-bb37" name="Plasma Dumps" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="8b5a-d5f0-e539-a0ee" incrementChildId="0d6e-d1da-4558-5a99" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="8b5a-d5f0-e539-a0ee" incrementChildId="4a98-4c68-15aa-a072" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="8b5a-d5f0-e539-a0ee" incrementChildId="90ee-0a6f-9336-975d" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="8b5a-d5f0-e539-a0ee" incrementChildId="a18c-40ae-d918-8109" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-        <entry id="28a7-4a00-8b9f-618b" name="Plasma Amplifiers" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="8b5a-d5f0-e539-a0ee" incrementChildId="a18c-40ae-d918-8109" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="8b5a-d5f0-e539-a0ee" incrementChildId="4a98-4c68-15aa-a072" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="8b5a-d5f0-e539-a0ee" incrementChildId="0d6e-d1da-4558-5a99" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="8b5a-d5f0-e539-a0ee" incrementChildId="90ee-0a6f-9336-975d" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-        <entry id="0d6e-d1da-4558-5a99" name="Ghar Bomb Trooper" points="63.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="952f-9f4c-cbc4-2ebc" profileTypeId="1650-77b3-10d1-6406" name="Ghar Bomb Trooper" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="3"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="10"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="4(12)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="7"/>
-                <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Large, Scramble Proof, Plasma Reactor"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="39b2-7138-f2dd-425b" targetId="e376-d612-25ff-b855" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="90ee-0a6f-9336-975d" name="Ghar Scutter" points="47.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="6790-53e2-2efa-2be5" targetId="562c-13be-8455-d77b" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="e66e-6adf-a0cd-5f9c" targetId="3fde-b133-beb3-43d7" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="a63a-862a-a167-f040" targetId="13e9-5eeb-7392-f018" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
       <rules>
         <rule id="ca5c-7445-3e1f-4676" name="Infantry Unit/Mixed Infantry+Mount" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="2b2a-cf47-51fe-1daf" targetId="931b-a54d-a846-cb74" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="016f-eaf3-dbd7-ac1e" targetId="a985-d1e1-a15f-c261" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="7729-636d-e51e-d6f7" targetId="f5cb-d1fc-6b00-39f5" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="9030-9dea-f00b-e2ed" name="Outcast Rebel Assault Squad" points="0.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="c8dc-aa17-3f85-1a20" name="Ghar Leader" points="64.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="da1d-e454-1800-044b" name="Leader Rank" defaultEntryId="0d25-cce8-cf4b-478d" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="bb13-ff27-bf60-82ef" targetId="0e9b-9aae-bd16-d30f" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="a28d-5daa-1acf-caa1" targetId="da65-5109-5f5f-0f9a" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="0d25-cce8-cf4b-478d" targetId="05af-fc97-7a19-cf8d" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+      <infoLinks>
+        <infoLink id="2b2a-cf47-51fe-1daf" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
           <profiles/>
-          <links>
-            <link id="0af9-d07a-2fca-4caf" targetId="562d-6cd9-4b4a-7019" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="4850-1a32-f160-03dc" name="Ghar Trooper" points="60.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <rules/>
+        </infoLink>
+        <infoLink id="016f-eaf3-dbd7-ac1e" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
           <profiles/>
-          <links>
-            <link id="d0f1-7c67-3951-8631" targetId="de07-7287-f4d3-bf98" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="7db0-3bc8-ba66-2437" name="Plasma Dumps" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="9030-9dea-f00b-e2ed" incrementChildId="c8dc-aa17-3f85-1a20" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="9030-9dea-f00b-e2ed" incrementChildId="4850-1a32-f160-03dc" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
           <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7729-636d-e51e-d6f7" hidden="false" targetId="f5cb-d1fc-6b00-39f5" type="rule">
           <profiles/>
-          <links>
-            <link id="8608-c223-4acd-7e72" targetId="4280-96f3-aa68-8d6e" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="3b0a-3a3a-9ba0-4a01" name="Plasma Amplifiers" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="9030-9dea-f00b-e2ed" incrementChildId="4850-1a32-f160-03dc" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="9030-9dea-f00b-e2ed" incrementChildId="c8dc-aa17-3f85-1a20" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
           <rules/>
-          <profiles/>
-          <links>
-            <link id="18c8-9dff-9749-1130" targetId="0448-a629-3df9-73c0" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="4a98-4c68-15aa-a072" name="Ghar Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="c216-69a9-3e8a-0f02" name="Ghar Leader" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="3"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="10"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="4(12)"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="8"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="8"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424" value="Leader, Large, Scramble Proof, Plasma Reactor"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="85b9-2e1c-9874-a211" hidden="false" targetId="f2a0-778f-5fa4-20af" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="1801-be82-bad9-46b6" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="1133-61fa-0a8e-be9c">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="e148-d3dc-c579-ecba" name="Leader 2" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="206a-a126-a295-7465" hidden="false" targetId="9d03-08db-93a6-4f05" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="5d73-1f5e-0487-13e2" name="Leader 3" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="f30e-8b02-26ec-f5a4" hidden="false" targetId="e048-25d9-af17-bdf0" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="20.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="1133-61fa-0a8e-be9c" name="Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="fbc6-19e6-ecb2-afe8" hidden="false" targetId="24a5-60f8-93fc-7dff" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="9f8b-ab48-0d2d-e501" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="64.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a18c-40ae-d918-8109" name="Ghar Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="4ba9-443d-2f8c-e499" hidden="false" targetId="de07-7287-f4d3-bf98" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="0e80-ade2-0809-2392" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="60.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3a43-be53-21c6-bb37" name="Plasma Dumps" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0d6e-d1da-4558-5a99" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4a98-4c68-15aa-a072" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="90ee-0a6f-9336-975d" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a18c-40ae-d918-8109" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="28a7-4a00-8b9f-618b" name="Plasma Amplifiers" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a18c-40ae-d918-8109" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4a98-4c68-15aa-a072" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0d6e-d1da-4558-5a99" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="90ee-0a6f-9336-975d" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0d6e-d1da-4558-5a99" name="Ghar Bomb Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="952f-9f4c-cbc4-2ebc" name="Ghar Bomb Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="3"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="10"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(12)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Large, Scramble Proof, Plasma Reactor"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="39b2-7138-f2dd-425b" hidden="false" targetId="e376-d612-25ff-b855" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="63.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="90ee-0a6f-9336-975d" name="Ghar Scutter" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="a63a-862a-a167-f040" hidden="false" targetId="13e9-5eeb-7392-f018" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="6790-53e2-2efa-2be5" hidden="false" targetId="562c-13be-8455-d77b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="e66e-6adf-a0cd-5f9c" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="47.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9030-9dea-f00b-e2ed" name="Outcast Rebel Assault Squad" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
       <rules>
         <rule id="fef7-39df-2b98-1c66" name="Infantry Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="85ac-ff6e-0649-05db" targetId="931b-a54d-a846-cb74" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="9666-60fb-6002-9667" targetId="a985-d1e1-a15f-c261" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="2c0c-fe84-bfff-3841" targetId="f5cb-d1fc-6b00-39f5" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="cadd-7f5d-ed2e-aba9" targetId="3cfd-07d8-f685-fa34" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="0b52-400d-e2fa-6607" targetId="36a7-e564-c80c-2a7e" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="46f3-8791-7cb4-e161" targetId="ff6d-c9e5-a6c4-f336" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="9222-95de-7dcd-a02d" targetId="f2a0-778f-5fa4-20af" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="c632-a7b6-ae64-6a40" name="Outcast Rebel Attack Crawler" points="186.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="170">
-      <entries>
-        <entry id="9578-b417-1394-8a76" name="Ghar Attack Crawler" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="abdf-c858-3e87-a1a9" name="&lt; 1st Weapon &gt;" defaultEntryId="7142-8408-6ffb-cd9a" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="7142-8408-6ffb-cd9a" targetId="6f9d-4f18-835f-deff" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="ce20-6678-6c82-c8ef" targetId="306c-a91f-3fc0-e059" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="abdf-c858-3e87-a1a9" incrementChildId="ce20-6678-6c82-c8ef" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="2a51-0818-8e4f-4586" name="&lt; 2nd Weapon &gt;" defaultEntryId="fb2e-3d15-419a-7a6d" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="fb2e-3d15-419a-7a6d" targetId="6f9d-4f18-835f-deff" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="e08a-8330-714e-cd8a" targetId="306c-a91f-3fc0-e059" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="2a51-0818-8e4f-4586" incrementChildId="e08a-8330-714e-cd8a" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="e6b3-72aa-3e3d-7418" profileTypeId="f9a2-eeae-3284-75fd" name="Ghar Attack Crawler" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="18c1-4764-7d08-708d" name="Ag" value="3"/>
-                <characteristic characteristicId="e39c-d7a4-86a8-d23d" name="Acc" value="5"/>
-                <characteristic characteristicId="0790-bfd5-1273-fe12" name="Str" value="10"/>
-                <characteristic characteristicId="5b77-3595-2819-675c" name="Res" value="13"/>
-                <characteristic characteristicId="c0d8-f6fd-a474-1385" name="Init" value="8"/>
-                <characteristic characteristicId="135d-efc3-5039-b6e6" name="Co" value="9"/>
-                <characteristic characteristicId="ab43-4d1c-4651-b424" name="Special" value="MOD2, Large, Crawler, Scramble Proof, Plasma Reactor"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links/>
-        </entry>
-        <entry id="6cf2-4af4-75a3-8f07" name="Plasma Amplifiers" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="c632-a7b6-ae64-6a40" incrementChildId="9578-b417-1394-8a76" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
+      <infoLinks>
+        <infoLink id="85ac-ff6e-0649-05db" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
           <profiles/>
-          <links/>
-        </entry>
-        <entry id="0b27-b8e0-7533-1d10" name="Plasma Dumps" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="c632-a7b6-ae64-6a40" incrementChildId="9578-b417-1394-8a76" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
           <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="9666-60fb-6002-9667" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
           <profiles/>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="2c0c-fe84-bfff-3841" hidden="false" targetId="f5cb-d1fc-6b00-39f5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="9222-95de-7dcd-a02d" hidden="false" targetId="f2a0-778f-5fa4-20af" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules>
-        <rule id="eed6-747d-2cbd-1d32" name="Vehicle Unit" hidden="false" book="">
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="c8dc-aa17-3f85-1a20" name="Ghar Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="0af9-d07a-2fca-4caf" hidden="false" targetId="562d-6cd9-4b4a-7019" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links>
-        <link id="6771-8b8b-1adc-e06b" targetId="931b-a54d-a846-cb74" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="741b-2188-da40-de57" targetId="23c8-9405-75ca-7f03" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="b7de-95a5-d07f-99ea" targetId="09d0-48ed-82d2-38b5" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="3dbd-a4eb-1340-ae81" targetId="a985-d1e1-a15f-c261" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="999a-f887-fa62-07e6" targetId="f5cb-d1fc-6b00-39f5" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="0193-5420-e0da-fd25" targetId="f2a0-778f-5fa4-20af" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="c27a-aa4f-97c0-ebef" name="Outcast Rebel Attack Scutters" points="0.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="8974-5164-823a-fe6c" name="Ghar Attack Scutter Leader" points="36.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Beyond the Gates of Antares" page="170">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="e731-c0ab-0ba9-c676" name="Leader Rank" defaultEntryId="c559-421a-a988-dbfc" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="c559-421a-a988-dbfc" name="Leader" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="da1d-e454-1800-044b" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="0d25-cce8-cf4b-478d">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="bb13-ff27-bf60-82ef" hidden="false" targetId="0e9b-9aae-bd16-d30f" type="selectionEntry">
                   <profiles/>
-                  <links>
-                    <link id="5b39-2a49-3a77-c370" targetId="24a5-60f8-93fc-7dff" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="98cb-1e8a-385f-e77e" profileTypeId="f9a2-eeae-3284-75fd" name="Ghar Attack Scutter Leader" hidden="false" book="Beyond the Gates of Antares" page="170">
-              <characteristics>
-                <characteristic characteristicId="18c1-4764-7d08-708d" name="Ag" value="5"/>
-                <characteristic characteristicId="e39c-d7a4-86a8-d23d" name="Acc" value="5"/>
-                <characteristic characteristicId="0790-bfd5-1273-fe12" name="Str" value="1"/>
-                <characteristic characteristicId="5b77-3595-2819-675c" name="Res" value="4(10)"/>
-                <characteristic characteristicId="c0d8-f6fd-a474-1385" name="Init" value="8"/>
-                <characteristic characteristicId="135d-efc3-5039-b6e6" name="Co" value="8"/>
-                <characteristic characteristicId="ab43-4d1c-4651-b424" name="Special" value="Leader, Large, Crawler, Scramble Proof, Plasma Reactor"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="30b2-e94a-83d5-0cdd" targetId="f2a0-778f-5fa4-20af" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="7fdb-3754-be08-c953" name="Ghar Attack Scutter" points="26.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Beyond the Gates of Antares" page="170">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="a28d-5daa-1acf-caa1" hidden="false" targetId="da65-5109-5f5f-0f9a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="0d25-cce8-cf4b-478d" hidden="false" targetId="05af-fc97-7a19-cf8d" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="64.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4850-1a32-f160-03dc" name="Ghar Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles/>
-          <links>
-            <link id="8a00-c21f-6020-a669" targetId="13e9-5eeb-7392-f018" linkType="profile">
+          <rules/>
+          <infoLinks>
+            <infoLink id="d0f1-7c67-3951-8631" hidden="false" targetId="de07-7287-f4d3-bf98" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="1e0c-2244-a076-556e" name="Plasma Amplifiers" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="60.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7db0-3bc8-ba66-2437" name="Plasma Dumps" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="8608-c223-4acd-7e72" hidden="false" targetId="4280-96f3-aa68-8d6e" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="c27a-aa4f-97c0-ebef" incrementChildId="8974-5164-823a-fe6c" incrementField="selections" incrementValue="1.0">
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="9030-9dea-f00b-e2ed" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c8dc-aa17-3f85-1a20" repeats="1"/>
+              </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="c27a-aa4f-97c0-ebef" incrementChildId="7fdb-3754-be08-c953" incrementField="selections" incrementValue="1.0">
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="9030-9dea-f00b-e2ed" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4850-1a32-f160-03dc" repeats="1"/>
+              </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
           </modifiers>
-          <rules/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3b0a-3a3a-9ba0-4a01" name="Plasma Amplifiers" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles/>
-          <links/>
-        </entry>
-        <entry id="af71-451e-6e05-d0c7" name="Plasma Dumps" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="18c8-9dff-9749-1130" hidden="false" targetId="0448-a629-3df9-73c0" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="c27a-aa4f-97c0-ebef" incrementChildId="7fdb-3754-be08-c953" incrementField="selections" incrementValue="1.0">
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="9030-9dea-f00b-e2ed" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4850-1a32-f160-03dc" repeats="1"/>
+              </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="c27a-aa4f-97c0-ebef" incrementChildId="8974-5164-823a-fe6c" incrementField="selections" incrementValue="1.0">
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="9030-9dea-f00b-e2ed" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c8dc-aa17-3f85-1a20" repeats="1"/>
+              </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
           </modifiers>
-          <rules/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="cadd-7f5d-ed2e-aba9" hidden="false" targetId="3cfd-07d8-f685-fa34" type="selectionEntry">
           <profiles/>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="0b52-400d-e2fa-6607" hidden="false" targetId="36a7-e564-c80c-2a7e" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="46f3-8791-7cb4-e161" hidden="false" targetId="ff6d-c9e5-a6c4-f336" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c632-a7b6-ae64-6a40" name="Outcast Rebel Attack Crawler" page="170" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
       <rules>
-        <rule id="0702-c8f1-8d5b-8900" name="Mounted Unit" hidden="false" book="Beyond the Gates of Antares" page="95">
+        <rule id="eed6-747d-2cbd-1d32" name="Vehicle Unit" book="" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="10fb-a495-0f52-b962" targetId="f5cb-d1fc-6b00-39f5" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="a984-6534-8962-0067" targetId="a985-d1e1-a15f-c261" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="4ae7-9649-084d-3397" targetId="931b-a54d-a846-cb74" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="055a-0fdc-4575-9e60" targetId="23c8-9405-75ca-7f03" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="fcf9-45a8-690a-8da6" targetId="f2a0-778f-5fa4-20af" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="8f8a-26e1-0356-939e" targetId="3fde-b133-beb3-43d7" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="5670-d9f9-4779-7a23" name="Outcast Rebel Battle Squad" points="0.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="c899-96c3-90ae-a7a9" name="Ghar Leader" points="64.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="ed36-f6c6-fac2-472f" name="Leader Rank" defaultEntryId="413a-de59-87e5-7423" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="7e9e-abc2-6eda-189c" targetId="0e9b-9aae-bd16-d30f" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="8dd1-7f91-54f6-3404" targetId="da65-5109-5f5f-0f9a" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="413a-de59-87e5-7423" targetId="05af-fc97-7a19-cf8d" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+      <infoLinks>
+        <infoLink id="6771-8b8b-1adc-e06b" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
           <profiles/>
-          <links>
-            <link id="6dfb-a1b6-be58-5fc1" targetId="562d-6cd9-4b4a-7019" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="d729-76b6-d41d-caca" targetId="f2a0-778f-5fa4-20af" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="d842-422d-f043-b735" name="Ghar Trooper" points="60.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <rules/>
+        </infoLink>
+        <infoLink id="741b-2188-da40-de57" hidden="false" targetId="23c8-9405-75ca-7f03" type="rule">
           <profiles/>
-          <links>
-            <link id="307d-b360-e3d6-b2ea" targetId="de07-7287-f4d3-bf98" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="b8b4-04a9-1ee9-228b" name="Plasma Dumps" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="5670-d9f9-4779-7a23" incrementChildId="c899-96c3-90ae-a7a9" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="5670-d9f9-4779-7a23" incrementChildId="d842-422d-f043-b735" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
           <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b7de-95a5-d07f-99ea" hidden="false" targetId="09d0-48ed-82d2-38b5" type="rule">
           <profiles/>
-          <links>
-            <link id="4065-1ed9-2939-5b44" targetId="4280-96f3-aa68-8d6e" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="ef06-9064-c307-e665" name="Plasma Amplifiers" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="5670-d9f9-4779-7a23" incrementChildId="d842-422d-f043-b735" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="5670-d9f9-4779-7a23" incrementChildId="c899-96c3-90ae-a7a9" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
           <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3dbd-a4eb-1340-ae81" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
           <profiles/>
-          <links>
-            <link id="b8e3-5e41-cdf0-30e5" targetId="0448-a629-3df9-73c0" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="999a-f887-fa62-07e6" hidden="false" targetId="f5cb-d1fc-6b00-39f5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="0193-5420-e0da-fd25" hidden="false" targetId="f2a0-778f-5fa4-20af" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="9578-b417-1394-8a76" name="Ghar Attack Crawler" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="e6b3-72aa-3e3d-7418" name="Ghar Attack Crawler" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="3"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="10"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="13"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="8"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="9"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424" value="MOD2, Large, Crawler, Scramble Proof, Plasma Reactor"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="abdf-c858-3e87-a1a9" name="&lt; 1st Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="7142-8408-6ffb-cd9a">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="7142-8408-6ffb-cd9a" hidden="false" targetId="6f9d-4f18-835f-deff" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="ce20-6678-6c82-c8ef" hidden="false" targetId="306c-a91f-3fc0-e059" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="10.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="2a51-0818-8e4f-4586" name="&lt; 2nd Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="fb2e-3d15-419a-7a6d">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="fb2e-3d15-419a-7a6d" hidden="false" targetId="6f9d-4f18-835f-deff" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="e08a-8330-714e-cd8a" hidden="false" targetId="306c-a91f-3fc0-e059" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="10.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6cf2-4af4-75a3-8f07" name="Plasma Amplifiers" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="c632-a7b6-ae64-6a40" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9578-b417-1394-8a76" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0b27-b8e0-7533-1d10" name="Plasma Dumps" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="c632-a7b6-ae64-6a40" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9578-b417-1394-8a76" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="186.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c27a-aa4f-97c0-ebef" name="Outcast Rebel Attack Scutters" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="0702-c8f1-8d5b-8900" name="Mounted Unit" book="Beyond the Gates of Antares" page="95" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="10fb-a495-0f52-b962" hidden="false" targetId="f5cb-d1fc-6b00-39f5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="a984-6534-8962-0067" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="4ae7-9649-084d-3397" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="055a-0fdc-4575-9e60" hidden="false" targetId="23c8-9405-75ca-7f03" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="fcf9-45a8-690a-8da6" hidden="false" targetId="f2a0-778f-5fa4-20af" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="8974-5164-823a-fe6c" name="Ghar Attack Scutter Leader" book="Beyond the Gates of Antares" page="170" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="98cb-1e8a-385f-e77e" name="Ghar Attack Scutter Leader" book="Beyond the Gates of Antares" page="170" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="1"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="4(10)"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="8"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="8"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424" value="Leader, Large, Crawler, Scramble Proof, Plasma Reactor"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="30b2-e94a-83d5-0cdd" hidden="false" targetId="f2a0-778f-5fa4-20af" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="e731-c0ab-0ba9-c676" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="c559-421a-a988-dbfc">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="c559-421a-a988-dbfc" name="Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="5b39-2a49-3a77-c370" hidden="false" targetId="24a5-60f8-93fc-7dff" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="36.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7fdb-3754-be08-c953" name="Ghar Attack Scutter" book="Beyond the Gates of Antares" page="170" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="8a00-c21f-6020-a669" hidden="false" targetId="13e9-5eeb-7392-f018" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="26.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1e0c-2244-a076-556e" name="Plasma Amplifiers" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="c27a-aa4f-97c0-ebef" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8974-5164-823a-fe6c" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="c27a-aa4f-97c0-ebef" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7fdb-3754-be08-c953" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="af71-451e-6e05-d0c7" name="Plasma Dumps" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="c27a-aa4f-97c0-ebef" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7fdb-3754-be08-c953" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="c27a-aa4f-97c0-ebef" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8974-5164-823a-fe6c" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="8f8a-26e1-0356-939e" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5670-d9f9-4779-7a23" name="Outcast Rebel Battle Squad" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
       <rules>
         <rule id="54a7-9a44-ddc3-e465" name="Infantry Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="5337-8aa7-11e4-24e8" targetId="931b-a54d-a846-cb74" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="96af-24be-477b-617d" targetId="a985-d1e1-a15f-c261" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="4e88-7e17-35a9-efdb" targetId="f5cb-d1fc-6b00-39f5" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="cf73-74f7-d7bd-e099" targetId="3fde-b133-beb3-43d7" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="6cfb-8ee0-4610-646d" name="Outcast Rebel Black Guard" points="0.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="0c5f-a39d-f318-124e" name="Outcast Rebel Leader" points="21.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="f3c1-a4fd-77c7-1ad3" name="Leader Rank" defaultEntryId="fb25-afca-e693-0a27" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="246c-fea3-dfb5-693c" targetId="0e9b-9aae-bd16-d30f" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="fb25-afca-e693-0a27" targetId="05af-fc97-7a19-cf8d" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+      <infoLinks>
+        <infoLink id="5337-8aa7-11e4-24e8" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
           <profiles/>
-          <links>
-            <link id="7e56-6dae-2924-222d" targetId="9770-5f42-fa8c-247c" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="f103-3d30-5144-f158" targetId="ed1e-82da-96a2-9c3e" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="set" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="6cfb-8ee0-4610-646d" incrementChildId="0c5f-a39d-f318-124e" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="6cfb-8ee0-4610-646d" incrementChildId="0c5f-a39d-f318-124e" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="f22f-86cd-4a95-b370" name="Outcast Rebel" points="8.0" categoryId="(No Category)" type="model" minSelections="5" maxSelections="11" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
           <rules/>
-          <profiles/>
-          <links>
-            <link id="9936-37ff-d15e-7936" targetId="b56d-892d-c25e-7379" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="38f6-2e46-7911-f96c" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="bd2f-24e3-1aeb-1758" targetId="a0c9-26de-c4d9-59cd" linkType="entry">
-              <modifiers>
-                <modifier type="set" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="f22f-86cd-4a95-b370" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="f22f-86cd-4a95-b370" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="cde7-d404-1b45-716c" targetId="6fc0-fbd7-b4c3-f78b" linkType="entry">
-              <modifiers>
-                <modifier type="set" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="f22f-86cd-4a95-b370" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="set" field="maxSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="f22f-86cd-4a95-b370" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+        </infoLink>
+        <infoLink id="96af-24be-477b-617d" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="4e88-7e17-35a9-efdb" hidden="false" targetId="f5cb-d1fc-6b00-39f5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="c899-96c3-90ae-a7a9" name="Ghar Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="6dfb-a1b6-be58-5fc1" hidden="false" targetId="562d-6cd9-4b4a-7019" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="d729-76b6-d41d-caca" hidden="false" targetId="f2a0-778f-5fa4-20af" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="ed36-f6c6-fac2-472f" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="413a-de59-87e5-7423">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="7e9e-abc2-6eda-189c" hidden="false" targetId="0e9b-9aae-bd16-d30f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="8dd1-7f91-54f6-3404" hidden="false" targetId="da65-5109-5f5f-0f9a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="413a-de59-87e5-7423" hidden="false" targetId="05af-fc97-7a19-cf8d" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="64.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d842-422d-f043-b735" name="Ghar Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="307d-b360-e3d6-b2ea" hidden="false" targetId="de07-7287-f4d3-bf98" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="60.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b8b4-04a9-1ee9-228b" name="Plasma Dumps" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="4065-1ed9-2939-5b44" hidden="false" targetId="4280-96f3-aa68-8d6e" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="5670-d9f9-4779-7a23" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c899-96c3-90ae-a7a9" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="5670-d9f9-4779-7a23" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d842-422d-f043-b735" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ef06-9064-c307-e665" name="Plasma Amplifiers" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="b8e3-5e41-cdf0-30e5" hidden="false" targetId="0448-a629-3df9-73c0" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="5670-d9f9-4779-7a23" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d842-422d-f043-b735" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="5670-d9f9-4779-7a23" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c899-96c3-90ae-a7a9" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="cf73-74f7-d7bd-e099" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6cfb-8ee0-4610-646d" name="Outcast Rebel Black Guard" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
       <rules>
         <rule id="e266-7204-4b62-9954" name="Infantry Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="438c-b342-0622-0896" targetId="c429-23e1-056e-cfd3" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="6cfb-8ee0-4610-646d" incrementChildId="0c5f-a39d-f318-124e" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="6cfb-8ee0-4610-646d" incrementChildId="f22f-86cd-4a95-b370" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="34f9-8663-d60b-8086" targetId="7a50-8a69-75b6-3cca" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="1ef9-102f-441e-cb1c" targetId="4003-9479-f9e0-a340" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="0ef8-b292-6e83-2f20" targetId="7f23-4831-7f76-fd6f" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="08ad-0896-7414-9670" targetId="dc72-b0e2-b8cb-2d5c" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="6cfb-8ee0-4610-646d" incrementChildId="0c5f-a39d-f318-124e" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="6cfb-8ee0-4610-646d" incrementChildId="f22f-86cd-4a95-b370" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-      </links>
-    </entry>
-    <entry id="f21b-beb2-224e-5e3f" name="Outcast Rebel Bombardment Crawler" points="256.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="170">
-      <entries>
-        <entry id="1a33-1125-41be-a84c" name="Ghar Bombardment Crawler" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="9eb2-f76c-73b5-402f" profileTypeId="f9a2-eeae-3284-75fd" name="Ghar Bombardment Crawler" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="18c1-4764-7d08-708d" name="Ag" value="3"/>
-                <characteristic characteristicId="e39c-d7a4-86a8-d23d" name="Acc" value="5"/>
-                <characteristic characteristicId="0790-bfd5-1273-fe12" name="Str" value="10"/>
-                <characteristic characteristicId="5b77-3595-2819-675c" name="Res" value="13"/>
-                <characteristic characteristicId="c0d8-f6fd-a474-1385" name="Init" value="8"/>
-                <characteristic characteristicId="135d-efc3-5039-b6e6" name="Co" value="9"/>
-                <characteristic characteristicId="ab43-4d1c-4651-b424" name="Special" value="MOD2, Large, Crawler, Scramble Proof, Plasma Reactor"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="13e6-878c-c923-5a97" targetId="5a09-7c98-31f2-0b1b" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="e938-8434-70f7-d9c7" targetId="3fde-b133-beb3-43d7" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="0019-d8b6-f4b8-fe36" targetId="3fde-b133-beb3-43d7" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="0e62-9dd3-f8d6-58e5" targetId="09d0-48ed-82d2-38b5" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="dabb-bc37-63b2-f834" targetId="f2a0-778f-5fa4-20af" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="a8a2-a078-6edf-978b" name="Plasma Amplifiers" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="f21b-beb2-224e-5e3f" incrementChildId="1a33-1125-41be-a84c" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="f21b-beb2-224e-5e3f" incrementChildId="ef3d-dcd6-70ae-c6c6" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
+      <infoLinks>
+        <infoLink id="34f9-8663-d60b-8086" hidden="false" targetId="7a50-8a69-75b6-3cca" type="rule">
           <profiles/>
-          <links>
-            <link id="8580-c966-a7b2-e3b0" targetId="0448-a629-3df9-73c0" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="6a4c-fdb7-ebdb-0a84" name="Plasma Dumps" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="f21b-beb2-224e-5e3f" incrementChildId="1a33-1125-41be-a84c" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="f21b-beb2-224e-5e3f" incrementChildId="ef3d-dcd6-70ae-c6c6" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
           <rules/>
-          <profiles/>
-          <links>
-            <link id="bb80-60c6-c83a-a75d" targetId="4280-96f3-aa68-8d6e" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="ef3d-dcd6-70ae-c6c6" name="Ghar Scutter" points="26.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <infoLinks/>
           <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="0b1b-0a86-07ce-c5ec" targetId="562c-13be-8455-d77b" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="5805-0b73-8f17-f572" targetId="3fde-b133-beb3-43d7" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="d99a-7cf4-44e7-db6a" targetId="13e9-5eeb-7392-f018" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="0c5f-a39d-f318-124e" name="Outcast Rebel Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="7e56-6dae-2924-222d" hidden="false" targetId="9770-5f42-fa8c-247c" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="f3c1-a4fd-77c7-1ad3" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="fb25-afca-e693-0a27">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="246c-fea3-dfb5-693c" hidden="false" targetId="0e9b-9aae-bd16-d30f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="fb25-afca-e693-0a27" hidden="false" targetId="05af-fc97-7a19-cf8d" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="f103-3d30-5144-f158" hidden="false" targetId="ed1e-82da-96a2-9c3e" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="minSelections" value="0.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="maxSelections" value="1.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="minSelections" value="0.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="maxSelections" value="1.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="21.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f22f-86cd-4a95-b370" name="Outcast Rebel" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="9936-37ff-d15e-7936" hidden="false" targetId="b56d-892d-c25e-7379" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="11.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="8.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="38f6-2e46-7911-f96c" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="bd2f-24e3-1aeb-1758" hidden="false" targetId="a0c9-26de-c4d9-59cd" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="minSelections" value="0.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="maxSelections" value="1.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="cde7-d404-1b45-716c" hidden="false" targetId="6fc0-fbd7-b4c3-f78b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="minSelections" value="0.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="maxSelections" value="1.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="438c-b342-0622-0896" hidden="false" targetId="c429-23e1-056e-cfd3" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="6cfb-8ee0-4610-646d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0c5f-a39d-f318-124e" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="6cfb-8ee0-4610-646d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f22f-86cd-4a95-b370" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="1ef9-102f-441e-cb1c" hidden="false" targetId="4003-9479-f9e0-a340" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="0ef8-b292-6e83-2f20" hidden="false" targetId="7f23-4831-7f76-fd6f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="08ad-0896-7414-9670" hidden="false" targetId="dc72-b0e2-b8cb-2d5c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="6cfb-8ee0-4610-646d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0c5f-a39d-f318-124e" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="6cfb-8ee0-4610-646d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f22f-86cd-4a95-b370" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f21b-beb2-224e-5e3f" name="Outcast Rebel Bombardment Crawler" page="170" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
       <rules>
-        <rule id="d6a3-4bb5-e5d9-3659" name="Vehicle Unit / Mixed Vehicle + Mounts" hidden="false" book="">
+        <rule id="d6a3-4bb5-e5d9-3659" name="Vehicle Unit / Mixed Vehicle + Mounts" book="" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="82e8-1e97-c543-e349" targetId="a985-d1e1-a15f-c261" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="a66d-463b-3e43-e86e" targetId="f5cb-d1fc-6b00-39f5" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="2645-00c7-46ac-40eb" targetId="23c8-9405-75ca-7f03" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="f118-b292-ee30-0032" targetId="931b-a54d-a846-cb74" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="8a8c-71c0-d041-09a6" name="Outcast Rebel Command Crawler" points="243.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" page="170">
-      <entries>
-        <entry id="cc54-51ee-9a73-2c3f" name="Ghar Commander" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="a1eb-a7e9-0ba1-9166" name="Leader Rank" defaultEntryId="4f80-8e2f-3425-932a" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="4f80-8e2f-3425-932a" name="Leader 2" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="6243-126a-8498-6540" targetId="9d03-08db-93a6-4f05" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="bbd9-af80-b959-dbe0" name="Leader 3" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="585f-d49e-dc61-d4ba" targetId="e048-25d9-af17-bdf0" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="4351-2a97-c5fa-68de" name="High Commander" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="6df5-d261-e1a6-cc51" targetId="48e7-7b6b-328c-29fe" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
+      <infoLinks>
+        <infoLink id="82e8-1e97-c543-e349" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
+          <profiles/>
           <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="a66d-463b-3e43-e86e" hidden="false" targetId="f5cb-d1fc-6b00-39f5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="2645-00c7-46ac-40eb" hidden="false" targetId="23c8-9405-75ca-7f03" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f118-b292-ee30-0032" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="1a33-1125-41be-a84c" name="Ghar Bombardment Crawler" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles>
-            <profile id="e177-ef68-f56f-fd00" profileTypeId="f9a2-eeae-3284-75fd" name="Ghar Commander" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="18c1-4764-7d08-708d" name="Ag" value="5"/>
-                <characteristic characteristicId="e39c-d7a4-86a8-d23d" name="Acc" value="5"/>
-                <characteristic characteristicId="0790-bfd5-1273-fe12" name="Str" value="10"/>
-                <characteristic characteristicId="5b77-3595-2819-675c" name="Res" value="13"/>
-                <characteristic characteristicId="c0d8-f6fd-a474-1385" name="Init" value="8"/>
-                <characteristic characteristicId="135d-efc3-5039-b6e6" name="Co" value="9"/>
-                <characteristic characteristicId="ab43-4d1c-4651-b424" name="Special" value="Command, Follow, Leader 2, Large Crawler, MOD2, Scramble Proof, Plasma Reactor"/>
-              </characteristics>
+            <profile id="9eb2-f76c-73b5-402f" name="Ghar Bombardment Crawler" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="3"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="10"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="13"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="8"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="9"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424" value="MOD2, Large, Crawler, Scramble Proof, Plasma Reactor"/>
+              </characteristics>
             </profile>
           </profiles>
-          <links>
-            <link id="bb84-7c0e-852e-ef11" targetId="3fde-b133-beb3-43d7" linkType="entry">
+          <rules/>
+          <infoLinks>
+            <infoLink id="0e62-9dd3-f8d6-58e5" hidden="false" targetId="09d0-48ed-82d2-38b5" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="66d8-4c57-7b8f-aa81" targetId="3fde-b133-beb3-43d7" linkType="entry">
+            </infoLink>
+            <infoLink id="dabb-bc37-63b2-f834" hidden="false" targetId="f2a0-778f-5fa4-20af" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="98af-ca21-6720-2126" targetId="f2a0-778f-5fa4-20af" linkType="rule">
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="13e6-878c-c923-5a97" hidden="false" targetId="5a09-7c98-31f2-0b1b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="a403-8e75-3775-b0a9" name="Plasma Amplifiers" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="e938-8434-70f7-d9c7" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="0019-d8b6-f4b8-fe36" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a8a2-a078-6edf-978b" name="Plasma Amplifiers" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="8580-c966-a7b2-e3b0" hidden="false" targetId="0448-a629-3df9-73c0" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="8a8c-71c0-d041-09a6" incrementChildId="cc54-51ee-9a73-2c3f" incrementField="selections" incrementValue="1.0">
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="f21b-beb2-224e-5e3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1a33-1125-41be-a84c" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="f21b-beb2-224e-5e3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ef3d-dcd6-70ae-c6c6" repeats="1"/>
+              </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
           </modifiers>
-          <rules/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6a4c-fdb7-ebdb-0a84" name="Plasma Dumps" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles/>
-          <links/>
-        </entry>
-        <entry id="6675-7341-53d3-7e85" name="Plasma Dumps" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="bb80-60c6-c83a-a75d" hidden="false" targetId="4280-96f3-aa68-8d6e" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="8a8c-71c0-d041-09a6" incrementChildId="8a8c-71c0-d041-09a6" incrementField="selections" incrementValue="1.0">
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="f21b-beb2-224e-5e3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1a33-1125-41be-a84c" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="f21b-beb2-224e-5e3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ef3d-dcd6-70ae-c6c6" repeats="1"/>
+              </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
           </modifiers>
-          <rules/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ef3d-dcd6-70ae-c6c6" name="Ghar Scutter" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles/>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="d99a-7cf4-44e7-db6a" hidden="false" targetId="13e9-5eeb-7392-f018" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="0b1b-0a86-07ce-c5ec" hidden="false" targetId="562c-13be-8455-d77b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="5805-0b73-8f17-f572" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="26.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="256.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8a8c-71c0-d041-09a6" name="Outcast Rebel Command Crawler" page="170" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
       <rules>
         <rule id="0436-9fe8-9e6b-50a5" name="Vehicle Command Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="6467-0c52-2d03-3bf8" targetId="1d76-267d-696a-2e8a" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="8915-9dfa-3860-1897" targetId="ae1d-2212-b0ef-48b6" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="340c-1a14-abeb-546e" targetId="931b-a54d-a846-cb74" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="c4ce-ab60-efd6-a256" targetId="23c8-9405-75ca-7f03" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="6212-fa71-4521-332a" targetId="09d0-48ed-82d2-38b5" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="d54c-a9c9-6971-285c" targetId="a985-d1e1-a15f-c261" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="6ac4-7768-08a8-a64f" targetId="f5cb-d1fc-6b00-39f5" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="8bf3-341f-b125-6334" name="Outcast Rebel Command Squad" points="0.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="b7fa-60d2-b829-a7be" name="Ghar Outcast Rebel Commander" points="51.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="d3b2-1969-407b-c61f" name="Leader Rank" defaultEntryId="86da-277a-ba37-4410" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="d2d6-30be-8bdb-e811" targetId="0e9b-9aae-bd16-d30f" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="8dae-6f58-6727-960d" targetId="da65-5109-5f5f-0f9a" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="86da-277a-ba37-4410" targetId="05af-fc97-7a19-cf8d" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+      <infoLinks>
+        <infoLink id="6467-0c52-2d03-3bf8" hidden="false" targetId="1d76-267d-696a-2e8a" type="rule">
           <profiles/>
-          <links>
-            <link id="71f3-5c76-98db-4716" targetId="4a94-ffc8-8d46-6869" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="2eb4-601c-fb91-f555" targetId="1d76-267d-696a-2e8a" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="051d-ccd9-1c23-6d4a" targetId="ae1d-2212-b0ef-48b6" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="909a-62ac-0351-8778" targetId="167d-cdd2-aafa-0394" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="5bd1-2159-c56d-73c1" name="Outcast Rebel" points="11.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
           <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="8915-9dfa-3860-1897" hidden="false" targetId="ae1d-2212-b0ef-48b6" type="rule">
           <profiles/>
-          <links>
-            <link id="74a8-cda0-82fe-223d" targetId="b56d-892d-c25e-7379" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="340c-1a14-abeb-546e" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="c4ce-ab60-efd6-a256" hidden="false" targetId="23c8-9405-75ca-7f03" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6212-fa71-4521-332a" hidden="false" targetId="09d0-48ed-82d2-38b5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="d54c-a9c9-6971-285c" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6ac4-7768-08a8-a64f" hidden="false" targetId="f5cb-d1fc-6b00-39f5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="cc54-51ee-9a73-2c3f" name="Ghar Commander" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="e177-ef68-f56f-fd00" name="Ghar Commander" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="10"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="13"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="8"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="9"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424" value="Command, Follow, Leader 2, Large Crawler, MOD2, Scramble Proof, Plasma Reactor"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="98af-ca21-6720-2126" hidden="false" targetId="f2a0-778f-5fa4-20af" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="a1eb-a7e9-0ba1-9166" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="4f80-8e2f-3425-932a">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="4f80-8e2f-3425-932a" name="Leader 2" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="6243-126a-8498-6540" hidden="false" targetId="9d03-08db-93a6-4f05" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="bbd9-af80-b959-dbe0" name="Leader 3" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="585f-d49e-dc61-d4ba" hidden="false" targetId="e048-25d9-af17-bdf0" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="4351-2a97-c5fa-68de" name="High Commander" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="6df5-d261-e1a6-cc51" hidden="false" targetId="48e7-7b6b-328c-29fe" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="20.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="bb84-7c0e-852e-ef11" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="66d8-4c57-7b8f-aa81" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a403-8e75-3775-b0a9" name="Plasma Amplifiers" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="8a8c-71c0-d041-09a6" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cc54-51ee-9a73-2c3f" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6675-7341-53d3-7e85" name="Plasma Dumps" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="8a8c-71c0-d041-09a6" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6675-7341-53d3-7e85" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="243.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8bf3-341f-b125-6334" name="Outcast Rebel Command Squad" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
       <rules>
         <rule id="dcc1-0cf8-5b64-89eb" name="Infantry Command Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="2c06-feb9-7429-4b91" targetId="dc72-b0e2-b8cb-2d5c" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="8bf3-341f-b125-6334" incrementChildId="b7fa-60d2-b829-a7be" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="8bf3-341f-b125-6334" incrementChildId="5bd1-2159-c56d-73c1" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="7abc-fe6e-6313-8353" targetId="7a50-8a69-75b6-3cca" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="3f95-7f8e-30d1-d868" targetId="4003-9479-f9e0-a340" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="c8ce-474c-2a29-aa16" targetId="7f23-4831-7f76-fd6f" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="be6d-09d2-5ae1-9a01" targetId="c429-23e1-056e-cfd3" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="8bf3-341f-b125-6334" incrementChildId="b7fa-60d2-b829-a7be" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="8bf3-341f-b125-6334" incrementChildId="5bd1-2159-c56d-73c1" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-      </links>
-    </entry>
-    <entry id="6ecf-63e6-ab1c-a4fe" name="Outcast Rebel Commander In Battle Armour" points="0.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="a447-3e39-8eeb-e605" name="Ghar Commander" points="92.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="8942-dc7d-ef26-f2fa" name="Plasma Claws" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="a447-3e39-8eeb-e605" incrementChildId="a447-3e39-8eeb-e605" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="9c97-f250-f3ec-a793" targetId="0a8d-432b-4cb0-6b78" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups>
-            <entryGroup id="b90e-ea97-650c-1347" name="Leader Rank" defaultEntryId="fe8e-e203-c9b3-ab58" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="fe8e-e203-c9b3-ab58" targetId="0e9b-9aae-bd16-d30f" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="101b-983c-bd99-6752" targetId="da65-5109-5f5f-0f9a" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="1295-3f98-9f4a-18b7" targetId="0435-82ed-58ff-4ea7" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+      <infoLinks>
+        <infoLink id="7abc-fe6e-6313-8353" hidden="false" targetId="7a50-8a69-75b6-3cca" type="rule">
           <profiles/>
-          <links>
-            <link id="2e9b-982f-2742-8a77" targetId="68fa-5d5f-eae2-3f66" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="9183-d94d-d8a6-9c54" name="Ghar Trooper 1" points="60.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="b66e-53bb-c769-589f" name="Plasma Claws" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="9183-d94d-d8a6-9c54" incrementChildId="9183-d94d-d8a6-9c54" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="827a-4899-b49b-0247" targetId="0a8d-432b-4cb0-6b78" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="f1eb-d4d7-aa0d-f6b0" targetId="de07-7287-f4d3-bf98" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="6d2d-8d49-60eb-391e" name="Plasma Dumps" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="6ecf-63e6-ab1c-a4fe" incrementChildId="a447-3e39-8eeb-e605" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="6ecf-63e6-ab1c-a4fe" incrementChildId="9183-d94d-d8a6-9c54" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="6ecf-63e6-ab1c-a4fe" incrementChildId="f9d0-d2bd-faea-32ca" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="0966-6dc7-5acb-a359" targetId="4280-96f3-aa68-8d6e" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="5223-0081-7e79-67e2" name="Plasma Amplifiers" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="6ecf-63e6-ab1c-a4fe" incrementChildId="a447-3e39-8eeb-e605" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="6ecf-63e6-ab1c-a4fe" incrementChildId="9183-d94d-d8a6-9c54" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="6ecf-63e6-ab1c-a4fe" incrementChildId="f9d0-d2bd-faea-32ca" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="736e-63ca-9785-c8df" targetId="0448-a629-3df9-73c0" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="f9d0-d2bd-faea-32ca" name="Ghar Trooper 2" points="60.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="3702-4189-6912-fd0e" name="Plasma Claws" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="f9d0-d2bd-faea-32ca" incrementChildId="f9d0-d2bd-faea-32ca" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="5a1f-b7b3-f8b4-95ce" targetId="0a8d-432b-4cb0-6b78" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="829e-a3cb-f3ed-161f" targetId="de07-7287-f4d3-bf98" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="b7fa-60d2-b829-a7be" name="Ghar Outcast Rebel Commander" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="71f3-5c76-98db-4716" hidden="false" targetId="4a94-ffc8-8d46-6869" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="2eb4-601c-fb91-f555" hidden="false" targetId="1d76-267d-696a-2e8a" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="051d-ccd9-1c23-6d4a" hidden="false" targetId="ae1d-2212-b0ef-48b6" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="909a-62ac-0351-8778" hidden="false" targetId="167d-cdd2-aafa-0394" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="d3b2-1969-407b-c61f" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="86da-277a-ba37-4410">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="d2d6-30be-8bdb-e811" hidden="false" targetId="0e9b-9aae-bd16-d30f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="8dae-6f58-6727-960d" hidden="false" targetId="da65-5109-5f5f-0f9a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="86da-277a-ba37-4410" hidden="false" targetId="05af-fc97-7a19-cf8d" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="51.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5bd1-2159-c56d-73c1" name="Outcast Rebel" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="74a8-cda0-82fe-223d" hidden="false" targetId="b56d-892d-c25e-7379" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="11.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="2c06-feb9-7429-4b91" hidden="false" targetId="dc72-b0e2-b8cb-2d5c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="8bf3-341f-b125-6334" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b7fa-60d2-b829-a7be" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="8bf3-341f-b125-6334" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5bd1-2159-c56d-73c1" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="3f95-7f8e-30d1-d868" hidden="false" targetId="4003-9479-f9e0-a340" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="c8ce-474c-2a29-aa16" hidden="false" targetId="7f23-4831-7f76-fd6f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="be6d-09d2-5ae1-9a01" hidden="false" targetId="c429-23e1-056e-cfd3" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="8bf3-341f-b125-6334" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b7fa-60d2-b829-a7be" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="8bf3-341f-b125-6334" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5bd1-2159-c56d-73c1" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6ecf-63e6-ab1c-a4fe" name="Outcast Rebel Commander In Battle Armour" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
       <rules>
         <rule id="10a9-3714-7f79-92b2" name="Infantry Command Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="3cc2-48f1-8cf7-ae8b" targetId="931b-a54d-a846-cb74" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="69d7-2b98-817b-7619" targetId="a985-d1e1-a15f-c261" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="36f2-9e18-633a-22fd" targetId="f5cb-d1fc-6b00-39f5" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="de90-f44d-068a-82e4" targetId="3fde-b133-beb3-43d7" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="7c3d-26af-84e5-51c4" name="Outcast Rebel Creeper" points="0.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BFX" page="90">
-      <entries>
-        <entry id="7516-1d67-a0c0-9317" name="Outcast Rebel Creeper" points="88.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="4ae2-28b0-6ec5-53ea" profileTypeId="f9a2-eeae-3284-75fd" name="Outcast Rebel Creeper" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="18c1-4764-7d08-708d" name="Ag" value="5"/>
-                <characteristic characteristicId="e39c-d7a4-86a8-d23d" name="Acc" value="5"/>
-                <characteristic characteristicId="0790-bfd5-1273-fe12" name="Str" value="1"/>
-                <characteristic characteristicId="5b77-3595-2819-675c" name="Res" value="10"/>
-                <characteristic characteristicId="c0d8-f6fd-a474-1385" name="Init" value="8"/>
-                <characteristic characteristicId="135d-efc3-5039-b6e6" name="Co" value="8"/>
-                <characteristic characteristicId="ab43-4d1c-4651-b424" name="Special" value="Large, Crawler, MOD2, Scramble Proof, Plasma Reactor"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="39df-66a6-97bc-21c7" targetId="f2a0-778f-5fa4-20af" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="47b6-1595-864a-c002" name="Plasma Amplifiers" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="7c3d-26af-84e5-51c4" incrementChildId="7516-1d67-a0c0-9317" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
+      <infoLinks>
+        <infoLink id="3cc2-48f1-8cf7-ae8b" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
           <profiles/>
-          <links>
-            <link id="dc57-da16-fee7-11d8" targetId="0448-a629-3df9-73c0" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="e5e7-9b9e-2d25-6bde" name="Plasma Dumps" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers>
-            <modifier type="increment" field="points" value="5.0" repeat="true" numRepeats="1" incrementParentId="7c3d-26af-84e5-51c4" incrementChildId="7516-1d67-a0c0-9317" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
           <rules/>
-          <profiles/>
-          <links>
-            <link id="94e5-fff5-123b-0533" targetId="4280-96f3-aa68-8d6e" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="5832-c55c-655e-ae32" name="&lt; Unit Options &gt;" defaultEntryId="654c-9346-bc9f-3c2d" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="654c-9346-bc9f-3c2d" targetId="6f9d-4f18-835f-deff" linkType="entry">
+        </infoLink>
+        <infoLink id="69d7-2b98-817b-7619" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="36f2-9e18-633a-22fd" hidden="false" targetId="f5cb-d1fc-6b00-39f5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="a447-3e39-8eeb-e605" name="Ghar Commander" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="2e9b-982f-2742-8a77" hidden="false" targetId="68fa-5d5f-eae2-3f66" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="baba-7bd0-e089-b791" targetId="306c-a91f-3fc0-e059" linkType="entry">
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="8942-dc7d-ef26-f2fa" name="Plasma Claws" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="true" numRepeats="1" incrementParentId="7c3d-26af-84e5-51c4" incrementChildId="7516-1d67-a0c0-9317" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats>
+                    <repeat field="selections" scope="a447-3e39-8eeb-e605" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8942-dc7d-ef26-f2fa" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="9c97-f250-f3ec-a793" hidden="false" targetId="0a8d-432b-4cb0-6b78" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="b90e-ea97-650c-1347" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="fe8e-e203-c9b3-ab58">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="fe8e-e203-c9b3-ab58" hidden="false" targetId="0e9b-9aae-bd16-d30f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="101b-983c-bd99-6752" hidden="false" targetId="da65-5109-5f5f-0f9a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="1295-3f98-9f4a-18b7" hidden="false" targetId="0435-82ed-58ff-4ea7" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="92.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9183-d94d-d8a6-9c54" name="Ghar Trooper 1" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="f1eb-d4d7-aa0d-f6b0" hidden="false" targetId="de07-7287-f4d3-bf98" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="b66e-53bb-c769-589f" name="Plasma Claws" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats>
+                    <repeat field="selections" scope="9183-d94d-d8a6-9c54" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b66e-53bb-c769-589f" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="827a-4899-b49b-0247" hidden="false" targetId="0a8d-432b-4cb0-6b78" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="60.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6d2d-8d49-60eb-391e" name="Plasma Dumps" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="0966-6dc7-5acb-a359" hidden="false" targetId="4280-96f3-aa68-8d6e" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="6ecf-63e6-ab1c-a4fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a447-3e39-8eeb-e605" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="6ecf-63e6-ab1c-a4fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9183-d94d-d8a6-9c54" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="6ecf-63e6-ab1c-a4fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f9d0-d2bd-faea-32ca" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5223-0081-7e79-67e2" name="Plasma Amplifiers" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="736e-63ca-9785-c8df" hidden="false" targetId="0448-a629-3df9-73c0" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="6ecf-63e6-ab1c-a4fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a447-3e39-8eeb-e605" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="6ecf-63e6-ab1c-a4fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9183-d94d-d8a6-9c54" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="6ecf-63e6-ab1c-a4fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f9d0-d2bd-faea-32ca" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f9d0-d2bd-faea-32ca" name="Ghar Trooper 2" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="829e-a3cb-f3ed-161f" hidden="false" targetId="de07-7287-f4d3-bf98" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="3702-4189-6912-fd0e" name="Plasma Claws" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats>
+                    <repeat field="selections" scope="f9d0-d2bd-faea-32ca" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3702-4189-6912-fd0e" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="5a1f-b7b3-f8b4-95ce" hidden="false" targetId="0a8d-432b-4cb0-6b78" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="60.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="de90-f44d-068a-82e4" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7c3d-26af-84e5-51c4" name="Outcast Rebel Creeper" book="BFX" page="90" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
       <rules>
-        <rule id="0d6d-b9c2-cc1c-b94b" name="Vehicle Unit" hidden="false" book="">
+        <rule id="0d6d-b9c2-cc1c-b94b" name="Vehicle Unit" book="" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="7da9-0492-5161-8a32" targetId="a985-d1e1-a15f-c261" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="92f7-bd0d-57b9-f64b" targetId="f5cb-d1fc-6b00-39f5" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="038f-cc5e-7495-8600" targetId="23c8-9405-75ca-7f03" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="7be4-bccd-4e18-53b6" targetId="931b-a54d-a846-cb74" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="d177-dff5-4845-3b29" targetId="09d0-48ed-82d2-38b5" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="7cf7-a4ad-ce2d-eba8" name="Outcast Rebel Disruptor Cannon Team" points="16.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="de51-23ed-0173-ba47" name="Outcast Crew" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
+      <infoLinks>
+        <infoLink id="7da9-0492-5161-8a32" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
           <profiles/>
-          <links>
-            <link id="e34a-8f95-1075-fa6b" targetId="b56d-892d-c25e-7379" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="cc71-0ba4-2876-cc38" name="Outcast Leader" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="d3c3-c5ff-1552-7d0b" name="Leader Rank" defaultEntryId="d813-a45b-705e-5144" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="99a0-ce67-06df-5518" name="Leader 2" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="cb31-6745-fde4-599b" targetId="9d03-08db-93a6-4f05" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="d813-a45b-705e-5144" name="Leader" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="aa5f-bdb7-15d1-83ac" targetId="24a5-60f8-93fc-7dff" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
           <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="92f7-bd0d-57b9-f64b" hidden="false" targetId="f5cb-d1fc-6b00-39f5" type="rule">
           <profiles/>
-          <links>
-            <link id="0875-519b-be7b-8626" targetId="9770-5f42-fa8c-247c" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="038f-cc5e-7495-8600" hidden="false" targetId="23c8-9405-75ca-7f03" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7be4-bccd-4e18-53b6" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="d177-dff5-4845-3b29" hidden="false" targetId="09d0-48ed-82d2-38b5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="7516-1d67-a0c0-9317" name="Outcast Rebel Creeper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="4ae2-28b0-6ec5-53ea" name="Outcast Rebel Creeper" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="1"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="10"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="8"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="8"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424" value="Large, Crawler, MOD2, Scramble Proof, Plasma Reactor"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="39df-66a6-97bc-21c7" hidden="false" targetId="f2a0-778f-5fa4-20af" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="88.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="47b6-1595-864a-c002" name="Plasma Amplifiers" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="dc57-da16-fee7-11d8" hidden="false" targetId="0448-a629-3df9-73c0" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="7c3d-26af-84e5-51c4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7516-1d67-a0c0-9317" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e5e7-9b9e-2d25-6bde" name="Plasma Dumps" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="94e5-fff5-123b-0533" hidden="false" targetId="4280-96f3-aa68-8d6e" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="7c3d-26af-84e5-51c4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7516-1d67-a0c0-9317" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5832-c55c-655e-ae32" name="&lt; Unit Options &gt;" hidden="false" collective="false" defaultSelectionEntryId="654c-9346-bc9f-3c2d">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="654c-9346-bc9f-3c2d" hidden="false" targetId="6f9d-4f18-835f-deff" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="baba-7bd0-e089-b791" hidden="false" targetId="306c-a91f-3fc0-e059" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats>
+                    <repeat field="selections" scope="7c3d-26af-84e5-51c4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7516-1d67-a0c0-9317" repeats="1"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7cf7-a4ad-ce2d-eba8" name="Outcast Rebel Disruptor Cannon Team" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
       <rules>
         <rule id="45cb-83a8-6ea1-a8b5" name="Weapon Team Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="034c-4fe0-a1a5-eb21" targetId="7a50-8a69-75b6-3cca" linkType="rule">
+      <infoLinks>
+        <infoLink id="034c-4fe0-a1a5-eb21" hidden="false" targetId="7a50-8a69-75b6-3cca" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="81c8-bbb9-9f59-c452" targetId="c70a-e0a0-0192-f2dc" linkType="entry">
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="de51-23ed-0173-ba47" name="Outcast Crew" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="e34a-8f95-1075-fa6b" hidden="false" targetId="b56d-892d-c25e-7379" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="cc71-0ba4-2876-cc38" name="Outcast Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="0875-519b-be7b-8626" hidden="false" targetId="9770-5f42-fa8c-247c" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="d3c3-c5ff-1552-7d0b" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="d813-a45b-705e-5144">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="99a0-ce67-06df-5518" name="Leader 2" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="cb31-6745-fde4-599b" hidden="false" targetId="9d03-08db-93a6-4f05" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="d813-a45b-705e-5144" name="Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="aa5f-bdb7-15d1-83ac" hidden="false" targetId="24a5-60f8-93fc-7dff" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="81c8-bbb9-9f59-c452" hidden="false" targetId="c70a-e0a0-0192-f2dc" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="7cf7-a4ad-ce2d-eba8" incrementChildId="cc71-0ba4-2876-cc38" incrementField="selections" incrementValue="1.0">
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="7cf7-a4ad-ce2d-eba8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cc71-0ba4-2876-cc38" repeats="1"/>
+              </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="7cf7-a4ad-ce2d-eba8" incrementChildId="de51-23ed-0173-ba47" incrementField="selections" incrementValue="1.0">
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="7cf7-a4ad-ce2d-eba8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="de51-23ed-0173-ba47" repeats="1"/>
+              </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
           </modifiers>
-        </link>
-        <link id="ef2d-7266-6da3-5cdf" targetId="a975-754b-83c3-802b" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="fa5d-9038-2bc4-b630" name="Outcast Rebel Mag Cannon Team" points="26.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="eeae-becc-d65d-5322" name="Outcast Crew" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="ef2d-7266-6da3-5cdf" hidden="false" targetId="a975-754b-83c3-802b" type="selectionEntry">
           <profiles/>
-          <links>
-            <link id="8f2a-80a8-dcea-0d89" targetId="b56d-892d-c25e-7379" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="c2e8-9d7e-6286-8c57" name="Outcast Leader" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="edb5-905b-9ff0-d3ff" name="Leader Rank" defaultEntryId="9454-9085-286f-baa7" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="5920-b558-9db3-f291" name="Leader 2" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="daaf-c458-3dc6-a2c2" targetId="9d03-08db-93a6-4f05" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="9454-9085-286f-baa7" name="Leader" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="6fae-dde6-291b-5fa7" targetId="24a5-60f8-93fc-7dff" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
           <rules/>
-          <profiles/>
-          <links>
-            <link id="cc72-d017-cf68-4a77" targetId="9770-5f42-fa8c-247c" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="16.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fa5d-9038-2bc4-b630" name="Outcast Rebel Mag Cannon Team" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
       <rules>
         <rule id="532b-e532-12c0-28ae" name="Weapon Team Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="1cbc-6518-dba8-a2f1" targetId="7a50-8a69-75b6-3cca" linkType="rule">
+      <infoLinks>
+        <infoLink id="1cbc-6518-dba8-a2f1" hidden="false" targetId="7a50-8a69-75b6-3cca" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="ba3c-73aa-2cd5-052b" targetId="c70a-e0a0-0192-f2dc" linkType="entry">
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="eeae-becc-d65d-5322" name="Outcast Crew" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="8f2a-80a8-dcea-0d89" hidden="false" targetId="b56d-892d-c25e-7379" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c2e8-9d7e-6286-8c57" name="Outcast Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="cc72-d017-cf68-4a77" hidden="false" targetId="9770-5f42-fa8c-247c" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="edb5-905b-9ff0-d3ff" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="9454-9085-286f-baa7">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="5920-b558-9db3-f291" name="Leader 2" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="daaf-c458-3dc6-a2c2" hidden="false" targetId="9d03-08db-93a6-4f05" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="9454-9085-286f-baa7" name="Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="6fae-dde6-291b-5fa7" hidden="false" targetId="24a5-60f8-93fc-7dff" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="ba3c-73aa-2cd5-052b" hidden="false" targetId="c70a-e0a0-0192-f2dc" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="fa5d-9038-2bc4-b630" incrementChildId="c2e8-9d7e-6286-8c57" incrementField="selections" incrementValue="1.0">
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="fa5d-9038-2bc4-b630" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c2e8-9d7e-6286-8c57" repeats="1"/>
+              </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="fa5d-9038-2bc4-b630" incrementChildId="eeae-becc-d65d-5322" incrementField="selections" incrementValue="1.0">
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="fa5d-9038-2bc4-b630" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eeae-becc-d65d-5322" repeats="1"/>
+              </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
           </modifiers>
-        </link>
-        <link id="2e16-54a0-a20e-2885" targetId="1df9-990c-8861-c567" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="e95f-bd48-575a-02f3" name="Outcast Rebel Mag Light Support Team" points="16.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="5453-2c0b-0bab-f7d8" name="Outcast Crew" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="2e16-54a0-a20e-2885" hidden="false" targetId="1df9-990c-8861-c567" type="selectionEntry">
           <profiles/>
-          <links>
-            <link id="0052-de75-e46e-2441" targetId="b56d-892d-c25e-7379" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="d306-97f4-a254-bf50" name="Outcast Leader" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="e9b8-d26b-28cd-befb" name="Leader Rank" defaultEntryId="d25e-230c-a96f-6d49" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="9dfa-84c7-626a-443d" name="Leader 2" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="4f61-b4b4-896c-5c50" targetId="9d03-08db-93a6-4f05" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="d25e-230c-a96f-6d49" name="Leader" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="5543-e6de-d9c3-ebe5" targetId="24a5-60f8-93fc-7dff" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
           <rules/>
-          <profiles/>
-          <links>
-            <link id="8022-4b96-ded5-eb53" targetId="9770-5f42-fa8c-247c" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="26.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e95f-bd48-575a-02f3" name="Outcast Rebel Mag Light Support Team" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
       <rules>
         <rule id="6830-76e9-be7d-edbf" name="Weapon Team Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="1454-08ca-b9db-d5c9" targetId="7a50-8a69-75b6-3cca" linkType="rule">
+      <infoLinks>
+        <infoLink id="1454-08ca-b9db-d5c9" hidden="false" targetId="7a50-8a69-75b6-3cca" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="43bf-e720-ee85-838c" targetId="c70a-e0a0-0192-f2dc" linkType="entry">
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="5453-2c0b-0bab-f7d8" name="Outcast Crew" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="0052-de75-e46e-2441" hidden="false" targetId="b56d-892d-c25e-7379" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d306-97f4-a254-bf50" name="Outcast Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="8022-4b96-ded5-eb53" hidden="false" targetId="9770-5f42-fa8c-247c" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="e9b8-d26b-28cd-befb" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="d25e-230c-a96f-6d49">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="9dfa-84c7-626a-443d" name="Leader 2" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="4f61-b4b4-896c-5c50" hidden="false" targetId="9d03-08db-93a6-4f05" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="d25e-230c-a96f-6d49" name="Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="5543-e6de-d9c3-ebe5" hidden="false" targetId="24a5-60f8-93fc-7dff" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="43bf-e720-ee85-838c" hidden="false" targetId="c70a-e0a0-0192-f2dc" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="e95f-bd48-575a-02f3" incrementChildId="d306-97f4-a254-bf50" incrementField="selections" incrementValue="1.0">
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="e95f-bd48-575a-02f3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d306-97f4-a254-bf50" repeats="1"/>
+              </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="e95f-bd48-575a-02f3" incrementChildId="5453-2c0b-0bab-f7d8" incrementField="selections" incrementValue="1.0">
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="e95f-bd48-575a-02f3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5453-2c0b-0bab-f7d8" repeats="1"/>
+              </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
           </modifiers>
-        </link>
-        <link id="8c2d-aa7c-43f5-0c16" targetId="f124-9b5b-1165-35e3" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="8903-dc57-d9d7-6392" name="Outcast Rebel Quad Mag Repeater Team" points="16.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="e149-4b0d-69d9-2a39" name="Outcast Crew" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="8c2d-aa7c-43f5-0c16" hidden="false" targetId="f124-9b5b-1165-35e3" type="selectionEntry">
           <profiles/>
-          <links>
-            <link id="1a08-33e5-6168-9978" targetId="b56d-892d-c25e-7379" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="7d5e-02b8-d090-58de" name="Outcast Leader" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="5a30-0254-33ae-ff5d" name="Leader Rank" defaultEntryId="4c69-d0c6-da08-f3f8" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="04a2-505e-732a-bb2a" name="Leader 2" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="6b99-cc78-1be6-5c98" targetId="9d03-08db-93a6-4f05" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="4c69-d0c6-da08-f3f8" name="Leader" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="7bcc-d1c3-615e-344b" targetId="24a5-60f8-93fc-7dff" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
           <rules/>
-          <profiles/>
-          <links>
-            <link id="d878-e0f2-a649-a036" targetId="9770-5f42-fa8c-247c" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="16.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8903-dc57-d9d7-6392" name="Outcast Rebel Quad Mag Repeater Team" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
       <rules>
         <rule id="ce3e-4f08-fdd5-af16" name="Weapon Team Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="2f62-87a6-ab9a-9ab5" targetId="7a50-8a69-75b6-3cca" linkType="rule">
+      <infoLinks>
+        <infoLink id="2f62-87a6-ab9a-9ab5" hidden="false" targetId="7a50-8a69-75b6-3cca" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="c1a1-7f2a-9f39-6144" targetId="c70a-e0a0-0192-f2dc" linkType="entry">
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="e149-4b0d-69d9-2a39" name="Outcast Crew" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="1a08-33e5-6168-9978" hidden="false" targetId="b56d-892d-c25e-7379" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7d5e-02b8-d090-58de" name="Outcast Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="d878-e0f2-a649-a036" hidden="false" targetId="9770-5f42-fa8c-247c" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="5a30-0254-33ae-ff5d" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="4c69-d0c6-da08-f3f8">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="04a2-505e-732a-bb2a" name="Leader 2" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="6b99-cc78-1be6-5c98" hidden="false" targetId="9d03-08db-93a6-4f05" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="4c69-d0c6-da08-f3f8" name="Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="7bcc-d1c3-615e-344b" hidden="false" targetId="24a5-60f8-93fc-7dff" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="c1a1-7f2a-9f39-6144" hidden="false" targetId="c70a-e0a0-0192-f2dc" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="8903-dc57-d9d7-6392" incrementChildId="7d5e-02b8-d090-58de" incrementField="selections" incrementValue="1.0">
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="8903-dc57-d9d7-6392" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7d5e-02b8-d090-58de" repeats="1"/>
+              </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="8903-dc57-d9d7-6392" incrementChildId="e149-4b0d-69d9-2a39" incrementField="selections" incrementValue="1.0">
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="8903-dc57-d9d7-6392" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e149-4b0d-69d9-2a39" repeats="1"/>
+              </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
           </modifiers>
-        </link>
-        <link id="5f37-0c38-4111-e414" targetId="3018-7ca0-b24e-e8c7" linkType="entry">
+          <constraints/>
+        </entryLink>
+        <entryLink id="5f37-0c38-4111-e414" hidden="false" targetId="3018-7ca0-b24e-e8c7" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="ac0c-ffe3-ca36-d4c0" name="Outcast Rebel Squad" points="0.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="ebff-8528-f0d6-8bfd" name="Ghar Outcast Leader" points="19.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="cd4c-2b67-0b74-96dd" name="Leader Rank" defaultEntryId="d35e-b864-9304-3e84" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="16.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ac0c-ffe3-ca36-d4c0" name="Outcast Rebel Squad" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="512f-b5be-36a9-2459" name="Infantry Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="7613-d6c7-6d24-93b2" hidden="false" targetId="7a50-8a69-75b6-3cca" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="ebff-8528-f0d6-8bfd" name="Ghar Outcast Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="5e04-41c0-3380-53a5" hidden="false" targetId="9770-5f42-fa8c-247c" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-              <links>
-                <link id="7445-be0b-2a47-a71f" targetId="0e9b-9aae-bd16-d30f" linkType="entry">
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="cd4c-2b67-0b74-96dd" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="d35e-b864-9304-3e84">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="7445-be0b-2a47-a71f" hidden="false" targetId="0e9b-9aae-bd16-d30f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-                <link id="d35e-b864-9304-3e84" targetId="05af-fc97-7a19-cf8d" linkType="entry">
+                  <constraints/>
+                </entryLink>
+                <entryLink id="d35e-b864-9304-3e84" hidden="false" targetId="05af-fc97-7a19-cf8d" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="19.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f634-df4a-d8c4-fd3b" name="Ghar Outcast" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles/>
-          <links>
-            <link id="5e04-41c0-3380-53a5" targetId="9770-5f42-fa8c-247c" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="f634-df4a-d8c4-fd3b" name="Ghar Outcast" points="6.0" categoryId="(No Category)" type="model" minSelections="5" maxSelections="11" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
           <rules/>
-          <profiles/>
-          <links>
-            <link id="94f8-e945-a728-46b2" targetId="b56d-892d-c25e-7379" linkType="profile">
+          <infoLinks>
+            <infoLink id="94f8-e945-a728-46b2" hidden="false" targetId="b56d-892d-c25e-7379" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="b402-5948-a9cb-bda7" name="Outcast Weapon Team of Two" points="26.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="11.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="6.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b402-5948-a9cb-bda7" name="Outcast Weapon Team of Two" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
           <rules/>
-          <profiles/>
-          <links>
-            <link id="22d4-54cd-a9e1-f46a" targetId="a975-754b-83c3-802b" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="1c26-f473-3e95-9f5a" name="Gun" defaultEntryId="6dd6-f310-a3ef-c03e" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="6dd6-f310-a3ef-c03e" targetId="4d36-a47c-487c-f893" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="22d4-54cd-a9e1-f46a" hidden="false" targetId="a975-754b-83c3-802b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="28ff-ecfd-1910-2b2f" targetId="afcd-8743-da8f-a190" linkType="entry">
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="26.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="1c26-f473-3e95-9f5a" name="Gun" hidden="false" collective="false" defaultSelectionEntryId="6dd6-f310-a3ef-c03e">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="6dd6-f310-a3ef-c03e" hidden="false" targetId="4d36-a47c-487c-f893" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="28ff-ecfd-1910-2b2f" hidden="false" targetId="afcd-8743-da8f-a190" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="ac0c-ffe3-ca36-d4c0" incrementChildId="b402-5948-a9cb-bda7" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="ac0c-ffe3-ca36-d4c0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b402-5948-a9cb-bda7" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="ac0c-ffe3-ca36-d4c0" incrementChildId="ebff-8528-f0d6-8bfd" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="ac0c-ffe3-ca36-d4c0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ebff-8528-f0d6-8bfd" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="ac0c-ffe3-ca36-d4c0" incrementChildId="f634-df4a-d8c4-fd3b" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="ac0c-ffe3-ca36-d4c0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f634-df4a-d8c4-fd3b" repeats="1"/>
+                  </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="512f-b5be-36a9-2459" name="Infantry Unit" hidden="false">
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links>
-        <link id="bee5-e186-0e85-a6f4" targetId="c429-23e1-056e-cfd3" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="ac0c-ffe3-ca36-d4c0" incrementChildId="ebff-8528-f0d6-8bfd" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="ac0c-ffe3-ca36-d4c0" incrementChildId="f634-df4a-d8c4-fd3b" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="7613-d6c7-6d24-93b2" targetId="7a50-8a69-75b6-3cca" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="3d26-b1d7-c495-4567" targetId="c70a-e0a0-0192-f2dc" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="4.0" repeat="true" numRepeats="1" incrementParentId="ac0c-ffe3-ca36-d4c0" incrementChildId="b402-5948-a9cb-bda7" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="ac0c-ffe3-ca36-d4c0" incrementChildId="f634-df4a-d8c4-fd3b" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="ac0c-ffe3-ca36-d4c0" incrementChildId="ebff-8528-f0d6-8bfd" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-      </links>
-    </entry>
-    <entry id="fd3a-9dc3-6585-6d3e" name="Tectorist Scouts" points="0.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="b572-c2ed-763c-a0a4" name="Tectorist Scout" points="5.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="bee5-e186-0e85-a6f4" hidden="false" targetId="c429-23e1-056e-cfd3" type="selectionEntry">
+          <profiles/>
           <rules/>
-          <profiles>
-            <profile id="d0e9-50a7-5823-cc89" profileTypeId="1650-77b3-10d1-6406" name="Tectorist Scouts" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="6"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="3"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="4"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="7"/>
-                <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Leader, Rebel, Shard"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-          </profiles>
-          <links>
-            <link id="f6a8-13c6-b9ac-c035" targetId="24a5-60f8-93fc-7dff" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="8061-c0ee-f0f9-6958" targetId="485f-1f8e-7808-4a17" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="ac0c-ffe3-ca36-d4c0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ebff-8528-f0d6-8bfd" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="ac0c-ffe3-ca36-d4c0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f634-df4a-d8c4-fd3b" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="3d26-b1d7-c495-4567" hidden="false" targetId="c70a-e0a0-0192-f2dc" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="4.0">
+              <repeats>
+                <repeat field="selections" scope="ac0c-ffe3-ca36-d4c0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b402-5948-a9cb-bda7" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="ac0c-ffe3-ca36-d4c0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f634-df4a-d8c4-fd3b" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="ac0c-ffe3-ca36-d4c0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ebff-8528-f0d6-8bfd" repeats="1"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fd3a-9dc3-6585-6d3e" name="Tectorist Scouts" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit">
+      <profiles/>
       <rules>
         <rule id="0361-c2bf-5185-8a0b" name="Special: Sharded Infantry Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
-      <profiles/>
-      <links>
-        <link id="bee5-b458-d288-7e29" targetId="3b86-3198-ef3c-030e" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="ab38-b3bf-48f2-832d" targetId="7a50-8a69-75b6-3cca" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="105a-88d6-b03c-e681" name="Wrecking Squad" points="0.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="2009-2564-ed64-e5d9" name="Outcast Rebel Leader" points="25.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="f260-f310-aaac-0ffc" name="Leader Rank" defaultEntryId="07a6-d6ee-7c54-e8fe" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="07a6-d6ee-7c54-e8fe" targetId="05af-fc97-7a19-cf8d" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
+      <infoLinks>
+        <infoLink id="ab38-b3bf-48f2-832d" hidden="false" targetId="7a50-8a69-75b6-3cca" type="rule">
           <profiles/>
-          <links>
-            <link id="08ed-2551-b524-dd0f" targetId="9770-5f42-fa8c-247c" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="8a76-6031-2e6b-1431" name="Outcast Rebel" points="15.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
           <rules/>
-          <profiles/>
-          <links>
-            <link id="e629-e97c-c4a7-68a9" targetId="b56d-892d-c25e-7379" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="b572-c2ed-763c-a0a4" name="Tectorist Scout" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="d0e9-50a7-5823-cc89" name="Tectorist Scouts" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="6"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="3"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader, Rebel, Shard"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="f6a8-13c6-b9ac-c035" hidden="false" targetId="24a5-60f8-93fc-7dff" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="8061-c0ee-f0f9-6958" hidden="false" targetId="485f-1f8e-7808-4a17" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="bee5-b458-d288-7e29" hidden="false" targetId="3b86-3198-ef3c-030e" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="105a-88d6-b03c-e681" name="Wrecking Squad" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit">
+      <profiles/>
       <rules>
         <rule id="f18d-d08c-1481-0f21" name="Infantry Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
       </rules>
+      <infoLinks>
+        <infoLink id="9565-8fa7-b579-d0b6" hidden="false" targetId="7a50-8a69-75b6-3cca" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="2009-2564-ed64-e5d9" name="Outcast Rebel Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="08ed-2551-b524-dd0f" hidden="false" targetId="9770-5f42-fa8c-247c" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="f260-f310-aaac-0ffc" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="07a6-d6ee-7c54-e8fe">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="07a6-d6ee-7c54-e8fe" hidden="false" targetId="05af-fc97-7a19-cf8d" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="25.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8a76-6031-2e6b-1431" name="Outcast Rebel" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="e629-e97c-c4a7-68a9" hidden="false" targetId="b56d-892d-c25e-7379" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="b056-62d0-b5ec-ca48" hidden="false" targetId="4003-9479-f9e0-a340" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="3ae4-7f9d-0069-74d8" hidden="false" targetId="7f23-4831-7f76-fd6f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="a27d-e086-220b-cb6c" hidden="false" targetId="ac9f-9690-ac50-3e99" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <entryLinks>
+    <entryLink id="399d-d4c1-3e11-e7e1" name="Army Options" hidden="false" targetId="529a-3e2a-4bd5-5e5f" type="selectionEntry" categoryEntryId="50ba-cf77-3941-189c">
       <profiles/>
-      <links>
-        <link id="9565-8fa7-b579-d0b6" targetId="7a50-8a69-75b6-3cca" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="b056-62d0-b5ec-ca48" targetId="4003-9479-f9e0-a340" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="3ae4-7f9d-0069-74d8" targetId="7f23-4831-7f76-fd6f" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="a27d-e086-220b-cb6c" targetId="ac9f-9690-ac50-3e99" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-  </entries>
-  <rules/>
-  <links/>
-  <sharedEntries>
-    <entry id="562c-13be-8455-d77b" name="Bomb Feeder" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="Main Rulebook" page="124">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </entryLink>
+  </entryLinks>
+  <sharedSelectionEntries>
+    <selectionEntry id="562c-13be-8455-d77b" name="Bomb Feeder" book="Main Rulebook" page="124" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="9b7b-ff28-ec49-0942" targetId="db27-0095-600e-23c4" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="e376-d612-25ff-b855" name="Disruptor Bomber" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="1acb-9789-cb8b-8ef9" profileTypeId="ecae-8ac8-2c13-0dd3" name="Disruptor Bomber" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="60"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="120"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D5, No Crew, Limited Ammo, No Cover, Disruptor"/>
-          </characteristics>
+      <infoLinks>
+        <infoLink id="9b7b-ff28-ec49-0942" hidden="false" targetId="db27-0095-600e-23c4" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e376-d612-25ff-b855" name="Disruptor Bomber" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="1acb-9789-cb8b-8ef9" name="Disruptor Bomber" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D5, No Crew, Limited Ammo, No Cover, Disruptor"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="d8cc-c090-9c63-5998" targetId="e140-2d88-ec8d-28a8" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="3666-098d-f1f2-ec43" targetId="0b3f-b043-b08c-ad14" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="a975-754b-83c3-802b" name="Disruptor Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="3fc4-77d8-d391-3905" profileTypeId="ecae-8ac8-2c13-0dd3" name="Disruptor Cannon" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="-"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D4, No Cover, Disruptor"/>
-          </characteristics>
+      <infoLinks>
+        <infoLink id="d8cc-c090-9c63-5998" hidden="false" targetId="e140-2d88-ec8d-28a8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+        </infoLink>
+        <infoLink id="3666-098d-f1f2-ec43" hidden="false" targetId="0b3f-b043-b08c-ad14" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a975-754b-83c3-802b" name="Disruptor Cannon" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="3fc4-77d8-d391-3905" name="Disruptor Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, No Cover, Disruptor"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="899b-680e-d59e-a442" targetId="e140-2d88-ec8d-28a8" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="ff6d-c9e5-a6c4-f336" name="Disruptor Discharger" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="72a8-99cd-7759-5303" profileTypeId="ecae-8ac8-2c13-0dd3" name="Disruptor Discharger" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="-"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="-"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="-"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Point Blank Shooting Only, Grenade, Blast D4, Disruptor"/>
-          </characteristics>
+      <infoLinks>
+        <infoLink id="899b-680e-d59e-a442" hidden="false" targetId="e140-2d88-ec8d-28a8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ff6d-c9e5-a6c4-f336" name="Disruptor Discharger" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="72a8-99cd-7759-5303" name="Disruptor Discharger" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="-"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="-"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Point Blank Shooting Only, Grenade, Blast D4, Disruptor"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="84fd-8f52-305f-f304" targetId="0bb9-6368-6b0e-0c1c" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="76d1-263c-00e2-7e8d" targetId="5344-3037-5451-66d9" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="7452-3046-3f4b-7e77" targetId="e650-ca8a-00be-3fd1" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="5f8c-16cb-14c1-dbd1" targetId="e140-2d88-ec8d-28a8" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="7b4d-32f1-18fb-a924" targetId="e140-2d88-ec8d-28a8" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="3cfd-07d8-f685-fa34" name="Gouger" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="9983-0148-efd4-e87b" profileTypeId="ecae-8ac8-2c13-0dd3" name="Gouger" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="-"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Down, Inaccurate"/>
-          </characteristics>
+      <infoLinks>
+        <infoLink id="84fd-8f52-305f-f304" hidden="false" targetId="0bb9-6368-6b0e-0c1c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+        </infoLink>
+        <infoLink id="76d1-263c-00e2-7e8d" hidden="false" targetId="5344-3037-5451-66d9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7452-3046-3f4b-7e77" hidden="false" targetId="e650-ca8a-00be-3fd1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="5f8c-16cb-14c1-dbd1" hidden="false" targetId="e140-2d88-ec8d-28a8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7b4d-32f1-18fb-a924" hidden="false" targetId="e140-2d88-ec8d-28a8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3cfd-07d8-f685-fa34" name="Gouger" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="9983-0148-efd4-e87b" name="Gouger" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Down, Inaccurate"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="dc53-88cf-67b6-f50c" targetId="4cb3-1c82-5192-1a7a" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="f96a-f7aa-7dff-a92d" targetId="c524-47f2-d062-eed0" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="ac9f-9690-ac50-3e99" name="Grabber" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="Main Rulebook" page="124">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="dc53-88cf-67b6-f50c" hidden="false" targetId="4cb3-1c82-5192-1a7a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f96a-f7aa-7dff-a92d" hidden="false" targetId="c524-47f2-d062-eed0" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ac9f-9690-ac50-3e99" name="Grabber" book="Main Rulebook" page="124" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="9123-7414-4eda-0134" targetId="43d7-b8cd-2dbc-d79b" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="5a09-7c98-31f2-0b1b" name="Heavy Disruptor Bomber" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="6829-9a72-421b-cfd5" profileTypeId="ecae-8ac8-2c13-0dd3" name="Heavy Disruptor Bomber" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="60"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="120"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OHx2, Blast D10, No Crew, Limited Ammo, No Cover, Disruptor"/>
-          </characteristics>
+      <infoLinks>
+        <infoLink id="9123-7414-4eda-0134" hidden="false" targetId="43d7-b8cd-2dbc-d79b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5a09-7c98-31f2-0b1b" name="Heavy Disruptor Bomber" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="6829-9a72-421b-cfd5" name="Heavy Disruptor Bomber" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OHx2, Blast D10, No Crew, Limited Ammo, No Cover, Disruptor"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="e118-3351-73ab-3039" targetId="e140-2d88-ec8d-28a8" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="ec41-5675-21d2-b9bc" targetId="0b3f-b043-b08c-ad14" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="0435-82ed-58ff-4ea7" name="High Commander" points="30.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="e118-3351-73ab-3039" hidden="false" targetId="e140-2d88-ec8d-28a8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ec41-5675-21d2-b9bc" hidden="false" targetId="0b3f-b043-b08c-ad14" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0435-82ed-58ff-4ea7" name="High Commander" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="e142-2dd7-1d70-0f2d" targetId="48e7-7b6b-328c-29fe" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="ac57-b0c4-464e-9774" name="Hybrid Plasma Light Support" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="e142-2dd7-1d70-0f2d" hidden="false" targetId="48e7-7b6b-328c-29fe" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="30.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ac57-b0c4-464e-9774" name="Hybrid Plasma Light Support" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="8592-5404-f9d1-f93b" name="Hybrid Reactor" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BFX" page="107">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8592-5404-f9d1-f93b" name="Hybrid Reactor" book="BFX" page="107" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="05af-fc97-7a19-cf8d" name="Leader" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="05af-fc97-7a19-cf8d" name="Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="6ed0-d806-e77d-98d7" targetId="24a5-60f8-93fc-7dff" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="0e9b-9aae-bd16-d30f" name="Leader 2" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="6ed0-d806-e77d-98d7" hidden="false" targetId="24a5-60f8-93fc-7dff" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0e9b-9aae-bd16-d30f" name="Leader 2" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="94ea-cf78-4b71-6d44" targetId="9d03-08db-93a6-4f05" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="da65-5109-5f5f-0f9a" name="Leader 3" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="94ea-cf78-4b71-6d44" hidden="false" targetId="9d03-08db-93a6-4f05" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="da65-5109-5f5f-0f9a" name="Leader 3" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="35f6-4a4a-f299-e85f" targetId="e048-25d9-af17-bdf0" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="4d36-a47c-487c-f893" name="Lugger Gun" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="98d1-3d6d-debb-e8f0" profileTypeId="ecae-8ac8-2c13-0dd3" name="Lugger Gun" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="-"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2, Limited Ammo"/>
-          </characteristics>
+      <infoLinks>
+        <infoLink id="35f6-4a4a-f299-e85f" hidden="false" targetId="e048-25d9-af17-bdf0" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4d36-a47c-487c-f893" name="Lugger Gun" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="98d1-3d6d-debb-e8f0" name="Lugger Gun" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Limited Ammo"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="7b96-6226-be5a-13d9" targetId="0dab-4247-3f70-96e7" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="8fbb-fa4e-9d17-e664" targetId="a9b4-063d-b7f2-c577" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="7870-c71a-3038-1e22" name="Lugger Guns" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="a7ee-5d84-004e-b2c7" profileTypeId="ecae-8ac8-2c13-0dd3" name="Lugger Gun" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="-"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2, Limited Ammo"/>
-          </characteristics>
+      <infoLinks>
+        <infoLink id="7b96-6226-be5a-13d9" hidden="false" targetId="0dab-4247-3f70-96e7" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+        </infoLink>
+        <infoLink id="8fbb-fa4e-9d17-e664" hidden="false" targetId="a9b4-063d-b7f2-c577" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7870-c71a-3038-1e22" name="Lugger Guns" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="a7ee-5d84-004e-b2c7" name="Lugger Gun" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Limited Ammo"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="2723-b72b-2d1a-95ee" targetId="0dab-4247-3f70-96e7" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="2a6d-38c7-e168-9943" targetId="a9b4-063d-b7f2-c577" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="306c-a91f-3fc0-e059" name="Mag Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="7074-7af7-cb33-9842" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Cannon" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="50"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="5"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Massive Damage"/>
-          </characteristics>
+      <infoLinks>
+        <infoLink id="2723-b72b-2d1a-95ee" hidden="false" targetId="0dab-4247-3f70-96e7" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+        </infoLink>
+        <infoLink id="2a6d-38c7-e168-9943" hidden="false" targetId="a9b4-063d-b7f2-c577" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="306c-a91f-3fc0-e059" name="Mag Cannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="7074-7af7-cb33-9842" name="Mag Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="50"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="5"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Massive Damage"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links/>
-    </entry>
-    <entry id="1df9-990c-8861-c567" name="Mag Cannon (Weapon Team)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1df9-990c-8861-c567" name="Mag Cannon (Weapon Team)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="1cbe-4730-f08c-a6c0" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Cannon" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="50"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="5"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Massive Damage"/>
-          </characteristics>
+        <profile id="1cbe-4730-f08c-a6c0" name="Mag Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="50"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="5"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Massive Damage"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links/>
-    </entry>
-    <entry id="afcd-8743-da8f-a190" name="Mag Gun" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="afcd-8743-da8f-a190" name="Mag Gun" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="5ac4-a65c-7ca5-f6a5" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Gun" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="60"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules"/>
-          </characteristics>
+        <profile id="5ac4-a65c-7ca5-f6a5" name="Mag Gun" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links/>
-    </entry>
-    <entry id="7f23-4831-7f76-fd6f" name="Mag Guns" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7f23-4831-7f76-fd6f" name="Mag Guns" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="fc9f-0877-25cf-3e17" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Gun" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="60"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules"/>
-          </characteristics>
+        <profile id="fc9f-0877-25cf-3e17" name="Mag Gun" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links/>
-    </entry>
-    <entry id="6f9d-4f18-835f-deff" name="Mag Light Support" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6f9d-4f18-835f-deff" name="Mag Light Support" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="118c-ea89-1867-bb09" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Light Support" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="50"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF 3"/>
-          </characteristics>
+        <profile id="118c-ea89-1867-bb09" name="Mag Light Support" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="50"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF 3"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links/>
-    </entry>
-    <entry id="f124-9b5b-1165-35e3" name="Mag Light Support (Weapon Team)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f124-9b5b-1165-35e3" name="Mag Light Support (Weapon Team)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="de21-7340-0cf9-2b91" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Light Support" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="50"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF 3"/>
-          </characteristics>
+        <profile id="de21-7340-0cf9-2b91" name="Mag Light Support" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="50"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF 3"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links/>
-    </entry>
-    <entry id="1b8c-cb95-f75e-7790" name="Mag Multilash" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1b8c-cb95-f75e-7790" name="Mag Multilash" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="dc72-b0e2-b8cb-2d5c" name="Maglash" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="dc72-b0e2-b8cb-2d5c" name="Maglash" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="66ab-8aa6-0aad-7137" profileTypeId="ecae-8ac8-2c13-0dd3" name="Maglash" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="-"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="-"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks"/>
-          </characteristics>
+        <profile id="66ab-8aa6-0aad-7137" name="Maglash" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="-"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="a742-ea4f-8be3-471b" targetId="3d3d-094e-e819-bbc6" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="ab08-23fc-b6b5-a20f" name="Maglashs" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="1194-ad4d-b79b-4557" profileTypeId="ecae-8ac8-2c13-0dd3" name="Maglash" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="-"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="-"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks"/>
-          </characteristics>
+      <infoLinks>
+        <infoLink id="a742-ea4f-8be3-471b" hidden="false" targetId="3d3d-094e-e819-bbc6" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ab08-23fc-b6b5-a20f" name="Maglashs" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="1194-ad4d-b79b-4557" name="Maglash" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="-"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="e2d1-f268-a03a-d807" targetId="3d3d-094e-e819-bbc6" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="a0c9-26de-c4d9-59cd" name="Micro-X Launcher" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="0" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="e2d1-f268-a03a-d807" hidden="false" targetId="3d3d-094e-e819-bbc6" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a0c9-26de-c4d9-59cd" name="Micro-X Launcher" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="29d5-220a-164f-9cce" profileTypeId="ecae-8ac8-2c13-0dd3" name="Micro-X Launcher - Overhead" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D4, No Cover"/>
-          </characteristics>
+        <profile id="29d5-220a-164f-9cce" name="Micro-X Launcher - Overhead" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D4, No Cover"/>
+          </characteristics>
         </profile>
-        <profile id="0961-cdd8-e81f-6250" profileTypeId="ecae-8ac8-2c13-0dd3" name="Micro-X Launcher - Direct Fire" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="-"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value=""/>
-          </characteristics>
+        <profile id="0961-cdd8-e81f-6250" name="Micro-X Launcher - Direct Fire" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value=""/>
+          </characteristics>
         </profile>
       </profiles>
-      <links/>
-    </entry>
-    <entry id="0924-6883-4fd0-7896" name="Plasma Amplifier" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0924-6883-4fd0-7896" name="Plasma Amplifier" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="cc93-b3fb-ea4e-672f" targetId="0448-a629-3df9-73c0" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="ed1e-82da-96a2-9c3e" name="Plasma Carbine" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="0" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="cc93-b3fb-ea4e-672f" hidden="false" targetId="0448-a629-3df9-73c0" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ed1e-82da-96a2-9c3e" name="Plasma Carbine" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="2b75-1d5a-781f-c81f" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Carbine - Single Shot" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules"/>
-          </characteristics>
+        <profile id="2b75-1d5a-781f-c81f" name="Plasma Carbine - Single Shot" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec"/>
+          </characteristics>
         </profile>
-        <profile id="cc69-fddf-25dd-df04" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Carbine - Scatter" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="-"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2"/>
-          </characteristics>
+        <profile id="cc69-fddf-25dd-df04" name="Plasma Carbine - Scatter" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links/>
-    </entry>
-    <entry id="36a7-e564-c80c-2a7e" name="Plasma Claw" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="3.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="36a7-e564-c80c-2a7e" name="Plasma Claw" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="7b7f-6710-a8ca-13a0" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Claw" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="-"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="-"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="-"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="D4"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Random SV, Hand to Hand Only"/>
-          </characteristics>
+        <profile id="7b7f-6710-a8ca-13a0" name="Plasma Claw" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="-"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="-"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="D4"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Random SV, Hand to Hand Only"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="552b-e451-f468-5bc2" targetId="30d6-c6b7-e415-04b6" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="4e02-a4cc-a3ca-5602" targetId="34b7-4d0d-35b3-8ebe" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="0a8d-432b-4cb0-6b78" name="Plasma Claw (Command)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles>
-        <profile id="f2fe-66ff-fe52-5e87" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Claw" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="-"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="-"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="-"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="D4"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Random SV, Hand to Hand Only"/>
-          </characteristics>
+      <infoLinks>
+        <infoLink id="552b-e451-f468-5bc2" hidden="false" targetId="30d6-c6b7-e415-04b6" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+        </infoLink>
+        <infoLink id="4e02-a4cc-a3ca-5602" hidden="false" targetId="34b7-4d0d-35b3-8ebe" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0a8d-432b-4cb0-6b78" name="Plasma Claw (Command)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="f2fe-66ff-fe52-5e87" name="Plasma Claw" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="-"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="-"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="D4"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Random SV, Hand to Hand Only"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="cae6-4609-37e1-2bc4" targetId="30d6-c6b7-e415-04b6" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="1777-c8cc-9229-4715" targetId="34b7-4d0d-35b3-8ebe" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="6e7f-8fb9-1596-4ab8" name="Plasma Dump" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="cae6-4609-37e1-2bc4" hidden="false" targetId="30d6-c6b7-e415-04b6" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="1777-c8cc-9229-4715" hidden="false" targetId="34b7-4d0d-35b3-8ebe" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6e7f-8fb9-1596-4ab8" name="Plasma Dump" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="5609-876e-7521-4f9e" targetId="4280-96f3-aa68-8d6e" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="c429-23e1-056e-cfd3" name="Plasma Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="5609-876e-7521-4f9e" hidden="false" targetId="4280-96f3-aa68-8d6e" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c429-23e1-056e-cfd3" name="Plasma Grenades" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="6fc0-fbd7-b4c3-f78b" name="Plasma Lance" points="6.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="0" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6fc0-fbd7-b4c3-f78b" name="Plasma Lance" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="648c-d115-3e1d-4507" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Single Shot" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value=""/>
-          </characteristics>
+        <profile id="648c-d115-3e1d-4507" name="Plasma Lance - Single Shot" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value=""/>
+          </characteristics>
         </profile>
-        <profile id="bc6c-565f-4912-7a0c" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Scatter" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="-"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2"/>
-          </characteristics>
+        <profile id="bc6c-565f-4912-7a0c" name="Plasma Lance - Scatter" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2"/>
+          </characteristics>
         </profile>
-        <profile id="9de4-b82d-6fd8-13b7" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Lance" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="-"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="4"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Choose Target, Inaccurate"/>
-          </characteristics>
+        <profile id="9de4-b82d-6fd8-13b7" name="Plasma Lance - Lance" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="4"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Choose Target, Inaccurate"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links/>
-    </entry>
-    <entry id="3018-7ca0-b24e-e8c7" name="Quad Mag Repeater" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="6.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3018-7ca0-b24e-e8c7" name="Quad Mag Repeater" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="e9b6-dc42-b707-9a5f" profileTypeId="ecae-8ac8-2c13-0dd3" name="Quad Mag Repeater" hidden="false" book="BFX" page="75">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="-"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF D8, Jams"/>
-          </characteristics>
+        <profile id="e9b6-dc42-b707-9a5f" name="Quad Mag Repeater" book="BFX" page="75" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF D8, Jams"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="163c-ea47-af86-0967" targetId="1702-a526-6e91-f2cd" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="c70a-e0a0-0192-f2dc" name="Reflex Armour" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="163c-ea47-af86-0967" hidden="false" targetId="1702-a526-6e91-f2cd" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c70a-e0a0-0192-f2dc" name="Reflex Armour" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="b2ed-6632-7d1f-b858" targetId="2094-a31c-bfab-8618" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="4003-9479-f9e0-a340" name="Reflex Armoured" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="b2ed-6632-7d1f-b858" hidden="false" targetId="2094-a31c-bfab-8618" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4003-9479-f9e0-a340" name="Reflex Armoured" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="ab97-1529-eaae-e56a" targetId="2094-a31c-bfab-8618" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="3fde-b133-beb3-43d7" name="Scourer Cannon" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="ab97-1529-eaae-e56a" hidden="false" targetId="2094-a31c-bfab-8618" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3fde-b133-beb3-43d7" name="Scourer Cannon" book="" hidden="false" collective="true" categoryEntryId="(No Category)" type="model">
       <profiles>
-        <profile id="3a17-075b-0005-da30" profileTypeId="ecae-8ac8-2c13-0dd3" name="Scourer Cannon - Dispersed" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="-"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3"/>
-          </characteristics>
+        <profile id="3a17-075b-0005-da30" name="Scourer Cannon - Dispersed" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3"/>
+          </characteristics>
         </profile>
-        <profile id="f1bd-dc3c-6c69-200a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Scourer Cannon - Concentrated" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="40"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="4"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules"/>
-          </characteristics>
+        <profile id="f1bd-dc3c-6c69-200a" name="Scourer Cannon - Concentrated" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="40"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="4"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec"/>
+          </characteristics>
         </profile>
-        <profile id="386e-981d-4010-4c7c" profileTypeId="ecae-8ac8-2c13-0dd3" name="Scourer Cannon - Disruptor" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="-"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D4, No Cover, Disruptor"/>
-          </characteristics>
+        <profile id="386e-981d-4010-4c7c" name="Scourer Cannon - Disruptor" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, No Cover, Disruptor"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links>
-        <link id="6248-6207-2542-bcf4" targetId="e140-2d88-ec8d-28a8" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="3b86-3198-ef3c-030e" name="Tector Rods" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="Main Rulebook" page="124">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles/>
-      <links>
-        <link id="31ac-5d3a-694c-2d0f" targetId="fd0c-1117-1405-8394" linkType="rule">
+      <infoLinks>
+        <infoLink id="6248-6207-2542-bcf4" hidden="false" targetId="e140-2d88-ec8d-28a8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-  </sharedEntries>
-  <sharedEntryGroups/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3b86-3198-ef3c-030e" name="Tector Rods" book="Main Rulebook" page="124" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="31ac-5d3a-694c-2d0f" hidden="false" targetId="fd0c-1117-1405-8394" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups/>
   <sharedRules>
     <rule id="0bb9-6368-6b0e-0c1c" name="Blast" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="db27-0095-600e-23c4" name="Bomb Feeder" hidden="false" book="Core" page="124">
-      <description>Prevents Bombers running out of ammo. Also allows a Bomber unit to shot twice once per game as 1 action.</description>
+    <rule id="db27-0095-600e-23c4" name="Bomb Feeder" book="Core" page="124" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>Prevents Bombers running out of ammo. Also allows a Bomber unit to shot twice once per game as 1 action.</description>
     </rule>
     <rule id="1d76-267d-696a-2e8a" name="Command" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="23c8-9405-75ca-7f03" name="Crawler" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="e140-2d88-ec8d-28a8" name="Disruptor" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Target gets no cover bonus to its Res rolls. Non-Ghar take 2 Pins. Can choose to hit Buddy Drones. Probes hit can only make successful Res tests on 1 regardless of Res Value</description>
-      <modifiers/>
     </rule>
-    <rule id="4cb3-1c82-5192-1a7a" name="Down" hidden="false" book="Core" page="74">
-      <description>A unit hit by a Gouger gun automatically goes down after shooting has ben worked out.</description>
+    <rule id="4cb3-1c82-5192-1a7a" name="Down" book="Core" page="74" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>A unit hit by a Gouger gun automatically goes down after shooting has ben worked out.</description>
     </rule>
     <rule id="2bb1-783e-8a6e-5970" name="Flitter" hidden="false">
-      <description>Flitters only move 15&quot;</description>
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>Flitters only move 15&quot;</description>
     </rule>
     <rule id="6d5c-d6f2-3426-e11c" name="Flitter Bomb" hidden="false">
-      <description>Flitters must move into contact with enemy units to have any effect. When you want them to explode roll a D10 on a 6-10 (rolling seperately if multiple Flitters are in contact) they explode cuasing D3 hits allocated to the model touching the bomb first, then any the play whose unit has been attacked chooses. The SV is D3, but only rolled once for all the Flitters exploding on the same target, and counts as having been inflicted in hand to hand. Counts as a Disruptor weapon for the purpose of putting additional pins on targets and damaging Buddy Drones.</description>
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>Flitters must move into contact with enemy units to have any effect. When you want them to explode roll a D10 on a 6-10 (rolling seperately if multiple Flitters are in contact) they explode cuasing D3 hits allocated to the model touching the bomb first, then any the play whose unit has been attacked chooses. The SV is D3, but only rolled once for all the Flitters exploding on the same target, and counts as having been inflicted in hand to hand. Counts as a Disruptor weapon for the purpose of putting additional pins on targets and damaging Buddy Drones.</description>
     </rule>
     <rule id="ae1d-2212-b0ef-48b6" name="Follow" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="2dca-9d1f-0a96-e2d2" name="Ghar Flitter" hidden="false" book="Core" page="119">
+    <rule id="2dca-9d1f-0a96-e2d2" name="Ghar Flitter" book="Core" page="119" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>If an enemy unit has one of more flitters within 5&quot; of it any Ghar shooting at it adds +! Axx if at least one flitter can be activated. Ghar Flitters give no bonus to OH shots. Flitters activate on a D10 roll of 6-10. Roll seperately for each Flitter</description>
-      <modifiers/>
     </rule>
-    <rule id="43d7-b8cd-2dbc-d79b" name="Ghar Grabber" hidden="false" book="Core" page="124">
-      <description>Can assist units in 5&quot; in Ghar in battle armouir and Scutters and any Ghar Vehicles. Assisted units reroll Ag tests, reroll damage chart, reroll attempts to recover from being down on the End Phase, and grants the unit Self-Repair</description>
+    <rule id="43d7-b8cd-2dbc-d79b" name="Ghar Grabber" book="Core" page="124" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>Can assist units in 5&quot; in Ghar in battle armouir and Scutters and any Ghar Vehicles. Assisted units reroll Ag tests, reroll damage chart, reroll attempts to recover from being down on the End Phase, and grants the unit Self-Repair</description>
     </rule>
     <rule id="e650-ca8a-00be-3fd1" name="Grenade" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="34b7-4d0d-35b3-8ebe" name="Hand to Hand Only" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="4a94-ffc8-8d46-6869" name="Hero" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="48e7-7b6b-328c-29fe" name="High Commander" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="fa58-3ec1-0b4e-b2f2" name="Hybrid Reactor" hidden="false" book="BFX" page="107">
+    <rule id="fa58-3ec1-0b4e-b2f2" name="Hybrid Reactor" book="BFX" page="107" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Hybrid reactors work the same as Plasma Ractors, but only burn out on a 10</description>
-      <modifiers/>
     </rule>
-    <rule id="c524-47f2-d062-eed0" name="Inaccurate" hidden="false" book="Core" page="74">
+    <rule id="c524-47f2-d062-eed0" name="Inaccurate" book="Core" page="74" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>-1 Acc</description>
-      <modifiers/>
     </rule>
-    <rule id="1702-a526-6e91-f2cd" name="Jams" hidden="false" book="BFX" page="75">
-      <description>On any Acc roll of a 10 the weapon has jammed. This means it can not fire on it&apos;s next turn.</description>
+    <rule id="1702-a526-6e91-f2cd" name="Jams" book="BFX" page="75" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>On any Acc roll of a 10 the weapon has jammed. This means it can not fire on it&apos;s next turn.</description>
     </rule>
     <rule id="931b-a54d-a846-cb74" name="Large" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="24a5-60f8-93fc-7dff" name="Leader" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="9d03-08db-93a6-4f05" name="Leader 2" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="e048-25d9-af17-bdf0" name="Leader 3" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="f2a0-778f-5fa4-20af" name="Limited" hidden="false">
-      <description>Only 25% of your army may be limited choices</description>
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>Only 25% of your army may be limited choices</description>
     </rule>
     <rule id="0dab-4247-3f70-96e7" name="Limited Ammo" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>After shooting roll once for the unit. On a 10 the weapons low on ammo, so may not rapid fire anymore. If this test is failed again the gun runs out of ammo.</description>
-      <modifiers/>
     </rule>
-    <rule id="0b3f-b043-b08c-ad14" name="Limited Ammo (Bomber)" hidden="false" book="Core" page="77">
-      <description>Unless it has a Bomb Feeder Scutter. if a disruptor bomber rolls a 10 to hit, the shot is not only a dud shot but also the weapon runs out of ammo.</description>
+    <rule id="0b3f-b043-b08c-ad14" name="Limited Ammo (Bomber)" book="Core" page="77" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>Unless it has a Bomb Feeder Scutter. if a disruptor bomber rolls a 10 to hit, the shot is not only a dud shot but also the weapon runs out of ammo.</description>
     </rule>
     <rule id="09d0-48ed-82d2-38b5" name="MOD2" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="3d3d-094e-e819-bbc6" name="Multiple Attacks" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="5344-3037-5451-66d9" name="No Cover" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="2ed7-3d50-bea9-5f27" name="Outcast Champion" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="0448-a629-3df9-73c0" name="Plasma Amplifier" hidden="false" book="Main Rulebook" page="125">
+    <rule id="0448-a629-3df9-73c0" name="Plasma Amplifier" book="Main Rulebook" page="125" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Increases the models MOD by 1. At the end of the turn on a 1-5 Amplifier runs out. If the unit fails a required order test on a 10 using the extra dice then the amplifer is destroyed and the unit suffers D5 Pins</description>
-      <modifiers/>
     </rule>
-    <rule id="4280-96f3-aa68-8d6e" name="Plasma Dump" hidden="false" book="Main Rulebook" page="124">
-      <description>A player who declares a Down order may Plasma Dump. Shots against that unit are at -2 Acc. In addition all units in 5&quot; of the Dump take D6 SV2 hits and recieves 1 pin. If the unit elects to remain down this will happen again at the start of each turn.</description>
+    <rule id="4280-96f3-aa68-8d6e" name="Plasma Dump" book="Main Rulebook" page="124" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>A player who declares a Down order may Plasma Dump. Shots against that unit are at -2 Acc. In addition all units in 5&quot; of the Dump take D6 SV2 hits and recieves 1 pin. If the unit elects to remain down this will happen again at the start of each turn.</description>
     </rule>
     <rule id="f5cb-d1fc-6b00-39f5" name="Plasma Reactor" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="30d6-c6b7-e415-04b6" name="Random SV" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="a9b4-063d-b7f2-c577" name="Rapid Fire (RF)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="7a50-8a69-75b6-3cca" name="Rebel" hidden="false" book="BFX" page="84">
-      <description>Units in 5&quot; of another friendly unit with this rule ignore 1 pin</description>
+    <rule id="7a50-8a69-75b6-3cca" name="Rebel" book="BFX" page="84" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>Units in 5&quot; of another friendly unit with this rule ignore 1 pin</description>
     </rule>
     <rule id="2094-a31c-bfab-8618" name="Reflex Armour" hidden="false">
-      <description>+1 Resistance</description>
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>+1 Resistance</description>
     </rule>
     <rule id="a985-d1e1-a15f-c261" name="Scramble Proof" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="485f-1f8e-7808-4a17" name="Shard" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="fd0c-1117-1405-8394" name="Tector Rods" hidden="false" book="Core Book" page="124">
-      <description>When a Ghar shoots at a unit in 15&quot; of 1 or more Tector Rods in may reroll 1 Accuracy Test.</description>
+    <rule id="fd0c-1117-1405-8394" name="Tector Rods" book="Core Book" page="124" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>When a Ghar shoots at a unit in 15&quot; of 1 or more Tector Rods in may reroll 1 Accuracy Test.</description>
     </rule>
     <rule id="57d1-980d-ee47-f717" name="Wound" hidden="false">
-      <description>May fail 1 Res test without being removed as a casualty. A 2nd fail will remove the model as normal.</description>
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>May fail 1 Res test without being removed as a casualty. A 2nd fail will remove the model as normal.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>
-    <profile id="13e9-5eeb-7392-f018" profileTypeId="1650-77b3-10d1-6406" name="Ghar Attack Scutter" hidden="false" book="Beyond the Gates of Antares" page="170">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="3"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="4(10)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="7"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Large, Crawler, Scramble Proof, Plasma Reactor"/>
-      </characteristics>
+    <profile id="13e9-5eeb-7392-f018" name="Ghar Attack Scutter" book="Beyond the Gates of Antares" page="170" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="3"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(10)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Large, Crawler, Scramble Proof, Plasma Reactor"/>
+      </characteristics>
     </profile>
-    <profile id="68fa-5d5f-eae2-3f66" profileTypeId="1650-77b3-10d1-6406" name="Ghar Commander in Battle Armour" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="3"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="10"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="4(12)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Command, Follow, Leader 2, Large, Scrumble Proof, Plasma Reactor"/>
-      </characteristics>
+    <profile id="68fa-5d5f-eae2-3f66" name="Ghar Commander in Battle Armour" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="3"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="10"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(12)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Follow, Leader 2, Large, Scrumble Proof, Plasma Reactor"/>
+      </characteristics>
     </profile>
-    <profile id="562d-6cd9-4b4a-7019" profileTypeId="f9a2-eeae-3284-75fd" name="Ghar Leader" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="18c1-4764-7d08-708d" name="Ag" value="3"/>
-        <characteristic characteristicId="e39c-d7a4-86a8-d23d" name="Acc" value="5"/>
-        <characteristic characteristicId="0790-bfd5-1273-fe12" name="Str" value="10"/>
-        <characteristic characteristicId="5b77-3595-2819-675c" name="Res" value="4(12)"/>
-        <characteristic characteristicId="c0d8-f6fd-a474-1385" name="Init" value="8"/>
-        <characteristic characteristicId="135d-efc3-5039-b6e6" name="Co" value="8"/>
-        <characteristic characteristicId="ab43-4d1c-4651-b424" name="Special" value="Leader, Large, Scramble Proof, Plasma Reactor"/>
-      </characteristics>
+    <profile id="562d-6cd9-4b4a-7019" name="Ghar Leader" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="3"/>
+        <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="10"/>
+        <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="4(12)"/>
+        <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="8"/>
+        <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="8"/>
+        <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424" value="Leader, Large, Scramble Proof, Plasma Reactor"/>
+      </characteristics>
     </profile>
-    <profile id="de07-7287-f4d3-bf98" profileTypeId="1650-77b3-10d1-6406" name="Ghar Trooper" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="3"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="10"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="4(12)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="7"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Large, Scramble Proof, Plasma Reactor"/>
-      </characteristics>
+    <profile id="de07-7287-f4d3-bf98" name="Ghar Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="3"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="10"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(12)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Large, Scramble Proof, Plasma Reactor"/>
+      </characteristics>
     </profile>
-    <profile id="b56d-892d-c25e-7379" profileTypeId="1650-77b3-10d1-6406" name="Outcast Rebel" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="6"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="3"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="4(5)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="7"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Rebel"/>
-      </characteristics>
+    <profile id="b56d-892d-c25e-7379" name="Outcast Rebel" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="6"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="3"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(5)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Rebel"/>
+      </characteristics>
     </profile>
-    <profile id="167d-cdd2-aafa-0394" profileTypeId="1650-77b3-10d1-6406" name="Outcast Rebel Commander" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="6"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="3"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="4(5)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="7"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Leader, Hero, Command, Follow, Rebel"/>
-      </characteristics>
+    <profile id="167d-cdd2-aafa-0394" name="Outcast Rebel Commander" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="6"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="3"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(5)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader, Hero, Command, Follow, Rebel"/>
+      </characteristics>
     </profile>
-    <profile id="9770-5f42-fa8c-247c" profileTypeId="1650-77b3-10d1-6406" name="Outcast Rebel Leader" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="6"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="3"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="4(5)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="7"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Leader, Rebel"/>
-      </characteristics>
+    <profile id="9770-5f42-fa8c-247c" name="Outcast Rebel Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="6"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="3"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(5)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader, Rebel"/>
+      </characteristics>
     </profile>
   </sharedProfiles>
 </catalogue>

--- a/Isorian.cat
+++ b/Isorian.cat
@@ -1,2387 +1,4422 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="eaf6-3f46-6191-754c" revision="4" gameSystemId="c339-677a-60db-4060" gameSystemRevision="0" battleScribeVersion="1.15" name="Isorian" authorName="Lee Long" authorContact="beasturr@live.co.uk" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
-  <entries>
-    <entry id="a3e3-761c-74f3-d2f2" name="Drone Commander Xan Tu" points="0.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Xilos" page="117">
-      <entries>
-        <entry id="f02d-da46-f322-5933" name="Weapon Drone" points="59.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
+<catalogue id="eaf6-3f46-6191-754c" name="Isorian" revision="5" battleScribeVersion="2.00" authorName="Lee Long" authorContact="beasturr@live.co.uk" gameSystemId="c339-677a-60db-4060" gameSystemRevision="0" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <profiles/>
+  <rules/>
+  <infoLinks/>
+  <costTypes/>
+  <profileTypes/>
+  <forceEntries/>
+  <selectionEntries>
+    <selectionEntry id="a3e3-761c-74f3-d2f2" name="Drone Commander Xan Tu" book="Xilos" page="117" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="f02d-da46-f322-5933" name="Weapon Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles/>
-          <links>
-            <link id="1637-0842-665f-7baf" targetId="18f2-0352-9cf8-66a5" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="f53a-1444-1c40-5103" name="Drone Commander" points="61.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
           <rules/>
+          <infoLinks>
+            <infoLink id="1637-0842-665f-7baf" hidden="false" targetId="18f2-0352-9cf8-66a5" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="59.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f53a-1444-1c40-5103" name="Drone Commander" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles/>
-          <links>
-            <link id="4445-ab9e-a23d-34b5" targetId="bed7-2549-f395-f271" linkType="profile">
+          <rules/>
+          <infoLinks>
+            <infoLink id="4445-ab9e-a23d-34b5" hidden="false" targetId="bed7-2549-f395-f271" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="ac26-bdf5-0bcf-d3a4" name="&lt; Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-          <links>
-            <link id="47d2-db02-12fe-cbad" targetId="001a-9f15-b25b-b784" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="3804-b86f-9c05-9420" targetId="3ac2-e4a6-9011-4985" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="fdb0-a151-6fac-8967" targetId="5ed8-6bd4-d0f7-d7f0" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="db77-785d-6eda-c4ba" targetId="651f-9469-74a5-505a" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="5ce9-5bd3-c6d5-879e" name="&lt; Weapon Drone Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="61.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ac26-bdf5-0bcf-d3a4" name="&lt; Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="3983-cb40-246a-1004" targetId="8c55-0529-22ab-3fa6" linkType="entry">
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="47d2-db02-12fe-cbad" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="3804-b86f-9c05-9420" hidden="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="fdb0-a151-6fac-8967" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="db77-785d-6eda-c4ba" hidden="false" targetId="651f-9469-74a5-505a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="5ce9-5bd3-c6d5-879e" name="&lt; Weapon Drone Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="3983-cb40-246a-1004" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="maxSelections" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="maxSelections" value="2.0">
+                  <repeats/>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-            <link id="31a4-5549-4299-cd23" targetId="a8d9-6fae-a541-9f4f" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="31a4-5549-4299-cd23" hidden="false" targetId="a8d9-6fae-a541-9f4f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="maxSelections" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="maxSelections" value="2.0">
+                  <repeats/>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-            <link id="2647-c41d-56e3-2be2" targetId="62c2-106a-28aa-6cf5" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="2647-c41d-56e3-2be2" hidden="false" targetId="62c2-106a-28aa-6cf5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3601-a65d-7f14-cf86" name="Isorian Andhak SC2 Medium Support Drone" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="3601-a65d-7f14-cf86" name="Isorian Andhak SC2 Medium Support Drone" points="0.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="156e-1f5a-b7e7-1783" name="&lt; Weapon Drone" points="93.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="bca1-3c81-da93-aefb" targetId="be8e-2c8f-8288-e92a" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="86e7-9193-c4cf-b4c7" name="&lt; Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="0f08-649f-cdb0-8d16" targetId="001a-9f15-b25b-b784" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="a405-a61d-2eb0-1e80" targetId="3ac2-e4a6-9011-4985" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="f787-39f9-566b-e5ff" targetId="5ed8-6bd4-d0f7-d7f0" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="f298-b1a6-4486-7b3a" name="&lt; Weapon Drone Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="34a7-a9ba-8af3-becb" name="&lt; Weapon Option &gt;" defaultEntryId="d929-5f73-e58b-90d8" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="d929-5f73-e58b-90d8" targetId="62c2-106a-28aa-6cf5" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="907e-68db-aaaf-9a2f" targetId="90ca-6c03-a803-a140" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="b25e-f181-2b5c-7cc4" targetId="6ded-5798-dd23-8e6f" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="2100-0b04-3ec7-174f" targetId="5a7d-3845-90ba-32eb" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <links>
-            <link id="4064-6c5e-df77-f08e" targetId="8c55-0529-22ab-3fa6" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="56c2-caa3-3666-bf3e" targetId="a8d9-6fae-a541-9f4f" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
       <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="d626-a99a-6470-71ad" name="Isorian Nhamak NC Light Support Drone" points="0.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="37d5-656f-d5c1-4397" name="&lt; Weapon Drone" points="59.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="156e-1f5a-b7e7-1783" name="&lt; Weapon Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles/>
-          <links>
-            <link id="7f94-248b-3341-8ab0" targetId="18f2-0352-9cf8-66a5" linkType="profile">
+          <rules/>
+          <infoLinks>
+            <infoLink id="bca1-3c81-da93-aefb" hidden="false" targetId="be8e-2c8f-8288-e92a" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="cf0a-fdfc-c22e-fadb" name="&lt; Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-          <links>
-            <link id="b508-d3f3-6f27-4975" targetId="001a-9f15-b25b-b784" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="50fc-d0da-6514-b4dd" targetId="3ac2-e4a6-9011-4985" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="e89f-034f-fda6-f951" targetId="5ed8-6bd4-d0f7-d7f0" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="4da3-5d4c-1262-53ab" name="&lt; Weapon Drone Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="93.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="86e7-9193-c4cf-b4c7" name="&lt; Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="c7a3-afb1-fa42-b4d3" targetId="8c55-0529-22ab-3fa6" linkType="entry">
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="0f08-649f-cdb0-8d16" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="a405-a61d-2eb0-1e80" hidden="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="f787-39f9-566b-e5ff" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="f298-b1a6-4486-7b3a" name="&lt; Weapon Drone Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="34a7-a9ba-8af3-becb" name="&lt; Weapon Option &gt;" hidden="false" collective="false" defaultSelectionEntryId="d929-5f73-e58b-90d8">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="d929-5f73-e58b-90d8" hidden="false" targetId="62c2-106a-28aa-6cf5" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="907e-68db-aaaf-9a2f" hidden="false" targetId="90ca-6c03-a803-a140" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="b25e-f181-2b5c-7cc4" hidden="false" targetId="6ded-5798-dd23-8e6f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="2100-0b04-3ec7-174f" hidden="false" targetId="5a7d-3845-90ba-32eb" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="4064-6c5e-df77-f08e" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="56c2-caa3-3666-bf3e" hidden="false" targetId="a8d9-6fae-a541-9f4f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d626-a99a-6470-71ad" name="Isorian Nhamak NC Light Support Drone" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="37d5-656f-d5c1-4397" name="&lt; Weapon Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="7f94-248b-3341-8ab0" hidden="false" targetId="18f2-0352-9cf8-66a5" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="59.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="cf0a-fdfc-c22e-fadb" name="&lt; Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="b508-d3f3-6f27-4975" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="50fc-d0da-6514-b4dd" hidden="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="e89f-034f-fda6-f951" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="4da3-5d4c-1262-53ab" name="&lt; Weapon Drone Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="c7a3-afb1-fa42-b4d3" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="maxSelections" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="maxSelections" value="2.0">
+                  <repeats/>
                   <conditions>
-                    <condition parentId="d626-a99a-6470-71ad" childId="37d5-656f-d5c1-4397" field="selections" type="greater than" value="1.0"/>
+                    <condition field="selections" scope="d626-a99a-6470-71ad" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="37d5-656f-d5c1-4397" type="greaterThan"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-            <link id="e462-4fcd-a5ee-e85b" targetId="a8d9-6fae-a541-9f4f" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="e462-4fcd-a5ee-e85b" hidden="false" targetId="a8d9-6fae-a541-9f4f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="maxSelections" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="maxSelections" value="2.0">
+                  <repeats/>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="f089-4381-fa63-0074" targetId="c74e-2993-3474-7869" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="c93d-d42c-8771-aa98" name="Isorian Phase Sniper" points="0.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="1518-7b74-035c-3c4e" name="Phase Sniper" points="52.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="f089-4381-fa63-0074" hidden="false" targetId="c74e-2993-3474-7869" type="selectionEntry">
+          <profiles/>
           <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c93d-d42c-8771-aa98" name="Isorian Phase Sniper" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="1518-7b74-035c-3c4e" name="Phase Sniper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles>
-            <profile id="dc3a-0672-55ef-4cd8" profileTypeId="1650-77b3-10d1-6406" name="Phase Sniper" hidden="false">
-              <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="8"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5 (7)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-                <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special"/>
-              </characteristics>
+            <profile id="dc3a-0672-55ef-4cd8" name="Phase Sniper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="8"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5 (7)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
             </profile>
           </profiles>
-          <links>
-            <link id="6fe6-c5a9-9088-53ee" targetId="bf65-f7cb-1b50-d144" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="8ba0-9319-020d-6785" targetId="2f22-37fa-4076-d255" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="913c-082e-c79c-e861" targetId="9443-effe-72e1-2f51" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="1aae-f5f3-cbb1-4b8c" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="ed05-2035-2eaa-d820" targetId="de46-fbd5-d8f5-7454" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="2ee2-a4b2-6698-7f32" targetId="cd4f-0ce9-a6a4-b34a" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="6cdd-2f72-70a0-e782" targetId="f095-7ba3-b868-32de" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="5ef8-5d7c-c5e8-9c90" targetId="41bd-5499-889a-ab16" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="b799-7e5e-0b8c-164c" targetId="b63d-0e1c-d14a-c3e4" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="406a-8de7-7dd6-ffbf" name="Isorian Support Team with Plasma Bombard" points="65.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="1664-f248-f1ed-7de3" name="Phase Trooper" points="15.0" categoryId="(No Category)" type="model" minSelections="3" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
           <rules/>
-          <profiles/>
-          <links>
-            <link id="21e2-1fe1-5fdf-818a" targetId="6688-b331-6578-fb30" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="879a-f5e6-2376-522a" targetId="bf65-f7cb-1b50-d144" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="c218-20ff-bfe9-51bd" targetId="2f22-37fa-4076-d255" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="0fa0-eff6-2314-dea8" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="7fc5-0a43-aa2b-9608" targetId="f095-7ba3-b868-32de" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="6fe6-c5a9-9088-53ee" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="8ba0-9319-020d-6785" hidden="false" targetId="2f22-37fa-4076-d255" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="913c-082e-c79c-e861" hidden="false" targetId="9443-effe-72e1-2f51" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="52.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="1aae-f5f3-cbb1-4b8c" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="ed05-2035-2eaa-d820" hidden="false" targetId="de46-fbd5-d8f5-7454" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="2ee2-a4b2-6698-7f32" hidden="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="6cdd-2f72-70a0-e782" hidden="false" targetId="f095-7ba3-b868-32de" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="5ef8-5d7c-c5e8-9c90" hidden="false" targetId="41bd-5499-889a-ab16" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="b799-7e5e-0b8c-164c" hidden="false" targetId="b63d-0e1c-d14a-c3e4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="406a-8de7-7dd6-ffbf" name="Isorian Support Team with Plasma Bombard" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="1664-f248-f1ed-7de3" name="Phase Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="21e2-1fe1-5fdf-818a" hidden="false" targetId="6688-b331-6578-fb30" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="879a-f5e6-2376-522a" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="c218-20ff-bfe9-51bd" hidden="false" targetId="2f22-37fa-4076-d255" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0fa0-eff6-2314-dea8" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="7fc5-0a43-aa2b-9608" hidden="false" targetId="f095-7ba3-b868-32de" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="minSelections" value="1.0">
+                  <repeats/>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-            <link id="435a-90a4-40b5-9aa2" targetId="3ac2-e4a6-9011-4985" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="435a-90a4-40b5-9aa2" hidden="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="64eb-8ae7-bc77-31d4" targetId="41bd-5499-889a-ab16" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="64eb-8ae7-bc77-31d4" hidden="false" targetId="41bd-5499-889a-ab16" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="237a-3820-dfb2-0b99" targetId="cd4f-0ce9-a6a4-b34a" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="237a-3820-dfb2-0b99" hidden="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="ac6f-1359-dbd6-9bb0" name="Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="d563-f5ad-f44c-e162" targetId="1bc9-ce44-fdbe-ef90" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="5265-231f-43ab-5d20" name="Isorian Support Team with X-Howitzer" points="55.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="7750-57ad-7e30-28c5" name="Phase Trooper" points="15.0" categoryId="(No Category)" type="model" minSelections="3" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="ac6f-1359-dbd6-9bb0" name="Weapon" hidden="false" collective="false">
           <profiles/>
-          <links>
-            <link id="fe22-4c0b-a4c9-d753" targetId="6688-b331-6578-fb30" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="5394-4256-ad47-a91d" targetId="bf65-f7cb-1b50-d144" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="109b-020a-b406-1392" targetId="2f22-37fa-4076-d255" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="2a6c-9381-d88e-8bd2" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="7e77-acbd-8c4e-c09a" targetId="f095-7ba3-b868-32de" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="d563-f5ad-f44c-e162" hidden="false" targetId="1bc9-ce44-fdbe-ef90" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="65.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5265-231f-43ab-5d20" name="Isorian Support Team with X-Howitzer" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="7750-57ad-7e30-28c5" name="Phase Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="fe22-4c0b-a4c9-d753" hidden="false" targetId="6688-b331-6578-fb30" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="5394-4256-ad47-a91d" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="109b-020a-b406-1392" hidden="false" targetId="2f22-37fa-4076-d255" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2a6c-9381-d88e-8bd2" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="7e77-acbd-8c4e-c09a" hidden="false" targetId="f095-7ba3-b868-32de" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="minSelections" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="minSelections" value="1.0">
+                  <repeats/>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-            <link id="651e-28ab-855b-7c6a" targetId="3ac2-e4a6-9011-4985" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="651e-28ab-855b-7c6a" hidden="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="e7ec-80b1-f4f0-1541" targetId="41bd-5499-889a-ab16" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="e7ec-80b1-f4f0-1541" hidden="false" targetId="41bd-5499-889a-ab16" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="e1bf-ad76-2471-3df5" targetId="cd4f-0ce9-a6a4-b34a" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="e1bf-ad76-2471-3df5" hidden="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="8850-385a-1947-074c" name="Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="8850-385a-1947-074c" name="Weapon" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="4a29-7598-47e2-1f4d" targetId="e2b4-a034-c8ce-e376" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="4a29-7598-47e2-1f4d" hidden="false" targetId="e2b4-a034-c8ce-e376" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="55.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a829-1685-c4b5-55b6" name="Kahloc KV Heavy Battle Drone" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="a829-1685-c4b5-55b6" name="Kahloc KV Heavy Battle Drone" points="0.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="9432-f296-0817-a41e" name="&lt; Heavy Combat Drone" points="408.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="9432-f296-0817-a41e" name="&lt; Heavy Combat Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles/>
-          <links>
-            <link id="52d9-2f82-4813-deb1" targetId="1c7c-b76a-8d9f-4405" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="fc27-7742-3460-32c5" targetId="c74e-2993-3474-7869" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="ba92-e188-5152-68a3" name="&lt; Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="25d4-fe83-5977-2551" targetId="001a-9f15-b25b-b784" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="3866-b4ff-b88f-c46f" targetId="2750-e65f-4c66-8235" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="2bbd-905d-dab7-121e" targetId="5ed8-6bd4-d0f7-d7f0" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="232d-2ec2-4ebb-33e8" name="&lt; Weapon Drone Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="ab1d-b82e-4fa4-af4b" name="&lt; Weapon Option &gt;" defaultEntryId="1f48-758b-70a2-1b46" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="a48c-1f8a-649a-6c31" targetId="c521-ffae-2a9d-88f9" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="1f48-758b-70a2-1b46" targetId="1bc9-ce44-fdbe-ef90" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <links>
-            <link id="c984-ceed-ca03-2965" targetId="8c55-0529-22ab-3fa6" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="c421-df4b-ccea-aa78" targetId="a8d9-6fae-a541-9f4f" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="3440-9714-d7d3-3653" name="Mahran Vesh MV5 Combat Drone" points="229.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="c49a-cae5-0917-dff0" name="&lt; Weapon Drone" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
           <rules/>
+          <infoLinks>
+            <infoLink id="52d9-2f82-4813-deb1" hidden="false" targetId="1c7c-b76a-8d9f-4405" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="fc27-7742-3460-32c5" hidden="false" targetId="c74e-2993-3474-7869" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="408.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ba92-e188-5152-68a3" name="&lt; Options &gt;" hidden="false" collective="false">
           <profiles/>
-          <links>
-            <link id="9c84-78ff-fad3-093b" targetId="eda1-434f-1771-a790" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="5980-fadb-0d1a-8e4b" name="&lt; Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="1015-29dc-212b-dc4d" targetId="001a-9f15-b25b-b784" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="5087-2dc6-723c-788e" targetId="2750-e65f-4c66-8235" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="4ea5-d717-39c9-e705" targetId="5ed8-6bd4-d0f7-d7f0" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="91d2-c0ae-c028-4591" name="&lt; Weapon Drone Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="fb98-64e6-ce83-57f9" name="&lt; Weapon Option &gt;" defaultEntryId="d8ef-55c7-2efb-ec04" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="6062-8f75-90de-9604" targetId="69d9-b84f-3c40-15fb" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="d0f0-9069-c124-7cd2" targetId="80bf-613e-52b4-f160" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="d8ef-55c7-2efb-ec04" targetId="3dfc-49e9-adcb-ae48" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <links>
-            <link id="04e7-e796-57e1-9c2e" targetId="8c55-0529-22ab-3fa6" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="7587-847d-9f8d-31dd" targetId="a8d9-6fae-a541-9f4f" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="ad84-1f7d-5b85-ad4a" targetId="e16f-acd1-265c-07f9" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="7d08-c97c-53ca-06ab" targetId="c74e-2993-3474-7869" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="fcb7-7abc-470a-26fe" name="Medi-Probe Shard" points="0.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="c7bd-920e-b6e5-ef99" name="&lt; Medi-probe" points="10.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
           <rules/>
-          <profiles/>
-          <links>
-            <link id="d758-744a-7ac4-7804" targetId="078e-4753-3545-ba51" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="0d09-f1bc-5547-135f" name="Nano Probe Net Shard" points="10.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="0" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="34f8-26e7-c193-56eb" name="Nano Probe" points="5.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <infoLinks/>
           <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="25d4-fe83-5977-2551" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="3866-b4ff-b88f-c46f" hidden="false" targetId="2750-e65f-4c66-8235" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="2bbd-905d-dab7-121e" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="232d-2ec2-4ebb-33e8" name="&lt; Weapon Drone Options &gt;" hidden="false" collective="false">
+          <profiles/>
           <rules/>
-          <profiles/>
-          <links>
-            <link id="ecb4-f327-4797-5d94" targetId="16bf-fee9-f1bf-8600" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers>
-        <modifier type="increment" field="maxInForce" value="1.0" repeat="true" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="total selections" incrementValue="1.0">
-          <conditions>
-            <condition parentId="roster" childId="a3e3-761c-74f3-d2f2" field="selections" type="equal to" value="1.0"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="6429-1b89-b557-736b" name="NuHu Senatexis" points="174.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="ae11-f605-d815-9109" name="&lt; Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+          <infoLinks/>
           <modifiers/>
-          <links>
-            <link id="6fd3-49ff-c60c-3624" targetId="f095-7ba3-b868-32de" linkType="entry">
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="ab1d-b82e-4fa4-af4b" name="&lt; Weapon Option &gt;" hidden="false" collective="false" defaultSelectionEntryId="1f48-758b-70a2-1b46">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="bb6a-48bd-2cf1-f430" targetId="057e-2e8a-1952-9de0" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="775b-177d-e6ac-c3ac" targetId="5ed8-6bd4-d0f7-d7f0" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="2523-96e0-03f8-2625" targetId="5343-3c10-ccc3-0233" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="6fd9-afd5-d70f-d751" targetId="41d1-a002-0258-c407" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="1133-9cc8-d005-ca82" targetId="a2e9-2b00-2191-a410" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="e3c8-4234-d63f-b52c" targetId="2f22-37fa-4076-d255" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="b702-73ca-4a1f-e0f5" targetId="c7a8-840b-096e-e2b8" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="0244-6cd5-9260-c12e" name="Pulse Bike Command Squad" points="168.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="fa12-b792-1fff-89e3" name="&lt; Pulse Bike Commander" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="ce12-0c6b-11e5-f498" name="&lt; Pulse Bike Commander Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="bd12-7ad6-eb09-08ba" targetId="a90a-fea5-107f-a019" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="5cac-dbde-7763-5ddd" targetId="9286-cbf7-0641-5ce1" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="c8d2-d4de-e467-c706" targetId="12f1-610b-0dc9-4732" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="77c5-7b49-1b1a-443b" targetId="eafe-a83e-6cfd-0559" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="ea21-ecb8-ce22-00d3" targetId="658c-b2dd-98f4-dafb" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="8b1d-c9da-076d-d08e" name="Pulse Bike Trooper" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="5f70-3d2c-69d6-3b63" targetId="34f9-12c5-7e7b-114c" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="3ad9-f6de-2222-14d7" targetId="12f1-610b-0dc9-4732" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="89fc-31e3-8d85-5d84" targetId="eafe-a83e-6cfd-0559" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="18db-e7fa-3661-289b" targetId="658c-b2dd-98f4-dafb" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="aba9-6548-4d89-9d71" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="01c1-76ad-1e19-2f22" name="&lt; Compactor Drone &gt;" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="7e3a-171d-c362-06f0" targetId="c87f-f5b0-1134-8ad9" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="792d-6942-fc08-f58a" targetId="d776-f344-44a4-c41b" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <links>
-            <link id="ffb4-8366-9f3a-ce9c" targetId="001a-9f15-b25b-b784" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="f8e2-982b-dc65-9be9" targetId="7dac-aa85-fc80-51d5" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="2f44-92da-46f8-619d" name="Pulse Bike Squad" points="136.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="de4c-b135-70a3-c87b" name="&lt; Pulse Bike Leader" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="8166-a3dd-75ec-ccde" name="&lt; Pulse Bike Leader Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="27d8-164a-139b-f635" targetId="cd4f-0ce9-a6a4-b34a" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="0179-fa9f-3b06-4db2" targetId="12f1-610b-0dc9-4732" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="5b9e-0f99-9282-7ef1" targetId="eafe-a83e-6cfd-0559" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="dd0f-496a-c08e-56b4" targetId="658c-b2dd-98f4-dafb" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="27e0-cc93-d2c1-3dec" targetId="9ed6-e3f2-8847-d7a2" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="8783-ed89-1004-1495" name="Pulse Bike Trooper" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="5664-48f1-1957-c3d8" targetId="34f9-12c5-7e7b-114c" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="1c5e-3cc6-d497-2644" targetId="12f1-610b-0dc9-4732" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="1318-0d29-4a43-dd78" targetId="eafe-a83e-6cfd-0559" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="0628-7b69-d134-8ece" targetId="658c-b2dd-98f4-dafb" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="2de5-7dde-c917-f126" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="eadf-8b1d-d337-25ad" name="&lt; Compactor Drone &gt;" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="16b9-1f19-f7e7-0da5" targetId="c87f-f5b0-1134-8ad9" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="221b-0c10-d482-195e" targetId="d776-f344-44a4-c41b" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <links>
-            <link id="ca55-43e4-8b73-294c" targetId="001a-9f15-b25b-b784" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="f96c-a56c-c07e-6da4" targetId="7dac-aa85-fc80-51d5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="0ecf-b9d9-f50e-90b3" targetId="651f-9469-74a5-505a" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers>
-        <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-          <conditions>
-            <condition parentId="roster" childId="0244-6cd5-9260-c12e" field="selections" type="equal to" value="1.0"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="7780-9268-8805-991a" name="Scout Probe Shard" points="0.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="275e-c158-8f26-53c9" name="&lt; Scout Probe" points="10.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="05b3-477e-3ab6-c2a4" targetId="56b9-5224-e0df-8218" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="f53b-8cb2-f46e-ec68" name="Senatex Command Squad" points="66.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="9217-51b5-1490-c20f" name="&lt; Senatex Commander" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="4845-6259-0e92-0f04" name="&lt; Senatex Commander Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="2d9d-8454-98ba-682e" name="Sling net ammo" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="a48c-1f8a-649a-6c31" hidden="false" targetId="c521-ffae-2a9d-88f9" type="selectionEntry">
                   <profiles/>
-                  <links/>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="6149-c82a-e122-2d99" targetId="a90a-fea5-107f-a019" linkType="entry">
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="e5ba-45ac-5c32-8928" targetId="9686-36fa-7ae7-f4dc" linkType="profile">
+                  <constraints/>
+                </entryLink>
+                <entryLink id="1f48-758b-70a2-1b46" hidden="false" targetId="1bc9-ce44-fdbe-ef90" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="c984-ceed-ca03-2965" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="be34-e860-46d0-d7e6" targetId="6c13-252f-55b8-4de9" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="c421-df4b-ccea-aa78" hidden="false" targetId="a8d9-6fae-a541-9f4f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="de1c-d5c3-afcd-f486" targetId="eafe-a83e-6cfd-0559" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="691a-aa46-2b4f-a09b" targetId="bf65-f7cb-1b50-d144" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="25b4-7c4e-e579-4fee" name="Strike Trooper" points="22.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="4d3d-b808-7a51-2ddb" targetId="6688-b331-6578-fb30" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="f7b9-5bbf-7725-846a" targetId="eafe-a83e-6cfd-0559" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="4ffe-2e60-ece1-d9c4" targetId="bf65-f7cb-1b50-d144" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="67f6-07bc-f0ba-b0bd" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="d30a-66b4-b1ee-5cdd" targetId="001a-9f15-b25b-b784" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="ead8-0218-98ae-8ddd" targetId="057e-2e8a-1952-9de0" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="5aef-5d71-d3a9-8546" targetId="9f16-5a27-44b5-7471" linkType="entry">
-              <modifiers>
-                <modifier type="set" field="points" value="6.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="f53b-8cb2-f46e-ec68" childId="25b4-7c4e-e579-4fee" field="selections" type="at least" value="4.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="f53b-8cb2-f46e-ec68" childId="25b4-7c4e-e579-4fee" field="selections" type="at least" value="3.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3440-9714-d7d3-3653" name="Mahran Vesh MV5 Combat Drone" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="model">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="a2f5-7c0a-21e5-7b0b" name="Senatex Phase Squad" points="32.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="3dd7-c3aa-50ca-26b2" name="Phase Trooper" points="20.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="7" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="c49a-cae5-0917-dff0" name="&lt; Weapon Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles/>
-          <links>
-            <link id="cfe4-65fc-7598-d48f" targetId="6688-b331-6578-fb30" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="3d5b-1da9-8a1e-fdff" targetId="bf65-f7cb-1b50-d144" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="333b-de0f-7f92-165d" targetId="eafe-a83e-6cfd-0559" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="da65-0727-324a-34da" name="Plasma Lance" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
           <rules/>
-          <profiles/>
-          <links>
-            <link id="73c1-5b5c-b994-a075" targetId="21a7-132d-6703-9ff6" linkType="entry">
+          <infoLinks>
+            <infoLink id="9c84-78ff-fad3-093b" hidden="false" targetId="eda1-434f-1771-a790" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="5ce3-0d5d-4909-be5b" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-          <links>
-            <link id="826e-6c50-646d-62a2" targetId="001a-9f15-b25b-b784" linkType="entry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5980-fadb-0d1a-8e4b" name="&lt; Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="1015-29dc-212b-dc4d" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-            <link id="482c-adc0-0ca1-f078" targetId="9f16-5a27-44b5-7471" linkType="entry">
+              <constraints/>
+            </entryLink>
+            <entryLink id="5087-2dc6-723c-788e" hidden="false" targetId="2750-e65f-4c66-8235" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="4ea5-d717-39c9-e705" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="91d2-c0ae-c028-4591" name="&lt; Weapon Drone Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="fb98-64e6-ce83-57f9" name="&lt; Weapon Option &gt;" hidden="false" collective="false" defaultSelectionEntryId="d8ef-55c7-2efb-ec04">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="6062-8f75-90de-9604" hidden="false" targetId="69d9-b84f-3c40-15fb" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="d0f0-9069-c124-7cd2" hidden="false" targetId="80bf-613e-52b4-f160" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="d8ef-55c7-2efb-ec04" hidden="false" targetId="3dfc-49e9-adcb-ae48" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="04e7-e796-57e1-9c2e" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="7587-847d-9f8d-31dd" hidden="false" targetId="a8d9-6fae-a541-9f4f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="ad84-1f7d-5b85-ad4a" hidden="false" targetId="e16f-acd1-265c-07f9" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="7d08-c97c-53ca-06ab" hidden="false" targetId="c74e-2993-3474-7869" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="229.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fcb7-7abc-470a-26fe" name="Medi-Probe Shard" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="c7bd-920e-b6e5-ef99" name="&lt; Medi-probe" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="d758-744a-7ac4-7804" hidden="false" targetId="078e-4753-3545-ba51" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0d09-f1bc-5547-135f" name="Nano Probe Net Shard" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="increment" field="maxInForce" value="1.0">
+          <repeats>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3e3-761c-74f3-d2f2" repeats="1"/>
+          </repeats>
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3e3-761c-74f3-d2f2" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="34f8-26e7-c193-56eb" name="Nano Probe" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="ecb4-f327-4797-5d94" hidden="false" targetId="16bf-fee9-f1bf-8600" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6429-1b89-b557-736b" name="NuHu Senatexis" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="6fd9-afd5-d70f-d751" hidden="false" targetId="41d1-a002-0258-c407" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ae11-f605-d815-9109" name="&lt; Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="6fd3-49ff-c60c-3624" hidden="false" targetId="f095-7ba3-b868-32de" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="bb6a-48bd-2cf1-f430" hidden="false" targetId="057e-2e8a-1952-9de0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="775b-177d-e6ac-c3ac" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="2523-96e0-03f8-2625" hidden="false" targetId="5343-3c10-ccc3-0233" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="1133-9cc8-d005-ca82" hidden="false" targetId="a2e9-2b00-2191-a410" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="e3c8-4234-d63f-b52c" hidden="false" targetId="2f22-37fa-4076-d255" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="b702-73ca-4a1f-e0f5" hidden="false" targetId="c7a8-840b-096e-e2b8" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="174.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0244-6cd5-9260-c12e" name="Pulse Bike Command Squad" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="fa12-b792-1fff-89e3" name="&lt; Pulse Bike Commander" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="5cac-dbde-7763-5ddd" hidden="false" targetId="9286-cbf7-0641-5ce1" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="ce12-0c6b-11e5-f498" name="&lt; Pulse Bike Commander Options &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="bd12-7ad6-eb09-08ba" hidden="false" targetId="a90a-fea5-107f-a019" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="c8d2-d4de-e467-c706" hidden="false" targetId="12f1-610b-0dc9-4732" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="77c5-7b49-1b1a-443b" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="ea21-ecb8-ce22-00d3" hidden="false" targetId="658c-b2dd-98f4-dafb" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8b1d-c9da-076d-d08e" name="Pulse Bike Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="5f70-3d2c-69d6-3b63" hidden="false" targetId="34f9-12c5-7e7b-114c" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="3ad9-f6de-2222-14d7" hidden="false" targetId="12f1-610b-0dc9-4732" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="89fc-31e3-8d85-5d84" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="18db-e7fa-3661-289b" hidden="false" targetId="658c-b2dd-98f4-dafb" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="aba9-6548-4d89-9d71" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="01c1-76ad-1e19-2f22" name="&lt; Compactor Drone &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="7e3a-171d-c362-06f0" hidden="false" targetId="c87f-f5b0-1134-8ad9" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="792d-6942-fc08-f58a" hidden="false" targetId="d776-f344-44a4-c41b" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="ffb4-8366-9f3a-ce9c" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="f8e2-982b-dc65-9be9" hidden="false" targetId="7dac-aa85-fc80-51d5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="168.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2f44-92da-46f8-619d" name="Pulse Bike Squad" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="hidden" value="false">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0244-6cd5-9260-c12e" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="de4c-b135-70a3-c87b" name="&lt; Pulse Bike Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="27e0-cc93-d2c1-3dec" hidden="false" targetId="9ed6-e3f2-8847-d7a2" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="8166-a3dd-75ec-ccde" name="&lt; Pulse Bike Leader Options &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="27d8-164a-139b-f635" hidden="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="0179-fa9f-3b06-4db2" hidden="false" targetId="12f1-610b-0dc9-4732" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="5b9e-0f99-9282-7ef1" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="dd0f-496a-c08e-56b4" hidden="false" targetId="658c-b2dd-98f4-dafb" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8783-ed89-1004-1495" name="Pulse Bike Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="5664-48f1-1957-c3d8" hidden="false" targetId="34f9-12c5-7e7b-114c" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="1c5e-3cc6-d497-2644" hidden="false" targetId="12f1-610b-0dc9-4732" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="1318-0d29-4a43-dd78" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="0628-7b69-d134-8ece" hidden="false" targetId="658c-b2dd-98f4-dafb" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2de5-7dde-c917-f126" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="eadf-8b1d-d337-25ad" name="&lt; Compactor Drone &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="16b9-1f19-f7e7-0da5" hidden="false" targetId="c87f-f5b0-1134-8ad9" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="221b-0c10-d482-195e" hidden="false" targetId="d776-f344-44a4-c41b" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="ca55-43e4-8b73-294c" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="f96c-a56c-c07e-6da4" hidden="false" targetId="7dac-aa85-fc80-51d5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="0ecf-b9d9-f50e-90b3" hidden="false" targetId="651f-9469-74a5-505a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="136.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7780-9268-8805-991a" name="Scout Probe Shard" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="275e-c158-8f26-53c9" name="&lt; Scout Probe" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="05b3-477e-3ab6-c2a4" hidden="false" targetId="56b9-5224-e0df-8218" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f53b-8cb2-f46e-ec68" name="Senatex Command Squad" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="9217-51b5-1490-c20f" name="&lt; Senatex Commander" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="e5ba-45ac-5c32-8928" hidden="false" targetId="9686-36fa-7ae7-f4dc" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="4845-6259-0e92-0f04" name="&lt; Senatex Commander Options &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <selectionEntries>
+                <selectionEntry id="2d9d-8454-98ba-682e" name="Sling net ammo" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="6149-c82a-e122-2d99" hidden="false" targetId="a90a-fea5-107f-a019" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="be34-e860-46d0-d7e6" hidden="false" targetId="6c13-252f-55b8-4de9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="de1c-d5c3-afcd-f486" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="691a-aa46-2b4f-a09b" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="25b4-7c4e-e579-4fee" name="Strike Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="4d3d-b808-7a51-2ddb" hidden="false" targetId="6688-b331-6578-fb30" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="f7b9-5bbf-7725-846a" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="4ffe-2e60-ece1-d9c4" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="22.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="67f6-07bc-f0ba-b0bd" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="d30a-66b4-b1ee-5cdd" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="ead8-0218-98ae-8ddd" hidden="false" targetId="057e-2e8a-1952-9de0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="5aef-5d71-d3a9-8546" hidden="false" targetId="9f16-5a27-44b5-7471" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
-                <modifier type="set" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="set" field="points" value="6.0">
+                  <repeats/>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="a2f5-7c0a-21e5-7b0b" incrementChildId="3dd7-c3aa-50ca-26b2" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats/>
                   <conditions>
-                    <condition parentId="a2f5-7c0a-21e5-7b0b" childId="3dd7-c3aa-50ca-26b2" field="selections" type="at least" value="5.0"/>
+                    <condition field="selections" scope="f53b-8cb2-f46e-ec68" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="25b4-7c4e-e579-4fee" type="atLeast"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats/>
                   <conditions>
-                    <condition parentId="a2f5-7c0a-21e5-7b0b" childId="3dd7-c3aa-50ca-26b2" field="selections" type="at least" value="6.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="a2f5-7c0a-21e5-7b0b" childId="3dd7-c3aa-50ca-26b2" field="selections" type="at least" value="7.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="a2f5-7c0a-21e5-7b0b" childId="da65-0727-324a-34da" field="selections" type="at least" value="1.0"/>
+                    <condition field="selections" scope="f53b-8cb2-f46e-ec68" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="25b4-7c4e-e579-4fee" type="atLeast"/>
                   </conditions>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-            </link>
-            <link id="d201-587c-ae9f-ac75" targetId="651f-9469-74a5-505a" linkType="entry">
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="66.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a2f5-7c0a-21e5-7b0b" name="Senatex Phase Squad" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="3dd7-c3aa-50ca-26b2" name="Phase Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="cfe4-65fc-7598-d48f" hidden="false" targetId="6688-b331-6578-fb30" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="b1e3-2d2a-8b67-fc51" name="Leader" defaultEntryId="f0c2-69ee-8b90-7528" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="f0c2-69ee-8b90-7528" name="&lt; Strike Leader" points="0.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups>
-                <entryGroup id="53a6-45f6-5682-c4e8" name="&lt; Strike Leader Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries>
-                    <entry id="80e9-9314-55b5-7258" name="Sling net ammo" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                      <entries/>
-                      <entryGroups/>
-                      <modifiers/>
-                      <rules/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="3d5b-1da9-8a1e-fdff" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="333b-de0f-7f92-165d" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="da65-0727-324a-34da" name="Plasma Lance" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="73c1-5b5c-b994-a075" hidden="false" targetId="21a7-132d-6703-9ff6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="3.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5ce3-0d5d-4909-be5b" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="826e-6c50-646d-62a2" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="482c-adc0-0ca1-f078" hidden="false" targetId="9f16-5a27-44b5-7471" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="a2f5-7c0a-21e5-7b0b" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3dd7-c3aa-50ca-26b2" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="a2f5-7c0a-21e5-7b0b" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3dd7-c3aa-50ca-26b2" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="a2f5-7c0a-21e5-7b0b" value="7.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3dd7-c3aa-50ca-26b2" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="a2f5-7c0a-21e5-7b0b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="da65-0727-324a-34da" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="d201-587c-ae9f-ac75" hidden="false" targetId="651f-9469-74a5-505a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="b1e3-2d2a-8b67-fc51" name="Leader" hidden="false" collective="false" defaultSelectionEntryId="f0c2-69ee-8b90-7528">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f0c2-69ee-8b90-7528" name="&lt; Strike Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="68ed-3fd5-b951-fe6f" hidden="false" targetId="af6e-dcdb-77a5-b67e" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="53a6-45f6-5682-c4e8" name="&lt; Strike Leader Options &gt;" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <selectionEntries>
+                    <selectionEntry id="80e9-9314-55b5-7258" name="Sling net ammo" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
                       <profiles/>
-                      <links/>
-                    </entry>
-                  </entries>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="4631-7558-0869-977f" targetId="cd4f-0ce9-a6a4-b34a" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-              </entryGroups>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="eb5d-a6e4-347d-da46" targetId="bf65-f7cb-1b50-d144" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="b5e3-8a48-3fba-2582" targetId="eafe-a83e-6cfd-0559" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="40dd-425c-09d9-342d" targetId="6c13-252f-55b8-4de9" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="68ed-3fd5-b951-fe6f" targetId="af6e-dcdb-77a5-b67e" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="b8a7-06c0-e922-02c2" name="Senatex Support Team" points="0.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="00bb-ced5-3641-b54c" name="Phase Trooper" points="15.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="41f9-49bf-1fb6-3278" targetId="6688-b331-6578-fb30" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="9523-c45f-ae8e-f7f8" targetId="bf65-f7cb-1b50-d144" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="51a8-2e2a-8c37-d728" targetId="2f22-37fa-4076-d255" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="8dc3-d26a-9d90-5bf3" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="3154-474d-e038-f888" targetId="001a-9f15-b25b-b784" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="34c8-92d1-548b-d72e" name="Weapon" defaultEntryId="5ca6-b792-5b22-8784" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="5ca6-b792-5b22-8784" targetId="afc8-4f62-e1e2-1e4c" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="2183-f7dc-0030-ca25" targetId="3dfc-49e9-adcb-ae48" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="45.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="2fa1-035d-c0c1-e653" name="Target Probe Shard" points="0.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="70f6-51e9-f4f6-761f" name="&lt; Target Probe" points="5.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="ec43-8043-3ccc-fe21" targetId="9ce3-1277-65a2-7ab0" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="c4d4-9418-6246-d85d" name="Tograh MV2 Transporter Drone " points="194.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="model" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="288e-be87-ca44-03e8" name="&lt; Transporter Drone" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="87f0-50e3-da01-55f0" targetId="1aa8-c7f2-fa2d-324a" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="460e-6cab-a7b9-878c" name="&lt; Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="9543-75e4-e4b2-ca03" targetId="001a-9f15-b25b-b784" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="03eb-ebb9-cdf3-ec98" targetId="3ac2-e4a6-9011-4985" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="b6d4-1bbf-8e0d-d2ac" targetId="5ed8-6bd4-d0f7-d7f0" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="c909-6003-f9c2-386e" name="&lt; Transporter Drone Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="daf1-967b-4024-7ec8" targetId="8c55-0529-22ab-3fa6" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="e50e-ac32-0154-fc96" targetId="a8d9-6fae-a541-9f4f" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="fb4e-c4f1-715d-c497" targetId="c74e-2993-3474-7869" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="a82b-95e0-b4e1-14fc" name="Tsan Ra Phase Squad" points="0.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="a70a-f477-4d54-af31" name="Tsan Trooper" points="27.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="c744-bf9b-df2c-c292" targetId="0c0e-7741-31cf-edf9" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="666b-8a2f-c33c-7b17" targetId="bf65-f7cb-1b50-d144" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="840d-bc4c-6ce5-20e0" targetId="86a3-8659-018c-f8a1" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="bb3b-c728-9ab4-049d" name="Unit Options" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="be29-fbfe-358b-6a61" targetId="001a-9f15-b25b-b784" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="80ba-4bd8-0948-31eb" targetId="9f16-5a27-44b5-7471" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="a82b-95e0-b4e1-14fc" childId="a70a-f477-4d54-af31" field="selections" type="at least" value="3.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="a82b-95e0-b4e1-14fc" childId="abe0-9a11-c0cf-025a" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="a82b-95e0-b4e1-14fc" childId="a70a-f477-4d54-af31" field="selections" type="at least" value="2.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="a82b-95e0-b4e1-14fc" childId="a70a-f477-4d54-af31" field="selections" type="at least" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="a82b-95e0-b4e1-14fc" childId="a70a-f477-4d54-af31" field="selections" type="at least" value="4.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="88e2-f4ed-6791-12a6" targetId="651f-9469-74a5-505a" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="541d-88e5-07fd-a7c4" name="Leader" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="abe0-9a11-c0cf-025a" name="Tsan Leader" points="39.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups>
-                <entryGroup id="e2c1-0bb8-c914-f0a7" name="Tsan Leader Options" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries>
-                    <entry id="3c98-0948-998b-1f76" name="Sling net ammo" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                      <entries/>
-                      <entryGroups/>
-                      <modifiers/>
                       <rules/>
-                      <profiles/>
-                      <links/>
-                    </entry>
-                  </entries>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="0499-6b2b-9f0e-e301" targetId="cd4f-0ce9-a6a4-b34a" linkType="entry">
+                      <infoLinks/>
                       <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-              </entryGroups>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="f252-9b73-66a0-84c2" targetId="bf65-f7cb-1b50-d144" linkType="entry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                      </constraints>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="5.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="4631-7558-0869-977f" hidden="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="eb5d-a6e4-347d-da46" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-                <link id="d024-bd76-05d9-46f0" targetId="e480-7c4e-fa39-3a68" linkType="profile">
+                  <constraints/>
+                </entryLink>
+                <entryLink id="b5e3-8a48-3fba-2582" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-                <link id="5317-a3d7-5287-fb45" targetId="86a3-8659-018c-f8a1" linkType="entry">
+                  <constraints/>
+                </entryLink>
+                <entryLink id="40dd-425c-09d9-342d" hidden="false" targetId="6c13-252f-55b8-4de9" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-                <link id="f607-7026-ae69-f1bc" targetId="6c13-252f-55b8-4de9" linkType="entry">
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="32.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b8a7-06c0-e922-02c2" name="Senatex Support Team" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="00bb-ced5-3641-b54c" name="Phase Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="41f9-49bf-1fb6-3278" hidden="false" targetId="6688-b331-6578-fb30" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="9523-c45f-ae8e-f7f8" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="51a8-2e2a-8c37-d728" hidden="false" targetId="2f22-37fa-4076-d255" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="8dc3-d26a-9d90-5bf3" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="3154-474d-e038-f888" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="34c8-92d1-548b-d72e" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="5ca6-b792-5b22-8784">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="5ca6-b792-5b22-8784" hidden="false" targetId="afc8-4f62-e1e2-1e4c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="2183-f7dc-0030-ca25" hidden="false" targetId="3dfc-49e9-adcb-ae48" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="45.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2fa1-035d-c0c1-e653" name="Target Probe Shard" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="70f6-51e9-f4f6-761f" name="&lt; Target Probe" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="ec43-8043-3ccc-fe21" hidden="false" targetId="9ce3-1277-65a2-7ab0" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c4d4-9418-6246-d85d" name="Tograh MV2 Transporter Drone " hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="288e-be87-ca44-03e8" name="&lt; Transporter Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="87f0-50e3-da01-55f0" hidden="false" targetId="1aa8-c7f2-fa2d-324a" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="460e-6cab-a7b9-878c" name="&lt; Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="9543-75e4-e4b2-ca03" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="03eb-ebb9-cdf3-ec98" hidden="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="b6d4-1bbf-8e0d-d2ac" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="c909-6003-f9c2-386e" name="&lt; Transporter Drone Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="daf1-967b-4024-7ec8" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="e50e-ac32-0154-fc96" hidden="false" targetId="a8d9-6fae-a541-9f4f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="fb4e-c4f1-715d-c497" hidden="false" targetId="c74e-2993-3474-7869" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="194.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a82b-95e0-b4e1-14fc" name="Tsan Ra Phase Squad" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="a70a-f477-4d54-af31" name="Tsan Trooper" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="c744-bf9b-df2c-c292" hidden="false" targetId="0c0e-7741-31cf-edf9" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="666b-8a2f-c33c-7b17" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="840d-bc4c-6ce5-20e0" hidden="false" targetId="86a3-8659-018c-f8a1" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="27.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="bb3b-c728-9ab4-049d" name="Unit Options" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="be29-fbfe-358b-6a61" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="80ba-4bd8-0948-31eb" hidden="false" targetId="9f16-5a27-44b5-7471" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="a82b-95e0-b4e1-14fc" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a70a-f477-4d54-af31" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="a82b-95e0-b4e1-14fc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="abe0-9a11-c0cf-025a" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="a82b-95e0-b4e1-14fc" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a70a-f477-4d54-af31" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="a82b-95e0-b4e1-14fc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a70a-f477-4d54-af31" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="a82b-95e0-b4e1-14fc" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a70a-f477-4d54-af31" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="88e2-f4ed-6791-12a6" hidden="false" targetId="651f-9469-74a5-505a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="541d-88e5-07fd-a7c4" name="Leader" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="abe0-9a11-c0cf-025a" name="Tsan Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="d024-bd76-05d9-46f0" hidden="false" targetId="e480-7c4e-fa39-3a68" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-  </entries>
-  <rules/>
-  <links/>
-  <sharedEntries>
-    <entry id="e745-6ace-c0d4-6e35" name="AG Chute (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="3ac2-e4a6-9011-4985" name="Batter Drone" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="2750-e65f-4c66-8235" name="Batter Drone (2)" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="b63d-0e1c-d14a-c3e4" name="Camo Drone " points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="c87f-f5b0-1134-8ad9" name="Compactor Drone" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="d776-f344-44a4-c41b" name="Compactor Drone with Compacted Plasma Cannon" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="b2e8-9d64-9d68-23e5" targetId="ffe9-0b4e-fc35-d442" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="c521-ffae-2a9d-88f9" name="Compression Bombard" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="a79e-c4ad-b89d-ac26" targetId="a854-0768-aa9e-8d94" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="6ded-5798-dd23-8e6f" name="Compression Cannon" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="80bf-613e-52b4-f160" name="Compression Cannon" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="f482-b1f7-5e3a-1960" name="Fractal Bombard" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="9156-5e49-d0a8-7993" targetId="cfed-0e3a-38c7-9618" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="90ca-6c03-a803-a140" name="Fractal Cannon" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="bc22-c5b0-170a-0ca8" targetId="e262-8ce4-a7d5-4d81" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="69d9-b84f-3c40-15fb" name="Fractal Cannon" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="4a79-2c10-c161-2234" targetId="e262-8ce4-a7d5-4d81" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="5343-3c10-ccc3-0233" name="Gun Drone (2)" points="14.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="c7a8-840b-096e-e2b8" name="IMTeL Stave (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="41bd-5499-889a-ab16" name="Leader" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="cd4f-0ce9-a6a4-b34a" name="Leader 2" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="a90a-fea5-107f-a019" name="Leader 3" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="9e56-0965-ea32-7ff4" name="Leader 3" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="eb71-6245-efd5-67c9" name="Mag Mortar" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="0e6a-0256-18e1-20af" name="&lt; Munition &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="a356-4661-a11e-41b8" name="Scrambler" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+                </infoLink>
+              </infoLinks>
               <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-            <entry id="a24b-a381-fb00-eb9f" name="Arc" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-            <entry id="3925-0866-3aea-e356" name="Blur" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-            <entry id="0afe-04ff-398b-3496" name="Scoot" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-            <entry id="5271-6bc1-1ad7-e9ba" name="Net " points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-            <entry id="1cd3-e444-8b62-dc9b" name="All" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-            <entry id="4d2c-7d84-fe17-0c8f" name="Grip" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-          </entries>
-          <entryGroups/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="e2c1-0bb8-c914-f0a7" name="Tsan Leader Options" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <selectionEntries>
+                    <selectionEntry id="3c98-0948-998b-1f76" name="Sling net ammo" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                      </constraints>
+                      <selectionEntries/>
+                      <selectionEntryGroups/>
+                      <entryLinks/>
+                      <costs>
+                        <cost name="pts" costTypeId="points" value="5.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="0499-6b2b-9f0e-e301" hidden="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <constraints/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="f252-9b73-66a0-84c2" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="5317-a3d7-5287-fb45" hidden="false" targetId="86a3-8659-018c-f8a1" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="f607-7026-ae69-f1bc" hidden="false" targetId="6c13-252f-55b8-4de9" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="39.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <entryLinks>
+    <entryLink id="c042-2f1c-a169-12cb" name="New EntryLink" hidden="false" targetId="529a-3e2a-4bd5-5e5f" type="selectionEntry" categoryEntryId="50ba-cf77-3941-189c">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </entryLink>
+  </entryLinks>
+  <sharedSelectionEntries>
+    <selectionEntry id="e745-6ace-c0d4-6e35" name="AG Chute (E)" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3ac2-e4a6-9011-4985" name="Batter Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2750-e65f-4c66-8235" name="Batter Drone (2)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b63d-0e1c-d14a-c3e4" name="Camo Drone " hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c87f-f5b0-1134-8ad9" name="Compactor Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d776-f344-44a4-c41b" name="Compactor Drone with Compacted Plasma Cannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="b2e8-9d64-9d68-23e5" hidden="false" targetId="ffe9-0b4e-fc35-d442" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c521-ffae-2a9d-88f9" name="Compression Bombard" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="9df9-40f7-3d08-b560" targetId="5ba2-ac85-01a5-31be" linkType="profile">
+      <rules/>
+      <infoLinks>
+        <infoLink id="a79e-c4ad-b89d-ac26" hidden="false" targetId="a854-0768-aa9e-8d94" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="057e-2e8a-1952-9de0" name="Medi-Drone" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6ded-5798-dd23-8e6f" name="Compression Cannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="a2e9-2b00-2191-a410" name="Nano Drone (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="80bf-613e-52b4-f160" name="Compression Cannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="bf65-f7cb-1b50-d144" name="Phase Armour (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f482-b1f7-5e3a-1960" name="Fractal Bombard" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="12f1-610b-0dc9-4732" name="Phase Armour Boost (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="9156-5e49-d0a8-7993" hidden="false" targetId="cfed-0e3a-38c7-9618" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="90ca-6c03-a803-a140" name="Fractal Cannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="9443-effe-72e1-2f51" name="Phase Rifle" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks>
+        <infoLink id="bc22-c5b0-170a-0ca8" hidden="false" targetId="e262-8ce4-a7d5-4d81" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="69d9-b84f-3c40-15fb" name="Fractal Cannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="4a79-2c10-c161-2234" hidden="false" targetId="e262-8ce4-a7d5-4d81" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5343-3c10-ccc3-0233" name="Gun Drone (2)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="14.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c7a8-840b-096e-e2b8" name="IMTeL Stave (E)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="41bd-5499-889a-ab16" name="Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cd4f-0ce9-a6a4-b34a" name="Leader 2" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a90a-fea5-107f-a019" name="Leader 3" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9e56-0965-ea32-7ff4" name="Leader 3" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eb71-6245-efd5-67c9" name="Mag Mortar" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="9df9-40f7-3d08-b560" hidden="false" targetId="5ba2-ac85-01a5-31be" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0e6a-0256-18e1-20af" name="&lt; Munition &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="a356-4661-a11e-41b8" name="Scrambler" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a24b-a381-fb00-eb9f" name="Arc" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3925-0866-3aea-e356" name="Blur" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0afe-04ff-398b-3496" name="Scoot" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5271-6bc1-1ad7-e9ba" name="Net " hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1cd3-e444-8b62-dc9b" name="All" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4d2c-7d84-fe17-0c8f" name="Grip" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="057e-2e8a-1952-9de0" name="Medi-Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a2e9-2b00-2191-a410" name="Nano Drone (E)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bf65-f7cb-1b50-d144" name="Phase Armour (E)" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="12f1-610b-0dc9-4732" name="Phase Armour Boost (E)" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9443-effe-72e1-2f51" name="Phase Rifle" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="a32c-5b2d-c145-c471" profileTypeId="ecae-8ac8-2c13-0dd3" name="Phase Rifle (E)" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="No Cover, RF D6 Fire Only, Concentrated Fire "/>
-          </characteristics>
+        <profile id="a32c-5b2d-c145-c471" name="Phase Rifle (E)" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="No Cover, RF D6 Fire Only, Concentrated Fire "/>
+          </characteristics>
         </profile>
       </profiles>
-      <links/>
-    </entry>
-    <entry id="4813-1c77-dd1e-605e" name="Phase Sniper" points="52.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4813-1c77-dd1e-605e" name="Phase Sniper" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
-        <profile id="bd27-bc1d-7b09-21f8" profileTypeId="1650-77b3-10d1-6406" name="Phase Sniper" hidden="false">
-          <characteristics>
-            <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-            <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="8"/>
-            <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-            <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5 (7)"/>
-            <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-            <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-            <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special"/>
-          </characteristics>
+        <profile id="bd27-bc1d-7b09-21f8" name="Phase Sniper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+            <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="8"/>
+            <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+            <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5 (7)"/>
+            <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+            <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+            <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+          </characteristics>
         </profile>
       </profiles>
-      <links/>
-    </entry>
-    <entry id="a8d9-6fae-a541-9f4f" name="Phaseshift Shield" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
       <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="1bc9-ce44-fdbe-ef90" name="Plasma Bombard (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
+      <infoLinks/>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="52.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a8d9-6fae-a541-9f4f" name="Phaseshift Shield" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="c3b5-10fe-6527-f82f" targetId="581f-ff61-2525-a4b4" linkType="profile">
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1bc9-ce44-fdbe-ef90" name="Plasma Bombard (E)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="c3b5-10fe-6527-f82f" hidden="false" targetId="581f-ff61-2525-a4b4" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="10e6-b49c-4401-a1cd" name="Plasma Cannon" points="35.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="10e6-b49c-4401-a1cd" name="Plasma Cannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="d5c2-2c99-c6f0-8b8e" targetId="ffe9-0b4e-fc35-d442" linkType="profile">
+      <rules/>
+      <infoLinks>
+        <infoLink id="d5c2-2c99-c6f0-8b8e" hidden="false" targetId="ffe9-0b4e-fc35-d442" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="5a7d-3845-90ba-32eb" name="Plasma Cannon" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="35.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5a7d-3845-90ba-32eb" name="Plasma Cannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="96a4-2cce-4307-8f7b" targetId="ffe9-0b4e-fc35-d442" linkType="profile">
+      <rules/>
+      <infoLinks>
+        <infoLink id="96a4-2cce-4307-8f7b" hidden="false" targetId="ffe9-0b4e-fc35-d442" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="3dfc-49e9-adcb-ae48" name="Plasma Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3dfc-49e9-adcb-ae48" name="Plasma Cannon" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="95ff-37b4-8a0c-72d9" targetId="ffe9-0b4e-fc35-d442" linkType="profile">
+      <rules/>
+      <infoLinks>
+        <infoLink id="95ff-37b4-8a0c-72d9" hidden="false" targetId="ffe9-0b4e-fc35-d442" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="eafe-a83e-6cfd-0559" name="Plasma Carbine (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eafe-a83e-6cfd-0559" name="Plasma Carbine (E)" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="a184-65ab-58d9-e876" targetId="4c0f-9a37-2cd9-3f28" linkType="profile">
+      <rules/>
+      <infoLinks>
+        <infoLink id="a184-65ab-58d9-e876" hidden="false" targetId="4c0f-9a37-2cd9-3f28" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="fb83-6166-8d22-f6e2" targetId="acdc-a95e-a973-0c70" linkType="profile">
+        </infoLink>
+        <infoLink id="fb83-6166-8d22-f6e2" hidden="false" targetId="acdc-a95e-a973-0c70" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="86a3-8659-018c-f8a1" name="Plasma Duocarb" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="86a3-8659-018c-f8a1" name="Plasma Duocarb" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="dfdc-086a-a087-8104" targetId="2c41-c23c-7075-40ca" linkType="profile">
+      <rules/>
+      <infoLinks>
+        <infoLink id="dfdc-086a-a087-8104" hidden="false" targetId="2c41-c23c-7075-40ca" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="10de-9889-c5f1-0997" targetId="d34f-8025-31e7-54b8" linkType="profile">
+        </infoLink>
+        <infoLink id="10de-9889-c5f1-0997" hidden="false" targetId="d34f-8025-31e7-54b8" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="9f16-5a27-44b5-7471" name="Plasma Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9f16-5a27-44b5-7471" name="Plasma Grenades" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="ae6b-5d5f-8311-739e" targetId="9c65-fbf8-41f5-47be" linkType="profile">
+      <rules/>
+      <infoLinks>
+        <infoLink id="ae6b-5d5f-8311-739e" hidden="false" targetId="9c65-fbf8-41f5-47be" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="3dd4-3b5c-6873-e8f2" name="Plasma Lance" points="3.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3dd4-3b5c-6873-e8f2" name="Plasma Lance" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="7122-7702-547f-efa1" targetId="3376-2497-6739-ec52" linkType="profile">
+      <rules/>
+      <infoLinks>
+        <infoLink id="7122-7702-547f-efa1" hidden="false" targetId="3376-2497-6739-ec52" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="cc9d-d4f8-59db-be3c" targetId="db92-0aca-cde3-4d2d" linkType="profile">
+        </infoLink>
+        <infoLink id="cc9d-d4f8-59db-be3c" hidden="false" targetId="db92-0aca-cde3-4d2d" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="6d1e-8151-bd04-c247" targetId="19f6-390a-0d7c-8acb" linkType="profile">
+        </infoLink>
+        <infoLink id="6d1e-8151-bd04-c247" hidden="false" targetId="19f6-390a-0d7c-8acb" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="7dac-aa85-fc80-51d5" name="Plasma Lance (Bike)" points="2.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="3.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7dac-aa85-fc80-51d5" name="Plasma Lance (Bike)" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="95fd-068f-3527-ff41" targetId="3376-2497-6739-ec52" linkType="profile">
+      <rules/>
+      <infoLinks>
+        <infoLink id="95fd-068f-3527-ff41" hidden="false" targetId="3376-2497-6739-ec52" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="3303-cedc-7f35-8d8c" targetId="db92-0aca-cde3-4d2d" linkType="profile">
+        </infoLink>
+        <infoLink id="3303-cedc-7f35-8d8c" hidden="false" targetId="db92-0aca-cde3-4d2d" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="8d2b-05f1-d035-fca6" targetId="19f6-390a-0d7c-8acb" linkType="profile">
+        </infoLink>
+        <infoLink id="8d2b-05f1-d035-fca6" hidden="false" targetId="19f6-390a-0d7c-8acb" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="21a7-132d-6703-9ff6" name="Plasma Lance (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="2.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="21a7-132d-6703-9ff6" name="Plasma Lance (E)" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="eae9-4fdc-d5ae-f150" targetId="3376-2497-6739-ec52" linkType="profile">
+      <rules/>
+      <infoLinks>
+        <infoLink id="eae9-4fdc-d5ae-f150" hidden="false" targetId="3376-2497-6739-ec52" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="44f0-8649-d04a-801b" targetId="db92-0aca-cde3-4d2d" linkType="profile">
+        </infoLink>
+        <infoLink id="44f0-8649-d04a-801b" hidden="false" targetId="db92-0aca-cde3-4d2d" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-        <link id="e52e-5001-8214-66e6" targetId="19f6-390a-0d7c-8acb" linkType="profile">
+        </infoLink>
+        <infoLink id="e52e-5001-8214-66e6" hidden="false" targetId="19f6-390a-0d7c-8acb" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="62c2-106a-28aa-6cf5" name="Plasma Light Support Gun" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="62c2-106a-28aa-6cf5" name="Plasma Light Support Gun" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="7d58-9532-baa3-0f50" targetId="2940-5bc4-f1ca-b78c" linkType="profile">
+      <rules/>
+      <infoLinks>
+        <infoLink id="7d58-9532-baa3-0f50" hidden="false" targetId="2940-5bc4-f1ca-b78c" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="c74e-2993-3474-7869" name="Plasma Light Support Gun (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c74e-2993-3474-7869" name="Plasma Light Support Gun (E)" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="f652-56d4-3777-5ff0" targetId="2940-5bc4-f1ca-b78c" linkType="profile">
+      <rules/>
+      <infoLinks>
+        <infoLink id="f652-56d4-3777-5ff0" hidden="false" targetId="2940-5bc4-f1ca-b78c" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="2f22-37fa-4076-d255" name="Plasma Pistol (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2f22-37fa-4076-d255" name="Plasma Pistol (E)" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="f9da-9df8-37a5-92ff" targetId="23fa-052e-36db-13a3" linkType="profile">
+      <rules/>
+      <infoLinks>
+        <infoLink id="f9da-9df8-37a5-92ff" hidden="false" targetId="23fa-052e-36db-13a3" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="658c-b2dd-98f4-dafb" name="Pulse Bike with Twin Plasma Carbines" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="658c-b2dd-98f4-dafb" name="Pulse Bike with Twin Plasma Carbines" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="8c55-0529-22ab-3fa6" name="Self Repair" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8c55-0529-22ab-3fa6" name="Self Repair" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="5ed8-6bd4-d0f7-d7f0" name="Shield Drone" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5ed8-6bd4-d0f7-d7f0" name="Shield Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="de46-fbd5-d8f5-7454" name="Shield Drone " points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="de46-fbd5-d8f5-7454" name="Shield Drone " hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="f095-7ba3-b868-32de" name="Spotter Drone" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f095-7ba3-b868-32de" name="Spotter Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="001a-9f15-b25b-b784" name="Spotter Drone " points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="001a-9f15-b25b-b784" name="Spotter Drone " hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="e16f-acd1-265c-07f9" name="Spotter Drone (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false">
-      <entries/>
-      <entryGroups/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e16f-acd1-265c-07f9" name="Spotter Drone (E)" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="76e8-05d6-ff37-7205" name="Subverter Matrix" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="76e8-05d6-ff37-7205" name="Subverter Matrix" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="651f-9469-74a5-505a" name="Synchroniser Drone" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-      <rules/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="651f-9469-74a5-505a" name="Synchroniser Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links/>
-    </entry>
-    <entry id="e2b4-a034-c8ce-e376" name="X-Howitzer (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="4b18-33b8-84e0-5c2e" name="&lt; Munitions &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="c518-dc83-0b3b-d5d0" name="Scrambler" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e2b4-a034-c8ce-e376" name="X-Howitzer (E)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a4a1-491f-e195-4e0d" hidden="false" targetId="d0b6-5e2a-243d-b6ea" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="4b18-33b8-84e0-5c2e" name="&lt; Munitions &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="c518-dc83-0b3b-d5d0" name="Scrambler" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links>
-                <link id="4f17-4153-49e1-f6dc" targetId="0a09-eb21-a6c6-ad31" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="16ea-fdb9-4f62-644a" name="Arc" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
               <rules/>
-              <profiles/>
-              <links>
-                <link id="a50f-9b72-3685-ce99" targetId="4052-0eb4-88d7-cab0" linkType="rule">
+              <infoLinks>
+                <infoLink id="4f17-4153-49e1-f6dc" hidden="false" targetId="0a09-eb21-a6c6-ad31" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="d695-e1d4-70ad-ab44" name="Blur" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+                </infoLink>
+              </infoLinks>
               <modifiers/>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="16ea-fdb9-4f62-644a" name="Arc" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links>
-                <link id="e23c-a9f0-0a42-b621" targetId="1373-7755-bef3-50d6" linkType="rule">
+              <rules/>
+              <infoLinks>
+                <infoLink id="a50f-9b72-3685-ce99" hidden="false" targetId="4052-0eb4-88d7-cab0" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="8a3f-6c9d-84ab-7ff7" name="Scoot" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+                </infoLink>
+              </infoLinks>
               <modifiers/>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d695-e1d4-70ad-ab44" name="Blur" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links>
-                <link id="5e49-ad1b-3c02-c442" targetId="f2cb-33fd-610a-eda3" linkType="rule">
+              <rules/>
+              <infoLinks>
+                <infoLink id="e23c-a9f0-0a42-b621" hidden="false" targetId="1373-7755-bef3-50d6" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="f919-51c2-e1f0-fa33" name="Net" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+                </infoLink>
+              </infoLinks>
               <modifiers/>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8a3f-6c9d-84ab-7ff7" name="Scoot" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links>
-                <link id="5eb1-95d1-6117-e8d2" targetId="b81d-9f77-4c39-3887" linkType="rule">
+              <rules/>
+              <infoLinks>
+                <infoLink id="5e49-ad1b-3c02-c442" hidden="false" targetId="f2cb-33fd-610a-eda3" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="6967-929f-0dac-4c2e" name="Grip" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+                </infoLink>
+              </infoLinks>
               <modifiers/>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f919-51c2-e1f0-fa33" name="Net" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links>
-                <link id="a1ce-1d22-c641-6d9d" targetId="053b-a389-59c4-0e00" linkType="rule">
+              <rules/>
+              <infoLinks>
+                <infoLink id="5eb1-95d1-6117-e8d2" hidden="false" targetId="b81d-9f77-4c39-3887" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="f58f-7571-0bda-13b5" name="All" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
+                </infoLink>
+              </infoLinks>
               <modifiers/>
-              <rules/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6967-929f-0dac-4c2e" name="Grip" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
               <profiles/>
-              <links>
-                <link id="c003-c2b5-f035-4444" targetId="4052-0eb4-88d7-cab0" linkType="rule">
+              <rules/>
+              <infoLinks>
+                <infoLink id="a1ce-1d22-c641-6d9d" hidden="false" targetId="053b-a389-59c4-0e00" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-                <link id="2b2f-ad1c-6533-e2d7" targetId="1373-7755-bef3-50d6" linkType="rule">
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f58f-7571-0bda-13b5" name="All" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="c003-c2b5-f035-4444" hidden="false" targetId="4052-0eb4-88d7-cab0" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-                <link id="7cae-5b3f-2e71-6e33" targetId="053b-a389-59c4-0e00" linkType="rule">
+                </infoLink>
+                <infoLink id="2b2f-ad1c-6533-e2d7" hidden="false" targetId="1373-7755-bef3-50d6" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-                <link id="be82-4f21-bf38-ae68" targetId="b81d-9f77-4c39-3887" linkType="rule">
+                </infoLink>
+                <infoLink id="7cae-5b3f-2e71-6e33" hidden="false" targetId="053b-a389-59c4-0e00" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-                <link id="ebcd-e2be-4841-8020" targetId="f2cb-33fd-610a-eda3" linkType="rule">
+                </infoLink>
+                <infoLink id="be82-4f21-bf38-ae68" hidden="false" targetId="b81d-9f77-4c39-3887" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-                <link id="5bab-a371-53ed-88d2" targetId="0a09-eb21-a6c6-ad31" linkType="rule">
+                </infoLink>
+                <infoLink id="ebcd-e2be-4841-8020" hidden="false" targetId="f2cb-33fd-610a-eda3" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
                   <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
+                </infoLink>
+                <infoLink id="5bab-a371-53ed-88d2" hidden="false" targetId="0a09-eb21-a6c6-ad31" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="85bd-3565-8ecd-a94f" name="X-Howitzer (E)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
-      <links>
-        <link id="a4a1-491f-e195-4e0d" targetId="d0b6-5e2a-243d-b6ea" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="85bd-3565-8ecd-a94f" name="X-Howitzer (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="4473-5846-9144-3ed7" name="&lt; Munitions &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="869a-d024-f01b-902a" name="Scrambler" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="538e-8399-5fd9-972e" targetId="0a09-eb21-a6c6-ad31" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="09ad-e164-6041-3e77" name="Arc" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="c58d-a6d9-f53f-bf5d" targetId="4052-0eb4-88d7-cab0" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="aa49-b3f4-5d76-5b99" name="Blur" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="e8ea-4904-644f-2434" targetId="1373-7755-bef3-50d6" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="b9f0-d72f-1cf6-a855" name="Scoot" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="1eac-780b-e921-e0cf" targetId="f2cb-33fd-610a-eda3" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="a1b1-9170-9e10-fa54" name="Net" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="e95f-1bbe-70fb-e3cd" targetId="b81d-9f77-4c39-3887" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="b4ec-d02c-b3b1-e937" name="Grip" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="6e15-34d7-c75e-912d" targetId="053b-a389-59c4-0e00" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="6fb5-f33d-8fcc-5d00" name="All" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="4674-2dd7-fa1b-a44b" targetId="4052-0eb4-88d7-cab0" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="c46e-1126-4846-466d" targetId="1373-7755-bef3-50d6" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="b5e5-b58a-0bab-51af" targetId="053b-a389-59c4-0e00" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="4349-8848-6641-8a17" targetId="b81d-9f77-4c39-3887" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="af57-f563-f84f-2c9a" targetId="f2cb-33fd-610a-eda3" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="b5da-6f53-11d9-af5a" targetId="0a09-eb21-a6c6-ad31" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
       <rules/>
-      <profiles/>
-      <links>
-        <link id="9d54-86cf-f28d-a5ef" targetId="d0b6-5e2a-243d-b6ea" linkType="profile">
+      <infoLinks>
+        <infoLink id="9d54-86cf-f28d-a5ef" hidden="false" targetId="d0b6-5e2a-243d-b6ea" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="afc8-4f62-e1e2-1e4c" name="X-Launcher (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="c249-3049-66be-c18b" name="&lt; Munitions &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="855b-3877-638b-99e8" name="Scrambler" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="594f-82ff-5ad7-c68d" targetId="0a09-eb21-a6c6-ad31" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="cf1c-5cab-dced-a300" name="Arc" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="8bce-b783-3ffc-92aa" targetId="4052-0eb4-88d7-cab0" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="bed3-8a4c-71e0-9a86" name="Blur" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="9be8-c879-a109-2f53" targetId="1373-7755-bef3-50d6" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="7207-1027-8e26-6930" name="Scoot" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="9bd6-49f8-24e5-7631" targetId="f2cb-33fd-610a-eda3" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="9b37-d7f7-9bb7-6061" name="Net" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="d053-1be2-c8f4-3f6c" targetId="b81d-9f77-4c39-3887" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="f569-f291-bc3a-fa3a" name="Grip" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="3be2-c872-ad5c-35f7" targetId="053b-a389-59c4-0e00" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="a6d2-1391-22e8-008b" name="All" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="1741-ddc1-2f5f-3ff2" targetId="4052-0eb4-88d7-cab0" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="b229-c301-4b0d-2ccd" targetId="1373-7755-bef3-50d6" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="c3df-d0d2-6144-d3f9" targetId="053b-a389-59c4-0e00" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="ed17-cff8-54c6-cf4d" targetId="b81d-9f77-4c39-3887" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="ff70-9ddf-025e-0a2d" targetId="f2cb-33fd-610a-eda3" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="3125-0cd8-92ea-7904" targetId="0a09-eb21-a6c6-ad31" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="d588-2e56-e502-10ec" targetId="b984-90ae-a8e5-83c8" linkType="profile">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="4473-5846-9144-3ed7" name="&lt; Munitions &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="6c13-252f-55b8-4de9" name="X-Sling (E)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="869a-d024-f01b-902a" name="Scrambler" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="538e-8399-5fd9-972e" hidden="false" targetId="0a09-eb21-a6c6-ad31" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="09ad-e164-6041-3e77" name="Arc" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="c58d-a6d9-f53f-bf5d" hidden="false" targetId="4052-0eb4-88d7-cab0" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="aa49-b3f4-5d76-5b99" name="Blur" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="e8ea-4904-644f-2434" hidden="false" targetId="1373-7755-bef3-50d6" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b9f0-d72f-1cf6-a855" name="Scoot" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="1eac-780b-e921-e0cf" hidden="false" targetId="f2cb-33fd-610a-eda3" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a1b1-9170-9e10-fa54" name="Net" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="e95f-1bbe-70fb-e3cd" hidden="false" targetId="b81d-9f77-4c39-3887" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b4ec-d02c-b3b1-e937" name="Grip" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="6e15-34d7-c75e-912d" hidden="false" targetId="053b-a389-59c4-0e00" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6fb5-f33d-8fcc-5d00" name="All" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="4674-2dd7-fa1b-a44b" hidden="false" targetId="4052-0eb4-88d7-cab0" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="c46e-1126-4846-466d" hidden="false" targetId="1373-7755-bef3-50d6" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="b5e5-b58a-0bab-51af" hidden="false" targetId="053b-a389-59c4-0e00" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="4349-8848-6641-8a17" hidden="false" targetId="b81d-9f77-4c39-3887" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="af57-f563-f84f-2c9a" hidden="false" targetId="f2cb-33fd-610a-eda3" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="b5da-6f53-11d9-af5a" hidden="false" targetId="0a09-eb21-a6c6-ad31" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="afc8-4f62-e1e2-1e4c" name="X-Launcher (E)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d588-2e56-e502-10ec" hidden="false" targetId="b984-90ae-a8e5-83c8" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="2d1d-7464-b34a-31f5" targetId="7c13-1aa1-5557-6103" linkType="profile">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c249-3049-66be-c18b" name="&lt; Munitions &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-  </sharedEntries>
-  <sharedEntryGroups/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="855b-3877-638b-99e8" name="Scrambler" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="594f-82ff-5ad7-c68d" hidden="false" targetId="0a09-eb21-a6c6-ad31" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="cf1c-5cab-dced-a300" name="Arc" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="8bce-b783-3ffc-92aa" hidden="false" targetId="4052-0eb4-88d7-cab0" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="bed3-8a4c-71e0-9a86" name="Blur" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="9be8-c879-a109-2f53" hidden="false" targetId="1373-7755-bef3-50d6" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7207-1027-8e26-6930" name="Scoot" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="9bd6-49f8-24e5-7631" hidden="false" targetId="f2cb-33fd-610a-eda3" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9b37-d7f7-9bb7-6061" name="Net" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="d053-1be2-c8f4-3f6c" hidden="false" targetId="b81d-9f77-4c39-3887" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f569-f291-bc3a-fa3a" name="Grip" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="3be2-c872-ad5c-35f7" hidden="false" targetId="053b-a389-59c4-0e00" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a6d2-1391-22e8-008b" name="All" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="1741-ddc1-2f5f-3ff2" hidden="false" targetId="4052-0eb4-88d7-cab0" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="b229-c301-4b0d-2ccd" hidden="false" targetId="1373-7755-bef3-50d6" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="c3df-d0d2-6144-d3f9" hidden="false" targetId="053b-a389-59c4-0e00" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="ed17-cff8-54c6-cf4d" hidden="false" targetId="b81d-9f77-4c39-3887" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="ff70-9ddf-025e-0a2d" hidden="false" targetId="f2cb-33fd-610a-eda3" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="3125-0cd8-92ea-7904" hidden="false" targetId="0a09-eb21-a6c6-ad31" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6c13-252f-55b8-4de9" name="X-Sling (E)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="2d1d-7464-b34a-31f5" hidden="false" targetId="7c13-1aa1-5557-6103" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups/>
   <sharedRules>
-    <rule id="7680-b7ff-1ca0-9855" name="AG Chute" hidden="false" book="BtGoA" page="120">
-      <description>May make 2M move and shoot when given advance order. +1 Ag. Treat difficult ground as suspensored vehicle. </description>
+    <rule id="7680-b7ff-1ca0-9855" name="AG Chute" book="BtGoA" page="120" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>May make 2M move and shoot when given advance order. +1 Ag. Treat difficult ground as suspensored vehicle. </description>
     </rule>
-    <rule id="4052-0eb4-88d7-cab0" name="Arc" hidden="false" book="BtGoA" page="88">
+    <rule id="4052-0eb4-88d7-cab0" name="Arc" book="BtGoA" page="88" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Creates 3&quot; sink area. Affects any shooter attemping to draw LOS and shoot through the arc. Roll a D10 if LOS goes through - 1-5 the shot is normal, 6-10 the shot automatically misses. Make test before rolling Acc to hit. 
 
 OH shots are affected if the target is within 3&quot; of the marker. </description>
-      <modifiers/>
     </rule>
-    <rule id="178b-d746-0f1a-74ec" name="Batter Drone" hidden="false" book="BtGoA" page="110">
+    <rule id="178b-d746-0f1a-74ec" name="Batter Drone" book="BtGoA" page="110" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Projects curved shield as template - must be positioned with outer side facing away from drone, no part of template more than 5&quot; from drone base. Template may be repositioned any time unit receives an order die.
 
 Enemy units shooting through shield suffer -2 ACC. Models positioned inside the shield do not receive the -2 ACC protection. Troops shooting from the inside convex side of the shield do not suffer the ACC penalty. 
 
 No protection is offered for OH shots.</description>
-      <modifiers/>
     </rule>
-    <rule id="1cb7-4402-2f6c-b3cf" name="Blast D10" hidden="false" book="BtGoA">
+    <rule id="1cb7-4402-2f6c-b3cf" name="Blast D10" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Inflicts D10 hits on a successful shooting attack.</description>
-      <modifiers/>
     </rule>
-    <rule id="82bc-e8ec-5e5a-56d2" name="Blast D3" hidden="false" book="BtGoA">
+    <rule id="82bc-e8ec-5e5a-56d2" name="Blast D3" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Inflicts D3 hits on a successful shooting attack.</description>
-      <modifiers/>
     </rule>
-    <rule id="27db-c218-b60e-869b" name="Blast D4" hidden="false" book="BtGoA">
+    <rule id="27db-c218-b60e-869b" name="Blast D4" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Inflicts D4 hits on a successful shooting attack.</description>
-      <modifiers/>
     </rule>
-    <rule id="3934-2688-e509-dbc5" name="Blast D5" hidden="false" book="BtGoA">
+    <rule id="3934-2688-e509-dbc5" name="Blast D5" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Inflicts D5 hits on a successful shooting attack.</description>
-      <modifiers/>
     </rule>
-    <rule id="1373-7755-bef3-50d6" name="Blur" hidden="false" book="BtGoA" page="89">
-      <description>Any unit within 3&quot; reduces Acc by D3 each time it shoots. If within two or more blur markers, roll a D3 for each and take highest.</description>
+    <rule id="1373-7755-bef3-50d6" name="Blur" book="BtGoA" page="89" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>Any unit within 3&quot; reduces Acc by D3 each time it shoots. If within two or more blur markers, roll a D3 for each and take highest.</description>
     </rule>
     <rule id="5c9b-1bde-ee01-04a4" name="Command" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="b0ca-8e7d-d03f-f027" name="Fast" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="7bc9-5e98-2914-5abd" name="Follow" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="053b-a389-59c4-0e00" name="Grip" hidden="false" book="BtGoA" page="87">
+    <rule id="053b-a389-59c4-0e00" name="Grip" book="BtGoA" page="87" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Unit beginning its move within 3&quot; must take and pass an Ag test. If failed it may not move, if passed it can move half rate, failed on a 10 it takes a pin and cannot move.
 
 If a unit moves within 3&quot; it must take the Ag test as above. </description>
-      <modifiers/>
     </rule>
     <rule id="3c64-6022-a5f1-9c04" name="Hero" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="9d5f-b605-0d92-695d" name="HL Armor" hidden="false" book="BtGoA" page="93">
+    <rule id="9d5f-b605-0d92-695d" name="HL Armor" book="BtGoA" page="93" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Ranges of 10&quot; or less, +1 to Res. Ranges of greater than 10&quot; +2 Res. Against any Blast hits, +3 Res. </description>
-      <modifiers/>
     </rule>
-    <rule id="f62d-5e99-81f7-07dd" name="Inaccurate" hidden="false" book="BtGoA" page="70">
-      <description>Additional -1 Acc penalty.</description>
+    <rule id="f62d-5e99-81f7-07dd" name="Inaccurate" book="BtGoA" page="70" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>Additional -1 Acc penalty.</description>
     </rule>
     <rule id="a221-d53c-b4bd-b52c" name="Large" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="e441-c3a6-7d61-2c63" name="Leader" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="7850-89e7-bab8-86e9" name="Leader 2" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="05bb-4d34-70cd-25d2" name="Leader 3" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="d8dc-cf25-ef95-c94b" name="Limited Choice" hidden="false" book="">
+    <rule id="d8dc-cf25-ef95-c94b" name="Limited Choice" book="" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="2ff2-534c-34fe-b56b" name="Medi-Drone" hidden="false" book="BtGoA" page="113">
+    <rule id="2ff2-534c-34fe-b56b" name="Medi-Drone" book="BtGoA" page="113" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Can only attend humans - not machines or Skarks. Any friendly unit within 5&quot; may re-roll one failed Res test each time it is shot at, fights H2H, or otherwise suffers damage. Units within 5&quot; of more than one medi-drone may re-roll one failed Res test for each medi-drone. </description>
-      <modifiers/>
     </rule>
     <rule id="5565-ce10-1c78-1ee7" name="MOD2" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
     <rule id="8151-2e24-94ee-0477" name="MOD3" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="b81d-9f77-4c39-3887" name="Net" hidden="false" book="BtGoA" page="88">
+    <rule id="b81d-9f77-4c39-3887" name="Net" book="BtGoA" page="88" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Roll to hit as normal for a blast weapon. Target does not suffer blast damage, rather suffers pins:
 
 X-Launcher: D3+1 pin
@@ -2389,49 +4424,82 @@ X-Howitzer: D5+1 pin
 Mag Mortar: D10+1 pin
 
 Targets that would normally force an Acc re-roll suffer half the number of pins rounded down. Divide pins equally between two or more units as normal.</description>
-      <modifiers/>
     </rule>
     <rule id="4abc-52df-bbed-7b28" name="New Rule" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="fbb8-f81a-2985-1273" name="Plasma Fade" hidden="false" book="BtGoA" page="76">
+    <rule id="fbb8-f81a-2985-1273" name="Plasma Fade" book="BtGoA" page="76" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>On the Acc roll of a 10 to hit the shot is a miss and the unit goes down.</description>
-      <modifiers/>
     </rule>
-    <rule id="f2cb-33fd-610a-eda3" name="Scoot" hidden="false" book="BtGoA" page="88">
+    <rule id="f2cb-33fd-610a-eda3" name="Scoot" book="BtGoA" page="88" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Only affects infantry, mounted, weapon team, beast, and humongous beast, command, and bike mounted units with living crew. Affects scramble proof units. Any affected unit within 3&quot; canno tbe given any order except run or down. Cannot make any reaction apart from go down.</description>
-      <modifiers/>
     </rule>
-    <rule id="0a09-eb21-a6c6-ad31" name="Scrambler" hidden="false" book="BtGoA" page="88">
+    <rule id="0a09-eb21-a6c6-ad31" name="Scrambler" book="BtGoA" page="88" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Enemy units within 3&quot; that are not scramble proof it loses Reflex Armor, Hyperlight Armor, and Phase Armor along with any bonuses. Units in Phase Armor cannot use their armor to go down.
 
 Weapon Drone and vehicles have Res reduced by 2 within 3&quot;. Buddy drones cease to function if the unit is within 3&quot;. Probes can do nothing at all while marker is within 3&quot;. Penalties are not cumulative.</description>
-      <modifiers/>
     </rule>
     <rule id="3377-9408-33bb-6a02" name="Self Repair" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="1c4c-aaaf-0a08-e69e" name="Self Repair" hidden="false" book="BtGoA" page="137">
+    <rule id="1c4c-aaaf-0a08-e69e" name="Self Repair" book="BtGoA" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Give unit rally order. If no pins exist after order, may attempt one repair on  immobilisation or weapon. 1-5 = success, 6-10 failure. Success = that function is working again.</description>
-      <modifiers/>
     </rule>
-    <rule id="1b89-5e18-0f71-7dc5" name="Slingnet Ammo" hidden="false" book="BtGoA" page="112">
-      <description>Fired direct unless from Micro X Launcher. Targets hit suffer no damage but take +1 additional pin. Cannot affect units that cannot be pinned when hit.</description>
+    <rule id="1b89-5e18-0f71-7dc5" name="Slingnet Ammo" book="BtGoA" page="112" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>Fired direct unless from Micro X Launcher. Targets hit suffer no damage but take +1 additional pin. Cannot affect units that cannot be pinned when hit.</description>
     </rule>
     <rule id="7c88-64d4-50ad-2313" name="Slow" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="19d8-5c9a-2e1f-4d8e" name="Spotter Drone" hidden="false" book="BtGoA" page="114">
+    <rule id="19d8-5c9a-2e1f-4d8e" name="Spotter Drone" book="BtGoA" page="114" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Unit may re-roll one miss each time it shoots as long as drone has LOS to target. Units may fire OH using drone as spotter as long as it has LOS to target. 
 
 Spotter drones may spot through another spotter drone (within 20&quot;) with LOS to the target. Unit does not receive spotter re-roll as their spotter does not have LOS to target.</description>
-      <modifiers/>
     </rule>
     <rule id="ab37-33d8-41f3-7532" name="Transport 10" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="3f71-546f-6b34-b449" name="Weapon Drone" hidden="false" book="BtGoA" page="115">
+    <rule id="3f71-546f-6b34-b449" name="Weapon Drone" book="BtGoA" page="115" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Always measure to model, not base. Not allowed to assault. Never take a break test, however auto-break if suffer pins equal to their Co stat. If drone fails a Res test, roll on Weapon Drone Damage Chart.
 
 D10 Result:
@@ -2441,485 +4509,611 @@ D10 Result:
 4: Take D3 additional pins and go down. Weapon malfunction.
 5: Take D6 additional pins and take a break test - destroyed if failed, go down if passed.
 6-10: Destroyed</description>
-      <modifiers/>
     </rule>
   </sharedRules>
   <sharedProfiles>
-    <profile id="a854-0768-aa9e-8d94" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Bombard" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-50"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="150"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="9/7/5"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Cycle"/>
-      </characteristics>
+    <profile id="a854-0768-aa9e-8d94" name="Compression Bombard" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="fb4a-7317-0e7a-7278" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Cannon" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="7/4/2"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Cycle"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-50"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="150"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="9/7/5"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Cycle"/>
       </characteristics>
+    </profile>
+    <profile id="fb4a-7317-0e7a-7278" name="Compression Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="bed7-2549-f395-f271" profileTypeId="1650-77b3-10d1-6406" name="Drone Commander" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="7"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="8"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Command, Follow, Leader 2"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="7/4/2"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Cycle"/>
       </characteristics>
+    </profile>
+    <profile id="bed7-2549-f395-f271" name="Drone Commander" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="cfed-0e3a-38c7-9618" profileTypeId="ecae-8ac8-2c13-0dd3" name="Fractal Bombard" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="50"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="200"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3 +2 max 10"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="7"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="8"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Follow, Leader 2"/>
       </characteristics>
+    </profile>
+    <profile id="cfed-0e3a-38c7-9618" name="Fractal Bombard" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="e262-8ce4-a7d5-4d81" profileTypeId="ecae-8ac8-2c13-0dd3" name="Fractal Cannon" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2 +1 max 10"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="50"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="200"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3 +2 max 10"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock"/>
       </characteristics>
+    </profile>
+    <profile id="e262-8ce4-a7d5-4d81" name="Fractal Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="be8e-2c8f-8288-e92a" profileTypeId="1650-77b3-10d1-6406" name="Isorian Andhak SC2 Medium Support Drone" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="7"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="10"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="-"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2 +1 max 10"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock"/>
       </characteristics>
+    </profile>
+    <profile id="be8e-2c8f-8288-e92a" name="Isorian Andhak SC2 Medium Support Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="18f2-0352-9cf8-66a5" profileTypeId="1650-77b3-10d1-6406" name="Isorian Nhamak NC Light Support Drone" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="7"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="8"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="-"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="7"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="10"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
       </characteristics>
+    </profile>
+    <profile id="18f2-0352-9cf8-66a5" name="Isorian Nhamak NC Light Support Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="1c7c-b76a-8d9f-4405" profileTypeId="1650-77b3-10d1-6406" name="Kahloc KV Heavy Battle Drone" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="15"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="MOD3, Slow, Large"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="7"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="8"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
       </characteristics>
+    </profile>
+    <profile id="1c7c-b76a-8d9f-4405" name="Kahloc KV Heavy Battle Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="5ba2-ac85-01a5-31be" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Mortar" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OHx2, Blast D10, No Cover"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="15"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="MOD3, Slow, Large"/>
       </characteristics>
+    </profile>
+    <profile id="5ba2-ac85-01a5-31be" name="Mag Mortar" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="eda1-434f-1771-a790" profileTypeId="1650-77b3-10d1-6406" name="Mahran Vesh MV5 Combat Drone" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="13"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="MOD2, Large"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OHx2, Blast D10, No Cover"/>
       </characteristics>
+    </profile>
+    <profile id="eda1-434f-1771-a790" name="Mahran Vesh MV5 Combat Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="078e-4753-3545-ba51" profileTypeId="1650-77b3-10d1-6406" name="Medi-Probe" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="-"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="-"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="-"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="-"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Shard"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="13"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="MOD2, Large"/>
       </characteristics>
+    </profile>
+    <profile id="078e-4753-3545-ba51" name="Medi-Probe" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="16bf-fee9-f1bf-8600" profileTypeId="1650-77b3-10d1-6406" name="Nano Probe" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="-"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="-"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="-"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="-"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Shard"/>
       </characteristics>
+    </profile>
+    <profile id="16bf-fee9-f1bf-8600" name="Nano Probe" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="41d1-a002-0258-c407" profileTypeId="1650-77b3-10d1-6406" name="NuHu Senatexis" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="4"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="4(7)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="9"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Command, Hero, Follow, Leader 3"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
       </characteristics>
+    </profile>
+    <profile id="41d1-a002-0258-c407" name="NuHu Senatexis" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="af6e-dcdb-77a5-b67e" profileTypeId="1650-77b3-10d1-6406" name="Phase Leader" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(7)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Leader"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="4"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(7)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="9"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Hero, Follow, Leader 3"/>
       </characteristics>
+    </profile>
+    <profile id="af6e-dcdb-77a5-b67e" name="Phase Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers>
-        <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+        <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2">
+          <repeats/>
           <conditions>
-            <condition parentId="direct parent" childId="cd4f-0ce9-a6a4-b34a" field="selections" type="equal to" value="1.0"/>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cd4f-0ce9-a6a4-b34a" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
       </modifiers>
-    </profile>
-    <profile id="42f9-6fbf-5a4c-76c2" profileTypeId="ecae-8ac8-2c13-0dd3" name="Phase Rifle" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="No Cover, RF D6 Fire Only, Concentrated Fire "/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader"/>
       </characteristics>
+    </profile>
+    <profile id="42f9-6fbf-5a4c-76c2" name="Phase Rifle" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="6688-b331-6578-fb30" profileTypeId="1650-77b3-10d1-6406" name="Phase Trooper" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(7)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="-"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="No Cover, RF D6 Fire Only, Concentrated Fire "/>
       </characteristics>
+    </profile>
+    <profile id="6688-b331-6578-fb30" name="Phase Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="581f-ff61-2525-a4b4" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Bombard" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="50"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="200"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="7"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Plasma Fade"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
       </characteristics>
+    </profile>
+    <profile id="581f-ff61-2525-a4b4" name="Plasma Bombard" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="ffe9-0b4e-fc35-d442" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Cannon" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="6"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Plasma Fade"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="50"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="200"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="7"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Plasma Fade"/>
       </characteristics>
+    </profile>
+    <profile id="ffe9-0b4e-fc35-d442" name="Plasma Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="4c0f-9a37-2cd9-3f28" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Carbine - Scatter" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Plasma Fade"/>
       </characteristics>
+    </profile>
+    <profile id="4c0f-9a37-2cd9-3f28" name="Plasma Carbine - Scatter" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="acdc-a95e-a973-0c70" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Carbine - Single Shot" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2"/>
       </characteristics>
+    </profile>
+    <profile id="acdc-a95e-a973-0c70" name="Plasma Carbine - Single Shot" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="2c41-c23c-7075-40ca" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Duocarb - Scatter" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
       </characteristics>
+    </profile>
+    <profile id="2c41-c23c-7075-40ca" name="Plasma Duocarb - Scatter" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="d34f-8025-31e7-54b8" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Duocarb - Single Shot" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3"/>
       </characteristics>
+    </profile>
+    <profile id="d34f-8025-31e7-54b8" name="Plasma Duocarb - Single Shot" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="9c65-fbf8-41f5-47be" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Grenade" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec"/>
       </characteristics>
+    </profile>
+    <profile id="9c65-fbf8-41f5-47be" name="Plasma Grenade" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="92a3-aaae-bc24-0d2d" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Grenade Bandolier" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="-"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="-"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D4, Hazardous H2H"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
       </characteristics>
+    </profile>
+    <profile id="92a3-aaae-bc24-0d2d" name="Plasma Grenade Bandolier" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="3376-2497-6739-ec52" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Lance" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="4"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Choose Target, Inaccurate"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="-"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, Hazardous H2H"/>
       </characteristics>
+    </profile>
+    <profile id="3376-2497-6739-ec52" name="Plasma Lance - Lance" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="19f6-390a-0d7c-8acb" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Scatter" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="4"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Choose Target, Inaccurate"/>
       </characteristics>
+    </profile>
+    <profile id="19f6-390a-0d7c-8acb" name="Plasma Lance - Scatter" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="db92-0aca-cde3-4d2d" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Single Shot" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2"/>
       </characteristics>
+    </profile>
+    <profile id="db92-0aca-cde3-4d2d" name="Plasma Lance - Single Shot" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="2940-5bc4-f1ca-b78c" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Light Support Gun" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
       </characteristics>
+    </profile>
+    <profile id="2940-5bc4-f1ca-b78c" name="Plasma Light Support Gun" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="23fa-052e-36db-13a3" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Pistol" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="30"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3"/>
       </characteristics>
+    </profile>
+    <profile id="23fa-052e-36db-13a3" name="Plasma Pistol" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="9286-cbf7-0641-5ce1" profileTypeId="1650-77b3-10d1-6406" name="Pulse Bike Commander" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(8)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Command, Follow, Fast, Large, Leader 2"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
       </characteristics>
+    </profile>
+    <profile id="9286-cbf7-0641-5ce1" name="Pulse Bike Commander" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers>
-        <modifier type="set" field="3baa-9cfd-f273-822d" value="Command, Follow, Fast, Large, Leader 3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+        <modifier type="set" field="3baa-9cfd-f273-822d" value="Command, Follow, Fast, Large, Leader 3">
+          <repeats/>
           <conditions>
-            <condition parentId="direct parent" childId="bd12-7ad6-eb09-08ba" field="selections" type="equal to" value="1.0"/>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bd12-7ad6-eb09-08ba" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
       </modifiers>
-    </profile>
-    <profile id="9ed6-e3f2-8847-d7a2" profileTypeId="1650-77b3-10d1-6406" name="Pulse Bike Leader" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(8)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Fast, Large, Leader"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(8)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Follow, Fast, Large, Leader 2"/>
       </characteristics>
+    </profile>
+    <profile id="9ed6-e3f2-8847-d7a2" name="Pulse Bike Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers>
-        <modifier type="set" field="3baa-9cfd-f273-822d" value="Fast, Large, Leader 2" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+        <modifier type="set" field="3baa-9cfd-f273-822d" value="Fast, Large, Leader 2">
+          <repeats/>
           <conditions>
-            <condition parentId="direct parent" childId="27d8-164a-139b-f635" field="selections" type="equal to" value="1.0"/>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="27d8-164a-139b-f635" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
       </modifiers>
-    </profile>
-    <profile id="34f9-12c5-7e7b-114c" profileTypeId="1650-77b3-10d1-6406" name="Pulse Bike Trooper" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5 (8)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Fast, Large"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(8)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Fast, Large, Leader"/>
       </characteristics>
+    </profile>
+    <profile id="34f9-12c5-7e7b-114c" name="Pulse Bike Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="56b9-5224-e0df-8218" profileTypeId="1650-77b3-10d1-6406" name="Scout Probe" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="-"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="-"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="-"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="-"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Shard"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5 (8)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Fast, Large"/>
       </characteristics>
+    </profile>
+    <profile id="56b9-5224-e0df-8218" name="Scout Probe" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-    <profile id="9686-36fa-7ae7-f4dc" profileTypeId="1650-77b3-10d1-6406" name="Senatex Commander" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(7)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Command, Follow, Leader 2"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Shard"/>
       </characteristics>
+    </profile>
+    <profile id="9686-36fa-7ae7-f4dc" name="Senatex Commander" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers>
-        <modifier type="set" field="3baa-9cfd-f273-822d" value="Command, Follow, Leader 3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+        <modifier type="set" field="3baa-9cfd-f273-822d" value="Command, Follow, Leader 3">
+          <repeats/>
           <conditions>
-            <condition parentId="direct parent" childId="a90a-fea5-107f-a019" field="selections" type="equal to" value="1.0"/>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a90a-fea5-107f-a019" type="equalTo"/>
           </conditions>
           <conditionGroups/>
         </modifier>
       </modifiers>
-    </profile>
-    <profile id="9ce3-1277-65a2-7ab0" profileTypeId="1650-77b3-10d1-6406" name="Targeter Probe" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="-"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="-"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="-"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="-"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Shard"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Follow, Leader 2"/>
       </characteristics>
-      <modifiers/>
     </profile>
-    <profile id="1aa8-c7f2-fa2d-324a" profileTypeId="1650-77b3-10d1-6406" name="Tograh MV2 Transporter Drone " hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="13"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="MOD2, Transport 10, Large"/>
-      </characteristics>
+    <profile id="9ce3-1277-65a2-7ab0" name="Targeter Probe" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Shard"/>
+      </characteristics>
     </profile>
-    <profile id="e480-7c4e-fa39-3a68" profileTypeId="1650-77b3-10d1-6406" name="Tsan Leader" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="7"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="6 (8)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Leader, Large"/>
-      </characteristics>
+    <profile id="1aa8-c7f2-fa2d-324a" name="Tograh MV2 Transporter Drone " hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="13"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="MOD2, Transport 10, Large"/>
+      </characteristics>
     </profile>
-    <profile id="0c0e-7741-31cf-edf9" profileTypeId="1650-77b3-10d1-6406" name="Tsan Trooper" hidden="false" book="Xilos" page="82">
-      <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="7"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="6 (8)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Large"/>
-      </characteristics>
+    <profile id="e480-7c4e-fa39-3a68" name="Tsan Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="7"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (8)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader, Large"/>
+      </characteristics>
     </profile>
-    <profile id="d0b6-5e2a-243d-b6ea" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Howitzer" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-50"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="250"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D10, No Cover"/>
-      </characteristics>
+    <profile id="0c0e-7741-31cf-edf9" name="Tsan Trooper" book="Xilos" page="82" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="7"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (8)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Large"/>
+      </characteristics>
     </profile>
-    <profile id="b984-90ae-a8e5-83c8" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Launcher" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="60"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="120"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D5, No Cover"/>
-      </characteristics>
+    <profile id="d0b6-5e2a-243d-b6ea" name="X-Howitzer" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-50"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="250"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D10, No Cover"/>
+      </characteristics>
     </profile>
-    <profile id="7c13-1aa1-5557-6103" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Sling" hidden="false">
-      <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D3"/>
-      </characteristics>
+    <profile id="b984-90ae-a8e5-83c8" name="X-Launcher" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D5, No Cover"/>
+      </characteristics>
+    </profile>
+    <profile id="7c13-1aa1-5557-6103" name="X-Sling" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D3"/>
+      </characteristics>
     </profile>
   </sharedProfiles>
 </catalogue>


### PR DESCRIPTION
Here's a more complete list of changes:

- renamed "Inerceptor Command Squad" to "Interceptor Command Squad" for C3
- renamed "Inerceptor Squad" to "Interceptor Squad" for C3
- Changed minimum Tactical choices to 4 for 1000points for C3
- Added 1,250 Force selection for C3
- C3 Support Team no longer added with two X-Launchers (validation error)
- C3 Support Team no long able to add multiple X-Launchers
- Added Army Options to all lists. 
- Removed incorrect validation error of "900pts of 100pts used for Army Options". This was a real pain.

As well, I "fixed" a number of errors in the Ghar, Ghar Rebels and Isorian lists. These errors were preventing the data from being saved, but I couldn't tell you if I fixed them in the correct way. List authors should look at these:

- Plasma Dumps
- Claws
- Nano Probe Net Shard. 

Lastly, the Freeborn and Freeborn Adventurerers have an existing Army Option solution. I added my own to this list for completeness, but the author of these lists can make his/her own choices.
