### PR TITLE
Freeborn, Freeborn Adventurers, Synchronizer Drone (and more!)

### DIFF
--- a/Beyond_the_Gates_of_Antares.gst
+++ b/Beyond_the_Gates_of_Antares.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="c339-677a-60db-4060" name="Beyond the Gates of Antares" revision="10" battleScribeVersion="2.00" authorName="Muggins" authorContact="mugginns@gmail.com" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="c339-677a-60db-4060" name="Beyond the Gates of Antares" revision="11" battleScribeVersion="2.00" authorName="Muggins" authorContact="mugginns@gmail.com" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -1797,28 +1797,34 @@
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="363e-f291-c4af-bb26" type="max"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="2241-be91-8e26-54e7" name="Block!" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2f6f-51d9-fe70-3de6" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="5.0"/>
-          </costs>
-        </selectionEntry>
         <selectionEntry id="48f5-af6d-b578-4820" name="Extra Shot" hidden="false" collective="false" type="upgrade">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="ac2c-7bc1-71db-4d3f" value="3">
+              <repeats/>
+              <conditions>
+                <condition field="limit::points" scope="roster" value="1250.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="ac2c-7bc1-71db-4d3f" value="2">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="limit::points" scope="roster" value="750.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                    <condition field="limit::points" scope="roster" value="1251.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="lessThan"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ac2c-7bc1-71db-4d3f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ac2c-7bc1-71db-4d3f" type="max"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups/>
@@ -1831,9 +1837,30 @@
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="03ed-b450-3ac3-851e" value="2">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="limit::points" scope="roster" value="750.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                    <condition field="limit::points" scope="roster" value="1251.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="lessThan"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="03ed-b450-3ac3-851e" value="3">
+              <repeats/>
+              <conditions>
+                <condition field="limit::points" scope="roster" value="1250.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="03ed-b450-3ac3-851e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03ed-b450-3ac3-851e" type="max"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups/>
@@ -1861,9 +1888,30 @@
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="7f4f-49a8-8469-068b" value="3">
+              <repeats/>
+              <conditions>
+                <condition field="limit::points" scope="roster" value="1250.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="7f4f-49a8-8469-068b" value="2">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="limit::points" scope="roster" value="750.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                    <condition field="limit::points" scope="roster" value="1251.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="lessThan"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7f4f-49a8-8469-068b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f4f-49a8-8469-068b" type="max"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups/>
@@ -1876,9 +1924,30 @@
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="e34d-fa3b-1266-c55b" value="3">
+              <repeats/>
+              <conditions>
+                <condition field="limit::points" scope="roster" value="1250.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="e34d-fa3b-1266-c55b" value="2">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="limit::points" scope="roster" value="750.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                    <condition field="limit::points" scope="roster" value="1251.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="lessThan"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e34d-fa3b-1266-c55b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e34d-fa3b-1266-c55b" type="max"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups/>
@@ -1900,6 +1969,42 @@
           <entryLinks/>
           <costs>
             <cost name="pts" costTypeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0fae-ec69-16cd-4153" name="Block!" hidden="false" collective="false" categoryEntryId="50ba-cf77-3941-189c" type="unit">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="8e83-28e3-b967-2d28" value="2">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="limit::points" scope="roster" value="750.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                    <condition field="limit::points" scope="roster" value="1251.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="lessThan"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="8e83-28e3-b967-2d28" value="3">
+              <repeats/>
+              <conditions>
+                <condition field="limit::points" scope="roster" value="1250.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e83-28e3-b967-2d28" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>

--- a/Concord.cat
+++ b/Concord.cat
@@ -1927,10 +1927,7 @@
         </infoLink>
       </infoLinks>
       <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1bf0-4229-a700-ce67" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3a36-d97f-0d0c-3c4a" type="max"/>
-      </constraints>
+      <constraints/>
       <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="97c5-cc1d-c9c0-ffae" name="&lt; Options &gt;" hidden="false" collective="false">

--- a/Concord.cat
+++ b/Concord.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="162d-cc8a-d6e7-6973" name="Concord" revision="13" battleScribeVersion="2.00" authorName="Glasvandrare / Vescarea" authorContact="tkjellberg@gmail.com" gameSystemId="c339-677a-60db-4060" gameSystemRevision="0" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="162d-cc8a-d6e7-6973" name="Concord" revision="14" battleScribeVersion="2.00" authorName="Glasvandrare / Vescarea" authorContact="tkjellberg@gmail.com" gameSystemId="c339-677a-60db-4060" gameSystemRevision="0" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>

--- a/Concord.cat
+++ b/Concord.cat
@@ -205,6 +205,13 @@
               <modifiers/>
               <constraints/>
             </entryLink>
+            <entryLink id="07d7-5e8b-8c30-dffa" name="New EntryLink" hidden="false" targetId="0ac6-5bdb-3d61-e6ce" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -363,13 +370,6 @@
               <modifiers/>
               <constraints/>
             </entryLink>
-            <entryLink id="7d7d-a379-286b-228e" hidden="false" targetId="21a7-132d-6703-9ff6" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
           </entryLinks>
           <costs>
             <cost name="pts" costTypeId="points" value="26.0"/>
@@ -388,6 +388,44 @@
           <entryLinks/>
           <costs>
             <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a0b9-c282-b1a9-f7f4" name="Drop Trooper (Lance)" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="f302-fb2e-ac27-fc18" hidden="false" targetId="1219-e29a-7fa7-a09e" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bc7d-c021-cf95-5044" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2acb-9c37-8188-c0cc" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="340d-143a-e047-ec0a" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="71f3-851a-f8d6-9a30" hidden="false" targetId="21a7-132d-6703-9ff6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="26.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -447,6 +485,13 @@
                   <conditionGroups/>
                 </modifier>
               </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="de78-e1e0-54f6-1ac5" name="New EntryLink" hidden="false" targetId="0ac6-5bdb-3d61-e6ce" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
               <constraints/>
             </entryLink>
           </entryLinks>
@@ -998,6 +1043,13 @@
               </modifiers>
               <constraints/>
             </entryLink>
+            <entryLink id="d19c-d02c-15e8-3e2b" name="New EntryLink" hidden="false" targetId="0ac6-5bdb-3d61-e6ce" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -1076,7 +1128,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="2">
                   <repeats>
-                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -1085,6 +1137,20 @@
               <constraints/>
             </entryLink>
             <entryLink id="f344-fd5e-1be4-343e" name="Plasma Lance" hidden="false" targetId="3dd4-3b5c-6873-e8f2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="ce15-2326-e497-81dd" name="New EntryLink" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="dc42-0d29-c55c-77ab" name="New EntryLink" hidden="false" targetId="0ac6-5bdb-3d61-e6ce" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -1806,6 +1872,13 @@
               <modifiers/>
               <constraints/>
             </entryLink>
+            <entryLink id="ef1e-a1e3-ff9f-85f1" name="New EntryLink" hidden="false" targetId="0ac6-5bdb-3d61-e6ce" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="4da3-5d4c-1262-53ab" name="&lt; Weapon Drone Options &gt;" hidden="false" collective="false">
@@ -1824,7 +1897,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="10">
                   <repeats>
-                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -1845,95 +1918,88 @@
     <selectionEntry id="8bdd-d11f-ed0d-dac8" name="C3D1/GP Light General Purpose Drone" book="" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="model">
       <profiles/>
       <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <selectionEntries>
-        <selectionEntry id="0fa5-4678-1a3f-decf" name="&lt; GP Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+      <infoLinks>
+        <infoLink id="fd26-e2c7-0e4f-22ec" hidden="false" targetId="f9ce-3eb5-0335-1b53" type="profile">
           <profiles/>
           <rules/>
-          <infoLinks>
-            <infoLink id="0f76-aef5-4eed-fb15" hidden="false" targetId="f9ce-3eb5-0335-1b53" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
+          <infoLinks/>
           <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1bf0-4229-a700-ce67" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3a36-d97f-0d0c-3c4a" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="97c5-cc1d-c9c0-ffae" name="&lt; Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
           <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="0411-749e-e748-cb7e" name="&lt; Options &gt;" hidden="false" collective="false">
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="f352-1f01-ac1e-8066" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="418e-8281-9f52-5710" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="07b5-6bbe-485f-fa1d" hidden="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="b3d1-0620-3de8-f5b9" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="8c08-5e2f-7fda-f019" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="increment" field="points" value="10">
-                      <repeats>
-                        <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
-                      </repeats>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2434-066a-e59a-00ca" type="max"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="92b5-4abb-5821-b649" hidden="false" targetId="76e8-05d6-ff37-7205" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="20.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
+            </entryLink>
+            <entryLink id="48d4-a21e-073b-3f58" hidden="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="0297-f8df-bd9f-048b" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="40b9-2bd4-ed1e-8aca" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f29-c1d8-0015-11d0" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="1f37-5d78-1905-36cf" hidden="false" targetId="76e8-05d6-ff37-7205" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="fd55-8ca6-6585-172a" name="New EntryLink" hidden="false" targetId="0ac6-5bdb-3d61-e6ce" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
+        <cost name="pts" costTypeId="points" value="20.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3601-a65d-7f14-cf86" name="C3D2 Medium Support Drone " hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
@@ -2009,6 +2075,13 @@
                   <conditionGroups/>
                 </modifier>
               </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="d9f1-70b9-e6e9-9027" name="New EntryLink" hidden="false" targetId="0ac6-5bdb-3d61-e6ce" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
               <constraints/>
             </entryLink>
           </entryLinks>
@@ -2624,7 +2697,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="2.0">
                   <repeats>
-                    <repeat field="selections" scope="6880-209f-8a1d-66e0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="008d-8ba9-1c63-93b5" repeats="1"/>
+                    <repeat field="selections" scope="6880-209f-8a1d-66e0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="008d-8ba9-1c63-93b5" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -2945,7 +3018,7 @@
         <cost name="pts" costTypeId="points" value="20.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2750-e65f-4c66-8235" name="Batter Drone (2)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+    <selectionEntry id="2750-e65f-4c66-8235" name="Batter Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -3115,7 +3188,7 @@
         <cost name="pts" costTypeId="points" value="5.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5343-3c10-ccc3-0233" name="Gun Drone (2)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+    <selectionEntry id="5343-3c10-ccc3-0233" name="Gun Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -3764,7 +3837,7 @@
         <cost name="pts" costTypeId="points" value="10.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5ed8-6bd4-d0f7-d7f0" name="Shield Drone (2)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+    <selectionEntry id="5ed8-6bd4-d0f7-d7f0" name="Shield Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -3794,7 +3867,7 @@
         <cost name="pts" costTypeId="points" value="10.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f095-7ba3-b868-32de" name="Spotter Drone (2)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+    <selectionEntry id="f095-7ba3-b868-32de" name="Spotter Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -4315,6 +4388,21 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="0ac6-5bdb-3d61-e6ce" name="Synchronizer Drone" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e479-7b6c-1873-d2c0" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups/>
   <sharedRules>
@@ -4576,19 +4664,19 @@ D10 Result:
     </rule>
   </sharedRules>
   <sharedProfiles>
-    <profile id="18f2-0352-9cf8-66a5" name="C3D1 Light Support Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+    <profile id="18f2-0352-9cf8-66a5" name="C3D1 Light Support Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406" profileTypeName="Model">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
       <characteristics>
-        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="7"/>
-        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
-        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
-        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="8"/>
-        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
-        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
       </characteristics>
     </profile>
     <profile id="f9ce-3eb5-0335-1b53" name="C3D1/GP Light General Purpose Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">

--- a/Freeborn.cat
+++ b/Freeborn.cat
@@ -1764,6 +1764,13 @@
               </modifiers>
               <constraints/>
             </entryLink>
+            <entryLink id="08d1-077e-9fb6-ae9e" name="New EntryLink" hidden="false" targetId="059e-3ead-10ef-9fd5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -3130,6 +3137,13 @@
               </modifiers>
               <constraints/>
             </entryLink>
+            <entryLink id="ae0d-a5cd-8064-125a" name="New EntryLink" hidden="false" targetId="059e-3ead-10ef-9fd5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -4450,6 +4464,13 @@
           </modifiers>
           <constraints/>
         </entryLink>
+        <entryLink id="f780-d437-080a-47c1" name="New EntryLink" hidden="false" targetId="059e-3ead-10ef-9fd5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="42.0"/>
@@ -4664,6 +4685,13 @@
               <constraints/>
             </entryLink>
             <entryLink id="6106-f50f-fc72-2dfa" name="New EntryLink" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="31dc-50a9-bd77-2abb" name="New EntryLink" hidden="false" targetId="059e-3ead-10ef-9fd5" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>

--- a/Freeborn.cat
+++ b/Freeborn.cat
@@ -1,8970 +1,9139 @@
-<?xml version="1.0" encoding="UTF-8"?><catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" battleScribeVersion="2.00" id="64d6-1cd3-6226-4554" revision="6" gameSystemId="c339-677a-60db-4060" gameSystemRevision="0" name="Freeborn" authorName="Michael Ovsenik / Vescarea" authorContact="FB">
-<selectionEntries>
-<selectionEntry id="66a7-b2ec-cfcc-8359" name="&lt; Command Squad Options - Must choose first" type="unit" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="1" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="c017-7f96-06bd-fd6b" name="Select one of the following option and the relevent selection will appear" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="3933-5e9f-f85c-ba75" name="1&lt; Add 2 extra bodygaurds" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="a400-34cd-f726-fbf6" name="9&lt; Add Batter Drone" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="ad0d-a741-67ad-5d5c" name="7&lt; Add up to 2 Gun Drones" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="d17a-ef4d-2148-25e8" name="8&lt; Add up to 2 shield Drones" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="6559-a8ba-d266-7c27" name="2&lt; HL Armour for unit" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="1ef5-d006-6a32-fddb" name="3&lt; Phase Armour for unit" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="a04c-3029-b790-0cdb" name="4&lt; Give Captain plasma Carbine" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="a90a-cec1-cd13-3c17" name="5&lt; Give Captain Compression Carbine" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="7f96-ddf7-af5d-958a" name="6&lt; Give Bodygaurds Compression carbines" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="39a7-bedc-c912-a9f0" name="0&lt; None" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers>
-<modifier type="set" field="minSelections" value="0.0">
-<conditions>
-<condition type="equalTo" value="0.0" field="selections" scope="parent" childId="39a7-bedc-c912-a9f0" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="ed16-8f24-873e-f6cd" name="Replace with Amano Harran and Bodyguards" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups/>
-<entryLinks/>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="7a95-8632-0c25-d086" name="Amano Harran and Bodyguards" type="unit" collective="false" hidden="true" book="Battle for Xilos" page="115" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe">
-<costs>
-<cost costTypeId="points" name="pts" value="126.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-</constraints>
-<modifiers>
-<modifier type="set" field="hidden" value="false">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="ed16-8f24-873e-f6cd" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-<selectionEntries>
-<selectionEntry id="8fe8-c920-4357-5561" name="Amano Harran, Oszoni Freeborn Mercenary Captain" type="model" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="955c-f291-a035-8308" name="&lt;Weapons&gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="0197-c3d6-ee4b-351e" name="Zantu Plasma Duelling Pistol" type="upgrade" collective="false" hidden="false" book="Battle for Xilos" page="115" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules>
-<rule id="a0dc-c29f-3f0d-da12" name="Dead Eye" hidden="false" book="Battle for Xilos" page="115">
-                      <description>When shooting with a Fire order, add +2 to Acc value rather than standard +1</description>
-                      <modifiers/>
-                    </rule>
-<rule id="5ffd-287d-8644-d70c" name="Duellist" hidden="false" book="Battle for Xilos" page="115">
-                      <description>When shooting simultaenously with an enemy unit, both sides roll 1d10. If the controlling player rolls higher, he shoots first and any result is applied to the target before it can fire back, including casualty removal and pinning.</description>
-                      <modifiers/>
-                    </rule>
-</rules>
-<profiles>
-<profile id="980e-e86b-7de6-4cff" profileTypeId="ecae-8ac8-2c13-0dd3" name="Zantu Plasma Duelling Pistol" hidden="false" book="Battle for Xilos" page="115">
-                      <characteristics>
-                        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="40"/>
-                        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-                        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Dead Eye, Duellist"/>
-                      </characteristics>
-                      <modifiers/>
-                    </profile>
-</profiles>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="72ab-7a5e-1ef3-875a" name="Xilos Stasis Key" type="upgrade" collective="false" hidden="false" book="Battle for Xilos" page="57" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="25.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules>
-<rule id="7ecb-bcba-21d4-a388" name="Stasis" hidden="false" book="Battle for Xilos" page="57">
-                      <description>Weapon can ONLY be fired with a Fire order, applying normal +1 Acc bonus. If target unit is hit, either switch its current Order Die to a Down order, or if it does not yet have an order, retrieve an Order Die from the bag and issue it a down order. Then, add a Stasis marker to the unit.			If a unit is in stasis at the turn end phase, then instead of making a recovery test to recover the Down Order Die, make a recovery test to remove the Stasis marker. The unit then remains Down until the next chance to make a recovery test, at which point the test applies to the Down Order Die.</description>
-                      <modifiers/>
-                    </rule>
-</rules>
-<profiles>
-<profile id="ce34-6972-faf0-fc0e" profileTypeId="ecae-8ac8-2c13-0dd3" name="Xilos Stasis Key" hidden="false" book="Battle for Xilos" page="57">
-                      <characteristics>
-                        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-                        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long"/>
-                        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme"/>
-                        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value"/>
-                        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Stasis"/>
-                      </characteristics>
-                      <modifiers/>
-                    </profile>
-</profiles>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups/>
-<entryLinks/>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules>
-<rule id="4346-96cf-a909-9ab2" name="Fast Shot" hidden="false" book="Battle for Xilos" page="115">
-              <description>With any hand or standard weapon, this model shoots twice instead of once using the same weapon at the same target. This ability CAN be used with the Xilos Stasis Key, but the key can still only fire with a Fire order.</description>
-              <modifiers/>
-            </rule>
-<rule id="191b-64ea-3f8e-b6e2" name="Charismatic Aura" hidden="false" book="Battle for Xilos" page="115">
-              <description>If any enemy unit is within 10" of the Amano Harran model then it cannot be given an order without taking an Order test against its Command, even if it has no pins, and both its Command and Initiative stat are reduced by -1 when making order and/or reaction tests.</description>
-              <modifiers/>
-            </rule>
-<rule id="1c55-16af-48d1-e10f" name="Wound" hidden="false" book="Battle for Xilos" page="115">
-              <description>If Amano Harran fails a Res test then instead of falling casualty he is wounded. Once wounded, if any further Res test is failed he is removed as a casualty. If Amano Harran is wounded then the unit cannot lose its last 1 pin. It can lose other pins as normal, but will always retain at least one.</description>
-              <modifiers/>
-            </rule>
-</rules>
-<profiles>
-<profile id="ac61-5231-2810-84b0" profileTypeId="1650-77b3-10d1-6406" name="Amano Harran, Oszoni Freeborn Mercenary Captain" hidden="false" book="Battle for Xilos" page="115">
-              <characteristics>
-                <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="6"/>
-                <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-                <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
-                <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-                <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="10"/>
-                <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="10"/>
-                <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Command, Follow, Hero, Leader 3, Wound, Fast Shot, Charismatic Aura"/>
-              </characteristics>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="64d6-1cd3-6226-4554" name="Freeborn" revision="7" battleScribeVersion="2.00" authorName="Michael Ovsenik / Vescarea" authorContact="FB" gameSystemId="c339-677a-60db-4060" gameSystemRevision="0" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <profiles/>
+  <rules/>
+  <infoLinks/>
+  <costTypes/>
+  <profileTypes/>
+  <forceEntries/>
+  <selectionEntries>
+    <selectionEntry id="7a95-8632-0c25-d086" name="Amano Harran and Bodyguards" book="Battle for Xilos" page="115" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="8fe8-c920-4357-5561" name="Amano Harran, Oszoni Freeborn Mercenary Captain" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="ac61-5231-2810-84b0" name="Amano Harran, Oszoni Freeborn Mercenary Captain" book="Battle for Xilos" page="115" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers>
                 <modifier type="append" field="f214-abe8-c922-c51b" value="(7)">
-<conditions/>
-<conditionGroups>
-<conditionGroup type="or">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
                       <conditions>
-                        <condition type="equalTo" value="1.0" field="selections" scope="7a95-8632-0c25-d086" childId="ddb6-781a-85af-eeeb" shared="true"/>
-                        <condition type="equalTo" value="1.0" field="selections" scope="7a95-8632-0c25-d086" childId="aa87-9d00-ec90-c775" shared="true"/>
+                        <condition field="selections" scope="7a95-8632-0c25-d086" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ddb6-781a-85af-eeeb" type="equalTo"/>
+                        <condition field="selections" scope="7a95-8632-0c25-d086" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="aa87-9d00-ec90-c775" type="equalTo"/>
                       </conditions>
                       <conditionGroups/>
                     </conditionGroup>
-</conditionGroups>
-</modifier>
+                  </conditionGroups>
+                </modifier>
               </modifiers>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="6"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="10"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="10"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Follow, Hero, Leader 3, Wound, Fast Shot, Charismatic Aura"/>
+              </characteristics>
             </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="12e9-6e86-5af0-79e8" targetId="7bc9-5e98-2914-5abd" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="5cce-7f58-827d-5129" targetId="5c9b-1bde-ee01-04a4" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="eca5-0e3f-2e2f-371a" targetId="3c64-6022-a5f1-9c04" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="f56e-220b-8d8d-e9c7" targetId="05bb-4d34-70cd-25d2" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="dc88-b28b-0f31-61c9" name="Bodyguard" type="model" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="21.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="6"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks>
-<entryLink id="35f7-fede-27fa-da27" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-<infoLinks>
-<infoLink id="ceda-f66e-0469-f72a" targetId="9fba-d6b7-c66d-99f0" type="profile">
-<modifiers>
-<modifier type="append" field="f214-abe8-c922-c51b" value="(7)">
-<conditions/>
-<conditionGroups>
-<conditionGroup type="or">
+          </profiles>
+          <rules>
+            <rule id="4346-96cf-a909-9ab2" name="Fast Shot" book="Battle for Xilos" page="115" hidden="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <description>With any hand or standard weapon, this model shoots twice instead of once using the same weapon at the same target. This ability CAN be used with the Xilos Stasis Key, but the key can still only fire with a Fire order.</description>
+            </rule>
+            <rule id="191b-64ea-3f8e-b6e2" name="Charismatic Aura" book="Battle for Xilos" page="115" hidden="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <description>If any enemy unit is within 10&quot; of the Amano Harran model then it cannot be given an order without taking an Order test against its Command, even if it has no pins, and both its Command and Initiative stat are reduced by -1 when making order and/or reaction tests.</description>
+            </rule>
+            <rule id="1c55-16af-48d1-e10f" name="Wound" book="Battle for Xilos" page="115" hidden="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <description>If Amano Harran fails a Res test then instead of falling casualty he is wounded. Once wounded, if any further Res test is failed he is removed as a casualty. If Amano Harran is wounded then the unit cannot lose its last 1 pin. It can lose other pins as normal, but will always retain at least one.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="12e9-6e86-5af0-79e8" hidden="false" targetId="7bc9-5e98-2914-5abd" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="5cce-7f58-827d-5129" hidden="false" targetId="5c9b-1bde-ee01-04a4" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="eca5-0e3f-2e2f-371a" hidden="false" targetId="3c64-6022-a5f1-9c04" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="f56e-220b-8d8d-e9c7" hidden="false" targetId="05bb-4d34-70cd-25d2" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="955c-f291-a035-8308" name="&lt;Weapons&gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="0197-c3d6-ee4b-351e" name="Zantu Plasma Duelling Pistol" book="Battle for Xilos" page="115" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles>
+                    <profile id="980e-e86b-7de6-4cff" name="Zantu Plasma Duelling Pistol" book="Battle for Xilos" page="115" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="40"/>
+                        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+                        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Dead Eye, Duellist"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules>
+                    <rule id="a0dc-c29f-3f0d-da12" name="Dead Eye" book="Battle for Xilos" page="115" hidden="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <description>When shooting with a Fire order, add +2 to Acc value rather than standard +1</description>
+                    </rule>
+                    <rule id="5ffd-287d-8644-d70c" name="Duellist" book="Battle for Xilos" page="115" hidden="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <description>When shooting simultaenously with an enemy unit, both sides roll 1d10. If the controlling player rolls higher, he shoots first and any result is applied to the target before it can fire back, including casualty removal and pinning.</description>
+                    </rule>
+                  </rules>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="72ab-7a5e-1ef3-875a" name="Xilos Stasis Key" book="Battle for Xilos" page="57" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles>
+                    <profile id="ce34-6972-faf0-fc0e" name="Xilos Stasis Key" book="Battle for Xilos" page="57" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+                        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa"/>
+                        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9"/>
+                        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a"/>
+                        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Stasis"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules>
+                    <rule id="7ecb-bcba-21d4-a388" name="Stasis" book="Battle for Xilos" page="57" hidden="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <description>Weapon can ONLY be fired with a Fire order, applying normal +1 Acc bonus. If target unit is hit, either switch its current Order Die to a Down order, or if it does not yet have an order, retrieve an Order Die from the bag and issue it a down order. Then, add a Stasis marker to the unit.			If a unit is in stasis at the turn end phase, then instead of making a recovery test to recover the Down Order Die, make a recovery test to remove the Stasis marker. The unit then remains Down until the next chance to make a recovery test, at which point the test applies to the Down Order Die.</description>
+                    </rule>
+                  </rules>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="25.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="dc88-b28b-0f31-61c9" name="Bodyguard" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="ceda-f66e-0469-f72a" hidden="false" targetId="9fba-d6b7-c66d-99f0" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="append" field="f214-abe8-c922-c51b" value="(7)">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups>
+                    <conditionGroup type="or">
                       <conditions>
-                        <condition type="equalTo" value="1.0" field="selections" scope="7a95-8632-0c25-d086" childId="ddb6-781a-85af-eeeb" shared="true"/>
-                        <condition type="equalTo" value="1.0" field="selections" scope="7a95-8632-0c25-d086" childId="aa87-9d00-ec90-c775" shared="true"/>
+                        <condition field="selections" scope="7a95-8632-0c25-d086" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ddb6-781a-85af-eeeb" type="equalTo"/>
+                        <condition field="selections" scope="7a95-8632-0c25-d086" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="aa87-9d00-ec90-c775" type="equalTo"/>
                       </conditions>
                       <conditionGroups/>
                     </conditionGroup>
-</conditionGroups>
-</modifier>
-</modifiers>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups>
-<selectionEntryGroup id="fa49-db82-4230-6855" name="&lt;Unit Armor&gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="ddb6-781a-85af-eeeb" targetId="eff8-bb0e-1b1d-bbb2" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="1.0">
-<conditions/>
-<conditionGroups/>
-<repeats>
-<repeat repeats="1" value="1.0" field="selections" scope="7a95-8632-0c25-d086" childId="8fe8-c920-4357-5561" shared="true"/>
-</repeats>
-</modifier>
-<modifier type="increment" field="points" value="1.0">
-<conditions/>
-<conditionGroups/>
-<repeats>
-<repeat repeats="1" value="1.0" field="selections" scope="7a95-8632-0c25-d086" childId="dc88-b28b-0f31-61c9" shared="true"/>
-</repeats>
-</modifier>
-</modifiers>
-</entryLink>
-<entryLink id="aa87-9d00-ec90-c775" targetId="eb94-d1e8-1084-71b3" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="1.0">
-<conditions/>
-<conditionGroups/>
-<repeats>
-<repeat repeats="1" value="1.0" field="selections" scope="7a95-8632-0c25-d086" childId="8fe8-c920-4357-5561" shared="true"/>
-</repeats>
-</modifier>
-<modifier type="increment" field="points" value="1.0">
-<conditions/>
-<conditionGroups/>
-<repeats>
-<repeat repeats="1" value="1.0" field="selections" scope="7a95-8632-0c25-d086" childId="dc88-b28b-0f31-61c9" shared="true"/>
-</repeats>
-</modifier>
-</modifiers>
-</entryLink>
-<entryLink id="5b9c-ebf8-2d76-ed50" targetId="03c2-174e-8617-cf04" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="ac48-df93-6a89-8648" name="&lt;Unit Options&gt;" collective="false" hidden="false">
-<constraints/>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="bf74-08ce-f02a-25d6" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="9ef5-e7d3-8f94-9a38" targetId="502c-9855-7269-eaa2" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="fae6-07a8-03bf-e759" targetId="573b-88bc-97d7-d890" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="4cf9-9568-6a33-5f18" targetId="d571-d584-85fc-9110" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="1b1b-5f67-48e7-b04d" targetId="4b9d-a0bf-396e-384b" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="81af-1353-1e75-955f" targetId="1707-586b-01df-0f80" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="1e83-2d30-37c1-f54f" targetId="d118-8115-df5f-2402" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="2.0">
-<conditions/>
-<conditionGroups/>
-<repeats>
-<repeat repeats="1" value="1.0" field="selections" scope="7a95-8632-0c25-d086" childId="8fe8-c920-4357-5561" shared="true"/>
-</repeats>
-</modifier>
-<modifier type="increment" field="points" value="2.0">
-<conditions/>
-<conditionGroups/>
-<repeats>
-<repeat repeats="1" value="1.0" field="selections" scope="7a95-8632-0c25-d086" childId="dc88-b28b-0f31-61c9" shared="true"/>
-</repeats>
-</modifier>
-</modifiers>
-</entryLink>
-<entryLink id="cad5-b340-7463-f360" targetId="059e-3ead-10ef-9fd5" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="1871-8acd-7ec8-8700" name="Block!" type="upgrade" collective="false" hidden="false" categoryEntryId="50ba-cf77-3941-189c">
-<costs>
-<cost costTypeId="points" name="pts" value="5.0"/>
-</costs>
-<constraints/>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="aadf-c739-5770-7605" targetId="5d2e-45d2-1707-87db" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="a44f-4447-aff2-0dcd" name="Domari Squad (Household Troops)" type="unit" collective="false" hidden="false" book="BtGoA" page="192" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe">
-<costs>
-<cost costTypeId="points" name="pts" value="22.0"/>
-</costs>
-<constraints/>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="c61f-6de1-069d-821f" name="&lt; Household Leader" type="model" collective="false" hidden="false" book="BtGoA" page="191" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="eeeb-14fc-3015-51fc" name="&lt; Leader Level &gt;" collective="false" hidden="false" defaultSelectionEntryId="af81-32d2-905d-4525">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="5b49-8a4d-07d2-fb89" targetId="02f3-3134-ae39-afed" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="af81-32d2-905d-4525" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="614f-b64a-4c29-8d4f" name="&lt; Ranged Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="2bc1-4f6e-02ba-7d1c">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="2bc1-4f6e-02ba-7d1c" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="48df-d58e-e0d1-d8df" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="3.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-<entryLink id="526a-3475-ccc6-063a" targetId="9cd6-dbb8-bdcb-0299" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="1.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-<entryLink id="052b-0bbe-d078-8a35" targetId="1631-5857-2139-960a" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="6.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="c976-a3c2-48e7-a65d" targetId="ed77-e875-0302-9bf4" type="profile">
-<modifiers>
-<modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="c61f-6de1-069d-821f" childId="5b49-8a4d-07d2-fb89" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="d441-f08b-6ae0-3ce1" name="Household Trooper" type="model" collective="false" hidden="false" book="BtGoA" page="192" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="15.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="5"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="7"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="9c0c-e485-c447-84fb" name="Ranged Weapon" collective="false" hidden="false" defaultSelectionEntryId="20d8-1c96-d87e-6005">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="20d8-1c96-d87e-6005" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="f4de-742c-31aa-3973" targetId="45dd-c1c8-46d5-0107" type="profile">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="a960-249c-ef1d-5e8c" name="Micro-X Launcher" type="model" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="a9e5-f8a1-aadd-0667" name="SlingNet Ammo for Micro-X Launcher" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="5.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks>
-<entryLink id="eb51-606e-6b9f-6c33" targetId="e7b0-651a-cc7c-f27e" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-<infoLinks/>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups>
-<selectionEntryGroup id="678a-8f30-acb7-0053" name="&lt; Unit Armor &gt;" collective="false" hidden="false" defaultSelectionEntryId="a03c-46bd-0028-b43e">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="a03c-46bd-0028-b43e" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="e31c-0032-c416-8471" name="&lt; Unit Options &gt;" collective="false" hidden="false">
-<constraints/>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="606b-c5e6-d436-9d3c" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="5163-e03b-fc25-9afe" targetId="d118-8115-df5f-2402" type="selectionEntry">
-<modifiers>
-<modifier type="set" field="points" value="2.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-<modifier type="increment" field="points" value="2.0">
-<conditions/>
-<conditionGroups/>
-<repeats>
-<repeat repeats="1" value="1.0" field="selections" scope="a44f-4447-aff2-0dcd" childId="d441-f08b-6ae0-3ce1" shared="true"/>
-</repeats>
-</modifier>
-<modifier type="increment" field="points" value="2.0">
-<conditions/>
-<conditionGroups/>
-<repeats>
-<repeat repeats="1" value="1.0" field="selections" scope="a44f-4447-aff2-0dcd" childId="a960-249c-ef1d-5e8c" shared="true"/>
-</repeats>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="307c-9503-74f9-f4b3" name="Extra Shot" type="upgrade" collective="false" hidden="false" categoryEntryId="50ba-cf77-3941-189c">
-<costs>
-<cost costTypeId="points" name="pts" value="10.0"/>
-</costs>
-<constraints/>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="4864-9551-d5ab-0fd1" targetId="e77b-02da-5143-229e" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="d05f-990a-ae91-4196" name="Feral Meld Skark (Mhagris)" type="unit" collective="false" hidden="false" book="BtGoA" page="193" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5">
-<costs>
-<cost costTypeId="points" name="pts" value="115.0"/>
-</costs>
-<constraints/>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="d398-8780-d6cb-1241" name="&gt; Feral Leader" type="model" collective="false" hidden="false" book="BtGoA" page="193" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="fa1b-d08c-0a23-97f5" name="&lt; Leader Level &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="64c7-ce38-13a1-0a67" targetId="02f3-3134-ae39-afed" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="6230-3ae4-17d6-9052" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="1aa6-aff0-4b33-9f78" name="Ranged Weapon" collective="false" hidden="false" defaultSelectionEntryId="43cf-0bae-d100-956c">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="43cf-0bae-d100-956c" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="ee88-cab4-5a29-66fe" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="3.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles>
-<profile id="fa1e-41af-d09a-4df9" profileTypeId="1650-77b3-10d1-6406" name="Feral Leader" hidden="false" book="BtGoA" page="193">
-              <characteristics>
-                <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-                <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="8"/>
-                <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="7 (8)"/>
-                <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-                <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-              </characteristics>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="35f7-fede-27fa-da27" hidden="false" targetId="1631-5857-2139-960a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="21.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="fa49-db82-4230-6855" name="&lt;Unit Armor&gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="ddb6-781a-85af-eeeb" hidden="false" targetId="eff8-bb0e-1b1d-bbb2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="7a95-8632-0c25-d086" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8fe8-c920-4357-5561" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="7a95-8632-0c25-d086" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dc88-b28b-0f31-61c9" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="aa87-9d00-ec90-c775" hidden="false" targetId="eb94-d1e8-1084-71b3" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="7a95-8632-0c25-d086" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8fe8-c920-4357-5561" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="7a95-8632-0c25-d086" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dc88-b28b-0f31-61c9" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="5b9c-ebf8-2d76-ed50" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="ac48-df93-6a89-8648" name="&lt;Unit Options&gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="bf74-08ce-f02a-25d6" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="9ef5-e7d3-8f94-9a38" hidden="false" targetId="502c-9855-7269-eaa2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="fae6-07a8-03bf-e759" hidden="false" targetId="573b-88bc-97d7-d890" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="4cf9-9568-6a33-5f18" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="1b1b-5f67-48e7-b04d" hidden="false" targetId="4b9d-a0bf-396e-384b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="81af-1353-1e75-955f" hidden="false" targetId="1707-586b-01df-0f80" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="1e83-2d30-37c1-f54f" hidden="false" targetId="d118-8115-df5f-2402" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="7a95-8632-0c25-d086" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8fe8-c920-4357-5561" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="7a95-8632-0c25-d086" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dc88-b28b-0f31-61c9" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="cad5-b340-7463-f360" hidden="false" targetId="059e-3ead-10ef-9fd5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="126.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1871-8acd-7ec8-8700" name="Block!" hidden="false" collective="false" categoryEntryId="50ba-cf77-3941-189c" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="aadf-c739-5770-7605" hidden="false" targetId="5d2e-45d2-1707-87db" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a44f-4447-aff2-0dcd" name="Domari Squad (Household Troops)" book="BtGoA" page="192" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="c61f-6de1-069d-821f" name="&lt; Household Leader" book="BtGoA" page="191" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="c976-a3c2-48e7-a65d" hidden="false" targetId="ed77-e875-0302-9bf4" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="c61f-6de1-069d-821f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5b49-8a4d-07d2-fb89" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="eeeb-14fc-3015-51fc" name="&lt; Leader Level &gt;" hidden="false" collective="false" defaultSelectionEntryId="af81-32d2-905d-4525">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="5b49-8a4d-07d2-fb89" hidden="false" targetId="02f3-3134-ae39-afed" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="af81-32d2-905d-4525" hidden="false" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="614f-b64a-4c29-8d4f" name="&lt; Ranged Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="2bc1-4f6e-02ba-7d1c">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="2bc1-4f6e-02ba-7d1c" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="48df-d58e-e0d1-d8df" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="3.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="526a-3475-ccc6-063a" hidden="false" targetId="9cd6-dbb8-bdcb-0299" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="1.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="052b-0bbe-d078-8a35" hidden="false" targetId="1631-5857-2139-960a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="6.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d441-f08b-6ae0-3ce1" name="Household Trooper" book="BtGoA" page="192" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="f4de-742c-31aa-3973" hidden="false" targetId="45dd-c1c8-46d5-0107" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="7f6f-e891-2de4-35ee" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2622-a3cb-1d92-700a" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fdb3-8ade-c49c-95e6" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a960-249c-ef1d-5e8c" name="Micro-X Launcher" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="a9e5-f8a1-aadd-0667" name="SlingNet Ammo for Micro-X Launcher" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="eb51-606e-6b9f-6c33" hidden="false" targetId="e7b0-651a-cc7c-f27e" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e31c-0032-c416-8471" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="606b-c5e6-d436-9d3c" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="5163-e03b-fc25-9afe" hidden="false" targetId="d118-8115-df5f-2402" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="2.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="a44f-4447-aff2-0dcd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d441-f08b-6ae0-3ce1" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="a44f-4447-aff2-0dcd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a960-249c-ef1d-5e8c" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="8d43-cdf0-216f-f977" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ebeb-6923-1172-6d05" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1a36-38f7-d041-af3b" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="22.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="307c-9503-74f9-f4b3" name="Extra Shot" hidden="false" collective="false" categoryEntryId="50ba-cf77-3941-189c" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="4864-9551-d5ab-0fd1" hidden="false" targetId="e77b-02da-5143-229e" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d05f-990a-ae91-4196" name="Feral Meld Skark (Mhagris)" book="BtGoA" page="193" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="bd78-00f6-6a00-c0c7" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="be9d-0689-3672-7135" hidden="false" targetId="b0ca-8e7d-d03f-f027" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ff01-5f28-c344-f670" hidden="false" targetId="f7af-59ec-acde-2f75" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="d398-8780-d6cb-1241" name="&gt; Feral Leader" book="BtGoA" page="193" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="fa1e-41af-d09a-4df9" name="Feral Leader" book="BtGoA" page="193" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="8"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="7 (8)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
             </profile>
-</profiles>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups>
-<selectionEntryGroup id="0b29-d80a-20b5-7e35" name="Armor" collective="false" hidden="false" defaultSelectionEntryId="6f2d-ec4e-ce5c-1488">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="6f2d-ec4e-ce5c-1488" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="199e-4b69-cffe-68a5" name="Close Combat Weapon" collective="false" hidden="false" defaultSelectionEntryId="3f7a-4f46-1255-79ab">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="3f7a-4f46-1255-79ab" targetId="b5e9-5297-04d2-2bf8" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="375e-22a4-1200-b6c6" name="Meld Skark" collective="false" hidden="false" defaultSelectionEntryId="ee4b-0b0e-386d-99b2">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="ee4b-0b0e-386d-99b2" targetId="eafe-29d5-1222-4155" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks>
-<entryLink id="1196-e275-ef1a-7a7c" targetId="3878-9363-1705-9eda" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="2.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-<infoLinks>
-<infoLink id="bd78-00f6-6a00-c0c7" targetId="a221-d53c-b4bd-b52c" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="be9d-0689-3672-7135" targetId="b0ca-8e7d-d03f-f027" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="ff01-5f28-c344-f670" targetId="f7af-59ec-acde-2f75" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="1044-b654-0ca0-e5ad" name="Feral Skark Squad (Mhagris)" type="unit" collective="false" hidden="false" book="BtGoA" page="193" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89">
-<costs>
-<cost costTypeId="points" name="pts" value="115.0"/>
-</costs>
-<constraints/>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="c7f9-56fe-b1f2-8d86" name="&lt; Feral Leader" type="model" collective="false" hidden="false" book="BtGoA" page="193" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="fdfc-05ca-f8f0-d848" name="&lt; Leader Level &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="7938-5e37-03c2-36f9" name="Leader Two" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="10.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="3c91-9185-0302-3739" targetId="7850-89e7-bab8-86e9" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="86b4-5321-c678-9f8e" name="Leader Three" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="20.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="f1b2-17c3-5c01-f840" targetId="05bb-4d34-70cd-25d2" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups/>
-<entryLinks/>
-</selectionEntryGroup>
-<selectionEntryGroup id="4835-5cca-c5ab-b665" name="Ranged Weapon" collective="false" hidden="false" defaultSelectionEntryId="a4b6-8b90-d408-47e6">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="a4b6-8b90-d408-47e6" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="ac42-4a97-d2ca-35a4" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="0.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-<entryLink id="4ed0-25b7-d8a9-9620" targetId="790a-6841-6372-870b" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="249d-04f1-6637-584a" targetId="1631-5857-2139-960a" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="5.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="ef9d-4e79-290c-20bc" targetId="41f2-0f61-9758-5e8d" type="profile">
-<modifiers>
-<modifier type="set" field="3baa-9cfd-f273-822d" value="Large, Fast, Skark 3 Attacks SV1, Leader 2">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="c7f9-56fe-b1f2-8d86" childId="7938-5e37-03c2-36f9" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-<modifier type="set" field="3baa-9cfd-f273-822d" value="Large, Fast, Skark 3 Attacks SV1, Leader 3">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="c7f9-56fe-b1f2-8d86" childId="86b4-5321-c678-9f8e" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="66d4-fa07-1bbf-5da2" name="Feral Fighter" type="model" collective="false" hidden="false" book="BtGoA" page="193" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="2"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="438b-90c8-d7c4-125e" targetId="1069-6287-7c2a-af01" type="profile">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups>
-<selectionEntryGroup id="6a38-a612-5d6b-f4b0" name="&lt; Unit Ranged Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="fe21-b7fd-711d-b2f5">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="fe21-b7fd-711d-b2f5" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="835f-70e0-eb3b-6fe3" name="&lt; Unit Armor&gt;" collective="false" hidden="false" defaultSelectionEntryId="3555-0453-6307-704b">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="3555-0453-6307-704b" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="f1fd-e630-1832-069b" name="&lt; Unit Close Combat Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="ae29-c766-0fde-446c">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="ae29-c766-0fde-446c" targetId="b5e9-5297-04d2-2bf8" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks>
-<entryLink id="bfab-953d-8387-49ad" targetId="1e33-99fa-00fc-0a32" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="4426-94bd-2acc-1aff" targetId="3878-9363-1705-9eda" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="6.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-<modifier type="increment" field="points" value="2.0">
-<conditions/>
-<conditionGroups/>
-<repeats>
-<repeat repeats="1" value="1.0" field="selections" scope="1044-b654-0ca0-e5ad" childId="66d4-fa07-1bbf-5da2" shared="true"/>
-</repeats>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-<infoLinks>
-<infoLink id="0d4c-9f77-f0bf-9e0c" targetId="a221-d53c-b4bd-b52c" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="fcbc-0bcd-8b26-fc45" targetId="b0ca-8e7d-d03f-f027" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="5cda-2300-7dae-8090" name="Feral Squad (Mhagris)" type="unit" collective="false" hidden="false" book="BTGOA" page="191" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe">
-<costs>
-<cost costTypeId="points" name="pts" value="18.0"/>
-</costs>
-<constraints/>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="060b-a9a7-c641-af07" name="&lt; Feral Leader" type="model" collective="false" hidden="false" book="BtGoA" page="191" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="7bf3-7f8c-bb36-8056" name="&lt; Leader Level &gt;" collective="false" hidden="false" defaultSelectionEntryId="02c0-bf97-34ab-30c2">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="cb7e-226f-de17-d52a" targetId="02f3-3134-ae39-afed" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="28b8-d291-d4ee-cb65" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="02c0-bf97-34ab-30c2" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="f6c4-adbe-a27d-129a" name="&lt; Ranged Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="b6be-4b77-ef52-cd3a">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="b6be-4b77-ef52-cd3a" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="f89e-fb57-67ee-cd21" targetId="9cd6-dbb8-bdcb-0299" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="1.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-<entryLink id="9f8e-1152-80b5-a7b3" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="3.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-<entryLink id="4a2f-9e80-09af-2aec" targetId="1631-5857-2139-960a" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="6.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="a390-861b-ce2b-149f" targetId="f23b-60da-348a-e6db" type="profile">
-<modifiers>
-<modifier type="append" field="f214-abe8-c922-c51b" value="(6)">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="5cda-2300-7dae-8090" childId="7959-d3d0-3fa6-31d2" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="26dc-46a0-f598-e869" name="Feral Fighter" type="model" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="11.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="5"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="11"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="b699-14bd-4f42-6832" name="&lt; Ranged Weapon &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="7b8a-0e82-ab5e-59cb" targetId="8f47-408e-cc6e-7a19" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="63e8-7025-f4e9-e92d" targetId="2ae1-18d0-fbc8-21ad" type="profile">
-<modifiers>
-<modifier type="append" field="f214-abe8-c922-c51b" value="(6)">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="5cda-2300-7dae-8090" childId="7959-d3d0-3fa6-31d2" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="2223-cd79-2176-f186" name="Micro-X Launcher" type="model" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks>
-<entryLink id="aae4-047f-f2ad-3a9a" targetId="e7b0-651a-cc7c-f27e" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-<infoLinks/>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups>
-<selectionEntryGroup id="13f2-f4e6-8cb9-000e" name="&lt; Unit Armor &gt;" collective="false" hidden="false" defaultSelectionEntryId="0479-9c51-eb5f-7880">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="0479-9c51-eb5f-7880" name="None" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="7959-d3d0-3fa6-31d2" targetId="2396-4159-e26c-6c42" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="2.0">
-<conditions/>
-<conditionGroups/>
-<repeats>
-<repeat repeats="1" value="1.0" field="selections" scope="5cda-2300-7dae-8090" childId="060b-a9a7-c641-af07" shared="true"/>
-</repeats>
-</modifier>
-<modifier type="increment" field="points" value="2.0">
-<conditions/>
-<conditionGroups/>
-<repeats>
-<repeat repeats="1" value="1.0" field="selections" scope="5cda-2300-7dae-8090" childId="26dc-46a0-f598-e869" shared="true"/>
-</repeats>
-</modifier>
-<modifier type="increment" field="points" value="2.0">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="5cda-2300-7dae-8090" childId="2223-cd79-2176-f186" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules>
-<rule id="0587-e7a6-cccd-a152" name="Infantry Unit" hidden="false" book="">
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="fa1b-d08c-0a23-97f5" name="&lt; Leader Level &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="64c7-ce38-13a1-0a67" hidden="false" targetId="02f3-3134-ae39-afed" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="6230-3ae4-17d6-9052" hidden="false" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="20">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="1aa6-aff0-4b33-9f78" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="43cf-0bae-d100-956c">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="43cf-0bae-d100-956c" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="ee88-cab4-5a29-66fe" hidden="false" targetId="1631-5857-2139-960a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="3">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="1196-e275-ef1a-7a7c" hidden="false" targetId="3878-9363-1705-9eda" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="fb95-4b44-a04d-ca9d" hidden="false" targetId="b5e9-5297-04d2-2bf8" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ed14-81ce-b1a5-0dff" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1c8a-2d0c-c615-a1b9" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="3e98-37a3-5af9-3035" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2239-35ae-c8b2-5852" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="38fc-c684-a726-ab1d" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="3e46-40fc-0a46-7e83" hidden="false" targetId="eafe-29d5-1222-4155" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ee3f-9442-e06a-b0f3" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fb7e-b4e7-b00f-e724" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="54.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1044-b654-0ca0-e5ad" name="Feral Skark Squad (Mhagris)" book="BtGoA" page="193" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0d4c-9f77-f0bf-9e0c" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="fcbc-0bcd-8b26-fc45" hidden="false" targetId="b0ca-8e7d-d03f-f027" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="c7f9-56fe-b1f2-8d86" name="&lt; Feral Leader" book="BtGoA" page="193" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="ef9d-4e79-290c-20bc" hidden="false" targetId="41f2-0f61-9758-5e8d" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Large, Fast, Skark 3 Attacks SV1, Leader 2">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="c7f9-56fe-b1f2-8d86" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7938-5e37-03c2-36f9" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Large, Fast, Skark 3 Attacks SV1, Leader 3">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="c7f9-56fe-b1f2-8d86" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="86b4-5321-c678-9f8e" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="fdfc-05ca-f8f0-d848" name="&lt; Leader Level &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="7938-5e37-03c2-36f9" name="Leader 2" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="3c91-9185-0302-3739" hidden="false" targetId="7850-89e7-bab8-86e9" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="86b4-5321-c678-9f8e" name="Leader 3" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="f1b2-17c3-5c01-f840" hidden="false" targetId="05bb-4d34-70cd-25d2" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="20.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="4835-5cca-c5ab-b665" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="a4b6-8b90-d408-47e6">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="a4b6-8b90-d408-47e6" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="ac42-4a97-d2ca-35a4" hidden="false" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="0.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="4ed0-25b7-d8a9-9620" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="249d-04f1-6637-584a" hidden="false" targetId="1631-5857-2139-960a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="5.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="66d4-fa07-1bbf-5da2" name="Feral Fighter" book="BtGoA" page="193" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="438b-90c8-d7c4-125e" hidden="false" targetId="1069-6287-7c2a-af01" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="bfab-953d-8387-49ad" hidden="false" targetId="1e33-99fa-00fc-0a32" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="4426-94bd-2acc-1aff" hidden="false" targetId="3878-9363-1705-9eda" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="2">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="1044-b654-0ca0-e5ad" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="66d4-fa07-1bbf-5da2" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="0f33-552b-ce1d-b900" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ef5d-a2ac-2e40-3ef5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4343-4d41-8f0a-020b" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="8a3f-5c0b-1173-ae49" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b47f-a733-5a44-10aa" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="932c-f874-3f78-b721" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="7df2-3031-8388-6af5" hidden="false" targetId="b5e9-5297-04d2-2bf8" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c0f4-feec-17a5-f36a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c001-8d20-22d0-4832" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="115.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5cda-2300-7dae-8090" name="Feral Squad (Mhagris)" book="BTGOA" page="191" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="0587-e7a6-cccd-a152" name="Infantry Unit" book="" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
-</rules>
-<profiles/>
-<entryLinks>
-<entryLink id="0e45-6566-b04a-b718" targetId="3878-9363-1705-9eda" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="2.0">
-<conditions/>
-<conditionGroups/>
-<repeats>
-<repeat repeats="1" value="1.0" field="selections" scope="5cda-2300-7dae-8090" childId="060b-a9a7-c641-af07" shared="true"/>
-</repeats>
-</modifier>
-<modifier type="increment" field="points" value="2.0">
-<conditions/>
-<conditionGroups/>
-<repeats>
-<repeat repeats="1" value="1.0" field="selections" scope="5cda-2300-7dae-8090" childId="26dc-46a0-f598-e869" shared="true"/>
-</repeats>
-</modifier>
-<modifier type="increment" field="points" value="2.0">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="5cda-2300-7dae-8090" childId="2223-cd79-2176-f186" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-<entryLink id="49e8-198a-92af-6784" targetId="d118-8115-df5f-2402" type="selectionEntry">
-<modifiers>
-<modifier type="set" field="points" value="2.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-<modifier type="increment" field="points" value="2.0">
-<conditions/>
-<conditionGroups/>
-<repeats>
-<repeat repeats="1" value="1.0" field="selections" scope="5cda-2300-7dae-8090" childId="26dc-46a0-f598-e869" shared="true"/>
-</repeats>
-</modifier>
-<modifier type="increment" field="points" value="2.0">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="5cda-2300-7dae-8090" childId="2223-cd79-2176-f186" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="04d7-b8fa-d20d-5a98" name="Freeborn Attack Skimmer (Striker)" type="unit" collective="false" hidden="false" book="BtGoA" page="193" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89">
-<costs>
-<cost costTypeId="points" name="pts" value="148.0"/>
-</costs>
-<constraints/>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="c30a-e7b6-bb84-7bb5" name="Striker" type="upgrade" collective="false" hidden="false" book="BtGoA" page="193" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="c647-b28b-df13-6d30" name="&lt; Unit Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="b030-5851-0170-e80b">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="b030-5851-0170-e80b" targetId="cf3a-e6a9-bdc0-e0ae" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="2691-8987-ab1a-2617" targetId="c2bf-0272-30c6-dd20" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="5.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="204f-7870-70cd-0175" targetId="2da6-e419-5126-a73b" type="profile">
-<modifiers>
-<modifier type="increment" field="f214-abe8-c922-c51b" value="1">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="04d7-b8fa-d20d-5a98" childId="d788-9457-e43f-3692" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="d788-9457-e43f-3692" name="HL Booster (adds +1 res)" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="24.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups>
-<selectionEntryGroup id="eb1e-c626-334f-2865" name="&lt; Unit Options &gt;" collective="false" hidden="false">
-<constraints/>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="a72d-0f8c-e2c5-99f2" targetId="d571-d584-85fc-9110" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="2979-eed7-b244-aefc" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules>
-<rule id="3282-4fa8-4571-f511" name="Vehicle Unit" hidden="false">
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="060b-a9a7-c641-af07" name="&lt; Feral Leader" book="BtGoA" page="191" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="a390-861b-ce2b-149f" hidden="false" targetId="f23b-60da-348a-e6db" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="append" field="f214-abe8-c922-c51b" value="(6)">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="5cda-2300-7dae-8090" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7959-d3d0-3fa6-31d2" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-        </rule>
-</rules>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="b3ea-1e90-ad90-ee02" targetId="5565-ce10-1c78-1ee7" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="48a7-1194-3630-6d90" targetId="a221-d53c-b4bd-b52c" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="b73b-6140-e2ca-f0c1" name="Freeborn Command Squad" type="unit" collective="false" hidden="true" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe">
-<costs>
-<cost costTypeId="points" name="pts" value="69.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-</constraints>
-<modifiers>
-<modifier type="set" field="hidden" value="false">
-<conditions/>
-<conditionGroups>
-<conditionGroup type="or">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="7bf3-7f8c-bb36-8056" name="&lt; Leader Level &gt;" hidden="false" collective="false" defaultSelectionEntryId="02c0-bf97-34ab-30c2">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="cb7e-226f-de17-d52a" hidden="false" targetId="02f3-3134-ae39-afed" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="28b8-d291-d4ee-cb65" hidden="false" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="20">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="02c0-bf97-34ab-30c2" hidden="false" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="f6c4-adbe-a27d-129a" name="&lt; Ranged Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="b6be-4b77-ef52-cd3a">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="b6be-4b77-ef52-cd3a" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="f89e-fb57-67ee-cd21" hidden="false" targetId="9cd6-dbb8-bdcb-0299" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="1.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="9f8e-1152-80b5-a7b3" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="3.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="4a2f-9e80-09af-2aec" hidden="false" targetId="1631-5857-2139-960a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="6.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="26dc-46a0-f598-e869" name="Feral Fighter" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="63e8-7025-f4e9-e92d" hidden="false" targetId="2ae1-18d0-fbc8-21ad" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="append" field="f214-abe8-c922-c51b" value="(6)">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="5cda-2300-7dae-8090" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7959-d3d0-3fa6-31d2" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="11.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="15af-eb2c-8493-64dc" hidden="false" targetId="8f47-408e-cc6e-7a19" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="dd45-eca8-e2e4-f920" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ca67-5ef2-7461-a2e6" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="11.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2223-cd79-2176-f186" name="Micro-X Launcher" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="aae4-047f-f2ad-3a9a" hidden="false" targetId="e7b0-651a-cc7c-f27e" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="13f2-f4e6-8cb9-000e" name="&lt; Unit Armor &gt;" hidden="false" collective="false" defaultSelectionEntryId="0479-9c51-eb5f-7880">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="0479-9c51-eb5f-7880" name="None" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="7959-d3d0-3fa6-31d2" hidden="false" targetId="2396-4159-e26c-6c42" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="5cda-2300-7dae-8090" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="060b-a9a7-c641-af07" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats>
+                    <repeat field="selections" scope="5cda-2300-7dae-8090" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="26dc-46a0-f598-e869" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="5cda-2300-7dae-8090" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2223-cd79-2176-f186" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="0e45-6566-b04a-b718" hidden="false" targetId="3878-9363-1705-9eda" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="5cda-2300-7dae-8090" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="060b-a9a7-c641-af07" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="5cda-2300-7dae-8090" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="26dc-46a0-f598-e869" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats/>
               <conditions>
-                <condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="3933-5e9f-f85c-ba75" shared="true"/>
-                <condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="a400-34cd-f726-fbf6" shared="true"/>
-                <condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="ad0d-a741-67ad-5d5c" shared="true"/>
-                <condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="d17a-ef4d-2148-25e8" shared="true"/>
-                <condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="39a7-bedc-c912-a9f0" shared="true"/>
+                <condition field="selections" scope="5cda-2300-7dae-8090" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2223-cd79-2176-f186" type="equalTo"/>
               </conditions>
               <conditionGroups/>
-            </conditionGroup>
-</conditionGroups>
-</modifier>
-</modifiers>
-<selectionEntries>
-<selectionEntry id="b36d-f9f6-80eb-6f8a" name="&lt; Freeborn Captain" type="model" collective="false" hidden="false" book="BtGoA" page="190" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="ee93-85a8-a748-3858" name="&lt; Leader Level &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="3a47-103d-769c-3d59" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="0c11-a12d-3376-0b4b" name="&lt;Freeborn Captain Equipment &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="d72b-f17d-2842-5908" name="&lt; Armour &gt;" collective="false" hidden="false" defaultSelectionEntryId="d821-bfad-6e70-be4a">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="d821-bfad-6e70-be4a" targetId="03c2-174e-8617-cf04" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="6343-7996-c9c2-e583" name="&lt; Weapons &gt;" collective="false" hidden="false" defaultSelectionEntryId="c38c-46e0-0457-f57d">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="c38c-46e0-0457-f57d" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<entryLinks/>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="75cc-7baf-4390-4597" targetId="2d89-bcdb-b942-b900" type="profile">
-<modifiers>
-<modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="b73b-6140-e2ca-f0c1" childId="3a47-103d-769c-3d59" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="6b48-ec12-ab6c-2063" name="Bodyguards" type="model" collective="false" hidden="false" book="BtGoA" page="190" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="21.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="2"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="4"/>
-</constraints>
-<modifiers>
-<modifier type="increment" field="maxSelections" value="2.0">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="3933-5e9f-f85c-ba75" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="c9a4-5ee7-f187-8235" name="&lt; Armour &gt;" collective="false" hidden="false" defaultSelectionEntryId="5b9a-d663-bb0e-6480">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="5b9a-d663-bb0e-6480" targetId="03c2-174e-8617-cf04" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="ce36-0f86-ad2b-2de0" name="&lt; Weapons &gt;" collective="false" hidden="false" defaultSelectionEntryId="ffe5-b36e-981d-67c8">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="ffe5-b36e-981d-67c8" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="16f3-2f8c-3e35-5557" targetId="9fba-d6b7-c66d-99f0" type="profile">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups>
-<selectionEntryGroup id="87b2-db05-700b-2ce2" name="&lt; Unit Options &gt;" collective="false" hidden="false">
-<constraints/>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="4e48-b0be-38f0-fb84" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="25ec-bc01-1917-42a1" targetId="502c-9855-7269-eaa2" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="e804-8e7c-7660-6271" targetId="573b-88bc-97d7-d890" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="19db-d0e1-8415-81fa" targetId="d118-8115-df5f-2402" type="selectionEntry">
-<modifiers>
-<modifier type="set" field="points" value="2.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-<modifier type="increment" field="points" value="2.0">
-<conditions/>
-<conditionGroups/>
-<repeats>
-<repeat repeats="1" value="1.0" field="selections" scope="b73b-6140-e2ca-f0c1" childId="6b48-ec12-ab6c-2063" shared="true"/>
-</repeats>
-</modifier>
-</modifiers>
-</entryLink>
-<entryLink id="3b4d-27c4-5549-02cb" targetId="4b9d-a0bf-396e-384b" type="selectionEntry">
-<modifiers>
-<modifier type="set" field="hidden" value="true">
-<conditions/>
-<conditionGroups/>
-</modifier>
-<modifier type="set" field="hidden" value="false">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="ad0d-a741-67ad-5d5c" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-<entryLink id="2c36-464a-243b-0e55" targetId="1707-586b-01df-0f80" type="selectionEntry">
-<modifiers>
-<modifier type="set" field="hidden" value="true">
-<conditions/>
-<conditionGroups/>
-</modifier>
-<modifier type="set" field="hidden" value="false">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="d17a-ef4d-2148-25e8" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-<entryLink id="8de0-52be-784c-00ce" targetId="d571-d584-85fc-9110" type="selectionEntry">
-<modifiers>
-<modifier type="set" field="hidden" value="true">
-<conditions/>
-<conditionGroups/>
-</modifier>
-<modifier type="set" field="hidden" value="false">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="a400-34cd-f726-fbf6" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="15e4-e4af-15f1-94c3" name="Freeborn Command Squad" type="unit" collective="false" hidden="true" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe">
-<costs>
-<cost costTypeId="points" name="pts" value="70.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-</constraints>
-<modifiers>
-<modifier type="set" field="hidden" value="false">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="7f96-ddf7-af5d-958a" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-<selectionEntries>
-<selectionEntry id="8b00-b972-e10d-1390" name="&lt; Freeborn Captain" type="model" collective="false" hidden="false" book="BtGoA" page="190" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="b997-071f-1f47-aee8" name="&lt; Leader Level &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="ed96-be90-06f3-0beb" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="992a-ced2-9419-513c" name="&lt;Freeborn Captain Equipment &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="f80a-cee4-23df-5b8d" name="&lt; Armour &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="0ca1-9662-209b-eb0d" targetId="03c2-174e-8617-cf04" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="a5f8-02a4-689a-510f" name="&lt; Weapons &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="c1d9-84de-92d6-cb72" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<entryLinks/>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="5545-8414-45f3-4c97" targetId="2d89-bcdb-b942-b900" type="profile">
-<modifiers>
-<modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="15e4-e4af-15f1-94c3" childId="ed96-be90-06f3-0beb" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="16e2-4b59-8a36-351a" name="Bodygaurds" type="model" collective="false" hidden="false" book="BtGoA" page="190" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="26.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="2"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="4"/>
-</constraints>
-<modifiers>
-<modifier type="increment" field="maxSelections" value="2.0">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="3933-5e9f-f85c-ba75" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="70fa-1e75-d60b-2e16" name="&lt; Armour &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="f41b-1c7d-c117-325d" targetId="03c2-174e-8617-cf04" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="05c5-0dc8-f360-2012" name="&lt; Weapons &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="b106-d8e7-67b5-3daf" targetId="059b-38f7-0313-5ae4" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="5e80-a56f-41a7-b337" targetId="9fba-d6b7-c66d-99f0" type="profile">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups>
-<selectionEntryGroup id="4fd9-336f-cb2a-74cb" name="&lt; Unit Options &gt;" collective="false" hidden="false">
-<constraints/>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="5c84-6fcb-23cb-c531" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="0534-209c-6e63-b751" targetId="502c-9855-7269-eaa2" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="3cc5-bd4f-f987-bb96" targetId="573b-88bc-97d7-d890" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="9289-3ce8-ce3b-c398" targetId="d118-8115-df5f-2402" type="selectionEntry">
-<modifiers>
-<modifier type="set" field="points" value="2.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-<modifier type="increment" field="points" value="2.0">
-<conditions/>
-<conditionGroups/>
-<repeats>
-<repeat repeats="1" value="1.0" field="selections" scope="15e4-e4af-15f1-94c3" childId="16e2-4b59-8a36-351a" shared="true"/>
-</repeats>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="4224-b512-8e27-a7ae" name="Freeborn Command Squad" type="unit" collective="false" hidden="true" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe">
-<costs>
-<cost costTypeId="points" name="pts" value="70.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-</constraints>
-<modifiers>
-<modifier type="set" field="hidden" value="false">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="a90a-cec1-cd13-3c17" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-<selectionEntries>
-<selectionEntry id="8166-8ae2-85a7-d508" name="&lt; Freeborn Captain" type="model" collective="false" hidden="false" book="BtGoA" page="190" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="ec55-a3a6-79d2-3d8d" name="&lt; Leader Level &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="7539-56fe-d7c4-3436" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="bc83-ae90-8685-ec61" name="&lt;Freeborn Captain Equipment &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="8610-880b-d363-2842" name="&lt; Armour &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="9413-43f9-5e3c-0e39" targetId="03c2-174e-8617-cf04" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="b05f-e970-7acf-b5c2" name="&lt; Weapons &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="dc7e-0219-458d-80af" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<entryLinks/>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="74c9-0721-edb2-fe31" targetId="2d89-bcdb-b942-b900" type="profile">
-<modifiers>
-<modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="4224-b512-8e27-a7ae" childId="ec55-a3a6-79d2-3d8d" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="733f-d5cf-9ed2-cd37" name="Bodygaurds" type="model" collective="false" hidden="false" book="BtGoA" page="190" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="26.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="2"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="4"/>
-</constraints>
-<modifiers>
-<modifier type="increment" field="maxSelections" value="2.0">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="3933-5e9f-f85c-ba75" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="2a25-debf-a112-08f8" name="&lt; Armour &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="94d8-34e0-0bd0-2f8f" targetId="03c2-174e-8617-cf04" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="64e2-25c4-0a20-fd6f" name="&lt; Weapons &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="f2d1-fbb0-ae51-637a" targetId="059b-38f7-0313-5ae4" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="433d-17af-98e2-e708" targetId="9fba-d6b7-c66d-99f0" type="profile">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups>
-<selectionEntryGroup id="01c0-de81-eb4f-6520" name="&lt; Unit Options &gt;" collective="false" hidden="false">
-<constraints/>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="2313-6b51-b6fc-4334" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="55b3-8e97-1f9f-99c1" targetId="502c-9855-7269-eaa2" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="6334-02c5-fe28-46b2" targetId="573b-88bc-97d7-d890" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="94a7-abc4-e849-288a" targetId="d118-8115-df5f-2402" type="selectionEntry">
-<modifiers>
-<modifier type="set" field="points" value="2.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-<modifier type="increment" field="points" value="2.0">
-<conditions/>
-<conditionGroups/>
-<repeats>
-<repeat repeats="1" value="1.0" field="selections" scope="4224-b512-8e27-a7ae" childId="733f-d5cf-9ed2-cd37" shared="true"/>
-</repeats>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="0f65-b8ed-b8b2-294a" name="Freeborn Command Squad" type="unit" collective="false" hidden="true" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe">
-<costs>
-<cost costTypeId="points" name="pts" value="70.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-</constraints>
-<modifiers>
-<modifier type="set" field="hidden" value="false">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="a04c-3029-b790-0cdb" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-<selectionEntries>
-<selectionEntry id="6f3f-e7de-8b1f-9a45" name="&lt; Freeborn Captain" type="model" collective="false" hidden="false" book="BtGoA" page="190" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="3f21-c5d0-9056-3513" name="&lt; Leader Level &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="6ef1-5f41-d717-8432" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="eba6-42f4-e601-d9d4" name="&lt;Freeborn Captain Equipment &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="0c25-94d1-2ee1-8f97" name="&lt; Armour &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="fd6b-8d29-bb72-1f1a" targetId="03c2-174e-8617-cf04" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="1d89-7fac-a8ca-dea9" name="&lt; Weapons &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="bfcd-6dc1-7032-9eca" targetId="059b-38f7-0313-5ae4" type="selectionEntry">
-<modifiers>
-<modifier type="set" field="points" value="8.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<entryLinks/>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="9559-7359-c187-35e7" targetId="2d89-bcdb-b942-b900" type="profile">
-<modifiers>
-<modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="0f65-b8ed-b8b2-294a" childId="6ef1-5f41-d717-8432" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="f539-7c50-1fed-c0fe" name="Bodygaurds" type="model" collective="false" hidden="false" book="BtGoA" page="190" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="26.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="2"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="4"/>
-</constraints>
-<modifiers>
-<modifier type="increment" field="maxSelections" value="2.0">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="3933-5e9f-f85c-ba75" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="db1b-d74c-4488-f114" name="&lt; Armour &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="9dbd-a1b9-f7e2-b802" targetId="03c2-174e-8617-cf04" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="da8e-2b95-0031-818a" name="&lt; Weapons &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="bcc8-515f-8cbc-7a6c" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="c830-2ab1-3be7-3427" targetId="9fba-d6b7-c66d-99f0" type="profile">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups>
-<selectionEntryGroup id="6c4b-1586-3d8b-dbda" name="&lt; Unit Options &gt;" collective="false" hidden="false">
-<constraints/>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="712a-24b1-dd4d-c34e" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="7484-dc39-dbc9-ced2" targetId="502c-9855-7269-eaa2" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="2981-4427-c93a-87d1" targetId="573b-88bc-97d7-d890" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="7113-0a49-238b-ccc3" targetId="d118-8115-df5f-2402" type="selectionEntry">
-<modifiers>
-<modifier type="set" field="points" value="2.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-<modifier type="increment" field="points" value="2.0">
-<conditions/>
-<conditionGroups/>
-<repeats>
-<repeat repeats="1" value="1.0" field="selections" scope="0f65-b8ed-b8b2-294a" childId="f539-7c50-1fed-c0fe" shared="true"/>
-</repeats>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="ff83-951c-1523-67b4" name="Freeborn Command Squad" type="unit" collective="false" hidden="true" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe">
-<costs>
-<cost costTypeId="points" name="pts" value="70.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-</constraints>
-<modifiers>
-<modifier type="set" field="hidden" value="false">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="6559-a8ba-d266-7c27" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-<selectionEntries>
-<selectionEntry id="0b68-b15d-4f21-400d" name="&lt; Freeborn Captain" type="model" collective="false" hidden="false" book="BtGoA" page="190" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="4f77-859f-d36f-3f51" name="&lt; Leader Level &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="fab0-fb87-4db4-b758" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="534d-0cc6-dc8f-0e4a" name="&lt;Freeborn Captain Equipment &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="6168-628e-5ed2-eaa9" name="&lt; Armour &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="be23-8e40-689c-4584" targetId="eff8-bb0e-1b1d-bbb2" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="5ec4-d224-e3cc-e5a6" name="&lt; Weapons &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="bff1-9762-306f-171b" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
-<modifiers>
-<modifier type="set" field="points" value="8.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<entryLinks/>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="865b-5fee-3347-eedb" targetId="2d89-bcdb-b942-b900" type="profile">
-<modifiers>
-<modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="ff83-951c-1523-67b4" childId="fab0-fb87-4db4-b758" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="b52c-6be6-7a76-ba77" name="Bodygaurds" type="model" collective="false" hidden="false" book="BtGoA" page="190" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="26.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="2"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="4"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="48ac-19f4-04e6-2834" name="&lt; Armour &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="f1f4-b68d-48a0-6c7f" targetId="eff8-bb0e-1b1d-bbb2" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="1095-6dad-810d-ff4f" name="&lt; Weapons &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="dde5-232c-c035-35fa" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="248c-567b-902f-d5d5" targetId="9fba-d6b7-c66d-99f0" type="profile">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups>
-<selectionEntryGroup id="4329-ec3b-739b-0050" name="&lt; Unit Options &gt;" collective="false" hidden="false">
-<constraints/>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="9bc9-cab0-4841-6c2c" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="c86a-f1fe-6d59-873f" targetId="502c-9855-7269-eaa2" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="e0aa-ee5e-c24a-c338" targetId="573b-88bc-97d7-d890" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="0aac-c5ca-badb-4434" targetId="d118-8115-df5f-2402" type="selectionEntry">
-<modifiers>
-<modifier type="set" field="points" value="2.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-<modifier type="increment" field="points" value="2.0">
-<conditions/>
-<conditionGroups/>
-<repeats>
-<repeat repeats="1" value="1.0" field="selections" scope="ff83-951c-1523-67b4" childId="b52c-6be6-7a76-ba77" shared="true"/>
-</repeats>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="d603-36ff-a2eb-312f" name="Freeborn Command Squad" type="unit" collective="false" hidden="true" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe">
-<costs>
-<cost costTypeId="points" name="pts" value="70.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-</constraints>
-<modifiers>
-<modifier type="set" field="hidden" value="false">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="1ef5-d006-6a32-fddb" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-<selectionEntries>
-<selectionEntry id="3c30-80dd-c936-7ccf" name="&lt; Freeborn Captain" type="model" collective="false" hidden="false" book="BtGoA" page="190" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="6111-3b3b-a2ef-bdbc" name="&lt; Leader Level &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="7671-d1cb-8583-32f9" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="c091-1c08-a4c1-1e30" name="&lt;Freeborn Captain Equipment &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="90d1-c02b-6791-3678" name="&lt; Armour &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="ef1a-0b88-41e9-520f" targetId="eb94-d1e8-1084-71b3" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="954d-9823-9e71-fdb2" name="&lt; Weapons &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="9620-1c29-bbc5-277d" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<entryLinks/>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="86ad-520b-f8d8-0b4d" targetId="2d89-bcdb-b942-b900" type="profile">
-<modifiers>
-<modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="d603-36ff-a2eb-312f" childId="7671-d1cb-8583-32f9" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="70ef-17b0-4cc6-59d6" name="Bodygaurds" type="model" collective="false" hidden="false" book="BtGoA" page="190" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="26.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="2"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="4"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="b2b0-8472-6f6f-b03b" name="&lt; Armour &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="4966-a136-1d34-1648" targetId="eb94-d1e8-1084-71b3" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="cd16-bf68-6808-737f" name="&lt; Weapons &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="7c24-c3ed-edef-f97d" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="8523-7e21-40bd-02f6" targetId="9fba-d6b7-c66d-99f0" type="profile">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups>
-<selectionEntryGroup id="1359-b8c0-aedb-1bbe" name="&lt; Unit Options &gt;" collective="false" hidden="false">
-<constraints/>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="3c36-c80e-c93c-f6a4" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="9092-1d24-81d4-4b37" targetId="502c-9855-7269-eaa2" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="e184-cee5-0fd5-9e41" targetId="573b-88bc-97d7-d890" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="6f0c-0da4-1e67-2635" targetId="d118-8115-df5f-2402" type="selectionEntry">
-<modifiers>
-<modifier type="set" field="points" value="2.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-<modifier type="increment" field="points" value="2.0">
-<conditions/>
-<conditionGroups/>
-<repeats>
-<repeat repeats="1" value="1.0" field="selections" scope="d603-36ff-a2eb-312f" childId="70ef-17b0-4cc6-59d6" shared="true"/>
-</repeats>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="6a1d-c668-c7e8-ed9f" name="Freeborn Heavy Support Team" type="unit" collective="false" hidden="false" book="BtGoA" page="194" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5">
-<costs>
-<cost costTypeId="points" name="pts" value="25.0"/>
-</costs>
-<constraints/>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="d45c-a6e2-b912-4bcd" name="Freeborn Crew" type="upgrade" collective="false" hidden="false" book="BtGoA" page="193" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="12.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="3"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="4"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="8b71-ca9c-1ca2-0abc" name="&lt; Unit Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="42ad-31e5-60a7-9e01">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="42ad-31e5-60a7-9e01" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="d718-d349-ce44-fe7e" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="3.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="9dd0-b9bb-59a6-5f05" name="&lt; Unit Armor &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="7632-f6c2-622d-6f3a" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="4d7b-6ff6-c6f1-e988" targetId="7267-3051-f1b4-0a88" type="profile">
-<modifiers/>
-</infoLink>
-<infoLink id="e688-49e6-a2dd-5f3f" targetId="87a3-460d-879a-92a5" type="profile">
-<modifiers>
-<modifier type="set" field="hidden" value="false">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="6a1d-c668-c7e8-ed9f" childId="5afb-493a-f716-72df" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups>
-<selectionEntryGroup id="a4e6-016c-c52f-4548" name="&lt; Support Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="f434-b021-4e80-826a">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="f434-b021-4e80-826a" targetId="cea7-8511-2208-1b1f" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="a076-8dc7-3360-7f97" targetId="b9f1-a313-3e59-57ab" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="10.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-<entryLink id="9d3d-0bdc-592a-8e5a" targetId="9733-7039-e306-26b5" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="10.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-<entryLink id="a2ac-6dfc-f14e-fcab" targetId="5149-5183-64d5-feaf" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="10.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="16f8-cbcf-1527-66e2" name="&lt; Unit Options &gt;" collective="false" hidden="false">
-<constraints/>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="5afb-493a-f716-72df" name="Promote Crew Member to Leader" collective="false" hidden="false">
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="fb3e-d593-1cf1-ad9d" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
-<modifiers>
-<modifier type="set" field="points" value="10.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<entryLinks>
-<entryLink id="b8ea-0f50-8af5-3fec" targetId="d571-d584-85fc-9110" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="97c0-d505-6d11-a769" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="b771-d383-4d92-ea6b" targetId="4364-45ee-ee83-ca30" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="1.0">
-<conditions/>
-<conditionGroups/>
-<repeats>
-<repeat repeats="1" value="1.0" field="selections" scope="6a1d-c668-c7e8-ed9f" childId="d45c-a6e2-b912-4bcd" shared="true"/>
-</repeats>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules>
-<rule id="99d8-ad33-bc0e-0a91" name="Weapon Team Unit" hidden="false">
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="49e8-198a-92af-6784" hidden="false" targetId="d118-8115-df5f-2402" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="points" value="2.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="5cda-2300-7dae-8090" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="26dc-46a0-f598-e869" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="5cda-2300-7dae-8090" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2223-cd79-2176-f186" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="18.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="04d7-b8fa-d20d-5a98" name="Freeborn Attack Skimmer (Striker)" book="BtGoA" page="193" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="3282-4fa8-4571-f511" name="Vehicle Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
-</rules>
-<profiles/>
-<entryLinks>
-<entryLink id="b8d9-62b2-a114-98f3" targetId="e329-9443-6cb2-bc53" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="1405-a43b-534b-ab05" name="Freeborn Nuhu Renegade" type="unit" collective="false" hidden="false" book="BtGoA" page="191" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe">
-<costs>
-<cost costTypeId="points" name="pts" value="114.0"/>
-</costs>
-<constraints/>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="a2f4-4dc6-77ae-47c3" name="&lt; Freeborn Renegade Option &gt;" collective="false" hidden="false" defaultSelectionEntryId="df76-0766-2149-0a05">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="df76-0766-2149-0a05" name="Freeborn Nuhu Renegade" type="model" collective="false" hidden="false" book="BtGoA" page="191" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="b8fc-7c31-a28e-2734" name="&lt; Close Combat Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="6411-27f7-6c9d-41d5">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="6411-27f7-6c9d-41d5" targetId="b357-a997-60e5-053e" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="dfa1-9c18-5508-8d84" name="&lt; Ranged Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="5252-b85f-713e-89e3">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="5252-b85f-713e-89e3" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="c045-a625-7025-1578" targetId="5c9b-1bde-ee01-04a4" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="4078-9939-a810-38ce" targetId="7bc9-5e98-2914-5abd" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="0cec-0def-8aec-1297" targetId="05bb-4d34-70cd-25d2" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="dfe4-8f70-63fd-fcb2" targetId="3c64-6022-a5f1-9c04" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="70d1-ee75-ecc4-1c5e" targetId="0c03-96a3-4833-bc67" type="profile">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="1b3e-6788-9f9a-5ed5" name="Freeborn NuHu Renegade Meld" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="163.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="7f1e-6fe3-4c0d-1835" name="&lt; Close Combat Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="4e50-184a-086b-ddf4">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="4e50-184a-086b-ddf4" targetId="b357-a997-60e5-053e" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="71f0-8ea7-438d-6aaf" name="&lt; Ranged Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="7123-c19b-8cec-f0c7">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="7123-c19b-8cec-f0c7" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="a00c-80d5-2a22-dfbf" targetId="5c9b-1bde-ee01-04a4" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="1773-4ee5-6db6-6430" targetId="7bc9-5e98-2914-5abd" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="10a2-0000-14c0-e073" targetId="3c64-6022-a5f1-9c04" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="79d1-47e4-312e-04d3" targetId="05bb-4d34-70cd-25d2" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="b9b0-d17f-a96e-d0c3" targetId="5565-ce10-1c78-1ee7" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="6355-4d83-0120-3b82" targetId="a97f-4540-de7b-5734" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="6792-be66-d3a6-276b" targetId="5e3d-6905-2b14-8cd1" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="062e-3dd5-efd6-8a93" targetId="68fe-17c2-2841-2cde" type="profile">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups/>
-<entryLinks/>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules>
-<rule id="b2d5-107a-301c-db27" name="Limited Choice" hidden="false" book="">
+      </rules>
+      <infoLinks>
+        <infoLink id="b3ea-1e90-ad90-ee02" hidden="false" targetId="5565-ce10-1c78-1ee7" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </rule>
-<rule id="05ad-d2b8-2f3f-67e1" name="Infantry Command Unit" hidden="false" book="">
+        </infoLink>
+        <infoLink id="48a7-1194-3630-6d90" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </rule>
-</rules>
-<profiles/>
-<entryLinks>
-<entryLink id="11d3-ea88-2582-dbc0" targetId="a1c9-551b-1532-ef5a" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="8c9e-c5c0-4339-2c9e" targetId="1707-586b-01df-0f80" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="b557-70e8-d27c-aa9d" targetId="cadc-e1ce-3615-ac4b" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="0223-7d39-0a7c-f8a9" name="Freeborn Skyraider Squad" type="unit" collective="false" hidden="false" book="BtGoA" page="174" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89">
-<costs>
-<cost costTypeId="points" name="pts" value="121.0"/>
-</costs>
-<constraints/>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="cffa-15d6-0631-ed32" name="&lt; Skyraider Leader" type="model" collective="false" hidden="false" book="BtGoA" page="192" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="6fb4-5cba-7e48-83e2" name="Leader Level" collective="false" hidden="false" defaultSelectionEntryId="e5fb-0118-831e-f517">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="86cc-1a90-418d-75d5" targetId="02f3-3134-ae39-afed" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="e5fb-0118-831e-f517" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="7e77-cac2-feab-67d6" targetId="5c9b-1bde-ee01-04a4" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="a17a-173b-6907-b7ee" targetId="7bc9-5e98-2914-5abd" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="1491-1d08-a7c9-d0f4" targetId="e18f-34de-2624-4133" type="profile">
-<modifiers/>
-</infoLink>
-<infoLink id="212a-5750-9cf2-9c7a" targetId="e18f-34de-2624-4133" type="profile">
-<modifiers>
-<modifier type="set" field="3baa-9cfd-f273-822d" value="Large, Fast, Leader 2">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="cffa-15d6-0631-ed32" childId="86cc-1a90-418d-75d5" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="b5b1-72ee-b28c-ed4a" name="Skyraider Trooper" type="model" collective="false" hidden="false" book="BtGoA" page="192" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="2"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="d042-54cc-962c-5c4e" name="&lt; Ranged Weapon &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="60da-034a-d954-5cfc" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="7303-1648-6de4-25ea" targetId="a654-5213-64f2-703a" type="profile">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups>
-<selectionEntryGroup id="84fe-b5cd-ab19-23e4" name="&lt; Skyraider &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="87a0-db4c-17e6-d240" targetId="a1a8-ba0b-2e45-8020" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="46d3-88f8-ecac-204c" name="&lt; Special Weapon Option &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="e34a-7c57-c72d-b20e" targetId="47d9-8149-9744-9849" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="8a5a-b8d3-b9f7-cffb" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="f5d5-4b78-eab5-56a2" name="&lt; Unit Armor &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="2"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="3304-35c1-b35b-5a16" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="41f4-516b-6edc-fa24" targetId="2e3d-bbaa-3f5c-ac53" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="d56e-be22-258f-698c" name="&lt; Unit Options &gt; " collective="false" hidden="false">
-<constraints/>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="a434-7a9b-75cb-d4be" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules>
-<rule id="a61b-d8b1-c4a3-6102" name="Mounted Command Unit" hidden="false">
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="c30a-e7b6-bb84-7bb5" name="Striker" book="BtGoA" page="193" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="204f-7870-70cd-0175" hidden="false" targetId="2da6-e419-5126-a73b" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="f214-abe8-c922-c51b" value="1">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="04d7-b8fa-d20d-5a98" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d788-9457-e43f-3692" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-        </rule>
-<rule id="572f-a685-c7aa-3d42" name="Limited Choice" hidden="false">
-          <modifiers/>
-        </rule>
-</rules>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="c8b0-00c2-4509-d681" targetId="b0ca-8e7d-d03f-f027" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="3fb0-934a-d1a8-ed1e" targetId="a221-d53c-b4bd-b52c" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="5db6-c261-8463-2fde" name="Freeborn Specialist Heavy Support Team" type="unit" collective="false" hidden="false" book="BtGoA" page="194" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5">
-<costs>
-<cost costTypeId="points" name="pts" value="45.0"/>
-</costs>
-<constraints/>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="bb44-58f4-62b7-989d" name="Freeborn Crew" type="upgrade" collective="false" hidden="false" book="BtGoA" page="193" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="12.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="3"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="4"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="da65-0295-8e02-4356" name="&lt; Unit Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="e081-6f9b-47f1-8d2e">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="e081-6f9b-47f1-8d2e" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="1af1-0c6d-46fc-9a90" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="3.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="8003-fecb-500b-a2f1" name="&lt; Unit Armor &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="76fe-447d-63af-8c97" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="7e69-7f6d-660b-ada8" targetId="7267-3051-f1b4-0a88" type="profile">
-<modifiers/>
-</infoLink>
-<infoLink id="f359-8e60-9b6c-caf8" targetId="87a3-460d-879a-92a5" type="profile">
-<modifiers>
-<modifier type="set" field="hidden" value="false">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="5db6-c261-8463-2fde" childId="4117-a3fe-bf51-e9fe" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups>
-<selectionEntryGroup id="7b8f-9d4d-fe28-010d" name="&lt; Support Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="c4cb-5ad3-29f5-e064">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="1d83-6417-d5ba-71b0" targetId="2cec-e1d7-c680-7ca0" type="selectionEntry">
-<modifiers>
-<modifier type="set" field="points" value="15.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-<entryLink id="c4cb-5ad3-29f5-e064" targetId="67b6-d6f5-5ba3-e50d" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="8ae5-cb57-4392-b6d3" name="&lt; Unit Options &gt;" collective="false" hidden="false">
-<constraints/>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="4117-a3fe-bf51-e9fe" name="Promote one crew to Leader" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="10.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="6735-38dd-ba7c-0697" targetId="d571-d584-85fc-9110" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="58d6-220a-a277-4d27" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="1bed-3774-e8f1-9891" targetId="4364-45ee-ee83-ca30" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="2.0">
-<conditions/>
-<conditionGroups/>
-<repeats>
-<repeat repeats="1" value="1.0" field="selections" scope="5db6-c261-8463-2fde" childId="bb44-58f4-62b7-989d" shared="true"/>
-</repeats>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules>
-<rule id="cfca-4aa7-d6d4-b77e" name="Weapon Team Unit" hidden="false">
-          <modifiers/>
-        </rule>
-</rules>
-<profiles/>
-<entryLinks>
-<entryLink id="a700-75fe-fedc-4a1d" targetId="e329-9443-6cb2-bc53" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="e040-74bb-81d2-742f" name="Freeborn Specialist Heavy Support Team w/ Compression Bombard" type="unit" collective="false" hidden="false" book="Battle for Xilos" page="19483" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5">
-<costs>
-<cost costTypeId="points" name="pts" value="45.0"/>
-</costs>
-<constraints/>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="3f02-0f65-aa87-f29b" name="Freeborn Crew" type="upgrade" collective="false" hidden="false" book="BtGoA" page="193" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="12.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="3"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="4"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="e24b-2ff8-7c27-8ba7" name="&lt; Unit Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="ff3e-645a-e8d0-d896">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="ff3e-645a-e8d0-d896" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="b5d8-4f59-792a-5aa0" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="3.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="a0b8-45f2-80c2-2e6f" name="&lt; Unit Armor &gt;" collective="false" hidden="false" defaultSelectionEntryId="9db6-ea3f-f9ce-9280">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="9db6-ea3f-f9ce-9280" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="2e53-4fbd-d21f-0ff4" targetId="7267-3051-f1b4-0a88" type="profile">
-<modifiers/>
-</infoLink>
-<infoLink id="a311-98bd-dc31-1e18" targetId="87a3-460d-879a-92a5" type="profile">
-<modifiers>
-<modifier type="set" field="hidden" value="false">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="e040-74bb-81d2-742f" childId="30cb-c08e-9c00-1db2" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups>
-<selectionEntryGroup id="10be-7777-50bb-0438" name="&lt; Support Weapon &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="1f73-aed3-4502-cebb" targetId="af24-45f9-4669-bf98" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="b980-251d-2639-9888" name="&lt; Unit Options &gt;" collective="false" hidden="false">
-<constraints/>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="30cb-c08e-9c00-1db2" name="Promote one crew to Leader" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="10.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="cdac-db4e-1fea-369a" targetId="d571-d584-85fc-9110" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="2daa-0c1c-11a8-0cb0" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="de04-6777-8685-d52a" targetId="4364-45ee-ee83-ca30" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="1.0">
-<conditions/>
-<conditionGroups/>
-<repeats>
-<repeat repeats="1" value="1.0" field="selections" scope="e040-74bb-81d2-742f" childId="3f02-0f65-aa87-f29b" shared="true"/>
-</repeats>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules>
-<rule id="b131-f742-1197-dc55" name="Weapon Team Unit" hidden="false">
-          <modifiers/>
-        </rule>
-</rules>
-<profiles/>
-<entryLinks>
-<entryLink id="9ba6-236f-73dc-a81d" targetId="e329-9443-6cb2-bc53" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="0f2b-5fd2-86c3-563b" name="Freeborn Support Team" type="unit" collective="false" hidden="false" book="BtGoA" page="193" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89">
-<costs>
-<cost costTypeId="points" name="pts" value="10.0"/>
-</costs>
-<constraints/>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="3b68-a4c9-03bb-dd68" name="Freeborn Crew" type="upgrade" collective="false" hidden="false" book="BtGoA" page="193" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="12.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="2"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="3"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="09ce-fa1f-63c6-0dee" name="&lt; Unit Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="e022-953c-7321-fa34">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="e022-953c-7321-fa34" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="af1b-11cd-5a0f-d758" name="&lt; Unit Armor &gt;" collective="false" hidden="false" defaultSelectionEntryId="20cd-dacc-9c25-5545">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="20cd-dacc-9c25-5545" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="6f07-d1a0-a27b-5ab4" targetId="c245-fa49-1569-2f23" type="profile">
-<modifiers/>
-</infoLink>
-<infoLink id="0ced-d327-0411-d442" targetId="a770-8327-b96d-b92e" type="profile">
-<modifiers>
-<modifier type="set" field="hidden" value="false">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="0f2b-5fd2-86c3-563b" childId="8943-c8c6-eaa4-c959" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups>
-<selectionEntryGroup id="85a1-9aa5-986c-0134" name="Weapon" collective="false" hidden="false" defaultSelectionEntryId="5764-6087-e7b6-4c73">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="7198-55af-d564-f2fd" targetId="6a2b-50c5-9a33-b756" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="10.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-<entryLink id="4711-a1d0-8193-4ddf" targetId="eed0-b68f-b5fb-92c7" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="5764-6087-e7b6-4c73" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="8c57-5f05-54c3-3b50" targetId="93db-3751-fdd4-08f9" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="40.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-<entryLink id="0bef-09de-cda1-001e" targetId="c2bf-0272-30c6-dd20" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="35.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-<entryLink id="3f8a-3a73-e583-707c" targetId="cf3a-e6a9-bdc0-e0ae" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="30.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-<entryLink id="a7eb-103f-f984-c4f9" targetId="71c9-4382-01cf-c737" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="10.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="52c4-3f29-7cff-341f" name="&lt; Unit Options &gt;" collective="false" hidden="false">
-<constraints/>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="3860-7352-2507-b377" name="Promote Crew Member to Leader" collective="false" hidden="false">
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="8943-c8c6-eaa4-c959" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
-<modifiers>
-<modifier type="set" field="points" value="10.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<entryLinks>
-<entryLink id="d6e9-f088-ecba-53b8" targetId="d571-d584-85fc-9110" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="e4a1-35cb-9989-c083" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="22d3-07af-fc6e-749c" targetId="4364-45ee-ee83-ca30" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="1.0">
-<conditions/>
-<conditionGroups/>
-<repeats>
-<repeat repeats="1" value="1.0" field="selections" scope="0f2b-5fd2-86c3-563b" childId="3b68-a4c9-03bb-dd68" shared="true"/>
-</repeats>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules>
-<rule id="a6d0-fc64-ad5d-674a" name="Weapon Team Unit" hidden="false">
-          <modifiers/>
-        </rule>
-</rules>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="cff3-e0da-411a-cbd9" name="Get Up!" type="upgrade" collective="false" hidden="false" categoryEntryId="50ba-cf77-3941-189c">
-<costs>
-<cost costTypeId="points" name="pts" value="10.0"/>
-</costs>
-<constraints/>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="8563-f338-4ece-a2d7" targetId="2afe-05bf-268b-84c2" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="4881-30cd-5020-cf21" name="Hound Probe shard" type="unit" collective="false" hidden="false" book="BtGoA" page="196" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints/>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="b84e-d168-f074-70e9" name="&gt; Hound Probe" type="model" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="5.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="4"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="6"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="de6a-8e84-305b-6721" targetId="00b8-b49c-4c61-2943" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="8bc7-33a7-b05c-29d5" targetId="d0a1-129b-f8e5-b1ad" type="profile">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups/>
-<rules>
-<rule id="a2c9-24be-fc58-b2ce" name="Probe Unit" hidden="false" book="">
-          <modifiers/>
-        </rule>
-</rules>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="bd58-a73b-e17b-89ae" name="Light General Purpose Drone" type="unit" collective="false" hidden="false" book="BtGoA" page="196" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d">
-<costs>
-<cost costTypeId="points" name="pts" value="20.0"/>
-</costs>
-<constraints/>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="136e-670b-fde8-eb08" name="GP Drone" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="ee6d-c97a-5f05-6da2" targetId="2dbd-14c5-219e-d37d" type="profile">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups>
-<selectionEntryGroup id="3dc6-b2b7-80a4-d6db" name="&lt; Unit Options &gt;" collective="false" hidden="false">
-<constraints/>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="7189-205b-e43f-4b47" name="Self Repair" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers>
-<modifier type="increment" field="points" value="10.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="4f3f-a904-dfd8-30e0" targetId="3377-9408-33bb-6a02" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="9c14-af40-c4a6-8c01" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="8fc1-59dc-574d-d478" targetId="d571-d584-85fc-9110" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="b30a-6adc-e0b9-35b5" targetId="1707-586b-01df-0f80" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="ee36-d310-391a-5a23" targetId="fb8b-7402-c5a9-8644" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules>
-<rule id="ae83-e15b-aca4-e246" name="Weapon Drone Unit" hidden="false" book="BtGoA">
-          <modifiers/>
-        </rule>
-</rules>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="bd92-cca5-ea64-865d" targetId="e167-a8e4-c26a-cafd" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="9cfb-19e0-05ac-1e47" name="M25 Type Heavy Combat Drone" type="unit" collective="false" hidden="false" book="BtGoA" page="195" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5">
-<costs>
-<cost costTypeId="points" name="pts" value="418.0"/>
-</costs>
-<constraints/>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="01f5-c3d0-42de-8d99" name="&gt; Transporter Drone" type="model" collective="false" hidden="false" book="BtGoA" page="195" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="0bd6-01b0-8347-296b" name="&lt; Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="dd0c-d323-b658-fa67">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="dd0c-d323-b658-fa67" targetId="67b6-d6f5-5ba3-e50d" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="62ea-7660-3ccf-313c" targetId="af24-45f9-4669-bf98" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="25.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="2c9f-5d67-5f75-022c" targetId="5425-1edf-f536-d5a1" type="profile">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups>
-<selectionEntryGroup id="bcac-a955-0a97-bdb0" name="&lt; Unit Options &gt;" collective="false" hidden="false">
-<constraints/>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="e39c-f576-faa5-f1da" name="Self Repair" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers>
-<modifier type="increment" field="points" value="10.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="ee9f-3fa4-0af8-ce9e" targetId="3377-9408-33bb-6a02" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="f37d-a025-3c15-4abf" targetId="1707-586b-01df-0f80" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="80cd-1a9a-13f7-0d35" targetId="8f68-d09d-6e26-c6ea" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="ecf7-a64a-293a-de72" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks>
-<entryLink id="3edb-e997-53e8-ad4a" targetId="e329-9443-6cb2-bc53" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-<infoLinks>
-<infoLink id="27e0-0043-07dc-ece0" targetId="a221-d53c-b4bd-b52c" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="9d1c-1cca-ed53-b1b0" targetId="7c88-64d4-50ad-2313" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="04b2-5695-d4ce-6256" targetId="8151-2e24-94ee-0477" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="530f-c210-1c10-4819" name="M4 Type Combat Drone" type="unit" collective="false" hidden="false" book="BtGoA" page="195" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5">
-<costs>
-<cost costTypeId="points" name="pts" value="249.0"/>
-</costs>
-<constraints/>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="30bd-b309-a7e2-ce17" name="&gt; Combat Drone" type="model" collective="false" hidden="false" book="BtGoA" page="195" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="e349-a387-3011-cdb4" name="&lt; Main Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="64cd-d0a7-af3d-bd56">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="64cd-d0a7-af3d-bd56" targetId="c2bf-0272-30c6-dd20" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="905e-efa8-94c5-0f56" targetId="93db-3751-fdd4-08f9" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="5.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-<entryLink id="c54e-bd52-591e-31d6" targetId="71c9-4382-01cf-c737" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="5.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks>
-<entryLink id="e4b6-ff25-d3f7-7d36" targetId="0f97-9dbe-566a-5ab0" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-<infoLinks>
-<infoLink id="a8b4-2c55-d8de-de72" targetId="eb0f-0718-35d7-1a00" type="profile">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups>
-<selectionEntryGroup id="42d3-0396-7538-2afe" name="&lt; Unit Options &gt;" collective="false" hidden="false">
-<constraints/>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="3d7b-8b6c-0bc7-2176" name="Self Repair" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers>
-<modifier type="increment" field="points" value="10.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="50db-2d5d-b0d3-7ab6" targetId="3377-9408-33bb-6a02" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="5b5a-646b-cdc9-70c6" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="6b3d-030d-2e2f-db4e" targetId="8f68-d09d-6e26-c6ea" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="c15c-7bd3-0f3e-e876" targetId="1707-586b-01df-0f80" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks>
-<entryLink id="1504-b595-21a5-1772" targetId="e329-9443-6cb2-bc53" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-<infoLinks>
-<infoLink id="b25f-8a2f-5932-bb6a" targetId="5565-ce10-1c78-1ee7" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="1334-f2ea-a5eb-674c" targetId="a221-d53c-b4bd-b52c" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="3df6-b3d9-248f-350b" name="M50 Type Heavy Combat Drone" type="unit" collective="false" hidden="false" book="BtGoA" page="195" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5">
-<costs>
-<cost costTypeId="points" name="pts" value="418.0"/>
-</costs>
-<constraints/>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="aaf8-6738-2b45-c252" name="&gt; Heavy Support Drone" type="model" collective="false" hidden="false" book="BtGoA" page="195" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="5086-9f66-b442-f987" name="&lt; Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="1e4a-57fb-e968-6982">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="1e4a-57fb-e968-6982" targetId="b9f1-a313-3e59-57ab" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="2b26-87e7-1e8f-ea79" targetId="9733-7039-e306-26b5" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="7053-b744-1b1a-bbeb" targetId="2cec-e1d7-c680-7ca0" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="25.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks>
-<entryLink id="c089-dc26-6ac4-a9e0" targetId="0f97-9dbe-566a-5ab0" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-<infoLinks>
-<infoLink id="250a-e588-2f82-7123" targetId="9e2a-f076-d4df-b60a" type="profile">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups>
-<selectionEntryGroup id="8226-5f69-098e-16a2" name="&lt; Unit Options &gt;" collective="false" hidden="false">
-<constraints/>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="b1c4-3032-4af5-5874" name="Self Repair" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers>
-<modifier type="increment" field="points" value="10.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="dc4e-ba2d-8399-9b36" targetId="3377-9408-33bb-6a02" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="92d7-f414-c1e1-175b" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="7a1a-41e1-fcdc-3390" targetId="8f68-d09d-6e26-c6ea" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="a7a7-9da8-ef6f-2592" targetId="1707-586b-01df-0f80" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks>
-<entryLink id="6d78-6ff1-689b-45b9" targetId="e329-9443-6cb2-bc53" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-<infoLinks>
-<infoLink id="2e55-1966-d767-c4f5" targetId="a221-d53c-b4bd-b52c" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="b56d-83bb-8c53-a2ee" targetId="7c88-64d4-50ad-2313" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="8342-2c8c-460a-7d1d" targetId="8151-2e24-94ee-0477" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="68e5-824d-8e72-1018" name="Marksman" type="upgrade" collective="false" hidden="false" categoryEntryId="50ba-cf77-3941-189c">
-<costs>
-<cost costTypeId="points" name="pts" value="15.0"/>
-</costs>
-<constraints>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="1" includeChildSelections="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="1" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="1054-eaa0-48d3-3dfa" targetId="5741-af68-9dc0-519f" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="771e-7953-547e-2082" name="Misgenic Rejects" type="unit" collective="false" hidden="false" book="BtGoA" page="196" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints/>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="6098-b5c2-1d8a-a1b6" name="Misgenic Rejects" type="model" collective="false" hidden="false" book="BtGoA" page="196" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="5.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="6"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="12"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="7079-9c86-12a0-461d" profileTypeId="1650-77b3-10d1-6406" name="Misgenic Rejects" hidden="false" book="BtGoA" page="196">
-              <characteristics>
-                <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-                <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
-                <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5"/>
-                <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-                <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="7"/>
-              </characteristics>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="c647-b28b-df13-6d30" name="&lt; Unit Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="b030-5851-0170-e80b">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="b030-5851-0170-e80b" hidden="false" targetId="cf3a-e6a9-bdc0-e0ae" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="2691-8987-ab1a-2617" hidden="false" targetId="c2bf-0272-30c6-dd20" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="5.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d788-9457-e43f-3692" name="HL Booster (adds +1 res)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="24.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="eb1e-c626-334f-2865" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="a72d-0f8c-e2c5-99f2" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="2979-eed7-b244-aefc" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="148.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d603-36ff-a2eb-312f" name="Freeborn Command Squad" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="8357-36da-c594-db8d" name="&lt; Freeborn Captain" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="86ad-520b-f8d8-0b4d" hidden="false" targetId="2d89-bcdb-b942-b900" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="d603-36ff-a2eb-312f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="10da-9ec5-f1d4-5055" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="10da-9ec5-f1d4-5055" hidden="false" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="180f-d0e9-ab8f-c59b" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="b7a4-49f4-826e-4ddb" hidden="false" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1e00-ce4c-4220-a846" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cdfc-590f-7e79-7007" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="276a-64e9-1c41-18ff" name="Bodyguards" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="8523-7e21-40bd-02f6" hidden="false" targetId="9fba-d6b7-c66d-99f0" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="56ad-2e88-69d6-c007" hidden="false" targetId="1631-5857-2139-960a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="896e-8a30-8934-5250" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8dc7-557c-557e-fd31" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="21.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="07ad-f33c-c099-2cb1" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="794d-d447-4730-5d29" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="0967-f919-3956-2173" hidden="false" targetId="502c-9855-7269-eaa2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="9859-1590-354c-81e8" hidden="false" targetId="573b-88bc-97d7-d890" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="1164-56f4-f26c-8ed6" hidden="false" targetId="d118-8115-df5f-2402" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="2">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="d603-36ff-a2eb-312f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="276a-64e9-1c41-18ff" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="d55d-daa6-368e-9814" name="New EntryLink" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42bd-a175-55f0-794e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="adde-a789-7e2e-287f" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="69.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6a1d-c668-c7e8-ed9f" name="Freeborn Heavy Support Team" book="BtGoA" page="194" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="99d8-ad33-bc0e-0a91" name="Weapon Team Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="d45c-a6e2-b912-4bcd" name="Freeborn Crew" book="BtGoA" page="193" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="4d7b-6ff6-c6f1-e988" hidden="false" targetId="7267-3051-f1b4-0a88" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="e688-49e6-a2dd-5f3f" hidden="false" targetId="87a3-460d-879a-92a5" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="6a1d-c668-c7e8-ed9f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5afb-493a-f716-72df" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="fb17-cf8f-e9c8-85e3" name="" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="28c7-9198-c535-3419" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a46e-4fa1-a34f-509a" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="12.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="a4e6-016c-c52f-4548" name="&lt; Support Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="f434-b021-4e80-826a">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="f434-b021-4e80-826a" hidden="false" targetId="cea7-8511-2208-1b1f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="a076-8dc7-3360-7f97" hidden="false" targetId="b9f1-a313-3e59-57ab" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="9d3d-0bdc-592a-8e5a" hidden="false" targetId="9733-7039-e306-26b5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="a2ac-6dfc-f14e-fcab" hidden="false" targetId="5149-5183-64d5-feaf" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="16f8-cbcf-1527-66e2" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="5afb-493a-f716-72df" name="Promote Crew Member to Leader" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="fb3e-d593-1cf1-ad9d" hidden="false" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="10.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="b8ea-0f50-8af5-3fec" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="97c0-d505-6d11-a769" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="b771-d383-4d92-ea6b" hidden="false" targetId="4364-45ee-ee83-ca30" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="6a1d-c668-c7e8-ed9f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d45c-a6e2-b912-4bcd" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="b16a-c09a-865b-c193" name="&lt; Unit Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="f70e-67d3-3d99-4d58">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e728-91f9-3329-c56f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3ef5-ea6e-a9ca-f9a4" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="f70e-67d3-3d99-4d58" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="ad27-eba3-5598-03ff" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="6a1d-c668-c7e8-ed9f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d45c-a6e2-b912-4bcd" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="b8d9-62b2-a114-98f3" hidden="false" targetId="e329-9443-6cb2-bc53" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1405-a43b-534b-ab05" name="Freeborn Nuhu Renegade" book="BtGoA" page="191" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="b2d5-107a-301c-db27" name="Limited Choice" book="" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+        <rule id="05ad-d2b8-2f3f-67e1" name="Infantry Command Unit" book="" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fd0-5751-a7bd-e888" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="a2f4-4dc6-77ae-47c3" name="&lt; Freeborn Renegade Option &gt;" hidden="false" collective="false" defaultSelectionEntryId="df76-0766-2149-0a05">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="df76-0766-2149-0a05" name="Freeborn Nuhu Renegade" book="BtGoA" page="191" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="c045-a625-7025-1578" hidden="false" targetId="5c9b-1bde-ee01-04a4" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="4078-9939-a810-38ce" hidden="false" targetId="7bc9-5e98-2914-5abd" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="0cec-0def-8aec-1297" hidden="false" targetId="05bb-4d34-70cd-25d2" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="dfe4-8f70-63fd-fcb2" hidden="false" targetId="3c64-6022-a5f1-9c04" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="70d1-ee75-ecc4-1c5e" hidden="false" targetId="0c03-96a3-4833-bc67" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="cd99-6df9-ebe5-8124" hidden="false" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c002-7a4f-c9d4-8912" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="036b-a7c3-f7dc-6798" type="min"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="0a70-8e28-15f1-adba" hidden="false" targetId="b357-a997-60e5-053e" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b48e-b4b9-87d8-85e8" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="01f4-9f9a-55ec-2dc2" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1b3e-6788-9f9a-5ed5" name="Freeborn NuHu Renegade Meld" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="a00c-80d5-2a22-dfbf" hidden="false" targetId="5c9b-1bde-ee01-04a4" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="1773-4ee5-6db6-6430" hidden="false" targetId="7bc9-5e98-2914-5abd" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="10a2-0000-14c0-e073" hidden="false" targetId="3c64-6022-a5f1-9c04" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="79d1-47e4-312e-04d3" hidden="false" targetId="05bb-4d34-70cd-25d2" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="b9b0-d17f-a96e-d0c3" hidden="false" targetId="5565-ce10-1c78-1ee7" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="6355-4d83-0120-3b82" hidden="false" targetId="a97f-4540-de7b-5734" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="6792-be66-d3a6-276b" hidden="false" targetId="5e3d-6905-2b14-8cd1" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="062e-3dd5-efd6-8a93" hidden="false" targetId="68fe-17c2-2841-2cde" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="44bc-87bb-110b-a30a" hidden="false" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="397d-e0ae-150f-2c1e" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f3f9-56bb-75df-345b" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="53c8-0eb6-c786-bfd7" hidden="false" targetId="b357-a997-60e5-053e" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bba9-6196-7f02-98eb" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3040-8e7e-b283-c4c2" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="163.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="11d3-ea88-2582-dbc0" hidden="false" targetId="a1c9-551b-1532-ef5a" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="8c9e-c5c0-4339-2c9e" hidden="false" targetId="1707-586b-01df-0f80" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="b557-70e8-d27c-aa9d" hidden="false" targetId="cadc-e1ce-3615-ac4b" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="114.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0223-7d39-0a7c-f8a9" name="Freeborn Skyraider Squad" book="BtGoA" page="174" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="a61b-d8b1-c4a3-6102" name="Mounted Command Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+        <rule id="572f-a685-c7aa-3d42" name="Limited Choice" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="c8b0-00c2-4509-d681" hidden="false" targetId="b0ca-8e7d-d03f-f027" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3fb0-934a-d1a8-ed1e" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="cffa-15d6-0631-ed32" name="&lt; Skyraider Leader" book="BtGoA" page="192" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="7e77-cac2-feab-67d6" hidden="false" targetId="5c9b-1bde-ee01-04a4" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="a17a-173b-6907-b7ee" hidden="false" targetId="7bc9-5e98-2914-5abd" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="1491-1d08-a7c9-d0f4" hidden="false" targetId="e18f-34de-2624-4133" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="212a-5750-9cf2-9c7a" hidden="false" targetId="e18f-34de-2624-4133" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Large, Fast, Leader 2">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="cffa-15d6-0631-ed32" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="86cc-1a90-418d-75d5" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="6fb4-5cba-7e48-83e2" name="Leader Level" hidden="false" collective="false" defaultSelectionEntryId="e5fb-0118-831e-f517">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="86cc-1a90-418d-75d5" hidden="false" targetId="02f3-3134-ae39-afed" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="e5fb-0118-831e-f517" hidden="false" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="3bb8-b5d6-a36d-c9b6" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="dcb3-69a2-b32e-2ee7" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7303-a0ed-81e9-7a4e" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b5b1-72ee-b28c-ed4a" name="Skyraider Trooper" book="BtGoA" page="192" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="7303-1648-6de4-25ea" hidden="false" targetId="a654-5213-64f2-703a" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="5047-3362-0ac2-aaee" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a101-f79e-e251-92a4" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e259-6e0c-6a88-a1fc" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="46d3-88f8-ecac-204c" name="&lt; Special Weapon Option &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="e34a-7c57-c72d-b20e" hidden="false" targetId="47d9-8149-9744-9849" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="8a5a-b8d3-b9f7-cffb" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d56e-be22-258f-698c" name="&lt; Unit Options &gt; " hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="a434-7a9b-75cb-d4be" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="ace0-e20a-ac38-ae3c" hidden="false" targetId="a1a8-ba0b-2e45-8020" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="aefb-7630-79c3-3bf8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4e13-3579-3cde-867c" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="033e-46f7-c17f-beea" hidden="false" targetId="2e3d-bbaa-3f5c-ac53" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="points" value="0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e787-6e58-ba45-21da" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ddea-4344-0ecf-9a71" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="4d9a-663c-d435-b383" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd09-f80c-69ba-1b50" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7227-0c10-2fb9-5896" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="121.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5db6-c261-8463-2fde" name="Freeborn Specialist Heavy Support Team" book="BtGoA" page="194" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="cfca-4aa7-d6d4-b77e" name="Weapon Team Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="bb44-58f4-62b7-989d" name="Freeborn Crew" book="BtGoA" page="193" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="7e69-7f6d-660b-ada8" hidden="false" targetId="7267-3051-f1b4-0a88" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="f359-8e60-9b6c-caf8" hidden="false" targetId="87a3-460d-879a-92a5" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="5db6-c261-8463-2fde" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4be2-a360-c4eb-3eae" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="78f3-4071-ae82-525f" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0322-2053-0732-2c33" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="60ae-3091-e91a-ffb7" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="12.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="7b8f-9d4d-fe28-010d" name="&lt; Support Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="c4cb-5ad3-29f5-e064">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="1d83-6417-d5ba-71b0" hidden="false" targetId="2cec-e1d7-c680-7ca0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="15.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="c4cb-5ad3-29f5-e064" hidden="false" targetId="67b6-d6f5-5ba3-e50d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="8ae5-cb57-4392-b6d3" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="db60-15ad-9c65-1620" name="Promote Crew Member to Leader" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4944-305f-c479-9ce1" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="4be2-a360-c4eb-3eae" hidden="false" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="10.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="6735-38dd-ba7c-0697" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="58d6-220a-a277-4d27" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="1bed-3774-e8f1-9891" hidden="false" targetId="4364-45ee-ee83-ca30" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="5db6-c261-8463-2fde" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bb44-58f4-62b7-989d" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="5f10-a2c6-5a5d-72cc" name="&lt; Unit Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="1677-8c79-2b8e-bbb7">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b35a-a694-6089-eaa0" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="786d-ef80-7b58-c335" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="1677-8c79-2b8e-bbb7" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="5a4a-c6a0-40de-a580" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="5db6-c261-8463-2fde" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bb44-58f4-62b7-989d" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="a700-75fe-fedc-4a1d" hidden="false" targetId="e329-9443-6cb2-bc53" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="45.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0f2b-5fd2-86c3-563b" name="Freeborn Support Team" book="BtGoA" page="193" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="a6d0-fc64-ad5d-674a" name="Weapon Team Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="3b68-a4c9-03bb-dd68" name="Freeborn Crew" book="BtGoA" page="193" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="6f07-d1a0-a27b-5ab4" hidden="false" targetId="c245-fa49-1569-2f23" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="0ced-d327-0411-d442" hidden="false" targetId="a770-8327-b96d-b92e" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="0f2b-5fd2-86c3-563b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8943-c8c6-eaa4-c959" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="2711-9b03-d242-afb9" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8244-60c9-73b8-7d2b" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3768-7869-45f6-f60c" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="b8c6-bbdd-917a-9ce8" name="" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6940-3785-aae5-e276" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="89c7-01a9-e15e-e7ec" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="12.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="85a1-9aa5-986c-0134" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="5764-6087-e7b6-4c73">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="7198-55af-d564-f2fd" hidden="false" targetId="6a2b-50c5-9a33-b756" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="4711-a1d0-8193-4ddf" hidden="false" targetId="eed0-b68f-b5fb-92c7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="5764-6087-e7b6-4c73" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="8c57-5f05-54c3-3b50" hidden="false" targetId="93db-3751-fdd4-08f9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="40.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="0bef-09de-cda1-001e" hidden="false" targetId="c2bf-0272-30c6-dd20" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="35.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="3f8a-3a73-e583-707c" hidden="false" targetId="cf3a-e6a9-bdc0-e0ae" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="30.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="a7eb-103f-f984-c4f9" hidden="false" targetId="71c9-4382-01cf-c737" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="40">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="52c4-3f29-7cff-341f" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="3860-7352-2507-b377" name="Promote Crew Member to Leader" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="8943-c8c6-eaa4-c959" hidden="false" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="10.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="d6e9-f088-ecba-53b8" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="e4a1-35cb-9989-c083" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="22d3-07af-fc6e-749c" hidden="false" targetId="4364-45ee-ee83-ca30" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="0f2b-5fd2-86c3-563b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3b68-a4c9-03bb-dd68" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cff3-e0da-411a-cbd9" name="Get Up!" hidden="false" collective="false" categoryEntryId="50ba-cf77-3941-189c" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="8563-f338-4ece-a2d7" hidden="false" targetId="2afe-05bf-268b-84c2" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4881-30cd-5020-cf21" name="Hound Probe Shard" book="BtGoA" page="196" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="a2c9-24be-fc58-b2ce" name="Probe Unit" book="" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="b84e-d168-f074-70e9" name="&gt; Hound Probe" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="de6a-8e84-305b-6721" hidden="false" targetId="00b8-b49c-4c61-2943" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="8bc7-33a7-b05c-29d5" hidden="false" targetId="d0a1-129b-f8e5-b1ad" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bd58-a73b-e17b-89ae" name="Light General Purpose Drone" book="BtGoA" page="196" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="ae83-e15b-aca4-e246" name="Weapon Drone Unit" book="BtGoA" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="bd92-cca5-ea64-865d" hidden="false" targetId="e167-a8e4-c26a-cafd" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="136e-670b-fde8-eb08" name="GP Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="ee6d-c97a-5f05-6da2" hidden="false" targetId="2dbd-14c5-219e-d37d" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="3dc6-b2b7-80a4-d6db" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="7189-205b-e43f-4b47" name="Self Repair" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="4f3f-a904-dfd8-30e0" hidden="false" targetId="3377-9408-33bb-6a02" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="9c14-af40-c4a6-8c01" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="8fc1-59dc-574d-d478" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="b30a-6adc-e0b9-35b5" hidden="false" targetId="1707-586b-01df-0f80" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="ee36-d310-391a-5a23" hidden="false" targetId="fb8b-7402-c5a9-8644" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="20">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9cfb-19e0-05ac-1e47" name="M25 Type Heavy Combat Drone" book="BtGoA" page="195" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="27e0-0043-07dc-ece0" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="9d1c-1cca-ed53-b1b0" hidden="false" targetId="7c88-64d4-50ad-2313" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="04b2-5695-d4ce-6256" hidden="false" targetId="8151-2e24-94ee-0477" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="01f5-c3d0-42de-8d99" name="&gt; Transporter Drone" book="BtGoA" page="195" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="2c9f-5d67-5f75-022c" hidden="false" targetId="5425-1edf-f536-d5a1" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="0bd6-01b0-8347-296b" name="&lt; Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="dd0c-d323-b658-fa67">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="dd0c-d323-b658-fa67" hidden="false" targetId="67b6-d6f5-5ba3-e50d" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="62ea-7660-3ccf-313c" hidden="false" targetId="af24-45f9-4669-bf98" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="25.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="bcac-a955-0a97-bdb0" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="e39c-f576-faa5-f1da" name="Self Repair" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="ee9f-3fa4-0af8-ce9e" hidden="false" targetId="3377-9408-33bb-6a02" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="f37d-a025-3c15-4abf" hidden="false" targetId="1707-586b-01df-0f80" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="80cd-1a9a-13f7-0d35" hidden="false" targetId="8f68-d09d-6e26-c6ea" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="ecf7-a64a-293a-de72" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="3edb-e997-53e8-ad4a" hidden="false" targetId="e329-9443-6cb2-bc53" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="418.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="530f-c210-1c10-4819" name="M4 Type Combat Drone" book="BtGoA" page="195" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="b25f-8a2f-5932-bb6a" hidden="false" targetId="5565-ce10-1c78-1ee7" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="1334-f2ea-a5eb-674c" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="30bd-b309-a7e2-ce17" name="&gt; Combat Drone" book="BtGoA" page="195" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="a8b4-2c55-d8de-de72" hidden="false" targetId="eb0f-0718-35d7-1a00" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="e349-a387-3011-cdb4" name="&lt; Main Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="64cd-d0a7-af3d-bd56">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="64cd-d0a7-af3d-bd56" hidden="false" targetId="c2bf-0272-30c6-dd20" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="905e-efa8-94c5-0f56" hidden="false" targetId="93db-3751-fdd4-08f9" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="5.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="c54e-bd52-591e-31d6" hidden="false" targetId="71c9-4382-01cf-c737" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="5.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="e4b6-ff25-d3f7-7d36" hidden="false" targetId="0f97-9dbe-566a-5ab0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="42d3-0396-7538-2afe" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="3d7b-8b6c-0bc7-2176" name="Self Repair" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="50db-2d5d-b0d3-7ab6" hidden="false" targetId="3377-9408-33bb-6a02" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="5b5a-646b-cdc9-70c6" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="6b3d-030d-2e2f-db4e" hidden="false" targetId="8f68-d09d-6e26-c6ea" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="c15c-7bd3-0f3e-e876" hidden="false" targetId="1707-586b-01df-0f80" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="1504-b595-21a5-1772" hidden="false" targetId="e329-9443-6cb2-bc53" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="249.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3df6-b3d9-248f-350b" name="M50 Type Heavy Combat Drone" book="BtGoA" page="195" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="2e55-1966-d767-c4f5" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b56d-83bb-8c53-a2ee" hidden="false" targetId="7c88-64d4-50ad-2313" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="8342-2c8c-460a-7d1d" hidden="false" targetId="8151-2e24-94ee-0477" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="aaf8-6738-2b45-c252" name="&gt; Heavy Support Drone" book="BtGoA" page="195" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="250a-e588-2f82-7123" hidden="false" targetId="9e2a-f076-d4df-b60a" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="5086-9f66-b442-f987" name="&lt; Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="1e4a-57fb-e968-6982">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="1e4a-57fb-e968-6982" hidden="false" targetId="b9f1-a313-3e59-57ab" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="2b26-87e7-1e8f-ea79" hidden="false" targetId="9733-7039-e306-26b5" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="7053-b744-1b1a-bbeb" hidden="false" targetId="2cec-e1d7-c680-7ca0" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="25.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="c089-dc26-6ac4-a9e0" hidden="false" targetId="0f97-9dbe-566a-5ab0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="8226-5f69-098e-16a2" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="b1c4-3032-4af5-5874" name="Self Repair" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="dc4e-ba2d-8399-9b36" hidden="false" targetId="3377-9408-33bb-6a02" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="92d7-f414-c1e1-175b" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="7a1a-41e1-fcdc-3390" hidden="false" targetId="8f68-d09d-6e26-c6ea" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="a7a7-9da8-ef6f-2592" hidden="false" targetId="1707-586b-01df-0f80" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="6d78-6ff1-689b-45b9" hidden="false" targetId="e329-9443-6cb2-bc53" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="418.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="68e5-824d-8e72-1018" name="Marksman" hidden="false" collective="false" categoryEntryId="50ba-cf77-3941-189c" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="1054-eaa0-48d3-3dfa" hidden="false" targetId="5741-af68-9dc0-519f" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="771e-7953-547e-2082" name="Misgenic Rejects" book="BtGoA" page="196" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="627d-95ce-0cb7-067d" hidden="false" targetId="db7a-5bd4-6400-f6d1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="6098-b5c2-1d8a-a1b6" name="Misgenic Rejects" book="BtGoA" page="196" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles>
+            <profile id="7079-9c86-12a0-461d" name="Misgenic Rejects" book="BtGoA" page="196" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
             </profile>
-</profiles>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="523a-c675-bb65-766b" name="Promote one reject to Leader" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="85a6-e9d0-03ac-593c" name="Leader One" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="10.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="5b45-20ce-68b0-7e0c" targetId="e441-c3a6-7d61-2c63" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="e3fa-3d4f-d370-193c" name="More Misgenic Abilities" type="upgrade" collective="false" hidden="false" book="BtGoA" page="196" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="10.0"/>
-</costs>
-<constraints/>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="627d-95ce-0cb7-067d" targetId="db7a-5bd4-6400-f6d1" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="e1f2-aa77-1cf5-d89f" name="Pull Yourself Together!" type="upgrade" collective="false" hidden="false" categoryEntryId="50ba-cf77-3941-189c">
-<costs>
-<cost costTypeId="points" name="pts" value="15.0"/>
-</costs>
-<constraints/>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="96ff-949d-ec39-33e0" targetId="8056-104a-5a5d-2089" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="969a-8139-9654-9cdf" name="Skyraider Command Squad" type="unit" collective="false" hidden="false" book="BtGoA" page="174" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89">
-<costs>
-<cost costTypeId="points" name="pts" value="164.0"/>
-</costs>
-<constraints/>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="d40e-0a4d-13fa-863b" name="&lt; Skyraider Captain" type="model" collective="false" hidden="false" book="BtGoA" page="192" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="e0b2-8c3a-7575-9736" name="Leader Level" collective="false" hidden="false">
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="4ac0-b84e-687f-e73b" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="0b4f-18e9-64d4-1bc8" targetId="5c9b-1bde-ee01-04a4" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="7780-1ba7-1b1c-b4c2" targetId="7bc9-5e98-2914-5abd" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="f186-3a30-6680-477f" targetId="e18f-34de-2624-4133" type="profile">
-<modifiers/>
-</infoLink>
-<infoLink id="8ac3-35e0-d064-d5b0" targetId="74dc-b388-dc1d-fb61" type="profile">
-<modifiers>
-<modifier type="set" field="3baa-9cfd-f273-822d" value="Command, Hero, Follow, Large, Fast, Leader 3">
-<conditions>
-<condition type="equalTo" value="1.0" field="selections" scope="d40e-0a4d-13fa-863b" childId="4ac0-b84e-687f-e73b" shared="true"/>
-</conditions>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="2c42-d94f-83c4-fb4f" name="Skyraider Trooper" type="model" collective="false" hidden="false" book="BtGoA" page="192" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="2"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="62da-827c-1a4c-bfef" name="&lt; Ranged Weapon &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="5c2c-6873-9857-0546" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="a18a-ce88-b9af-89e7" targetId="a654-5213-64f2-703a" type="profile">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups>
-<selectionEntryGroup id="2996-96fd-31e3-fe8c" name="&lt; Skyraider &gt;" collective="false" hidden="false" defaultSelectionEntryId="92a3-2543-174e-504b">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="92a3-2543-174e-504b" targetId="a1a8-ba0b-2e45-8020" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="5f94-8423-056d-5f54" name="&lt; Special Weapon Option &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="b3cb-790e-d4ae-710a" targetId="47d9-8149-9744-9849" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="0f9b-216d-3f08-d82e" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="2d2f-4f61-9b31-50b5" name="&lt; Unit Armor &gt;" collective="false" hidden="false" defaultSelectionEntryId="6df8-de07-b4b9-201f">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="2"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="6df8-de07-b4b9-201f" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="0eff-479f-05c9-7f65" targetId="2e3d-bbaa-3f5c-ac53" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="1858-3233-777b-6a0f" name="&lt; Unit Options &gt; " collective="false" hidden="false">
-<constraints/>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="8350-a307-4835-3176" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules>
-<rule id="76be-d990-01b2-40b5" name="Mounted Command Unit" hidden="false">
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="12.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e3fa-3d4f-d370-193c" name="More Misgenic Abilities" book="BtGoA" page="196" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="690e-1ce7-7aec-5838" name="Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="6e77-edfe-926a-4297" hidden="false" targetId="e441-c3a6-7d61-2c63" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cf35-4f58-d1db-38da" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e1f2-aa77-1cf5-d89f" name="Pull Yourself Together!" hidden="false" collective="false" categoryEntryId="50ba-cf77-3941-189c" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="96ff-949d-ec39-33e0" hidden="false" targetId="8056-104a-5a5d-2089" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="969a-8139-9654-9cdf" name="Skyraider Command Squad" book="BtGoA" page="174" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="76be-d990-01b2-40b5" name="Mounted Command Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
-<rule id="801f-37d3-aeef-35ef" name="Limited Choice" hidden="false">
+        <rule id="801f-37d3-aeef-35ef" name="Limited Choice" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
-</rules>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="8ada-48df-990a-b1c6" targetId="b0ca-8e7d-d03f-f027" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="0026-0fee-242b-f524" targetId="a221-d53c-b4bd-b52c" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="1fc7-db89-4652-3c98" name="Superior Shard" type="upgrade" collective="false" hidden="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d">
-<costs>
-<cost costTypeId="points" name="pts" value="15.0"/>
-</costs>
-<constraints>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="1" includeChildSelections="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="1" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="661d-86ab-a747-8bb5" targetId="d4f5-697e-dbf0-ced2" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="859c-f6ff-bc8a-74cf" name="T7 Type Transporter Drone" type="unit" collective="false" hidden="false" book="BtGoA" page="195" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5">
-<costs>
-<cost costTypeId="points" name="pts" value="164.0"/>
-</costs>
-<constraints/>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="e215-3b85-89ba-1fc8" name="&gt; Transporter Drone" type="model" collective="false" hidden="false" book="BtGoA" page="195" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="8a07-2ee4-8417-4ab3" name="&lt; Weapon &gt;" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="4ff7-f2df-7ced-d8f0" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="d2cf-994c-12f0-9c5b" targetId="6a2b-50c5-9a33-b756" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="10.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-<entryLink id="5a7f-0ae6-6b32-4321" targetId="cf3a-e6a9-bdc0-e0ae" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="30.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-<entryLink id="439c-15d6-48b7-16d2" targetId="ac1e-a740-57b7-cc64" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="10.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="a5f0-4afc-16c4-72f9" targetId="5425-1edf-f536-d5a1" type="profile">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups>
-<selectionEntryGroup id="48a3-5d25-ade2-1097" name="&lt; Unit Options &gt;" collective="false" hidden="false">
-<constraints/>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="ad46-f5e3-e9f3-a7de" name="Self Repair" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers>
-<modifier type="increment" field="points" value="10.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="4565-ded9-505e-aced" targetId="3377-9408-33bb-6a02" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="064d-4c81-4e23-79d4" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="b2ad-61e0-f7fe-f5d0" targetId="d571-d584-85fc-9110" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="6f20-1361-0577-c4cf" targetId="1707-586b-01df-0f80" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="c985-b014-70bf-635d" targetId="5565-ce10-1c78-1ee7" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="40c3-e6f7-a42a-fd30" targetId="a221-d53c-b4bd-b52c" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="8eaf-ef10-dfe5-8f3a" targetId="ab37-33d8-41f3-7532" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="aa6c-67b7-3d3b-2a61" name="Targeter Probe Shard" type="unit" collective="false" hidden="false" book="BtGoA" page="196" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints/>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="31ff-3d6d-2a30-3b5a" name="&gt; Targeter Probe" type="model" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="5.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="4"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="6"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="58b0-e470-5c3a-0e30" targetId="00b8-b49c-4c61-2943" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="6620-e65c-9afa-7ed9" targetId="4d5f-ccb4-75c2-cbf2" type="profile">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups/>
-<rules>
-<rule id="8104-2eac-f495-21f9" name="Probe Unit" hidden="false" book="">
+      </rules>
+      <infoLinks>
+        <infoLink id="8ada-48df-990a-b1c6" hidden="false" targetId="b0ca-8e7d-d03f-f027" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="0026-0fee-242b-f524" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="d40e-0a4d-13fa-863b" name="&lt; Skyraider Captain" book="BtGoA" page="192" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="0b4f-18e9-64d4-1bc8" hidden="false" targetId="5c9b-1bde-ee01-04a4" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="7780-1ba7-1b1c-b4c2" hidden="false" targetId="7bc9-5e98-2914-5abd" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="f186-3a30-6680-477f" hidden="false" targetId="e18f-34de-2624-4133" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="8ac3-35e0-d064-d5b0" hidden="false" targetId="74dc-b388-dc1d-fb61" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command, Hero, Follow, Large, Fast, Leader 3">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="d40e-0a4d-13fa-863b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4ac0-b84e-687f-e73b" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="e0b2-8c3a-7575-9736" name="Leader Level" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="4ac0-b84e-687f-e73b" hidden="false" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2c42-d94f-83c4-fb4f" name="Skyraider Trooper" book="BtGoA" page="192" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="a18a-ce88-b9af-89e7" hidden="false" targetId="a654-5213-64f2-703a" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="26f1-7dcb-03d1-424a" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8897-3279-efd1-e42c" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7d69-a1c8-7033-0d30" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5f94-8423-056d-5f54" name="&lt; Special Weapon Option &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="b3cb-790e-d4ae-710a" hidden="false" targetId="47d9-8149-9744-9849" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="0f9b-216d-3f08-d82e" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1858-3233-777b-6a0f" name="&lt; Unit Options &gt; " hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="8350-a307-4835-3176" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="b0e1-bfb5-7e9d-3356" hidden="false" targetId="a1a8-ba0b-2e45-8020" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1eb3-50a0-f4c9-4260" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e1ac-6559-6fab-f767" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="5a47-8810-8886-eec9" hidden="false" targetId="2e3d-bbaa-3f5c-ac53" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3001-9c54-a35e-b48c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c8b-f085-099d-ac33" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="933a-95e7-9737-5e00" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7983-187f-ac36-fce7" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="285d-b593-ba1a-36c1" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="164.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1fc7-db89-4652-3c98" name="Superior Shard" hidden="false" collective="false" categoryEntryId="50ba-cf77-3941-189c" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="661d-86ab-a747-8bb5" hidden="false" targetId="d4f5-697e-dbf0-ced2" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="859c-f6ff-bc8a-74cf" name="T7 Type Transporter Drone" book="BtGoA" page="195" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="c985-b014-70bf-635d" hidden="false" targetId="5565-ce10-1c78-1ee7" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="40c3-e6f7-a42a-fd30" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="8eaf-ef10-dfe5-8f3a" hidden="false" targetId="ab37-33d8-41f3-7532" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="e215-3b85-89ba-1fc8" name="&gt; Transporter Drone" book="BtGoA" page="195" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="a5f0-4afc-16c4-72f9" hidden="false" targetId="5425-1edf-f536-d5a1" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="8a07-2ee4-8417-4ab3" name="&lt; Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="4ff7-f2df-7ced-d8f0">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="4ff7-f2df-7ced-d8f0" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="d2cf-994c-12f0-9c5b" hidden="false" targetId="6a2b-50c5-9a33-b756" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="10.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="5a7f-0ae6-6b32-4321" hidden="false" targetId="cf3a-e6a9-bdc0-e0ae" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="30.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="439c-15d6-48b7-16d2" hidden="false" targetId="ac1e-a740-57b7-cc64" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="10.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="48a3-5d25-ade2-1097" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries>
+            <selectionEntry id="ad46-f5e3-e9f3-a7de" name="Self Repair" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="4565-ded9-505e-aced" hidden="false" targetId="3377-9408-33bb-6a02" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="064d-4c81-4e23-79d4" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="b2ad-61e0-f7fe-f5d0" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="6f20-1361-0577-c4cf" hidden="false" targetId="1707-586b-01df-0f80" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="164.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="aa6c-67b7-3d3b-2a61" name="Targeter Probe Shard" book="BtGoA" page="196" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="8104-2eac-f495-21f9" name="Probe Unit" book="" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
         </rule>
-</rules>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="40ad-08b6-fa6a-0171" name="Vardanari Squad (Guards)" type="unit" collective="false" hidden="false" book="BtGoA" page="191" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe">
-<costs>
-<cost costTypeId="points" name="pts" value="42.0"/>
-</costs>
-<constraints/>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="c3fa-7787-a4d1-50f8" name="&lt; Vardanari Leader" type="model" collective="false" hidden="false" book="BtGoA" page="191" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="189f-239f-cc54-f496" name="&lt; Leader Level &gt;" collective="false" hidden="false" defaultSelectionEntryId="7ea8-bf13-37df-8acf">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="6cd8-052e-b9da-e94e" name="Leader 2" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="10.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="f2ac-6316-75a8-0504" targetId="7850-89e7-bab8-86e9" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="7ea8-bf13-37df-8acf" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="f5ed-8cd5-154e-1987" name="&lt; Ranged Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="c12f-a100-2c77-940b">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="2"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="c12f-a100-2c77-940b" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="02d9-18d6-822b-c297" targetId="179a-c0cc-49cc-c946" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks>
-<entryLink id="dbcb-5feb-24da-acaf" targetId="8de3-1e72-72ef-e7a3" type="selectionEntry">
-<modifiers>
-<modifier type="increment" field="points" value="5.0">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</entryLink>
-</entryLinks>
-<infoLinks>
-<infoLink id="1a89-bc54-c850-a7a0" targetId="62fc-1d76-c6fd-a3eb" type="profile">
-<modifiers>
-<modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2">
-<conditions/>
-<conditionGroups/>
-</modifier>
-</modifiers>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="97e8-d8ef-1bec-906d" name="Vardanari Guard" type="model" collective="false" hidden="false" book="BtGoA" page="191" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="19.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="5"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="7"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="4ca6-7e89-8b59-f1d5" targetId="702f-c8a7-d8cf-01c1" type="profile">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups>
-<selectionEntryGroup id="fff7-d85d-7713-194d" name="Ranged Weapon" collective="false" hidden="false" defaultSelectionEntryId="1b32-6cc9-8dc9-64b3">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="1b32-6cc9-8dc9-64b3" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="8836-8c4d-3a4f-5d40" name="Armor" collective="false" hidden="false" defaultSelectionEntryId="a575-c942-e1b2-0d29">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="a575-c942-e1b2-0d29" targetId="03c2-174e-8617-cf04" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks>
-<entryLink id="7876-6071-860a-2b8f" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="a7b4-9779-24e9-b2a7" targetId="573b-88bc-97d7-d890" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="4e0f-95bb-f4f1-6030" name="Well Prepared" type="upgrade" collective="false" hidden="false" categoryEntryId="50ba-cf77-3941-189c">
-<costs>
-<cost costTypeId="points" name="pts" value="5.0"/>
-</costs>
-<constraints/>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="69f3-3470-5212-8eaa" targetId="75d2-6efa-9640-61df" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<rules/>
-<entryLinks/>
-<infoLinks/>
-<sharedSelectionEntries>
-<selectionEntry id="e9dd-1dc6-3c92-4305" name="AG Chute" type="upgrade" collective="true" hidden="false" book="BtGoA" page="120" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="54c4-0df3-268c-9fe1" targetId="7daf-414b-c030-7626" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="828e-3aa2-3dbf-f2cb" name="Auto-Workshop" type="upgrade" collective="false" hidden="false" book="BtGoA" page="120" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="-1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="2aa0-3909-ff3b-5bfe" targetId="b7c6-fc7c-d48b-aae4" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="d571-d584-85fc-9110" name="Batter Drone" type="upgrade" collective="false" hidden="false" book="BtGoA" page="11" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="20.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="2686-6df4-4601-e99f" targetId="f0d9-1e5a-ec20-b27c" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="8f68-d09d-6e26-c6ea" name="Batter Drone (2)" type="upgrade" collective="false" hidden="false" book="BtGoA" page="11" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="20.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="0a02-46cc-7e6f-28b0" targetId="f0d9-1e5a-ec20-b27c" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="af35-43cb-665c-f896" name="Booster Drone" type="upgrade" collective="true" hidden="false" book="BtGoA" page="111" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="77b8-dc0d-36ff-0f1d" name="Borer Drone" type="upgrade" collective="false" hidden="false" book="BtGoA" page="111" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="-1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="f67e-b103-c5e0-7d92" targetId="4e34-753f-b082-2e00" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="4933-25f0-2896-ac60" name="Camo Drone" type="upgrade" collective="false" hidden="false" book="BtGoA" page="112" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="0235-7440-f324-d8e9" targetId="5f48-f41c-fd96-6a1a" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="babd-f951-933b-1254" name="Compactor Drone" type="unit" collective="false" hidden="false" book="BtGoA" page="112" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="d5b5-2649-62fd-e305" targetId="3995-c066-c957-5ffe" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="666e-aa69-6e72-f168" name="Compactor Drone with Mag Cannon" type="unit" collective="false" hidden="false" book="BtGoA" page="112" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks>
-<entryLink id="9c4f-f6de-c09c-eab2" targetId="6a2b-50c5-9a33-b756" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-<infoLinks>
-<infoLink id="663f-33f4-57b5-7a11" targetId="3995-c066-c957-5ffe" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="2144-e450-c8f2-af26" name="Compactor Drone with Mag Light Support" type="unit" collective="false" hidden="false" book="BtGoA" page="112" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks>
-<entryLink id="d525-3a93-38f1-7e4e" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-<infoLinks>
-<infoLink id="4e01-7b13-2e6c-0f97" targetId="3995-c066-c957-5ffe" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="0299-39fc-32bd-8ac2" name="Compactor Drone with Plasma Cannon" type="unit" collective="false" hidden="false" book="BtGoA" page="112" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks>
-<entryLink id="e506-bd0d-b513-7050" targetId="c2bf-0272-30c6-dd20" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-<infoLinks>
-<infoLink id="ae6e-0698-5ad9-8d26" targetId="3995-c066-c957-5ffe" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="af24-45f9-4669-bf98" name="Compression Bombard" type="upgrade" collective="false" hidden="false" book="BtGoA" page="84" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="f3f6-794b-82b3-a39a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Bombard" hidden="false" book="BtGoA" page="84">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10-50"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="150"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="9/7/5"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Cycle, Heavy Weapon"/>
-          </characteristics>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="31ff-3d6d-2a30-3b5a" name="&gt; Targeter Probe" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="58b0-e470-5c3a-0e30" hidden="false" targetId="00b8-b49c-4c61-2943" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="6620-e65c-9afa-7ed9" hidden="false" targetId="4d5f-ccb4-75c2-cbf2" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-        </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="d318-c320-5b7c-b089" targetId="7db4-2d14-3984-37d9" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="a2f7-528d-dd59-9d00" targetId="a41d-d55e-6d97-049d" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="b53d-32d6-c4fc-cefc" targetId="cf7f-6f85-e64e-0363" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="71c9-4382-01cf-c737" name="Compression Cannon" type="upgrade" collective="false" hidden="false" book="BtGoA" page="78" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="b626-3a7f-ecf5-ea69" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Cannon" hidden="false" book="BtGoA" page="78">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="7/4/2"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Cycle,  Light Support Weapon"/>
-          </characteristics>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="40ad-08b6-fa6a-0171" name="Vardanari Squad (Guards)" book="BtGoA" page="191" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="c3fa-7787-a4d1-50f8" name="&lt; Vardanari Leader" book="BtGoA" page="191" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="1a89-bc54-c850-a7a0" hidden="false" targetId="62fc-1d76-c6fd-a3eb" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-        </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="a6f9-23ce-e99d-7c15" targetId="7db4-2d14-3984-37d9" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="3003-31fb-fb6c-3084" targetId="a41d-d55e-6d97-049d" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="70d5-a230-ba57-ead0" targetId="cf7f-6f85-e64e-0363" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="059b-38f7-0313-5ae4" name="Compression Carbine" type="upgrade" collective="true" hidden="false" book="BtGoA" page="72" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="e580-6389-7ec6-d445" targetId="7db4-2d14-3984-37d9" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="b230-6dc2-fc21-9332" targetId="75cb-cf9b-dd3d-9177" type="profile">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="72ba-15e7-dbf7-816c" name="D-Spinner" type="upgrade" collective="true" hidden="false" book="BtGoA" page="66" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="bc08-23ff-215d-d442" profileTypeId="ecae-8ac8-2c13-0dd3" name="D-Spinner" hidden="false" book="BtGoA" page="66">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="Varies"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks, Variable Res/Strike, Grenade, Hand Weapon"/>
-          </characteristics>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="189f-239f-cc54-f496" name="&lt; Leader Level &gt;" hidden="false" collective="false" defaultSelectionEntryId="7ea8-bf13-37df-8acf">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="6cd8-052e-b9da-e94e" name="Leader 2" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="f2ac-6316-75a8-0504" hidden="false" targetId="7850-89e7-bab8-86e9" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="7ea8-bf13-37df-8acf" hidden="false" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="dbcb-5feb-24da-acaf" hidden="false" targetId="8de3-1e72-72ef-e7a3" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="1f89-4b44-31d7-43e3" hidden="false" targetId="1631-5857-2139-960a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa1f-5a2d-7c2a-416f" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e28-e475-4a83-b50c" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="e45b-18f1-2c11-8402" hidden="false" targetId="179a-c0cc-49cc-c946" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3cd9-4fa2-aac1-3e44" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4285-2ea2-bd4e-8ddd" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="97e8-d8ef-1bec-906d" name="Vardanari Guard" book="BtGoA" page="191" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="4ca6-7e89-8b59-f1d5" hidden="false" targetId="702f-c8a7-d8cf-01c1" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-        </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="bf1e-fb77-9e71-f9fe" targetId="2cbd-47c9-de87-ec2a" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="363c-73f0-41ad-dfb8" targetId="99fd-f354-1703-5941" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="91a4-fa2b-910b-b8f8" targetId="b466-7990-db34-55b1" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="ff6c-f8d8-94e6-57bc" name="Disruptor Bomber" type="upgrade" collective="false" hidden="false" book="BtGoA" page="77" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="c100-99b7-2ff6-24a0" profileTypeId="ecae-8ac8-2c13-0dd3" name="Disruptor Bomber" hidden="false" book="BtGoA" page="77">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="60"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="120"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D5, No Crew, Limited Ammo, No Cover, Disruptor,  Light Support Weapon"/>
-          </characteristics>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="19.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="7876-6071-860a-2b8f" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="5bfd-e568-cff9-ff1b" targetId="c3bc-87fd-fa5d-5055" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="ada8-a0a5-d314-27a6" targetId="b050-496a-ed16-2b2a" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="c9a5-e124-997c-44ea" targetId="f502-611e-9704-97bb" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="b3e6-5aa3-ef1f-f7b1" targetId="5efa-64a9-bbc9-3dba" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="df53-3436-c62e-c73e" targetId="a41d-d55e-6d97-049d" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="7fb2-1ffe-610d-7f33" targetId="6305-72fa-da02-235b" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="f771-f4b5-0047-de53" name="Disruptor Cannon" type="upgrade" collective="false" hidden="false" book="BtGoA" page="79" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="17db-4b84-9d1b-122d" profileTypeId="ecae-8ac8-2c13-0dd3" name="Disruptor Cannon" hidden="false" book="BtGoA" page="79">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D4, No Cover, Disruptor, Light Support Weapon"/>
-          </characteristics>
+          <constraints/>
+        </entryLink>
+        <entryLink id="a7b4-9779-24e9-b2a7" hidden="false" targetId="573b-88bc-97d7-d890" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="48bb-4c87-e0f2-08b4" targetId="ca96-58c9-9551-d4fe" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="3b06-bc9e-4002-8aeb" targetId="a41d-d55e-6d97-049d" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="8e03-d6b4-1fab-5cd2" targetId="6305-72fa-da02-235b" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="396e-b157-b3bb-a5e7" name="Disruptor Discharger" type="upgrade" collective="false" hidden="false" book="BtGoA" page="86" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="-1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="de01-ba7b-11ee-55ca" profileTypeId="ecae-8ac8-2c13-0dd3" name="Disruptor Discharger" hidden="false" book="BtGoA" page="86">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="Point blank shooting only"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="Point blank shooting only"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="Point blank shooting only"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D4, No Cover, Disruptor, Grenade"/>
-          </characteristics>
+          <constraints/>
+        </entryLink>
+        <entryLink id="099f-e4f3-192f-4fab" hidden="false" targetId="1631-5857-2139-960a" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="e755-a7a2-1343-d27a" targetId="5d64-4bf5-e947-95d1" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="b2cb-0542-2c44-9f1b" targetId="ca96-58c9-9551-d4fe" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="049f-1e26-3f5d-a4f9" targetId="a41d-d55e-6d97-049d" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="adad-ebe2-3953-6510" targetId="6305-72fa-da02-235b" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="2cec-e1d7-c680-7ca0" name="Fractal Bombard" type="upgrade" collective="false" hidden="false" book="BtGoA" page="83" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="279b-22b3-c3ff-1320" profileTypeId="ecae-8ac8-2c13-0dd3" name="Fractal Bombard" hidden="false" book="BtGoA" page="83">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="50"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="200"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="3 + 2 Max 10"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock, Heavy Weapon"/>
-          </characteristics>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4fb8-a660-f0e6-1a40" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="877b-a14d-61b7-5c11" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="88aa-1888-1b34-bdf4" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="fe6a-32a9-1211-b766" targetId="d50c-3bbe-c62d-34c3" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="93db-3751-fdd4-08f9" name="Fractal Cannon" type="upgrade" collective="false" hidden="false" book="BtGoA" page="76" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="cb47-aad3-9a1b-1266" profileTypeId="ecae-8ac8-2c13-0dd3" name="Fractal Cannon" hidden="false" book="BtGoA" page="76">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2 + 1 Max 10"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock,  Light Support Weapon"/>
-          </characteristics>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ee7d-56b0-fe8a-b8b6" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="58ff-f2c9-34ec-aeef" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="961a-71ba-47e1-15fa" hidden="false" targetId="d118-8115-df5f-2402" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="2">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2">
+              <repeats>
+                <repeat field="selections" scope="40ad-08b6-fa6a-0171" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97e8-d8ef-1bec-906d" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="42.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4e0f-95bb-f4f1-6030" name="Well Prepared" hidden="false" collective="false" categoryEntryId="50ba-cf77-3941-189c" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="69f3-3470-5212-8eaa" hidden="false" targetId="75d2-6efa-9640-61df" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="b7b4-01fa-5f1f-ebee" targetId="d50c-3bbe-c62d-34c3" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="aac7-43b0-4a5c-05bb" name="Frag Borer" type="upgrade" collective="false" hidden="false" book="BtGoA" page="77" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="5cb2-9abf-ed28-03ff" profileTypeId="ecae-8ac8-2c13-0dd3" name="Frag Borer" hidden="false" book="BtGoA" page="77">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="60"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="3 + 1 Max 10"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock,  Light Support Weapon"/>
-          </characteristics>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="403e-ef5d-e336-5353" name="Freeborn Command Squad (Special)" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="94c3-4236-446e-67b9" name="&lt; Freeborn Captain" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="c9b3-087a-dd39-3e13" hidden="false" targetId="2d89-bcdb-b942-b900" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="403e-ef5d-e336-5353" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d585-88db-e32c-172b" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-        </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="eac9-8b04-b66c-5db6" targetId="d50c-3bbe-c62d-34c3" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="3975-3892-22f2-0c8e" name="Ghar Plasma Claw" type="upgrade" collective="false" hidden="false" book="BtGoA" page="66" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="57de-9415-94c2-a9cd" profileTypeId="ecae-8ac8-2c13-0dd3" name="Ghar Plasma Claw" hidden="false" book="BtGoA" page="66">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="D4"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Random SV,  Hand Weapon"/>
-          </characteristics>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b755-8ba1-4be2-641f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b399-aaae-1b07-8678" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="480e-e9ce-704e-a023" name="&lt; Weapon &gt;" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d947-d910-a119-977a" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8006-b69c-1794-7a77" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="1ddd-ba8c-50d8-4796" name="New EntryLink" hidden="false" targetId="1631-5857-2139-960a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="8">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="dac9-6ab7-aac1-a741" name="New EntryLink" hidden="false" targetId="059b-38f7-0313-5ae4" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="8">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="d585-88db-e32c-172b" hidden="false" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a1a5-6b86-1320-13c2" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="b63e-62fe-b301-e902" hidden="false" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="322b-67e4-d85f-1e47" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9efc-de6a-c79d-2a89" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="85a8-6838-c06b-99a3" name="Bodyguards" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="2021-2f78-5e07-3dc7" hidden="false" targetId="9fba-d6b7-c66d-99f0" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-        </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="7eb4-a0e1-1e61-3d82" targetId="b6e3-9cf0-1a9f-a941" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="f319-5d36-f853-9d45" name="Gouger Gun" type="upgrade" collective="false" hidden="false" book="BtGoA" page="74" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="5caa-0eb3-a2c8-d79c" profileTypeId="ecae-8ac8-2c13-0dd3" name="Gouger Gun" hidden="false" book="BtGoA" page="74">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10-20"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Down, Inaccurate, Standard Weapon"/>
-          </characteristics>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e05f-5f96-09b0-5752" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8a9a-f4ed-d2fb-70f0" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="21.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="d83a-db6a-6bb3-b067" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="6c43-9149-1b89-35e5" targetId="9444-e2a0-8048-5ce9" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="aa66-a1ad-73f1-8bd2" targetId="3b84-9d0e-a3c1-6c1f" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="b8d1-46be-c623-ad68" name="Gun Drone" type="upgrade" collective="false" hidden="false" book="BtGoA" page="112" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="14.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="4b9d-a0bf-396e-384b" name="Gun Drone (2)" type="upgrade" collective="true" hidden="false" book="BtGoA" page="112" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="14.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="f9cf-568d-998b-c3ca" name="Heavy Disruptor Bomber" type="upgrade" collective="false" hidden="false" book="BtGoA" page="80" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="a9a7-e90e-e54a-e37c" profileTypeId="ecae-8ac8-2c13-0dd3" name="Heavy Disruptor Bomber" hidden="false" book="BtGoA" page="80">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="60"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="120"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="OH x2, Blast D10, Limited Ammo, No Cover, Disruptor, Heavy Weapon"/>
-          </characteristics>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="bd17-f54f-fec2-724e" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="f33f-ca8b-2c50-a3a3" hidden="false" targetId="502c-9855-7269-eaa2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="450d-3f63-6598-41e6" hidden="false" targetId="573b-88bc-97d7-d890" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="705f-619a-f751-5f4d" hidden="false" targetId="d118-8115-df5f-2402" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="2">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="403e-ef5d-e336-5353" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="85a8-6838-c06b-99a3" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="9900-a400-684e-b1b4" name="New EntryLink" hidden="false" targetId="4b9d-a0bf-396e-384b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="8f75-16d6-9343-a263" name="New EntryLink" hidden="false" targetId="1707-586b-01df-0f80" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="6106-f50f-fc72-2dfa" name="New EntryLink" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="396b-0574-e281-d445" name="&lt; Armor &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="baaa-0b37-7581-545a" targetId="aef6-6934-1dee-6fa0" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="ad5f-454c-b4ec-0b29" targetId="04d9-a48d-7b25-4dd3" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="3dc5-ce4c-aaf4-7bc4" targetId="a41d-d55e-6d97-049d" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="1d69-8270-126c-b660" targetId="6305-72fa-da02-235b" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="564d-3561-f5e4-783d" name="Heavy Frag Borer" type="upgrade" collective="false" hidden="false" book="BtGoA" page="83" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="4001-9da2-86d1-6b80" profileTypeId="ecae-8ac8-2c13-0dd3" name="Heavy Frag Borer" hidden="false" book="BtGoA" page="83">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="60"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="6 + 1 Max 10"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock, Heavy Weapon"/>
-          </characteristics>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fd7-7c4a-14af-ab7f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="67ba-60c5-c779-df3d" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="f31e-b6ab-c2f7-a5ab" name="New EntryLink" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="64c6-abaa-e41b-95b4" name="New EntryLink" hidden="false" targetId="eff8-bb0e-1b1d-bbb2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="1">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="403e-ef5d-e336-5353" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="85a8-6838-c06b-99a3" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="3925-4e8d-bcc1-c29f" name="New EntryLink" hidden="false" targetId="eb94-d1e8-1084-71b3" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="1">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="403e-ef5d-e336-5353" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="85a8-6838-c06b-99a3" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6264-159e-143d-7b60" name="&lt; Weapons &gt;" hidden="false" collective="false" defaultSelectionEntryId="6540-90ba-a708-664d">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="174d-fb91-0ee1-de89" targetId="d50c-3bbe-c62d-34c3" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="5149-5183-64d5-feaf" name="Heavy Mag Cannon" type="upgrade" collective="false" hidden="false" book="BtGoA" page="81" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="49f7-05c7-8536-e088" profileTypeId="ecae-8ac8-2c13-0dd3" name="Heavy Mag Cannon" hidden="false" book="BtGoA" page="81">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="50"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="10"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="250"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="6"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Massive Damage, Heavy Weapon"/>
-          </characteristics>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a29f-41eb-4c20-0d2b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1837-2c5e-c02c-d572" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="6540-90ba-a708-664d" hidden="false" targetId="1631-5857-2139-960a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="5465-a7f1-c89e-c52d" name="New EntryLink" hidden="false" targetId="059b-38f7-0313-5ae4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="69.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0af0-76e5-b1eb-f274" name="Freeborn Specialist Heavy Support Team w/ Compression Bombard" book="Battle for Xilos" page="83" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="871b-7ea5-9072-1ef5" name="Weapon Team Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="2226-327b-9cef-5629" targetId="c863-510b-e239-be92" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="4fbe-feab-de05-5312" name="Heavy Tractor Maul" type="upgrade" collective="false" hidden="false" book="BtGoA" page="65" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="05cc-6d3b-93d8-0b0e" profileTypeId="ecae-8ac8-2c13-0dd3" name="Heavy Tractor Maul" hidden="false" book="BtGoA" page="65">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks, Hand Weapon"/>
-          </characteristics>
+        </rule>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries>
+        <selectionEntry id="f0a8-29ef-aa07-9a43" name="Freeborn Crew" book="BtGoA" page="193" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="2518-8d84-1caa-3963" hidden="false" targetId="7267-3051-f1b4-0a88" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="024a-7589-baec-6cc2" hidden="false" targetId="87a3-460d-879a-92a5" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="0af0-76e5-b1eb-f274" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="71b8-817b-0886-9baa" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0fcf-1b9f-2557-db91" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="23ba-6a8a-f380-d654" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="1161-8d15-2e2f-6638" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e759-50d8-d01c-a89f" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e939-ee2b-43e7-f4e0" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="12.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="711a-09a0-33ac-b041" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="223c-a4a7-e66c-22d4" name="Promote Crew Member to Leader" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="734c-a4ff-c390-a61a" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="71b8-817b-0886-9baa" hidden="false" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="10.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="e4a1-ea2c-7e0d-7ee5" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="a1ee-b308-4d60-e745" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="66a0-f732-e21c-ff86" hidden="false" targetId="4364-45ee-ee83-ca30" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="0af0-76e5-b1eb-f274" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f0a8-29ef-aa07-9a43" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="2e2a-c1d3-23b0-dbd5" name="&lt; Unit Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="fcbc-0a66-a5b0-426e">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7efe-9fb4-e1a3-9d8b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5ad2-e981-d975-5c6b" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="fcbc-0a66-a5b0-426e" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="c3db-bfd4-244f-935d" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="0af0-76e5-b1eb-f274" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f0a8-29ef-aa07-9a43" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="f7d7-0f5e-dd8e-2483" hidden="false" targetId="e329-9443-6cb2-bc53" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+        <entryLink id="3d38-fa9f-02c2-84f3" hidden="false" targetId="af24-45f9-4669-bf98" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1752-9127-f999-ad0d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5bcd-553c-6d07-a2cd" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="45.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <entryLinks/>
+  <sharedSelectionEntries>
+    <selectionEntry id="e9dd-1dc6-3c92-4305" name="AG Chute" book="BtGoA" page="120" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="54c4-0df3-268c-9fe1" hidden="false" targetId="7daf-414b-c030-7626" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="828e-3aa2-3dbf-f2cb" name="Auto-Workshop" book="BtGoA" page="120" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="2aa0-3909-ff3b-5bfe" hidden="false" targetId="b7c6-fc7c-d48b-aae4" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d571-d584-85fc-9110" name="Batter Drone" book="BtGoA" page="11" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="2686-6df4-4601-e99f" hidden="false" targetId="f0d9-1e5a-ec20-b27c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8f68-d09d-6e26-c6ea" name="Batter Drone (2)" book="BtGoA" page="11" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0a02-46cc-7e6f-28b0" hidden="false" targetId="f0d9-1e5a-ec20-b27c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="af35-43cb-665c-f896" name="Booster Drone" book="BtGoA" page="111" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="77b8-dc0d-36ff-0f1d" name="Borer Drone" book="BtGoA" page="111" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="f67e-b103-c5e0-7d92" hidden="false" targetId="4e34-753f-b082-2e00" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4933-25f0-2896-ac60" name="Camo Drone" book="BtGoA" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0235-7440-f324-d8e9" hidden="false" targetId="5f48-f41c-fd96-6a1a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="babd-f951-933b-1254" name="Compactor Drone" book="BtGoA" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d5b5-2649-62fd-e305" hidden="false" targetId="3995-c066-c957-5ffe" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="666e-aa69-6e72-f168" name="Compactor Drone with Mag Cannon" book="BtGoA" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="663f-33f4-57b5-7a11" hidden="false" targetId="3995-c066-c957-5ffe" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="9c4f-f6de-c09c-eab2" hidden="false" targetId="6a2b-50c5-9a33-b756" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2144-e450-c8f2-af26" name="Compactor Drone with Mag Light Support" book="BtGoA" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="4e01-7b13-2e6c-0f97" hidden="false" targetId="3995-c066-c957-5ffe" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="d525-3a93-38f1-7e4e" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0299-39fc-32bd-8ac2" name="Compactor Drone with Plasma Cannon" book="BtGoA" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="ae6e-0698-5ad9-8d26" hidden="false" targetId="3995-c066-c957-5ffe" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="e506-bd0d-b513-7050" hidden="false" targetId="c2bf-0272-30c6-dd20" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="af24-45f9-4669-bf98" name="Compression Bombard" book="BtGoA" page="84" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="f3f6-794b-82b3-a39a" name="Compression Bombard" book="BtGoA" page="84" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-50"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="150"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="9/7/5"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Cycle, Heavy Weapon"/>
+          </characteristics>
         </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="c401-a6db-93c9-69e0" targetId="2cbd-47c9-de87-ec2a" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="eff8-bb0e-1b1d-bbb2" name="HL armor" type="model" collective="true" hidden="false" book="BtGoA" page="93" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="2a6f-a102-e7b6-54c7" targetId="b436-1f8a-5d3a-2d7d" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="2e3d-bbaa-3f5c-ac53" name="HL Booster (Eq)" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="1.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="-1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="b458-ac53-f980-4960" targetId="56ab-52fc-9557-2586" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="573b-88bc-97d7-d890" name="HL Booster Drone" type="model" collective="false" hidden="false" book="BtGoA" page="121" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="20.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="68d9-bb11-1862-acca" targetId="56ab-52fc-9557-2586" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="1b16-412b-662a-5467" name="Homer Drone" type="upgrade" collective="false" hidden="false" book="BtGoA" page="112" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="e015-e1a0-3cd3-a350" targetId="ca2b-9550-eb1e-77c8" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="4364-45ee-ee83-ca30" name="Impact Cloak " type="upgrade" collective="true" hidden="false" book="BtGoA" page="93" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules>
-<rule id="5da7-d6db-a841-0ff0" name="Impact Cloak" hidden="false" book="BtGoA" page="93">
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d318-c320-5b7c-b089" hidden="false" targetId="7db4-2d14-3984-37d9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="a2f7-528d-dd59-9d00" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b53d-32d6-c4fc-cefc" hidden="false" targetId="cf7f-6f85-e64e-0363" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="71c9-4382-01cf-c737" name="Compression Cannon" book="BtGoA" page="78" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="b626-3a7f-ecf5-ea69" name="Compression Cannon" book="BtGoA" page="78" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="7/4/2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Cycle,  Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a6f9-23ce-e99d-7c15" hidden="false" targetId="7db4-2d14-3984-37d9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3003-31fb-fb6c-3084" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="70d5-a230-ba57-ead0" hidden="false" targetId="cf7f-6f85-e64e-0363" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="059b-38f7-0313-5ae4" name="Compression Carbine" book="BtGoA" page="72" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="e580-6389-7ec6-d445" hidden="false" targetId="7db4-2d14-3984-37d9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b230-6dc2-fc21-9332" hidden="false" targetId="75cb-cf9b-dd3d-9177" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="72ba-15e7-dbf7-816c" name="D-Spinner" book="BtGoA" page="66" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="bc08-23ff-215d-d442" name="D-Spinner" book="BtGoA" page="66" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="Varies"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks, Variable Res/Strike, Grenade, Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="bf1e-fb77-9e71-f9fe" hidden="false" targetId="2cbd-47c9-de87-ec2a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="363c-73f0-41ad-dfb8" hidden="false" targetId="99fd-f354-1703-5941" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="91a4-fa2b-910b-b8f8" hidden="false" targetId="b466-7990-db34-55b1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ff6c-f8d8-94e6-57bc" name="Disruptor Bomber" book="BtGoA" page="77" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="c100-99b7-2ff6-24a0" name="Disruptor Bomber" book="BtGoA" page="77" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D5, No Crew, Limited Ammo, No Cover, Disruptor,  Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="5bfd-e568-cff9-ff1b" hidden="false" targetId="c3bc-87fd-fa5d-5055" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ada8-a0a5-d314-27a6" hidden="false" targetId="b050-496a-ed16-2b2a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="c9a5-e124-997c-44ea" hidden="false" targetId="f502-611e-9704-97bb" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b3e6-5aa3-ef1f-f7b1" hidden="false" targetId="5efa-64a9-bbc9-3dba" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="df53-3436-c62e-c73e" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7fb2-1ffe-610d-7f33" hidden="false" targetId="6305-72fa-da02-235b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f771-f4b5-0047-de53" name="Disruptor Cannon" book="BtGoA" page="79" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="17db-4b84-9d1b-122d" name="Disruptor Cannon" book="BtGoA" page="79" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, No Cover, Disruptor, Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="48bb-4c87-e0f2-08b4" hidden="false" targetId="ca96-58c9-9551-d4fe" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3b06-bc9e-4002-8aeb" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="8e03-d6b4-1fab-5cd2" hidden="false" targetId="6305-72fa-da02-235b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="396e-b157-b3bb-a5e7" name="Disruptor Discharger" book="BtGoA" page="86" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="de01-ba7b-11ee-55ca" name="Disruptor Discharger" book="BtGoA" page="86" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="Point blank shooting only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="Point blank shooting only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="Point blank shooting only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, No Cover, Disruptor, Grenade"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="e755-a7a2-1343-d27a" hidden="false" targetId="5d64-4bf5-e947-95d1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b2cb-0542-2c44-9f1b" hidden="false" targetId="ca96-58c9-9551-d4fe" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="049f-1e26-3f5d-a4f9" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="adad-ebe2-3953-6510" hidden="false" targetId="6305-72fa-da02-235b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2cec-e1d7-c680-7ca0" name="Fractal Bombard" book="BtGoA" page="83" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="279b-22b3-c3ff-1320" name="Fractal Bombard" book="BtGoA" page="83" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="50"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="200"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3 + 2 Max 10"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="fe6a-32a9-1211-b766" hidden="false" targetId="d50c-3bbe-c62d-34c3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="93db-3751-fdd4-08f9" name="Fractal Cannon" book="BtGoA" page="76" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="cb47-aad3-9a1b-1266" name="Fractal Cannon" book="BtGoA" page="76" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2 + 1 Max 10"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock,  Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="b7b4-01fa-5f1f-ebee" hidden="false" targetId="d50c-3bbe-c62d-34c3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="aac7-43b0-4a5c-05bb" name="Frag Borer" book="BtGoA" page="77" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="5cb2-9abf-ed28-03ff" name="Frag Borer" book="BtGoA" page="77" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3 + 1 Max 10"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock,  Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="eac9-8b04-b66c-5db6" hidden="false" targetId="d50c-3bbe-c62d-34c3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3975-3892-22f2-0c8e" name="Ghar Plasma Claw" book="BtGoA" page="66" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="57de-9415-94c2-a9cd" name="Ghar Plasma Claw" book="BtGoA" page="66" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="D4"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Random SV,  Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="7eb4-a0e1-1e61-3d82" hidden="false" targetId="b6e3-9cf0-1a9f-a941" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f319-5d36-f853-9d45" name="Gouger Gun" book="BtGoA" page="74" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="5caa-0eb3-a2c8-d79c" name="Gouger Gun" book="BtGoA" page="74" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Down, Inaccurate, Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="6c43-9149-1b89-35e5" hidden="false" targetId="9444-e2a0-8048-5ce9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="aa66-a1ad-73f1-8bd2" hidden="false" targetId="3b84-9d0e-a3c1-6c1f" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b8d1-46be-c623-ad68" name="Gun Drone" book="BtGoA" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="14.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4b9d-a0bf-396e-384b" name="Gun Drone (2)" book="BtGoA" page="112" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="14.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f9cf-568d-998b-c3ca" name="Heavy Disruptor Bomber" book="BtGoA" page="80" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="a9a7-e90e-e54a-e37c" name="Heavy Disruptor Bomber" book="BtGoA" page="80" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH x2, Blast D10, Limited Ammo, No Cover, Disruptor, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="baaa-0b37-7581-545a" hidden="false" targetId="aef6-6934-1dee-6fa0" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ad5f-454c-b4ec-0b29" hidden="false" targetId="04d9-a48d-7b25-4dd3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3dc5-ce4c-aaf4-7bc4" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="1d69-8270-126c-b660" hidden="false" targetId="6305-72fa-da02-235b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="564d-3561-f5e4-783d" name="Heavy Frag Borer" book="BtGoA" page="83" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="4001-9da2-86d1-6b80" name="Heavy Frag Borer" book="BtGoA" page="83" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6 + 1 Max 10"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="174d-fb91-0ee1-de89" hidden="false" targetId="d50c-3bbe-c62d-34c3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5149-5183-64d5-feaf" name="Heavy Mag Cannon" book="BtGoA" page="81" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="49f7-05c7-8536-e088" name="Heavy Mag Cannon" book="BtGoA" page="81" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="50"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="10"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="250"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Massive Damage, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="2226-327b-9cef-5629" hidden="false" targetId="c863-510b-e239-be92" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4fbe-feab-de05-5312" name="Heavy Tractor Maul" book="BtGoA" page="65" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="05cc-6d3b-93d8-0b0e" name="Heavy Tractor Maul" book="BtGoA" page="65" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks, Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="c401-a6db-93c9-69e0" hidden="false" targetId="2cbd-47c9-de87-ec2a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eff8-bb0e-1b1d-bbb2" name="HL armor" book="BtGoA" page="93" hidden="false" collective="true" categoryEntryId="(No Category)" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="2a6f-a102-e7b6-54c7" hidden="false" targetId="b436-1f8a-5d3a-2d7d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2e3d-bbaa-3f5c-ac53" name="HL Booster (Eq)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="b458-ac53-f980-4960" hidden="false" targetId="56ab-52fc-9557-2586" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="1.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="573b-88bc-97d7-d890" name="HL Booster Drone" book="BtGoA" page="121" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="68d9-bb11-1862-acca" hidden="false" targetId="56ab-52fc-9557-2586" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1b16-412b-662a-5467" name="Homer Drone" book="BtGoA" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="e015-e1a0-3cd3-a350" hidden="false" targetId="ca2b-9550-eb1e-77c8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4364-45ee-ee83-ca30" name="Impact Cloak " book="BtGoA" page="93" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules>
+        <rule id="5da7-d6db-a841-0ff0" name="Impact Cloak" book="BtGoA" page="93" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
           <description>Add +2 to Res in hand to hand combat.</description>
-          <modifiers/>
         </rule>
-</rules>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="74e7-3e15-6b19-94e8" name="Impact Cloak (Eq)" type="upgrade" collective="true" hidden="false" book="BtGoA" page="93" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules>
-<rule id="a94d-f3ac-90df-d53a" name="Impact Cloak" hidden="false" book="BtGoA" page="93">
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="74e7-3e15-6b19-94e8" name="Impact Cloak (Eq)" book="BtGoA" page="93" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules>
+        <rule id="a94d-f3ac-90df-d53a" name="Impact Cloak" book="BtGoA" page="93" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
           <description>Add +2 to Res in hand to hand combat.</description>
-          <modifiers/>
         </rule>
-</rules>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="f99c-daab-b3d7-9c61" name="Implosion Grenades" type="upgrade" collective="false" hidden="false" book="BtGoA" page="85" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="-1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="50ac-e85f-6480-9e2e" profileTypeId="ecae-8ac8-2c13-0dd3" name="Implosion Grenades" hidden="false" book="BtGoA" page="85">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Hazardous H2H, Grenade"/>
-          </characteristics>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f99c-daab-b3d7-9c61" name="Implosion Grenades" book="BtGoA" page="85" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="50ac-e85f-6480-9e2e" name="Implosion Grenades" book="BtGoA" page="85" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Hazardous H2H, Grenade"/>
+          </characteristics>
         </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="9868-0703-9743-d4b5" targetId="1c2c-6574-0a17-f90c" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="b357-a997-60e5-053e" name="IMTel Stave" type="upgrade" collective="false" hidden="false" book="BtGoA" page="67" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="d6be-b9a8-1ea3-d1ee" name="IMTel Stave - Standard" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="9cc5-5341-3598-a655" profileTypeId="ecae-8ac8-2c13-0dd3" name="IMTel Stave - Standard" hidden="false" book="BtGoA" page="67">
-              <characteristics>
-                <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-                <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-                <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-                <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="3 Attacks, Hand Weapon"/>
-              </characteristics>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="9868-0703-9743-d4b5" hidden="false" targetId="1c2c-6574-0a17-f90c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b357-a997-60e5-053e" name="IMTel Stave" book="BtGoA" page="67" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="d6be-b9a8-1ea3-d1ee" name="IMTel Stave - Standard" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="9cc5-5341-3598-a655" name="IMTel Stave - Standard" book="BtGoA" page="67" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="051e-0412-fe0f-16d2" targetId="61e2-3707-ade3-c9ad" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="da2f-6bd2-fb0e-5e5e" name="IMTel Stave - Nano Drone Boost" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="cf0b-c836-c681-d9c0" profileTypeId="ecae-8ac8-2c13-0dd3" name="IMTel Stave - Nano Drone Boost" hidden="false" book="BtGoA" page="67">
               <characteristics>
-                <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-                <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="6"/>
-                <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="3 Attacks, Blast D3, Exhausted, Hand Weapon"/>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="3 Attacks, Hand Weapon"/>
               </characteristics>
-              <modifiers/>
             </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="8918-00b1-258e-5005" targetId="61e2-3707-ade3-c9ad" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="a14f-0f5e-7b8f-63f5" targetId="1acd-39d3-94e7-48e1" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="e461-67a4-a88e-a136" targetId="4232-2801-36cf-704c" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="5346-a420-8994-c5ed" name="Interceptor Bike" type="upgrade" collective="false" hidden="false" book="BtGoA" page="100" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="c7d2-5723-e428-dd5a" name="Ranged Weapon" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="3"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="3"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="fa7c-b456-730f-167f" targetId="47d9-8149-9744-9849" type="selectionEntry">
-<modifiers/>
-</entryLink>
-<entryLink id="ec8f-9506-26e0-53ec" targetId="78dd-7840-1210-fb35" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="d3a3-d3e0-1480-e349" name="Intruder Skimmer" type="upgrade" collective="true" hidden="false" book="BtGoA" page="9" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="e102-2c84-66f5-fba9" name="Ranged Weapon" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="ed95-b0bc-1c54-77ce" name="Twin Mag Repeaters" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="3aa7-ded4-1810-f136" targetId="f31c-6e5c-19c0-ada7" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="fc7e-7c0e-65e0-8c33" name="Leader" type="upgrade" collective="false" hidden="false" book="" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="b121-6dcc-8053-c5a2" targetId="e441-c3a6-7d61-2c63" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="02f3-3134-ae39-afed" name="Leader 2" type="upgrade" collective="false" hidden="false" book="BtGoA" page="135" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="10.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="0240-940c-2896-fe6d" targetId="7850-89e7-bab8-86e9" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="5a4c-2f5e-40a2-91d4" name="Leader 3" type="upgrade" collective="false" hidden="false" book="BtGoA" page="135" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="20.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="0722-f7c8-1f58-524e" targetId="05bb-4d34-70cd-25d2" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="222a-c399-636e-c285" name="Lectro Lance" type="upgrade" collective="false" hidden="false" book="BtGoA" page="66" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="1194-e016-79d8-8f37" profileTypeId="ecae-8ac8-2c13-0dd3" name="Lectro Lance" hidden="false" book="BtGoA" page="66">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Hand Weapon"/>
-          </characteristics>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="051e-0412-fe0f-16d2" hidden="false" targetId="61e2-3707-ade3-c9ad" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-        </profile>
-</profiles>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="10e4-842d-bb66-6204" name="Lectro Lash" type="upgrade" collective="false" hidden="false" book="BtGoA" page="65" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="0e1a-a803-d9c9-9f0a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Lectro Lash" hidden="false" book="BtGoA" page="65">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="3 Attacks, Hand Weapon"/>
-          </characteristics>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="da2f-6bd2-fb0e-5e5e" name="IMTel Stave - Nano Drone Boost" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="cf0b-c836-c681-d9c0" name="IMTel Stave - Nano Drone Boost" book="BtGoA" page="67" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="3 Attacks, Blast D3, Exhausted, Hand Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="8918-00b1-258e-5005" hidden="false" targetId="61e2-3707-ade3-c9ad" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="a14f-0f5e-7b8f-63f5" hidden="false" targetId="1acd-39d3-94e7-48e1" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="e461-67a4-a88e-a136" hidden="false" targetId="4232-2801-36cf-704c" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-        </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="485e-5cd5-458a-5b01" targetId="61e2-3707-ade3-c9ad" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="3ad3-bfdd-6120-7c29" name="Lugger Gun" type="upgrade" collective="false" hidden="false" book="BtGoA" page="73" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="5c6f-c4ef-b4a1-32eb" profileTypeId="ecae-8ac8-2c13-0dd3" name="Lugger Gun" hidden="false" book="BtGoA" page="73">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2, Limited Ammo, Standard Weapon"/>
-          </characteristics>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5346-a420-8994-c5ed" name="Interceptor Bike" book="BtGoA" page="100" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c7d2-5723-e428-dd5a" name="Ranged Weapon" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="a5ed-7915-9221-076b" targetId="0cb1-ea91-e5bc-4f75" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="cc2c-1225-57ca-f1ed" targetId="5efa-64a9-bbc9-3dba" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="6a2b-50c5-9a33-b756" name="Mag Cannon" type="upgrade" collective="false" hidden="false" book="BtGoA" page="75" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="295a-d623-e2d2-c684" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Cannon" hidden="false" book="BtGoA" page="75">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="5"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="5"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Massive Damage, Light Support Weapon"/>
-          </characteristics>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="fa7c-b456-730f-167f" hidden="false" targetId="47d9-8149-9744-9849" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="ec8f-9506-26e0-53ec" hidden="false" targetId="78dd-7840-1210-fb35" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d3a3-d3e0-1480-e349" name="Intruder Skimmer" book="BtGoA" page="9" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e102-2c84-66f5-fba9" name="Ranged Weapon" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="ba14-c26b-33c6-8283" targetId="c863-510b-e239-be92" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="84ac-0f31-c388-d0bd" name="Mag Gun" type="upgrade" collective="true" hidden="false" book="BtGoA" page="69" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="d809-b3af-7007-a7b3" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Gun" hidden="false" book="BtGoA" page="69">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="60"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
-          </characteristics>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="ed95-b0bc-1c54-77ce" name="Twin Mag Repeaters" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="3aa7-ded4-1810-f136" hidden="false" targetId="f31c-6e5c-19c0-ada7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fc7e-7c0e-65e0-8c33" name="Leader" book="" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="b121-6dcc-8053-c5a2" hidden="false" targetId="e441-c3a6-7d61-2c63" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </profile>
-</profiles>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="8f47-408e-cc6e-7a19" name="Mag Gun (Eq)" type="upgrade" collective="true" hidden="false" book="BtGoA" page="69" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="33ca-cc05-d33e-3d00" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Gun" hidden="false" book="BtGoA" page="69">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="60"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
-          </characteristics>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="02f3-3134-ae39-afed" name="Leader 2" book="BtGoA" page="135" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0240-940c-2896-fe6d" hidden="false" targetId="7850-89e7-bab8-86e9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </profile>
-</profiles>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="cea7-8511-2208-1b1f" name="Mag Heavy Support" type="upgrade" collective="false" hidden="false" book="BtGoA" page="81" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="c318-2375-d610-2950" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Heavy Support" hidden="false" book="BtGoA" page="81">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="5"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="RF5, Heavy Weapon"/>
-          </characteristics>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5a4c-2f5e-40a2-91d4" name="Leader 3" book="BtGoA" page="135" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0722-f7c8-1f58-524e" hidden="false" targetId="05bb-4d34-70cd-25d2" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="d752-3c59-1096-f66d" targetId="b0cb-c022-0531-4852" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="b5e9-5297-04d2-2bf8" name="Mag Lash" type="upgrade" collective="true" hidden="false" book="BtGoA" page="67" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="f404-2eda-272f-57cf" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Lash" hidden="false" book="BtGoA" page="67">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks"/>
-          </characteristics>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="222a-c399-636e-c285" name="Lectro Lance" book="BtGoA" page="66" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="1194-e016-79d8-8f37" name="Lectro Lance" book="BtGoA" page="66" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="a97e-ddef-2a97-6023" targetId="2cbd-47c9-de87-ec2a" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="a00c-0542-f2a5-8124" name="Mag Light Support" type="upgrade" collective="false" hidden="false" book="BtGoA" page="75" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="df5b-35ce-669c-6aee" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Light Support" hidden="false" book="BtGoA" page="75">
           <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="50"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3, Light Support Weapon"/>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Hand Weapon"/>
           </characteristics>
-          <modifiers/>
         </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="1edc-0547-c0b3-df09" targetId="97d4-67cb-2671-ca29" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="9733-7039-e306-26b5" name="Mag Mortar" type="upgrade" collective="false" hidden="false" book="BtGoA" page="81" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="d461-69b8-c506-322a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Mortar" hidden="false" book="BtGoA" page="81">
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="10e4-842d-bb66-6204" name="Lectro Lash" book="BtGoA" page="65" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="0e1a-a803-d9c9-9f0a" name="Lectro Lash" book="BtGoA" page="65" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
           <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="OH x2, Blast D10, No Cover, Heavy Weapon"/>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="3 Attacks, Hand Weapon"/>
           </characteristics>
-          <modifiers/>
         </profile>
-</profiles>
-<entryLinks>
-<entryLink id="3203-24a2-4083-bc0d" targetId="bc4e-7cd8-4017-d911" type="selectionEntryGroup">
-<modifiers/>
-</entryLink>
-</entryLinks>
-<infoLinks>
-<infoLink id="f42c-7e9e-5b27-6658" targetId="aef6-6934-1dee-6fa0" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="bfd1-e214-1717-c121" targetId="04d9-a48d-7b25-4dd3" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="f78e-6fd2-fff5-58e2" targetId="a41d-d55e-6d97-049d" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="8690-3ab7-9fef-06ee" name="Mag Pistol" type="upgrade" collective="true" hidden="false" book="BtGoA" page="68" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="57f9-ac99-e46c-2757" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Pistol" hidden="false" book="BtGoA" page="68">
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="485e-5cd5-458a-5b01" hidden="false" targetId="61e2-3707-ade3-c9ad" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3ad3-bfdd-6120-7c29" name="Lugger Gun" book="BtGoA" page="73" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="5c6f-c4ef-b4a1-32eb" name="Lugger Gun" book="BtGoA" page="73" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
           <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="30"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Hand Weapon"/>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Limited Ammo, Standard Weapon"/>
           </characteristics>
-          <modifiers/>
         </profile>
-</profiles>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="790a-6841-6372-870b" name="Mag Repeater" type="upgrade" collective="true" hidden="false" book="BtGoA" page="69" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="1c20-93a8-d402-9d61" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Repeater" hidden="false" book="BtGoA" page="69">
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a5ed-7915-9221-076b" hidden="false" targetId="0cb1-ea91-e5bc-4f75" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="cc2c-1225-57ca-f1ed" hidden="false" targetId="5efa-64a9-bbc9-3dba" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6a2b-50c5-9a33-b756" name="Mag Cannon" book="BtGoA" page="75" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="295a-d623-e2d2-c684" name="Mag Cannon" book="BtGoA" page="75" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
           <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2, Standard Weapon"/>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="5"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="5"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Massive Damage, Light Support Weapon"/>
           </characteristics>
-          <modifiers/>
         </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="af4a-bed9-243c-993e" targetId="0cb1-ea91-e5bc-4f75" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="3ecf-d559-4559-c1bb" name="Mass Compactor" type="upgrade" collective="false" hidden="false" book="BtGoA" page="71" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="b468-06b2-1a5d-2ec0" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mass Compactor" hidden="false" book="BtGoA" page="71">
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="ba14-c26b-33c6-8283" hidden="false" targetId="c863-510b-e239-be92" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="84ac-0f31-c388-d0bd" name="Mag Gun" book="BtGoA" page="69" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="d809-b3af-7007-a7b3" name="Mag Gun" book="BtGoA" page="69" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
           <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="30"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="3/2/1"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Standard Weapon"/>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
           </characteristics>
-          <modifiers/>
         </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="068c-0048-aa5f-9906" targetId="7db4-2d14-3984-37d9" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="af50-5808-cb3e-2ec9" targetId="a41d-d55e-6d97-049d" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="502c-9855-7269-eaa2" name="Medi-Drone" type="model" collective="false" hidden="false" book="BtGoA" page="113" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="20.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="a034-e97d-eddd-d272" targetId="4039-88e8-9f6d-bfb3" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="eafe-29d5-1222-4155" name="Meld Skark" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="-1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules>
-<rule id="68b7-72bd-610b-2ae3" name="Meld Skark" hidden="false" book="BtGoA" page="194">
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8f47-408e-cc6e-7a19" name="Mag Gun (Eq)" book="BtGoA" page="69" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="33ca-cc05-d33e-3d00" name="Mag Gun" book="BtGoA" page="69" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cea7-8511-2208-1b1f" name="Mag Heavy Support" book="BtGoA" page="81" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="c318-2375-d610-2950" name="Mag Heavy Support" book="BtGoA" page="81" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="5"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF5, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d752-3c59-1096-f66d" hidden="false" targetId="b0cb-c022-0531-4852" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b5e9-5297-04d2-2bf8" name="Mag Lash" book="BtGoA" page="67" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="f404-2eda-272f-57cf" name="Mag Lash" book="BtGoA" page="67" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a97e-ddef-2a97-6023" hidden="false" targetId="2cbd-47c9-de87-ec2a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a00c-0542-f2a5-8124" name="Mag Light Support" book="BtGoA" page="75" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="df5b-35ce-669c-6aee" name="Mag Light Support" book="BtGoA" page="75" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="50"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3, Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="1edc-0547-c0b3-df09" hidden="false" targetId="97d4-67cb-2671-ca29" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9733-7039-e306-26b5" name="Mag Mortar" book="BtGoA" page="81" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="d461-69b8-c506-322a" name="Mag Mortar" book="BtGoA" page="81" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH x2, Blast D10, No Cover, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="f42c-7e9e-5b27-6658" hidden="false" targetId="aef6-6934-1dee-6fa0" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="bfd1-e214-1717-c121" hidden="false" targetId="04d9-a48d-7b25-4dd3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f78e-6fd2-fff5-58e2" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="3203-24a2-4083-bc0d" hidden="false" targetId="bc4e-7cd8-4017-d911" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8690-3ab7-9fef-06ee" name="Mag Pistol" book="BtGoA" page="68" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="57f9-ac99-e46c-2757" name="Mag Pistol" book="BtGoA" page="68" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="790a-6841-6372-870b" name="Mag Repeater" book="BtGoA" page="69" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="1c20-93a8-d402-9d61" name="Mag Repeater" book="BtGoA" page="69" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="af4a-bed9-243c-993e" hidden="false" targetId="0cb1-ea91-e5bc-4f75" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3ecf-d559-4559-c1bb" name="Mass Compactor" book="BtGoA" page="71" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="b468-06b2-1a5d-2ec0" name="Mass Compactor" book="BtGoA" page="71" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3/2/1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="068c-0048-aa5f-9906" hidden="false" targetId="7db4-2d14-3984-37d9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="af50-5808-cb3e-2ec9" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="502c-9855-7269-eaa2" name="Medi-Drone" book="BtGoA" page="113" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a034-e97d-eddd-d272" hidden="false" targetId="4039-88e8-9f6d-bfb3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eafe-29d5-1222-4155" name="Meld Skark" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules>
+        <rule id="68b7-72bd-610b-2ae3" name="Meld Skark" book="BtGoA" page="194" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
           <description>6 Attacks, SV1</description>
-          <modifiers/>
         </rule>
-</rules>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="1a9d-01a2-ee09-883c" name="Micro-X Launcher" type="upgrade" collective="false" hidden="false" book="BtGoA" page="71" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="756b-b4d4-8824-056b" name="Micro X-Launcher - Overhead" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="b067-87fe-65b4-6bd8" profileTypeId="ecae-8ac8-2c13-0dd3" name="Micro X-Launcher Overhead" hidden="false" book="BtGoA" page="71">
-              <characteristics>
-                <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10-20"/>
-                <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-                <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-                <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D4, No Cover, Standard Weapon"/>
-              </characteristics>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1a9d-01a2-ee09-883c" name="Micro-X Launcher" book="BtGoA" page="71" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="756b-b4d4-8824-056b" name="Micro X-Launcher - Overhead" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="b067-87fe-65b4-6bd8" name="Micro X-Launcher Overhead" book="BtGoA" page="71" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="29b1-77a8-eac1-dcb8" targetId="c3bc-87fd-fa5d-5055" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="5888-4d4d-b427-d1f3" targetId="ca96-58c9-9551-d4fe" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="de68-1314-0e93-bc44" targetId="a41d-d55e-6d97-049d" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="b484-5b5d-96fb-e628" name="Micro X-Launcher - Direct Fire" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="c0c1-ee5f-5c1f-77a0" profileTypeId="ecae-8ac8-2c13-0dd3" name="Micro X-Launcher - Direct Fire" hidden="false" book="BtGoA" page="71">
               <characteristics>
-                <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-                <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D4, No Cover, Standard Weapon"/>
               </characteristics>
-              <modifiers/>
             </profile>
-</profiles>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="e7b0-651a-cc7c-f27e" name="Micro-X Launcher (Eq)" type="upgrade" collective="false" hidden="false" book="BtGoA" page="71" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="3bdc-c653-a2ab-de1c" profileTypeId="ecae-8ac8-2c13-0dd3" name="Micro X-Launcher - Direct Fire" hidden="false" book="BtGoA" page="71">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
-          </characteristics>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="29b1-77a8-eac1-dcb8" hidden="false" targetId="c3bc-87fd-fa5d-5055" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="5888-4d4d-b427-d1f3" hidden="false" targetId="ca96-58c9-9551-d4fe" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="de68-1314-0e93-bc44" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
-        </profile>
-<profile id="7649-e5a8-d706-0d24" profileTypeId="ecae-8ac8-2c13-0dd3" name="Micro X-Launcher Overhead" hidden="false" book="BtGoA" page="71">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10-20"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="5"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D4, No Cover, Standard Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="ede2-e3e5-c94d-4378" targetId="ca96-58c9-9551-d4fe" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="c25b-badb-e157-f945" targetId="a41d-d55e-6d97-049d" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="83cb-eec9-94c0-8fc1" targetId="c3bc-87fd-fa5d-5055" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="7849-7fc2-0006-8fbd" name="Munitions" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="cf32-46fd-cdce-80dd" name="Munitions" collective="false" hidden="false">
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="5"/>
-</constraints>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="2f9e-d8b5-f1a8-6e4c" name="Scrambler" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="5.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers>
-<modifier type="set" field="hidden" value="true">
-<conditions/>
-<conditionGroups/>
-<repeats>
-<repeat repeats="1" value="1.0" field="selections" scope="cf32-46fd-cdce-80dd" childId="057c-a217-e792-8ef7" shared="true"/>
-</repeats>
-</modifier>
-</modifiers>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="c2fb-c9db-5e9c-dcfe" targetId="7a3b-74a5-3ced-dd88" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="9622-01bf-0303-e5f7" targetId="b996-131f-b84a-4724" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="47c5-9ed0-b50a-45b7" name="Arc" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="5.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers>
-<modifier type="set" field="hidden" value="true">
-<conditions/>
-<conditionGroups/>
-<repeats>
-<repeat repeats="1" value="1.0" field="selections" scope="cf32-46fd-cdce-80dd" childId="057c-a217-e792-8ef7" shared="true"/>
-</repeats>
-</modifier>
-</modifiers>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="1838-cbe5-7c85-395d" targetId="c1ba-c745-22a8-e2d7" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="6568-0044-8497-b002" targetId="b996-131f-b84a-4724" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="876b-029d-8c49-cf28" name="Blur" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="5.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers>
-<modifier type="set" field="hidden" value="true">
-<conditions/>
-<conditionGroups/>
-<repeats>
-<repeat repeats="1" value="1.0" field="selections" scope="cf32-46fd-cdce-80dd" childId="057c-a217-e792-8ef7" shared="true"/>
-</repeats>
-</modifier>
-</modifiers>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="8a68-f508-7c9e-1ee4" targetId="117a-a2aa-4be7-dffe" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="1fe7-d90c-fd8b-2777" targetId="b996-131f-b84a-4724" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="2f18-3173-0eea-f19f" name="Scoot" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="5.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers>
-<modifier type="set" field="hidden" value="true">
-<conditions/>
-<conditionGroups/>
-<repeats>
-<repeat repeats="1" value="1.0" field="selections" scope="cf32-46fd-cdce-80dd" childId="057c-a217-e792-8ef7" shared="true"/>
-</repeats>
-</modifier>
-</modifiers>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="a787-c45e-8df6-7cdb" targetId="28a0-7151-a0c5-9495" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="4acd-4d6e-c5ce-c202" targetId="b996-131f-b84a-4724" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="99d6-3f14-a1e9-779b" name="Net" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="5.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers>
-<modifier type="set" field="hidden" value="true">
-<conditions/>
-<conditionGroups/>
-<repeats>
-<repeat repeats="1" value="1.0" field="selections" scope="cf32-46fd-cdce-80dd" childId="057c-a217-e792-8ef7" shared="true"/>
-</repeats>
-</modifier>
-</modifiers>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="c8d2-16b3-5523-a9b1" targetId="ac33-af99-2d76-c981" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="e014-fd16-bd43-6ead" name="Grip" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="5.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers>
-<modifier type="set" field="hidden" value="true">
-<conditions/>
-<conditionGroups/>
-<repeats>
-<repeat repeats="1" value="1.0" field="selections" scope="cf32-46fd-cdce-80dd" childId="057c-a217-e792-8ef7" shared="true"/>
-</repeats>
-</modifier>
-</modifiers>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="6ffa-8857-9b93-35b5" targetId="1045-95cb-5504-9050" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="3eba-9eb4-bf44-4b04" targetId="b996-131f-b84a-4724" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="057c-a217-e792-8ef7" name="All" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="15.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="7fae-ff88-b94e-934e" targetId="c1ba-c745-22a8-e2d7" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="49a1-2fba-ff8f-c1b0" targetId="117a-a2aa-4be7-dffe" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="7acb-0144-9a6a-9840" targetId="1045-95cb-5504-9050" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="878e-a6f2-d2ce-4e02" targetId="ac33-af99-2d76-c981" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="ed06-0ab3-bc83-05de" targetId="28a0-7151-a0c5-9495" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="03ee-325f-d6f1-fd20" targetId="7a3b-74a5-3ced-dd88" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="8d63-0835-da60-a624" targetId="b996-131f-b84a-4724" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups/>
-<entryLinks/>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="bf0f-913b-e028-8891" name="Nano Drone" type="upgrade" collective="false" hidden="false" book="BtGoA" page="113" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="20.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="4173-19e8-aa99-3e22" targetId="c1c6-f9c7-c84f-d57d" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="cadc-e1ce-3615-ac4b" name="Nano Drones (2)" type="upgrade" collective="false" hidden="false" book="BtGoA" page="113" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="20.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="ce7f-8e3d-c50c-b636" targetId="c1c6-f9c7-c84f-d57d" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="6b54-c223-3c4a-5de7" name="Overload Ammo" type="upgrade" collective="true" hidden="false" book="BtGoA" page="89" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="6edf-03c1-417f-13e8" targetId="3559-4b87-980d-f90d" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="eb94-d1e8-1084-71b3" name="Phase Armor" type="upgrade" collective="true" hidden="false" book="BtGoA" page="93" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="3da3-80ac-dc11-6809" targetId="b28d-571e-af69-4582" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="5725-5e4d-d4f2-1dd0" name="Phase Rifle" type="upgrade" collective="false" hidden="false" book="BtGoA" page="72" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="d2b1-2482-5f97-a4e4" profileTypeId="ecae-8ac8-2c13-0dd3" name="Phase Rifle" hidden="false" book="BtGoA" page="72">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="No Cover, RF D6 Fire Only, Concentrated Fire, Standard Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="0d4d-4f3f-c86d-9dbe" targetId="a41d-d55e-6d97-049d" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="b46e-26ca-aad6-e64b" targetId="1863-c041-6dc4-c62d" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="6fea-ec6b-df33-2abe" targetId="5fb8-4f09-d496-4ea9" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="a18f-8d16-f879-e590" name="Phaseshift Shield" type="upgrade" collective="false" hidden="false" book="BtGoA" page="122" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="-1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="67b6-d6f5-5ba3-e50d" name="Plasma Bombard" type="upgrade" collective="false" hidden="false" book="BtGoA" page="82" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="a5d1-11c5-eb13-f676" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Bombard" hidden="false" book="BtGoA" page="82">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="200"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="7"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Plasma Fade, Heavy Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="7388-9f57-6e2a-eadb" targetId="6b03-2ad4-34c1-7f73" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="c2bf-0272-30c6-dd20" name="Plasma Cannon" type="upgrade" collective="false" hidden="false" book="BtGoA" page="76" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="dce6-92d7-7812-820a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Cannon" hidden="false" book="BtGoA" page="76">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="4"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="6"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Plasma Fade, Light Support Weapon"/>
-          </characteristics>
-          <modifiers/>
-        </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="3c39-3d6d-7a5a-f2f5" targetId="6b03-2ad4-34c1-7f73" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="1631-5857-2139-960a" name="Plasma Carbine " type="model" collective="true" hidden="false" book="BtGoA" page="70" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="0212-5213-7d18-d37f" targetId="ee9c-ada6-953a-b774" type="profile">
-<modifiers/>
-</infoLink>
-<infoLink id="d572-ea69-f6bd-9b8f" targetId="b56d-0f1d-de00-62c4" type="profile">
-<modifiers/>
-</infoLink>
-<infoLink id="b55d-3878-89ca-fb86" targetId="0cb1-ea91-e5bc-4f75" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="b018-6101-d2e3-b4ea" name="Plasma Carbine (Eq)" type="model" collective="true" hidden="false" book="BtGoA" page="70" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="7c09-db8c-68d9-485b" targetId="ee9c-ada6-953a-b774" type="profile">
-<modifiers/>
-</infoLink>
-<infoLink id="8179-73ab-e5c7-065c" targetId="b56d-0f1d-de00-62c4" type="profile">
-<modifiers/>
-</infoLink>
-<infoLink id="f29e-ac68-7310-1db0" targetId="0cb1-ea91-e5bc-4f75" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="d118-8115-df5f-2402" name="Plasma Grenades" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="8771-f173-82cd-3509" targetId="96f9-325b-69f7-13b4" type="profile">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="47d9-8149-9744-9849" name="Plasma Lance" type="upgrade" collective="false" hidden="false" book="BtGoA" page="70" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="b6e9-addd-c005-4547" name="Plasma Lance - Single Shot" type="upgrade" collective="false" hidden="false" book="BtGoA" page="70" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="3799-96cf-d949-da4e" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Single Shot" hidden="false" book="BtGoA" page="70">
-              <characteristics>
-                <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-                <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-                <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
-              </characteristics>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b484-5b5d-96fb-e628" name="Micro X-Launcher - Direct Fire" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="c0c1-ee5f-5c1f-77a0" name="Micro X-Launcher - Direct Fire" book="BtGoA" page="71" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </profile>
-</profiles>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="80ed-e766-57b1-3d2a" name="Plasma Lance - Scatter" type="upgrade" collective="false" hidden="false" book="BtGoA" page="70" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="9ad5-3648-6628-2caa" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Scatter" hidden="false" book="BtGoA" page="70">
               <characteristics>
-                <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-                <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2, Standard Weapon"/>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
               </characteristics>
-              <modifiers/>
             </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="3f8e-ffa3-e1eb-fde7" targetId="0cb1-ea91-e5bc-4f75" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="4069-4420-c5b5-56af" name="Plasma Lance - Lance" type="upgrade" collective="false" hidden="false" book="BtGoA" page="70" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="f44f-9fdb-7e3c-bf9e" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Lance" hidden="false" book="BtGoA" page="70">
-              <characteristics>
-                <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="4"/>
-                <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Choose Target, Inaccurate, Standard Weapon"/>
-              </characteristics>
-              <modifiers/>
-            </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="7213-775a-deac-dce8" targetId="fd72-d48c-e8af-4883" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="9752-310b-98a1-37af" targetId="3b84-9d0e-a3c1-6c1f" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="cf3a-e6a9-bdc0-e0ae" name="Plasma Light Support" type="upgrade" collective="false" hidden="false" book="BtGoA" page="76" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="d429-b8cc-aca0-aac9" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Light Support" hidden="false" book="BtGoA" page="76">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3, Light Support Weapon"/>
-          </characteristics>
+          </profiles>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="9e8b-6ee9-56f0-aedf" targetId="97d4-67cb-2671-ca29" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="0f97-9dbe-566a-5ab0" name="Plasma Light Support (Eq)" type="upgrade" collective="false" hidden="false" book="BtGoA" page="76" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="4477-6aca-5fe1-2d03" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Light Support" hidden="false" book="BtGoA" page="76">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="4"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3, Light Support Weapon"/>
-          </characteristics>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e7b0-651a-cc7c-f27e" name="Micro-X Launcher (Eq)" book="BtGoA" page="71" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="3bdc-c653-a2ab-de1c" name="Micro X-Launcher - Direct Fire" book="BtGoA" page="71" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+          </characteristics>
         </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="61c1-b16a-8335-9497" targetId="97d4-67cb-2671-ca29" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="9cd6-dbb8-bdcb-0299" name="Plasma Pistol" type="upgrade" collective="false" hidden="false" book="BtGoA" page="68" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="3d5e-ab8a-1859-49b2" targetId="2e7c-b5f9-e3e5-9125" type="profile">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="e6db-6ed3-1a26-ea56" name="Plasma Pistol (Eq)" type="upgrade" collective="true" hidden="false" book="BtGoA" page="68" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="d7c4-2e9d-b85d-2cda" targetId="2e7c-b5f9-e3e5-9125" type="profile">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="2396-4159-e26c-6c42" name="Reflex Armor" type="upgrade" collective="true" hidden="false" book="BtGoA" page="93" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="6826-c718-8070-65a3" targetId="18c0-c86d-0b2c-23af" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="9cdf-f068-bbde-2d0c" name="Reflex Armor (Eq)" type="upgrade" collective="true" hidden="false" book="BtGoA" page="93" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="fead-bc73-7559-09fc" targetId="18c0-c86d-0b2c-23af" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="03c2-174e-8617-cf04" name="Reflex Armor/ Impact Cloak (Eq)" type="upgrade" collective="true" hidden="false" book="BtGoA" page="93" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="a445-3a2a-b5dc-dff6" targetId="18c0-c86d-0b2c-23af" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="abe2-ce1e-271f-5a85" name="Scourer Cannon" type="upgrade" collective="false" hidden="false" book="BtGoA" page="73" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="ccbf-d756-25d7-40f4" name="Scourer Cannon - Dispersed" type="upgrade" collective="false" hidden="true" book="BtGoA" page="73" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="03b8-44da-840d-df59" profileTypeId="ecae-8ac8-2c13-0dd3" name="Scourer Cannon - Dispersed" hidden="false" book="BtGoA" page="73">
-              <characteristics>
-                <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-                <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3, Standard Weapon"/>
-              </characteristics>
+        <profile id="7649-e5a8-d706-0d24" name="Micro X-Launcher Overhead" book="BtGoA" page="71" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="5"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D4, No Cover, Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="ede2-e3e5-c94d-4378" hidden="false" targetId="ca96-58c9-9551-d4fe" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="c25b-badb-e157-f945" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="83cb-eec9-94c0-8fc1" hidden="false" targetId="c3bc-87fd-fa5d-5055" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7849-7fc2-0006-8fbd" name="Munitions" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="cf32-46fd-cdce-80dd" name="Munitions" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="2f9e-d8b5-f1a8-6e4c" name="Scrambler" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="c2fb-c9db-5e9c-dcfe" hidden="false" targetId="7a3b-74a5-3ced-dd88" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="9622-01bf-0303-e5f7" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats>
+                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="47c5-9ed0-b50a-45b7" name="Arc" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="1838-cbe5-7c85-395d" hidden="false" targetId="c1ba-c745-22a8-e2d7" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="6568-0044-8497-b002" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats>
+                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="876b-029d-8c49-cf28" name="Blur" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="8a68-f508-7c9e-1ee4" hidden="false" targetId="117a-a2aa-4be7-dffe" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="1fe7-d90c-fd8b-2777" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats>
+                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="2f18-3173-0eea-f19f" name="Scoot" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="a787-c45e-8df6-7cdb" hidden="false" targetId="28a0-7151-a0c5-9495" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="4acd-4d6e-c5ce-c202" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats>
+                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="99d6-3f14-a1e9-779b" name="Net" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="c8d2-16b3-5523-a9b1" hidden="false" targetId="ac33-af99-2d76-c981" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats>
+                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e014-fd16-bd43-6ead" name="Grip" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="6ffa-8857-9b93-35b5" hidden="false" targetId="1045-95cb-5504-9050" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="3eba-9eb4-bf44-4b04" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats>
+                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="057c-a217-e792-8ef7" name="All" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="7fae-ff88-b94e-934e" hidden="false" targetId="c1ba-c745-22a8-e2d7" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="49a1-2fba-ff8f-c1b0" hidden="false" targetId="117a-a2aa-4be7-dffe" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="7acb-0144-9a6a-9840" hidden="false" targetId="1045-95cb-5504-9050" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="878e-a6f2-d2ce-4e02" hidden="false" targetId="ac33-af99-2d76-c981" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="ed06-0ab3-bc83-05de" hidden="false" targetId="28a0-7151-a0c5-9495" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="03ee-325f-d6f1-fd20" hidden="false" targetId="7a3b-74a5-3ced-dd88" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="8d63-0835-da60-a624" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
               <modifiers/>
-            </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="6631-7298-fd9d-ce64" targetId="97d4-67cb-2671-ca29" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="713c-944f-32ee-fe55" name="Scourer Cannon - Concentrated" type="upgrade" collective="false" hidden="false" book="BtGoA" page="73" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints/>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="0f28-d6ef-0f10-6e8f" profileTypeId="ecae-8ac8-2c13-0dd3" name="Scourer Cannon - Concentrated" hidden="false" book="BtGoA" page="73">
-              <characteristics>
-                <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
-                <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="40"/>
-                <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="4"/>
-                <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
-              </characteristics>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bf0f-913b-e028-8891" name="Nano Drone" book="BtGoA" page="113" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="4173-19e8-aa99-3e22" hidden="false" targetId="c1c6-f9c7-c84f-d57d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cadc-e1ce-3615-ac4b" name="Nano Drone" book="BtGoA" page="113" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="ce7f-8e3d-c50c-b636" hidden="false" targetId="c1c6-f9c7-c84f-d57d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6b54-c223-3c4a-5de7" name="Overload Ammo" book="BtGoA" page="89" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="6edf-03c1-417f-13e8" hidden="false" targetId="3559-4b87-980d-f90d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eb94-d1e8-1084-71b3" name="Phase Armor" book="BtGoA" page="93" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="3da3-80ac-dc11-6809" hidden="false" targetId="b28d-571e-af69-4582" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5725-5e4d-d4f2-1dd0" name="Phase Rifle" book="BtGoA" page="72" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="d2b1-2482-5f97-a4e4" name="Phase Rifle" book="BtGoA" page="72" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="No Cover, RF D6 Fire Only, Concentrated Fire, Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0d4d-4f3f-c86d-9dbe" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b46e-26ca-aad6-e64b" hidden="false" targetId="1863-c041-6dc4-c62d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6fea-ec6b-df33-2abe" hidden="false" targetId="5fb8-4f09-d496-4ea9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a18f-8d16-f879-e590" name="Phaseshift Shield" book="BtGoA" page="122" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="67b6-d6f5-5ba3-e50d" name="Plasma Bombard" book="BtGoA" page="82" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="a5d1-11c5-eb13-f676" name="Plasma Bombard" book="BtGoA" page="82" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="200"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="7"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Plasma Fade, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="7388-9f57-6e2a-eadb" hidden="false" targetId="6b03-2ad4-34c1-7f73" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c2bf-0272-30c6-dd20" name="Plasma Cannon" book="BtGoA" page="76" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="dce6-92d7-7812-820a" name="Plasma Cannon" book="BtGoA" page="76" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="4"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Plasma Fade, Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="3c39-3d6d-7a5a-f2f5" hidden="false" targetId="6b03-2ad4-34c1-7f73" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1631-5857-2139-960a" name="Plasma Carbine " book="BtGoA" page="70" hidden="false" collective="true" categoryEntryId="(No Category)" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0212-5213-7d18-d37f" hidden="false" targetId="ee9c-ada6-953a-b774" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="d572-ea69-f6bd-9b8f" hidden="false" targetId="b56d-0f1d-de00-62c4" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b55d-3878-89ca-fb86" hidden="false" targetId="0cb1-ea91-e5bc-4f75" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d118-8115-df5f-2402" name="Plasma Grenades" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="8771-f173-82cd-3509" hidden="false" targetId="96f9-325b-69f7-13b4" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="47d9-8149-9744-9849" name="Plasma Lance" book="BtGoA" page="70" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="b6e9-addd-c005-4547" name="Plasma Lance - Single Shot" book="BtGoA" page="70" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="3799-96cf-d949-da4e" name="Plasma Lance - Single Shot" book="BtGoA" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
               <modifiers/>
-            </profile>
-</profiles>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="9a2e-529c-2e81-0d99" name="Scourer Cannon - Disruptor" type="upgrade" collective="false" hidden="false" book="BtGoA" page="73" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints/>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="1b2e-f75a-2b45-9cde" profileTypeId="ecae-8ac8-2c13-0dd3" name="Scourer Cannon - Disruptor" hidden="false" book="BtGoA" page="73">
               <characteristics>
-                <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
-                <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-                <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D4, No Cover, Disruptor, Standard Weapon"/>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
               </characteristics>
-              <modifiers/>
             </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="393a-a871-9061-745a" targetId="ca96-58c9-9551-d4fe" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="dee2-529a-c466-8b1e" targetId="a41d-d55e-6d97-049d" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="1a7e-03a3-9055-86c1" targetId="6305-72fa-da02-235b" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="b145-19b3-baae-ff39" name="Shield Drone" type="upgrade" collective="false" hidden="false" book="BtGoA" page="114" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="10.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="65a3-4c38-417c-cc9f" targetId="b08d-74dd-1a32-8bdc" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="1707-586b-01df-0f80" name="Shield Drone (2)" type="upgrade" collective="false" hidden="false" book="BtGoA" page="114" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="10.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="b2fa-ba86-d0d2-1a30" targetId="b08d-74dd-1a32-8bdc" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="1e33-99fa-00fc-0a32" name="Skark" type="upgrade" collective="true" hidden="false" book="BtGoA" page="131" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules>
-<rule id="3983-4050-5e06-8fd3" name="Skark" hidden="false" book="BtGoA" page="131">
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="80ed-e766-57b1-3d2a" name="Plasma Lance - Scatter" book="BtGoA" page="70" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="9ad5-3648-6628-2caa" name="Plasma Lance - Scatter" book="BtGoA" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Standard Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="3f8e-ffa3-e1eb-fde7" hidden="false" targetId="0cb1-ea91-e5bc-4f75" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4069-4420-c5b5-56af" name="Plasma Lance - Lance" book="BtGoA" page="70" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="f44f-9fdb-7e3c-bf9e" name="Plasma Lance - Lance" book="BtGoA" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="4"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Choose Target, Inaccurate, Standard Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="7213-775a-deac-dce8" hidden="false" targetId="fd72-d48c-e8af-4883" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="9752-310b-98a1-37af" hidden="false" targetId="3b84-9d0e-a3c1-6c1f" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cf3a-e6a9-bdc0-e0ae" name="Plasma Light Support" book="BtGoA" page="76" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="d429-b8cc-aca0-aac9" name="Plasma Light Support" book="BtGoA" page="76" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3, Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="9e8b-6ee9-56f0-aedf" hidden="false" targetId="97d4-67cb-2671-ca29" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0f97-9dbe-566a-5ab0" name="Plasma Light Support (Eq)" book="BtGoA" page="76" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="4477-6aca-5fe1-2d03" name="Plasma Light Support" book="BtGoA" page="76" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="4"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3, Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="61c1-b16a-8335-9497" hidden="false" targetId="97d4-67cb-2671-ca29" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9cd6-dbb8-bdcb-0299" name="Plasma Pistol" book="BtGoA" page="68" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="3d5e-ab8a-1859-49b2" hidden="false" targetId="2e7c-b5f9-e3e5-9125" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e6db-6ed3-1a26-ea56" name="Plasma Pistol (Eq)" book="BtGoA" page="68" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d7c4-2e9d-b85d-2cda" hidden="false" targetId="2e7c-b5f9-e3e5-9125" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2396-4159-e26c-6c42" name="Reflex Armor" book="BtGoA" page="93" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="6826-c718-8070-65a3" hidden="false" targetId="18c0-c86d-0b2c-23af" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9cdf-f068-bbde-2d0c" name="Reflex Armor (Eq)" book="BtGoA" page="93" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="fead-bc73-7559-09fc" hidden="false" targetId="18c0-c86d-0b2c-23af" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="03c2-174e-8617-cf04" name="Reflex Armor/ Impact Cloak (Eq)" book="BtGoA" page="93" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a445-3a2a-b5dc-dff6" hidden="false" targetId="18c0-c86d-0b2c-23af" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="abe2-ce1e-271f-5a85" name="Scourer Cannon" book="BtGoA" page="73" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="ccbf-d756-25d7-40f4" name="Scourer Cannon - Dispersed" book="BtGoA" page="73" hidden="true" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="03b8-44da-840d-df59" name="Scourer Cannon - Dispersed" book="BtGoA" page="73" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3, Standard Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="6631-7298-fd9d-ce64" hidden="false" targetId="97d4-67cb-2671-ca29" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="713c-944f-32ee-fe55" name="Scourer Cannon - Concentrated" book="BtGoA" page="73" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="0f28-d6ef-0f10-6e8f" name="Scourer Cannon - Concentrated" book="BtGoA" page="73" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="40"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="4"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9a2e-529c-2e81-0d99" name="Scourer Cannon - Disruptor" book="BtGoA" page="73" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="1b2e-f75a-2b45-9cde" name="Scourer Cannon - Disruptor" book="BtGoA" page="73" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, No Cover, Disruptor, Standard Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="393a-a871-9061-745a" hidden="false" targetId="ca96-58c9-9551-d4fe" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="dee2-529a-c466-8b1e" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="1a7e-03a3-9055-86c1" hidden="false" targetId="6305-72fa-da02-235b" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b145-19b3-baae-ff39" name="Shield Drone" book="BtGoA" page="114" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="65a3-4c38-417c-cc9f" hidden="false" targetId="b08d-74dd-1a32-8bdc" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1707-586b-01df-0f80" name="Shield Drone (2)" book="BtGoA" page="114" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="b2fa-ba86-d0d2-1a30" hidden="false" targetId="b08d-74dd-1a32-8bdc" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1e33-99fa-00fc-0a32" name="Skark" book="BtGoA" page="131" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules>
+        <rule id="3983-4050-5e06-8fd3" name="Skark" book="BtGoA" page="131" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
           <description>Three attacks at SV1.</description>
-          <modifiers/>
         </rule>
-</rules>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="a1a8-ba0b-2e45-8020" name="Skyraider" type="upgrade" collective="true" hidden="false" book="BtGoA" page="192" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="d918-4412-0ae1-6f74" name="Weapon" collective="false" hidden="false" defaultSelectionEntryId="467e-1407-3119-60ef">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="467e-1407-3119-60ef" targetId="f31c-6e5c-19c0-ada7" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="8de3-1e72-72ef-e7a3" name="SlingNet Ammo" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="27d6-5dd8-337d-1005" targetId="5bd0-9ab2-0523-cbc8" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="db03-7794-daeb-fef6" name="Solar Charges" type="upgrade" collective="true" hidden="false" book="BtGoA" page="85" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="457b-abde-ffd5-bb14" profileTypeId="ecae-8ac8-2c13-0dd3" name="Solar Charges" hidden="false" book="BtGoA" page="85">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D3, Hazardhous H2H, Grenade"/>
-          </characteristics>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a1a8-ba0b-2e45-8020" name="Skyraider" book="BtGoA" page="192" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="216d-1988-8085-ac5b" hidden="false" targetId="f31c-6e5c-19c0-ada7" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="7a23-290e-0678-0165" targetId="1acd-39d3-94e7-48e1" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="7cdc-f9ef-85bc-947a" targetId="1c2c-6574-0a17-f90c" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="3878-9363-1705-9eda" name="Soma Graft" type="upgrade" collective="false" hidden="false" book="BtGoA" page="121" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="3d50-6009-476b-2dd3" targetId="1253-ef5b-67d4-3e18" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="f3aa-148a-0460-c7e5" name="Spotter Drone" type="upgrade" collective="false" hidden="false" book="BtGoA" page="114" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="10.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="b096-0158-02cc-ad91" targetId="fdbd-254f-8dd7-b658" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="a1c9-551b-1532-ef5a" name="Spotter Drone (2)" type="upgrade" collective="false" hidden="false" book="BtGoA" page="114" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="10.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="af19-89d3-df23-32fc" targetId="fdbd-254f-8dd7-b658" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="e329-9443-6cb2-bc53" name="Spotter Drone (Eq)" type="upgrade" collective="false" hidden="false" book="BtGoA" page="114" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="65b9-8262-6f60-281e" targetId="fdbd-254f-8dd7-b658" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="6bfe-ff47-b61c-afd2" name="Sub-mounted X-Sling" type="upgrade" collective="true" hidden="false" book="BtGoA" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks>
-<entryLink id="a9af-f28d-4e65-6d1b" targetId="b08e-548a-fda7-0a4e" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="fb8b-7402-c5a9-8644" name="Subverter Matrix" type="upgrade" collective="false" hidden="false" book="BtGoA" page="122" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="24bd-bd70-2f6b-0434" targetId="cd8d-624c-ed86-e310" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="059e-3ead-10ef-9fd5" name="Synchroniser Drone" type="upgrade" collective="false" hidden="false" book="Battle for Xilos" page="79" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="20.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="f848-9ddf-c5b7-7291" targetId="c526-9fd9-f1c5-6893" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="02f1-fd15-ca9d-ad79" name="Tractor Maul" type="upgrade" collective="false" hidden="false" book="BtGoA" page="65" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="0f4d-9895-e878-29ea" profileTypeId="ecae-8ac8-2c13-0dd3" name="Tractor Maul" hidden="false" book="BtGoA" page="65">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks, Hand Weapon"/>
-          </characteristics>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7c99-2526-5c26-5cb6" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1809-ec86-d299-c2c1" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8de3-1e72-72ef-e7a3" name="SlingNet Ammo" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="27d6-5dd8-337d-1005" hidden="false" targetId="5bd0-9ab2-0523-cbc8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="311e-56e1-d1bc-36a1" targetId="2cbd-47c9-de87-ec2a" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="ac1e-a740-57b7-cc64" name="Twin Mag Light Support" type="upgrade" collective="false" hidden="false" book="BtGoA" page="75" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="25d4-13e2-3977-4bd4" name="Mag Light Support" collective="false" hidden="false" defaultSelectionEntryId="d17e-2eae-cc33-8d46">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="d17e-2eae-cc33-8d46" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="c10e-6e9c-dabb-e6f1" name="Mag Light Support" collective="false" hidden="false" defaultSelectionEntryId="b385-bf67-9722-e7f9">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="b385-bf67-9722-e7f9" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="f31c-6e5c-19c0-ada7" name="Twin Mag Repeaters" type="upgrade" collective="false" hidden="false" book="BtGoA" page="69" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="4e5a-4594-d2da-527c" name="Mag Repeater" collective="false" hidden="false" defaultSelectionEntryId="513b-6ec0-e655-02cd">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="513b-6ec0-e655-02cd" targetId="790a-6841-6372-870b" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-<selectionEntryGroup id="273a-5de1-c9e1-5310" name="Mag Repeater" collective="false" hidden="false" defaultSelectionEntryId="6e82-7e87-0e72-610f">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="6e82-7e87-0e72-610f" targetId="790a-6841-6372-870b" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="78dd-7840-1210-fb35" name="Twin Plasma Carbines" type="upgrade" collective="false" hidden="false" book="BtGoA" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups>
-<selectionEntryGroup id="306b-df6b-34af-a65f" name="Plasma Carbine" collective="false" hidden="false" defaultSelectionEntryId="50f5-f0eb-d9cb-a569">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<entryLinks>
-<entryLink id="50f5-f0eb-d9cb-a569" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
-<modifiers/>
-</entryLink>
-</entryLinks>
-</selectionEntryGroup>
-</selectionEntryGroups>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks/>
-</selectionEntry>
-<selectionEntry id="b9f1-a313-3e59-57ab" name="X-Howitzer" type="upgrade" collective="false" hidden="false" book="BtGoA" page="82" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="acf4-2a5f-e9a1-6d3c" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Howitzer" hidden="false" book="BtGoA" page="82">
-          <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10-50"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="250"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D10, No Cover, Heavy Weapon"/>
-          </characteristics>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="db03-7794-daeb-fef6" name="Solar Charges" book="BtGoA" page="85" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="457b-abde-ffd5-bb14" name="Solar Charges" book="BtGoA" page="85" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
-        </profile>
-</profiles>
-<entryLinks>
-<entryLink id="92e5-9a8f-2921-8280" targetId="bc4e-7cd8-4017-d911" type="selectionEntryGroup">
-<modifiers/>
-</entryLink>
-</entryLinks>
-<infoLinks>
-<infoLink id="6f40-42de-4957-1df4" targetId="c3bc-87fd-fa5d-5055" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="b631-2638-986b-4611" targetId="04d9-a48d-7b25-4dd3" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="7c8b-6880-8593-4b52" targetId="a41d-d55e-6d97-049d" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="eed0-b68f-b5fb-92c7" name="X-Launcher" type="upgrade" collective="false" hidden="false" book="BtGoA" page="78" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="2489-100b-d116-96c6" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Launcher" hidden="false" book="BtGoA" page="78">
           <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="60"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="120"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D5, No Cover,  Light Support Weapon"/>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D3, Hazardhous H2H, Grenade"/>
           </characteristics>
-          <modifiers/>
         </profile>
-</profiles>
-<entryLinks>
-<entryLink id="7bb9-56de-ae51-c52b" targetId="bc4e-7cd8-4017-d911" type="selectionEntryGroup">
-<modifiers/>
-</entryLink>
-</entryLinks>
-<infoLinks>
-<infoLink id="cbba-ff32-112c-3173" targetId="c3bc-87fd-fa5d-5055" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="57ac-1f50-9d13-b33b" targetId="b050-496a-ed16-2b2a" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="613e-43c3-a036-e997" targetId="a41d-d55e-6d97-049d" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="b08e-548a-fda7-0a4e" name="X-Sling" type="upgrade" collective="true" hidden="false" book="BtGoA" page="68" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="3cec-d2e0-b0ed-7856" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Sling" hidden="false" book="BtGoA" page="68">
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="7a23-290e-0678-0165" hidden="false" targetId="1acd-39d3-94e7-48e1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7cdc-f9ef-85bc-947a" hidden="false" targetId="1c2c-6574-0a17-f90c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3878-9363-1705-9eda" name="Soma Graft" book="BtGoA" page="121" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="3d50-6009-476b-2dd3" hidden="false" targetId="1253-ef5b-67d4-3e18" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f3aa-148a-0460-c7e5" name="Spotter Drone" book="BtGoA" page="114" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="b096-0158-02cc-ad91" hidden="false" targetId="fdbd-254f-8dd7-b658" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a1c9-551b-1532-ef5a" name="Spotter Drone (2)" book="BtGoA" page="114" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="af19-89d3-df23-32fc" hidden="false" targetId="fdbd-254f-8dd7-b658" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e329-9443-6cb2-bc53" name="Spotter Drone (Eq)" book="BtGoA" page="114" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="65b9-8262-6f60-281e" hidden="false" targetId="fdbd-254f-8dd7-b658" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6bfe-ff47-b61c-afd2" name="Sub-mounted X-Sling" book="BtGoA" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="a9af-f28d-4e65-6d1b" hidden="false" targetId="b08e-548a-fda7-0a4e" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fb8b-7402-c5a9-8644" name="Subverter Matrix" book="BtGoA" page="122" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="24bd-bd70-2f6b-0434" hidden="false" targetId="cd8d-624c-ed86-e310" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="059e-3ead-10ef-9fd5" name="Synchroniser Drone" book="Battle for Xilos" page="79" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="f848-9ddf-c5b7-7291" hidden="false" targetId="c526-9fd9-f1c5-6893" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="02f1-fd15-ca9d-ad79" name="Tractor Maul" book="BtGoA" page="65" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="0f4d-9895-e878-29ea" name="Tractor Maul" book="BtGoA" page="65" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
           <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D3, Hand Weapon"/>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks, Hand Weapon"/>
           </characteristics>
-          <modifiers/>
         </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="ff22-4293-45d6-b483" targetId="1acd-39d3-94e7-48e1" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="179a-c0cc-49cc-c946" name="X-Sling (Eq)" type="upgrade" collective="true" hidden="false" book="BtGoA" page="68" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="0.0"/>
-</costs>
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles>
-<profile id="8977-826a-5f65-6907" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Sling" hidden="false" book="BtGoA" page="68">
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="311e-56e1-d1bc-36a1" hidden="false" targetId="2cbd-47c9-de87-ec2a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ac1e-a740-57b7-cc64" name="Twin Mag Light Support" book="BtGoA" page="75" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="25d4-13e2-3977-4bd4" name="Mag Light Support" hidden="false" collective="false" defaultSelectionEntryId="d17e-2eae-cc33-8d46">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="d17e-2eae-cc33-8d46" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="c10e-6e9c-dabb-e6f1" name="Mag Light Support" hidden="false" collective="false" defaultSelectionEntryId="b385-bf67-9722-e7f9">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="b385-bf67-9722-e7f9" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f31c-6e5c-19c0-ada7" name="Twin Mag Repeaters" book="BtGoA" page="69" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="1b07-3eff-2e27-38b4" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4145-6509-879d-de77" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7f4c-e360-1e4c-e1be" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="4c79-65ca-5680-9c6f" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6828-c40c-08cb-eff8" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b464-5333-0aaf-d974" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="78dd-7840-1210-fb35" name="Twin Plasma Carbines" book="BtGoA" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="306b-df6b-34af-a65f" name="Plasma Carbine" hidden="false" collective="false" defaultSelectionEntryId="50f5-f0eb-d9cb-a569">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="50f5-f0eb-d9cb-a569" hidden="false" targetId="1631-5857-2139-960a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b9f1-a313-3e59-57ab" name="X-Howitzer" book="BtGoA" page="82" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="acf4-2a5f-e9a1-6d3c" name="X-Howitzer" book="BtGoA" page="82" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
           <characteristics>
-            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D3, Hand Weapon"/>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-50"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="250"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D10, No Cover, Heavy Weapon"/>
           </characteristics>
-          <modifiers/>
         </profile>
-</profiles>
-<entryLinks/>
-<infoLinks>
-<infoLink id="f51f-aab5-2da1-d5d0" targetId="1acd-39d3-94e7-48e1" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</sharedSelectionEntries>
-<sharedSelectionEntryGroups>
-<selectionEntryGroup id="bc4e-7cd8-4017-d911" name="Munitions" collective="false" hidden="false">
-<constraints>
-<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="5"/>
-<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
-<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
-<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
-<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
-</constraints>
-<modifiers/>
-<selectionEntries>
-<selectionEntry id="c816-58ed-3726-86b5" name="Scrambler" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="5.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="55f1-0e9f-4b69-56c1" targetId="7a3b-74a5-3ced-dd88" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="69e5-ef01-7a5e-3f24" targetId="b996-131f-b84a-4724" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="e0bc-ff63-7ed9-9768" name="Arc" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="5.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="6614-fd6d-aecf-1070" targetId="c1ba-c745-22a8-e2d7" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="6979-177c-42e8-27bf" targetId="b996-131f-b84a-4724" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="d6cb-2428-f1b5-0f11" name="Blur" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="5.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="a019-91dd-3b84-e72e" targetId="117a-a2aa-4be7-dffe" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="b4a9-0df0-5149-5785" targetId="b996-131f-b84a-4724" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="bbac-d335-536a-e63d" name="Scoot" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="5.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="0e1e-3e34-5c36-4bbf" targetId="28a0-7151-a0c5-9495" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="cc03-4929-b882-43a6" targetId="b996-131f-b84a-4724" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="2a9e-c888-1e5a-ea11" name="Net" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="5.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="f4bd-099a-19ab-8138" targetId="ac33-af99-2d76-c981" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="b932-f489-37e5-e6b4" name="Grip" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="5.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="eee1-31e1-599c-0bd8" targetId="1045-95cb-5504-9050" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="df1a-7d7c-9316-5794" targetId="b996-131f-b84a-4724" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-<selectionEntry id="f766-367d-f5c0-fc59" name="All" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
-<costs>
-<cost costTypeId="points" name="pts" value="15.0"/>
-</costs>
-<constraints>
-<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
-</constraints>
-<modifiers/>
-<selectionEntries/>
-<selectionEntryGroups/>
-<rules/>
-<profiles/>
-<entryLinks/>
-<infoLinks>
-<infoLink id="1874-10fd-bc26-7005" targetId="c1ba-c745-22a8-e2d7" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="0234-4b9e-9342-68f7" targetId="117a-a2aa-4be7-dffe" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="6234-ec86-062c-0073" targetId="1045-95cb-5504-9050" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="a285-cf7f-7fac-f9ab" targetId="ac33-af99-2d76-c981" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="11d8-fdb9-76ff-2c4c" targetId="28a0-7151-a0c5-9495" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="9abb-2789-75c0-d3a8" targetId="7a3b-74a5-3ced-dd88" type="rule">
-<modifiers/>
-</infoLink>
-<infoLink id="1492-b598-eb64-0ea0" targetId="b996-131f-b84a-4724" type="rule">
-<modifiers/>
-</infoLink>
-</infoLinks>
-</selectionEntry>
-</selectionEntries>
-<selectionEntryGroups/>
-<entryLinks/>
-</selectionEntryGroup>
-</sharedSelectionEntryGroups>
-<sharedRules>
-<rule id="2cbd-47c9-de87-ec2a" name="2 Attacks" hidden="false" book="BtGoA" page="133">
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="6f40-42de-4957-1df4" hidden="false" targetId="c3bc-87fd-fa5d-5055" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b631-2638-986b-4611" hidden="false" targetId="04d9-a48d-7b25-4dd3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7c8b-6880-8593-4b52" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="92e5-9a8f-2921-8280" hidden="false" targetId="bc4e-7cd8-4017-d911" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eed0-b68f-b5fb-92c7" name="X-Launcher" book="BtGoA" page="78" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="2489-100b-d116-96c6" name="X-Launcher" book="BtGoA" page="78" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D5, No Cover,  Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="cbba-ff32-112c-3173" hidden="false" targetId="c3bc-87fd-fa5d-5055" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="57ac-1f50-9d13-b33b" hidden="false" targetId="b050-496a-ed16-2b2a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="613e-43c3-a036-e997" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="7bb9-56de-ae51-c52b" hidden="false" targetId="bc4e-7cd8-4017-d911" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b08e-548a-fda7-0a4e" name="X-Sling" book="BtGoA" page="68" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="3cec-d2e0-b0ed-7856" name="X-Sling" book="BtGoA" page="68" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D3, Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="ff22-4293-45d6-b483" hidden="false" targetId="1acd-39d3-94e7-48e1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="179a-c0cc-49cc-c946" name="X-Sling (Eq)" book="BtGoA" page="68" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+      <profiles>
+        <profile id="8977-826a-5f65-6907" name="X-Sling" book="BtGoA" page="68" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D3, Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="f51f-aab5-2da1-d5d0" hidden="false" targetId="1acd-39d3-94e7-48e1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="bc4e-7cd8-4017-d911" name="Munitions" hidden="false" collective="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInForce" type="min"/>
+        <constraint field="selections" scope="force" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="minInRoster" type="min"/>
+        <constraint field="selections" scope="roster" value="-1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
+        <constraint field="points" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="minPoints" type="min"/>
+        <constraint field="points" scope="parent" value="-1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxPoints" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="c816-58ed-3726-86b5" name="Scrambler" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="55f1-0e9f-4b69-56c1" hidden="false" targetId="7a3b-74a5-3ced-dd88" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="69e5-ef01-7a5e-3f24" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e0bc-ff63-7ed9-9768" name="Arc" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="6614-fd6d-aecf-1070" hidden="false" targetId="c1ba-c745-22a8-e2d7" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="6979-177c-42e8-27bf" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d6cb-2428-f1b5-0f11" name="Blur" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="a019-91dd-3b84-e72e" hidden="false" targetId="117a-a2aa-4be7-dffe" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="b4a9-0df0-5149-5785" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="bbac-d335-536a-e63d" name="Scoot" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="0e1e-3e34-5c36-4bbf" hidden="false" targetId="28a0-7151-a0c5-9495" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="cc03-4929-b882-43a6" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="2a9e-c888-1e5a-ea11" name="Net" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="f4bd-099a-19ab-8138" hidden="false" targetId="ac33-af99-2d76-c981" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b932-f489-37e5-e6b4" name="Grip" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="eee1-31e1-599c-0bd8" hidden="false" targetId="1045-95cb-5504-9050" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="df1a-7d7c-9316-5794" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f766-367d-f5c0-fc59" name="All" book="BtGoA" page="87" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="1874-10fd-bc26-7005" hidden="false" targetId="c1ba-c745-22a8-e2d7" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="0234-4b9e-9342-68f7" hidden="false" targetId="117a-a2aa-4be7-dffe" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="6234-ec86-062c-0073" hidden="false" targetId="1045-95cb-5504-9050" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="a285-cf7f-7fac-f9ab" hidden="false" targetId="ac33-af99-2d76-c981" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="11d8-fdb9-76ff-2c4c" hidden="false" targetId="28a0-7151-a0c5-9495" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="9abb-2789-75c0-d3a8" hidden="false" targetId="7a3b-74a5-3ced-dd88" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="1492-b598-eb64-0ea0" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
+  <sharedRules>
+    <rule id="2cbd-47c9-de87-ec2a" name="2 Attacks" book="BtGoA" page="133" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Two attacks in close combat.</description>
-      <modifiers/>
     </rule>
-<rule id="61e2-3707-ade3-c9ad" name="3 Attacks" hidden="false" book="BtGoA" page="133">
+    <rule id="61e2-3707-ade3-c9ad" name="3 Attacks" book="BtGoA" page="133" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Three attacks in close combat.</description>
-      <modifiers/>
     </rule>
-<rule id="7daf-414b-c030-7626" name="AG Chute" hidden="false" book="BtGoA" page="120">
+    <rule id="7daf-414b-c030-7626" name="AG Chute" book="BtGoA" page="120" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May make 2M move and shoot when given advance order. +1 Ag. Treat difficult ground as suspensored vehicle. </description>
-      <modifiers/>
     </rule>
-<rule id="c1ba-c745-22a8-e2d7" name="Arc" hidden="false" book="BtGoA" page="88">
-      <description>Creates 3" sink area. Affects any shooter attemping to draw LOS and shoot through the arc. Roll a D10 if LOS goes through - 1-5 the shot is normal, 6-10 the shot automatically misses. Make test before rolling Acc to hit. 
+    <rule id="c1ba-c745-22a8-e2d7" name="Arc" book="BtGoA" page="88" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Creates 3&quot; sink area. Affects any shooter attemping to draw LOS and shoot through the arc. Roll a D10 if LOS goes through - 1-5 the shot is normal, 6-10 the shot automatically misses. Make test before rolling Acc to hit. 
 
-OH shots are affected if the target is within 3" of the marker. </description>
-      <modifiers/>
+OH shots are affected if the target is within 3&quot; of the marker. </description>
     </rule>
-<rule id="b7c6-fc7c-d48b-aae4" name="Auto-Workshop" hidden="false" book="BtGoA" page="121">
-      <description>Activated from any order to the unit. Affects every vehicle, weapon drone, weapon team, and machine mounted unit within 5" of the unit, and itself. Roll D10 - on 1-5, nothing happens, 6-10 each unit removes a pin.</description>
+    <rule id="b7c6-fc7c-d48b-aae4" name="Auto-Workshop" book="BtGoA" page="121" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>Activated from any order to the unit. Affects every vehicle, weapon drone, weapon team, and machine mounted unit within 5&quot; of the unit, and itself. Roll D10 - on 1-5, nothing happens, 6-10 each unit removes a pin.</description>
     </rule>
-<rule id="f0d9-1e5a-ec20-b27c" name="Batter Drone" hidden="false" book="BtGoA" page="110">
-      <description>Projects curved shield as template - must be positioned with outer side facing away from drone, no part of template more than 5" from drone base. Template may be repositioned any time unit receives an order die.
+    <rule id="f0d9-1e5a-ec20-b27c" name="Batter Drone" book="BtGoA" page="110" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Projects curved shield as template - must be positioned with outer side facing away from drone, no part of template more than 5&quot; from drone base. Template may be repositioned any time unit receives an order die.
 
 Enemy units shooting through shield suffer -2 ACC. Models positioned inside the shield do not receive the -2 ACC protection. Troops shooting from the inside convex side of the shield do not suffer the ACC penalty. 
 
 No protection is offered for OH shots.</description>
-      <modifiers/>
     </rule>
-<rule id="04d9-a48d-7b25-4dd3" name="Blast D10" hidden="false" book="BtGoA">
+    <rule id="04d9-a48d-7b25-4dd3" name="Blast D10" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Inflicts D10 hits on a successful shooting attack.</description>
-      <modifiers/>
     </rule>
-<rule id="1acd-39d3-94e7-48e1" name="Blast D3" hidden="false" book="BtGoA">
+    <rule id="1acd-39d3-94e7-48e1" name="Blast D3" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Inflicts D3 hits on a successful shooting attack.</description>
-      <modifiers/>
     </rule>
-<rule id="ca96-58c9-9551-d4fe" name="Blast D4" hidden="false" book="BtGoA">
+    <rule id="ca96-58c9-9551-d4fe" name="Blast D4" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Inflicts D4 hits on a successful shooting attack.</description>
-      <modifiers/>
     </rule>
-<rule id="b050-496a-ed16-2b2a" name="Blast D5" hidden="false" book="BtGoA">
+    <rule id="b050-496a-ed16-2b2a" name="Blast D5" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Inflicts D5 hits on a successful shooting attack.</description>
-      <modifiers/>
     </rule>
-<rule id="5d2e-45d2-1707-87db" name="Block!" hidden="false" page="159">
+    <rule id="5d2e-45d2-1707-87db" name="Block!" page="159" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>The Order Die drawn from the bag is returned and another random die is drawn. This dice stands and cannot be blocked. Use once and discard. You can buy as many Blocks as you are allowed Auxiliary choices in your Army</description>
-      <modifiers/>
     </rule>
-<rule id="117a-a2aa-4be7-dffe" name="Blur" hidden="false" book="BtGoA" page="89">
-      <description>Any unit within 3" reduces Acc by D3 each time it shoots. If within two or more blur markers, roll a D3 for each and take highest.</description>
+    <rule id="117a-a2aa-4be7-dffe" name="Blur" book="BtGoA" page="89" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>Any unit within 3&quot; reduces Acc by D3 each time it shoots. If within two or more blur markers, roll a D3 for each and take highest.</description>
     </rule>
-<rule id="c3e6-4e9b-858c-80d3" name="Booster Drone" hidden="false" book="BtGoA" page="92">
+    <rule id="c3e6-4e9b-858c-80d3" name="Booster Drone" book="BtGoA" page="92" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Infantry, Weapon Team, or Command unit gains +1 armor bonus from reflex, hyperlight, and phase armor. Cannot benefit units with HL boosters.</description>
-      <modifiers/>
     </rule>
-<rule id="4e34-753f-b082-2e00" name="Borer Drone" hidden="false" book="BtGoA" page="111">
+    <rule id="4e34-753f-b082-2e00" name="Borer Drone" book="BtGoA" page="111" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Every model in the owning unit gains +1 Str for all Strength tests and H2H. 
 
 Unit may put up temporary cover by making any action without a move. May result from order or reaction and can include a down action from failed order check. Unit benefits from 2+ Res as long as it does not move. Is not cumulative with other cover bonuses.</description>
-      <modifiers/>
     </rule>
-<rule id="5f48-f41c-fd96-6a1a" name="Camo Drone" hidden="false" book="BtGoA" page="111">
-      <description>If unit goes down it cannot be targeted at ranges of more than 10". If a unit with the drone goes down as reaction to enemy shooting from more than 10" away then the unit can no longer be targeted. OH shots will miss and have no effect. Scout probes can compromise this effect within 10".
+    <rule id="5f48-f41c-fd96-6a1a" name="Camo Drone" book="BtGoA" page="111" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>If unit goes down it cannot be targeted at ranges of more than 10&quot;. If a unit with the drone goes down as reaction to enemy shooting from more than 10&quot; away then the unit can no longer be targeted. OH shots will miss and have no effect. Scout probes can compromise this effect within 10&quot;.
 
 </description>
-      <modifiers/>
     </rule>
-<rule id="fd72-d48c-e8af-4883" name="Choose Target" hidden="false" book="BtGoA" page="70">
+    <rule id="fd72-d48c-e8af-4883" name="Choose Target" book="BtGoA" page="70" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May fire at a different target from the test of the unit. If more than one model has a weapon with Choose Target, all weapons with Choose Target must shoot at same target.</description>
-      <modifiers/>
     </rule>
-<rule id="5c9b-1bde-ee01-04a4" name="Command" hidden="false" book="BtGoA" page="133">
-      <description>Friendly units within 10" can use this model's Co value for any Co based test instead of their own. Pins still affect this Co value.</description>
+    <rule id="5c9b-1bde-ee01-04a4" name="Command" book="BtGoA" page="133" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>Friendly units within 10&quot; can use this model&apos;s Co value for any Co based test instead of their own. Pins still affect this Co value.</description>
     </rule>
-<rule id="3995-c066-c957-5ffe" name="Compactor Drone" hidden="false" book="BtGoA" page="112">
-      <description>May carry one of the following: all of a mounted unit's bikes, a unit's support weapon, an entire weapon drone unit complete with any associated buddy drones other than compactor drones, or an entire probe shard.
+    <rule id="3995-c066-c957-5ffe" name="Compactor Drone" book="BtGoA" page="112" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>May carry one of the following: all of a mounted unit&apos;s bikes, a unit&apos;s support weapon, an entire weapon drone unit complete with any associated buddy drones other than compactor drones, or an entire probe shard.
 
 May load or unload when their unit makes an action, even down order following failed order test. </description>
-      <modifiers/>
     </rule>
-<rule id="7db4-2d14-3984-37d9" name="Compressor" hidden="false" book="BtGoA" page="71">
+    <rule id="7db4-2d14-3984-37d9" name="Compressor" book="BtGoA" page="71" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>SV value varies with range band.</description>
-      <modifiers/>
     </rule>
-<rule id="5fb8-4f09-d496-4ea9" name="Concentrated Fire" hidden="false" book="BtGoA" page="72">
+    <rule id="5fb8-4f09-d496-4ea9" name="Concentrated Fire" book="BtGoA" page="72" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Any lucky hits can be allocated to the same model, do not have to be distributed evenly.</description>
-      <modifiers/>
     </rule>
-<rule id="c34f-bbca-9bfc-6874" name="Crawler" hidden="false" book="BtGoA" page="133">
+    <rule id="c34f-bbca-9bfc-6874" name="Crawler" book="BtGoA" page="133" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Crawlers are restricted when moving over certain terrain types as described in the terrain section. They cross obstacles in the same manner as a heavy weapon team. They cannot cross at a run and must test to cross at advance rate. Crossing obstacles, p22</description>
-      <modifiers/>
     </rule>
-<rule id="cf7f-6f85-e64e-0363" name="Cycle" hidden="false" book="BtGoA" page="78">
+    <rule id="cf7f-6f85-e64e-0363" name="Cycle" book="BtGoA" page="78" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>On the Acc roll of a 10 shot misses and weapon team goes down.</description>
-      <modifiers/>
     </rule>
-<rule id="6305-72fa-da02-235b" name="Disruptor" hidden="false" book="BtGoA" page="79">
+    <rule id="6305-72fa-da02-235b" name="Disruptor" book="BtGoA" page="79" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>A target hit by a disruptor weapon gets no cover bonus to its Res roll against the hit.
 
 A non-Ghar target hit by a disruptor weapon takes 2 pins rather than the usual 1 pin. If the target has Res &gt; 10, it takes these pins even if the hit is successfully resisted. Ghar do not suffer these pins. 
@@ -8972,140 +9141,236 @@ A non-Ghar target hit by a disruptor weapon takes 2 pins rather than the usual 1
 Buddy drones can be allocated hits from this weapon by the shooter from any hits, not just lucky hits.
 
 If the target is a probe it only passes Res tests on a 1.</description>
-      <modifiers/>
     </rule>
-<rule id="9444-e2a0-8048-5ce9" name="Down" hidden="false" book="BtGoA" page="74">
+    <rule id="9444-e2a0-8048-5ce9" name="Down" book="BtGoA" page="74" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Unit hit automatically goes down after shooting has been worked out whether casualties are caused or not. </description>
-      <modifiers/>
     </rule>
-<rule id="4232-2801-36cf-704c" name="Exhausted" hidden="false" book="BtGoA" page="67">
+    <rule id="4232-2801-36cf-704c" name="Exhausted" book="BtGoA" page="67" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Rolls of 10 on Str or Acc to-hit rolls cannot be re-rolled and stave has become exhausted. Make a test at the turn end phase - 1-5 it is still exhausted, 6-10 it is replenished.</description>
-      <modifiers/>
     </rule>
-<rule id="e77b-02da-5143-229e" name="Extra Shot" hidden="false" page="159">
+    <rule id="e77b-02da-5143-229e" name="Extra Shot" page="159" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>If you score a Lucky Hit with any shot you can make one more shot with that model using the same weapon with exactly the same score required to hit the same target. Roll one more shot to score a hit. Use once and discard. You can buy as many Extra Shots as you are allowed Auxiliary choices in your Army.</description>
-      <modifiers/>
     </rule>
-<rule id="b0ca-8e7d-d03f-f027" name="Fast" hidden="false" book="BtGoA" page="133">
-      <description>Move at double pace - 10" per advance, 20" for run. Shots fired at fast targets with a run order must re-roll hits. 
+    <rule id="b0ca-8e7d-d03f-f027" name="Fast" book="BtGoA" page="133" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Move at double pace - 10&quot; per advance, 20&quot; for run. Shots fired at fast targets with a run order must re-roll hits. 
 Fast units may break off of assault after point blank shooting has been conducted. They may move through the enemy during this move.</description>
-      <modifiers/>
     </rule>
-<rule id="7bc9-5e98-2914-5abd" name="Follow" hidden="false" book="BtGoA" page="13">
-      <description>When a leader with follow gives his unit an order, any other friendly units within 5" may make the same action as long as they have no pins and are otherwise able to make the action.</description>
+    <rule id="7bc9-5e98-2914-5abd" name="Follow" book="BtGoA" page="13" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>When a leader with follow gives his unit an order, any other friendly units within 5&quot; may make the same action as long as they have no pins and are otherwise able to make the action.</description>
     </rule>
-<rule id="d50c-3bbe-c62d-34c3" name="Fractal Lock" hidden="false" book="BtGoA" page="83">
+    <rule id="d50c-3bbe-c62d-34c3" name="Fractal Lock" book="BtGoA" page="83" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>If the weapon hits, it locks on. If the target does not move and the unit receives a fire order it automatically hits. Each time it auto-hits the SV value goes up by 2.</description>
-      <modifiers/>
     </rule>
-<rule id="2afe-05bf-268b-84c2" name="Get Up!" hidden="false" page="159">
+    <rule id="2afe-05bf-268b-84c2" name="Get Up!" page="159" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>When making a Recovery Test (to recover a Down order die) you will succeed on a roll of anything but a 10 regardless of the value you would normally test against. A roll of a 10 is still a failure, and no pin markers are removed, as standard. Use once and discard. You can buy as many Get Up!(s) as you are allowed Auxiliary choices in your Army.</description>
-      <modifiers/>
     </rule>
-<rule id="b466-7990-db34-55b1" name="Grenade" hidden="false" book="BtGoA" page="85">
+    <rule id="b466-7990-db34-55b1" name="Grenade" book="BtGoA" page="85" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>In H2H counts as hand weapon +1 Str bonus. Grenade hits compound in H2H - if a model takes suffers two or more hits from grenades, add all SVs together and take one Res test.</description>
-      <modifiers/>
     </rule>
-<rule id="1045-95cb-5504-9050" name="Grip" hidden="false" book="BtGoA" page="87">
-      <description>Unit beginning its move within 3" must take and pass an Ag test. If failed it may not move, if passed it can move half rate, failed on a 10 it takes a pin and cannot move.
+    <rule id="1045-95cb-5504-9050" name="Grip" book="BtGoA" page="87" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Unit beginning its move within 3&quot; must take and pass an Ag test. If failed it may not move, if passed it can move half rate, failed on a 10 it takes a pin and cannot move.
 
-If a unit moves within 3" it must take the Ag test as above. </description>
-      <modifiers/>
+If a unit moves within 3&quot; it must take the Ag test as above. </description>
     </rule>
-<rule id="5f6c-7c20-3cbc-bcc8" name="Gun Drone" hidden="false" book="BtGoA" page="112">
+    <rule id="5f6c-7c20-3cbc-bcc8" name="Gun Drone" book="BtGoA" page="112" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Shoots as if it were an ordinary member of its unit with the same Acc value. Draw LOS in the same way as other models in the unit.</description>
-      <modifiers/>
     </rule>
-<rule id="1c2c-6574-0a17-f90c" name="Hazardous H2H" hidden="false" book="BtGoA" page="85">
+    <rule id="1c2c-6574-0a17-f90c" name="Hazardous H2H" book="BtGoA" page="85" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Any H2H Str roll of 10 hits the user, not enemy.</description>
-      <modifiers/>
     </rule>
-<rule id="a846-6829-3398-bac1" name="Heavy" hidden="false" book="BtGoA" page="134">
+    <rule id="a846-6829-3398-bac1" name="Heavy" book="BtGoA" page="134" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Movement restricted across obstacles per p22. Cannot cross obstacles at a run. Agility test required to cross at advance. When rolling resistance checks only fail on a 10, roll on damage chart p37.</description>
-      <modifiers/>
     </rule>
-<rule id="3c64-6022-a5f1-9c04" name="Hero" hidden="false" book="BtGoA" page="134">
-      <description>Friendly units within 10" may use this model's Init stat. </description>
+    <rule id="3c64-6022-a5f1-9c04" name="Hero" book="BtGoA" page="134" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>Friendly units within 10&quot; may use this model&apos;s Init stat. </description>
     </rule>
-<rule id="34e0-c5a3-3998-5d0b" name="High Commander" hidden="false" book="BtGoA" page="134">
+    <rule id="34e0-c5a3-3998-5d0b" name="High Commander" book="BtGoA" page="134" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May re-roll every failed resist test once. May use command, hero, and follow special rules on any units.</description>
-      <modifiers/>
     </rule>
-<rule id="b436-1f8a-5d3a-2d7d" name="HL Armor" hidden="false" book="BtGoA" page="93">
-      <description>Ranges of 10" or less, +1 to Res. Ranges of greater than 10" +2 Res. Against any Blast hits, +3 Res. </description>
+    <rule id="b436-1f8a-5d3a-2d7d" name="HL Armor" book="BtGoA" page="93" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>Ranges of 10&quot; or less, +1 to Res. Ranges of greater than 10&quot; +2 Res. Against any Blast hits, +3 Res. </description>
     </rule>
-<rule id="56ab-52fc-9557-2586" name="HL Booster" hidden="false" book="BtGoA" page="93">
+    <rule id="56ab-52fc-9557-2586" name="HL Booster" book="BtGoA" page="93" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>+1 Res on top of all other bonuses.</description>
-      <modifiers/>
     </rule>
-<rule id="ca2b-9550-eb1e-77c8" name="Homer Drone" hidden="false" book="BtGoA" page="112">
+    <rule id="ca2b-9550-eb1e-77c8" name="Homer Drone" book="BtGoA" page="112" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Unit may be transported off the table by using a Run order. If taking an order test and failed on a 10, homer drone is destroyed. Once removed from the battlefield unit cannot return. Only the unit and equipment may be transported - not objectives.</description>
-      <modifiers/>
     </rule>
-<rule id="3b84-9d0e-a3c1-6c1f" name="Inaccurate" hidden="false" book="BtGoA" page="70">
+    <rule id="3b84-9d0e-a3c1-6c1f" name="Inaccurate" book="BtGoA" page="70" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Additional -1 Acc penalty.</description>
-      <modifiers/>
     </rule>
-<rule id="96c4-7a43-2a4c-d7d3" name="Infiltrator" hidden="false" book="BtGoA" page="134">
-      <description>May make a special pre-game run action. May sprint, test for exhaustion. May not move within 10" of enemy. May lay a minefield before game starts.</description>
+    <rule id="96c4-7a43-2a4c-d7d3" name="Infiltrator" book="BtGoA" page="134" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>May make a special pre-game run action. May sprint, test for exhaustion. May not move within 10&quot; of enemy. May lay a minefield before game starts.</description>
     </rule>
-<rule id="a221-d53c-b4bd-b52c" name="Large" hidden="false" book="BtGoA" page="134">
+    <rule id="a221-d53c-b4bd-b52c" name="Large" book="BtGoA" page="134" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Cannot sprint unless also fast. Passes when testing Ag to move through dense terrain reduce movement to half. Passes on a one mean unit can move at full rate. Failure means unit cannot move, failure on a 10 gains one pin. 
 
 Units may fire over regular sized units at no penalty. Large targets never gain cover bonuses to their Res stat. May not enter buildings. </description>
-      <modifiers/>
     </rule>
-<rule id="7cfb-9874-dfe0-b136" name="Lava Spit" hidden="false" book="BtGoA" page="135">
+    <rule id="7cfb-9874-dfe0-b136" name="Lava Spit" book="BtGoA" page="135" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Lavamites may shoot during point blank shooting at SV 2.</description>
-      <modifiers/>
     </rule>
-<rule id="e441-c3a6-7d61-2c63" name="Leader" hidden="false" book="BtGoA" page="135">
+    <rule id="e441-c3a6-7d61-2c63" name="Leader" book="BtGoA" page="135" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May re-roll one failed res test per leader level. </description>
-      <modifiers/>
     </rule>
-<rule id="7850-89e7-bab8-86e9" name="Leader 2" hidden="false" book="BtGoA">
+    <rule id="7850-89e7-bab8-86e9" name="Leader 2" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May re-roll one failed res test per leader level.</description>
-      <modifiers/>
     </rule>
-<rule id="05bb-4d34-70cd-25d2" name="Leader 3" hidden="false" book="BtGoA">
+    <rule id="05bb-4d34-70cd-25d2" name="Leader 3" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May re-roll one failed res test per leader level.</description>
-      <modifiers/>
     </rule>
-<rule id="5efa-64a9-bbc9-3dba" name="Limited Ammo" hidden="false" book="BtGoA" page="73,77">
+    <rule id="5efa-64a9-bbc9-3dba" name="Limited Ammo" book="BtGoA" page="73,77" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Risks running out of ammunition.</description>
-      <modifiers/>
     </rule>
-<rule id="d8dc-cf25-ef95-c94b" name="Limited Choice" hidden="false" book="BtGoA">
+    <rule id="d8dc-cf25-ef95-c94b" name="Limited Choice" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May only be taken as 1 in 4 choices of entire force.</description>
-      <modifiers/>
     </rule>
-<rule id="5741-af68-9dc0-519f" name="Marksman" hidden="false" page="159">
+    <rule id="5741-af68-9dc0-519f" name="Marksman" page="159" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>When rolling to-hit against a unit with a shooting attack, you may re-roll all of the shots. If you choose to do this you must take ALL of the shots again regardless of whether they hit or miss, and whatever result you roll the second time stands, with no further re-rolls allowed. You can only buy ONE Marksman regardless of Army size.</description>
-      <modifiers/>
     </rule>
-<rule id="c863-510b-e239-be92" name="Massive Damage" hidden="false" book="BtGoA" page="75">
-      <description>If the mag cannon's target rolls for damage on a damage table it suffers Massive Damage - page 37.</description>
+    <rule id="c863-510b-e239-be92" name="Massive Damage" book="BtGoA" page="75" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>If the mag cannon&apos;s target rolls for damage on a damage table it suffers Massive Damage - page 37.</description>
     </rule>
-<rule id="4039-88e8-9f6d-bfb3" name="Medi-Drone" hidden="false" book="BtGoA" page="113">
-      <description>Can only attend humans - not machines or Skarks. Any friendly unit within 5" may re-roll one failed Res test each time it is shot at, fights H2H, or otherwise suffers damage. Units within 5" of more than one medi-drone may re-roll one failed Res test for each medi-drone. </description>
+    <rule id="4039-88e8-9f6d-bfb3" name="Medi-Drone" book="BtGoA" page="113" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>Can only attend humans - not machines or Skarks. Any friendly unit within 5&quot; may re-roll one failed Res test each time it is shot at, fights H2H, or otherwise suffers damage. Units within 5&quot; of more than one medi-drone may re-roll one failed Res test for each medi-drone. </description>
     </rule>
-<rule id="137e-c2b6-65b7-ecc3" name="Medic" hidden="false" book="BtGoA" page="135">
-      <description>Units within 5" of a medic unit may re-roll one failed Res test each time it is shot at. Medi-probes and drones may add their re-rolls to total number of re-rolls.
+    <rule id="137e-c2b6-65b7-ecc3" name="Medic" book="BtGoA" page="135" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Units within 5&quot; of a medic unit may re-roll one failed Res test each time it is shot at. Medi-probes and drones may add their re-rolls to total number of re-rolls.
 
 Cannot be used on non-humans. </description>
-      <modifiers/>
     </rule>
-<rule id="a97f-4540-de7b-5734" name="Meld" hidden="false" book="BtGoA" page="128">
+    <rule id="a97f-4540-de7b-5734" name="Meld" book="BtGoA" page="128" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Single unit of two NuHu but only has one Res value. If a Res test is failed, roll on Meld Damage Chart. </description>
-      <modifiers/>
     </rule>
-<rule id="5e3d-6905-2b14-8cd1" name="Meld Damage" hidden="false" book="BtGoA" page="128">
+    <rule id="5e3d-6905-2b14-8cd1" name="Meld Damage" book="BtGoA" page="128" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>D10 Result
 1	No effect
 2-3 	Take one additional pin and Go Down
@@ -9113,9 +9378,12 @@ Cannot be used on non-humans. </description>
 6-8 	Take D3 additional pins and Go Down, MOD units lose one order die
 9 	One of the NuHu falls casualty, breaking the meld. Remaining model reverts to normal NuHu stats. MOD 	is lost. Surviving NuHu takes D3 additional pins and goes down.
 10 	Destroyed. The unit is destroyed, and both NuHu are removed as casualties.</description>
-      <modifiers/>
     </rule>
-<rule id="db7a-5bd4-6400-f6d1" name="Misgenic Abilities" hidden="false" book="BtGoA" page="196">
+    <rule id="db7a-5bd4-6400-f6d1" name="Misgenic Abilities" book="BtGoA" page="196" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Set after deployment. May choose one of the following before the game and pay 10 points to gain any further qualities on a D10 roll. Duplicates may be added together or treated as a 10 roll.
 
 D10 Result:
@@ -9123,27 +9391,39 @@ D10 Result:
 2 Gnarly Hide: +1 Resist
 3 Bulging Muscles: +1 Str
 4 Lightning Reflexes: +1 Init
-5 Piercing Scream: gains a shooting attack with 10" effective range and SV 0
+5 Piercing Scream: gains a shooting attack with 10&quot; effective range and SV 0
 6 Belches Acid: SV 1 in H2H
 7 Exudes Noxious Vapors: H2H enemies must re-roll successful hits
-8 Mesmerising: any enemy unit within 5" must pass command test at -1 to do anything, even with no pins.
+8 Mesmerising: any enemy unit within 5&quot; must pass command test at -1 to do anything, even with no pins.
 9 Cunning Leader: unit leader gains command and Init 8. If unit has no leader, it gains a leader with base Co and Init.
 10 Choose one of the above qualities.</description>
-      <modifiers/>
     </rule>
-<rule id="5565-ce10-1c78-1ee7" name="MOD2" hidden="false" book="BtGoA" page="136">
+    <rule id="5565-ce10-1c78-1ee7" name="MOD2" book="BtGoA" page="136" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Unit contributes two die to the dice pool and may act twice per turn. Always treated as having used the most recent action.</description>
-      <modifiers/>
     </rule>
-<rule id="8151-2e24-94ee-0477" name="MOD3" hidden="false" book="BtGoA">
+    <rule id="8151-2e24-94ee-0477" name="MOD3" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Unit contributes three die to the dice pool and may act thrice per turn. Always treated as having used the most recent action.</description>
-      <modifiers/>
     </rule>
-<rule id="c1c6-f9c7-c84f-d57d" name="Nano Drone" hidden="false" book="BtGoA" page="113">
+    <rule id="c1c6-f9c7-c84f-d57d" name="Nano Drone" book="BtGoA" page="113" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Shots against the unit suffer -2 Acc. Cannot be combined with a Batter drone. Unit counts as having HL armor. IMtel stave may be boosted by Nano Drone.</description>
-      <modifiers/>
     </rule>
-<rule id="ac33-af99-2d76-c981" name="Net" hidden="false" book="BtGoA" page="88">
+    <rule id="ac33-af99-2d76-c981" name="Net" book="BtGoA" page="88" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Roll to hit as normal for a blast weapon. Target does not suffer blast damage, rather suffers pins:
 
 X-Launcher: D3+1 pin
@@ -9151,114 +9431,192 @@ X-Howitzer: D5+1 pin
 Mag Mortar: D10+1 pin
 
 Targets that would normally force an Acc re-roll suffer half the number of pins rounded down. Divide pins equally between two or more units as normal.</description>
-      <modifiers/>
     </rule>
-<rule id="a41d-d55e-6d97-049d" name="No Cover" hidden="false" book="BtGoA" page="71">
+    <rule id="a41d-d55e-6d97-049d" name="No Cover" book="BtGoA" page="71" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>No cover bonus to Res roll.</description>
-      <modifiers/>
     </rule>
-<rule id="f502-611e-9704-97bb" name="No Crew" hidden="false" book="BtGoA" page="7">
+    <rule id="f502-611e-9704-97bb" name="No Crew" book="BtGoA" page="7" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>When carried by a model in battle armor it counts as having full crew.</description>
-      <modifiers/>
     </rule>
-<rule id="c3bc-87fd-fa5d-5055" name="OH" hidden="false" book="BtGoA" page="34">
+    <rule id="c3bc-87fd-fa5d-5055" name="OH" book="BtGoA" page="34" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Fires as an Overhead weapon.</description>
+    </rule>
+    <rule id="aef6-6934-1dee-6fa0" name="OHx2" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-<rule id="aef6-6934-1dee-6fa0" name="OHx2" hidden="false" book="BtGoA">
+    <rule id="7db4-6bd3-fb59-706d" name="Outcast" book="BtGoA" page="136" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </rule>
-<rule id="7db4-6bd3-fb59-706d" name="Outcast" hidden="false" book="BtGoA" page="136">
       <description>Command, hero, and follow rules only work on Outcast units. Cannot benefit from command, hero, or follow from non-Outcast unless it is a High Commander.</description>
-      <modifiers/>
     </rule>
-<rule id="3559-4b87-980d-f90d" name="Overload Ammo" hidden="false" book="BtGoA" page="89">
+    <rule id="3559-4b87-980d-f90d" name="Overload Ammo" book="BtGoA" page="89" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Can only be used with direct fire. SV = 3, single hit. If a 10 is rolled on Acc roll, shot misses, cannot be re-rolled, and overload ammo cannot be used again.</description>
-      <modifiers/>
     </rule>
-<rule id="b28d-571e-af69-4582" name="Phase Armor" hidden="false" book="BtGoA" page="93">
-      <description>10" or less, +1 Res. Greater than 10", +2 Res. May make a down reaction even if it already has order die - flip to down if so. </description>
+    <rule id="b28d-571e-af69-4582" name="Phase Armor" book="BtGoA" page="93" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>10&quot; or less, +1 Res. Greater than 10&quot;, +2 Res. May make a down reaction even if it already has order die - flip to down if so. </description>
     </rule>
-<rule id="6b03-2ad4-34c1-7f73" name="Plasma Fade" hidden="false" book="BtGoA" page="76">
+    <rule id="6b03-2ad4-34c1-7f73" name="Plasma Fade" book="BtGoA" page="76" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>On the Acc roll of a 10 to hit the shot is a miss and the unit goes down.</description>
-      <modifiers/>
     </rule>
-<rule id="0f12-545e-1c86-f482" name="Plasma Reactor" hidden="false" book="BtGoA" page="1367">
+    <rule id="0f12-545e-1c86-f482" name="Plasma Reactor" book="BtGoA" page="1367" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Lucky hits are allocated by shooter and hit plasma reactor. On a Res failure of 10, roll for every other model in unit and on a 10 they are removed as well.</description>
-      <modifiers/>
     </rule>
-<rule id="5d64-4bf5-e947-95d1" name="Point Blank Shooting Only" hidden="false" book="BtGoA" page="86">
+    <rule id="5d64-4bf5-e947-95d1" name="Point Blank Shooting Only" book="BtGoA" page="86" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May only be used for point blank shooting. Cannot be used for H2H.</description>
-      <modifiers/>
     </rule>
-<rule id="8056-104a-5a5d-2089" name="Pull Yourself Together!" hidden="false" page="159">
-      <description>At the end of any turn you can expend a "Pull Yourself Together!" to remove one pin from one unit. Use once and discard. You can buy as many as you are allowed Auxiliary choices in your Army but can only use ONE per turn.</description>
+    <rule id="8056-104a-5a5d-2089" name="Pull Yourself Together!" page="159" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>At the end of any turn you can expend a &quot;Pull Yourself Together!&quot; to remove one pin from one unit. Use once and discard. You can buy as many as you are allowed Auxiliary choices in your Army but can only use ONE per turn.</description>
     </rule>
-<rule id="b6e3-9cf0-1a9f-a941" name="Random SV" hidden="false" book="BtGoA" page="66">
+    <rule id="b6e3-9cf0-1a9f-a941" name="Random SV" book="BtGoA" page="66" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Roll every round for entire unit to determine SV. </description>
-      <modifiers/>
     </rule>
-<rule id="9ad5-9fc3-726e-852a" name="Rapid Sprint" hidden="false" book="BtGoA" page="136">
+    <rule id="9ad5-9fc3-726e-852a" name="Rapid Sprint" book="BtGoA" page="136" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May sprint at 4M. </description>
-      <modifiers/>
     </rule>
-<rule id="18c0-c86d-0b2c-23af" name="Reflex Armour" hidden="false" book="BtGoA" page="93">
+    <rule id="18c0-c86d-0b2c-23af" name="Reflex Armour" book="BtGoA" page="93" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>-Troops with Reflex Armour Shield add +1 to their Res value.
 -Troops with Reflex Armour and Impact Cloaks add +2 to their Res value, in hand to hand fighting.
 -Troops mounted on bikes with Reflex Armour and HL Boosters add +2 to their Res value.
 </description>
-      <modifiers/>
     </rule>
-<rule id="1863-c041-6dc4-c62d" name="RF D6 Fire Only" hidden="false" book="BtGoA" page="72">
+    <rule id="1863-c041-6dc4-c62d" name="RF D6 Fire Only" book="BtGoA" page="72" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Rapid Fire D6 when making a fire action. When shooting with advance action weapon has one shot. If issued in multiples, roll D6 for all weapons in unit.</description>
-      <modifiers/>
     </rule>
-<rule id="0cb1-ea91-e5bc-4f75" name="RF2" hidden="false" book="BtGoA">
+    <rule id="0cb1-ea91-e5bc-4f75" name="RF2" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May fire two shots at rapid fire. Suffers additional -1 ACC at Long or Extreme Ranges.</description>
-      <modifiers/>
     </rule>
-<rule id="97d4-67cb-2671-ca29" name="RF3" hidden="false" book="BtGoA">
+    <rule id="97d4-67cb-2671-ca29" name="RF3" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May fire three shots at rapid fire. Suffers additional -1 ACC at Long or Extreme Ranges.</description>
-      <modifiers/>
     </rule>
-<rule id="b0cb-c022-0531-4852" name="RF5" hidden="false" book="BtGoA">
+    <rule id="b0cb-c022-0531-4852" name="RF5" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May fire five shots at rapid fire. Suffers additional -1 ACC at Long or Extreme Ranges.</description>
-      <modifiers/>
     </rule>
-<rule id="f7af-59ec-acde-2f75" name="Savage Strike" hidden="false" book="BtGoA" page="136">
+    <rule id="f7af-59ec-acde-2f75" name="Savage Strike" book="BtGoA" page="136" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Passes order check to assault on any roll except a 10, regardless of modifiers.</description>
-      <modifiers/>
     </rule>
-<rule id="28a0-7151-a0c5-9495" name="Scoot" hidden="false" book="BtGoA" page="88">
-      <description>Only affects infantry, mounted, weapon team, beast, and humongous beast, command, and bike mounted units with living crew. Affects scramble proof units. Any affected unit within 3" canno tbe given any order except run or down. Cannot make any reaction apart from go down.</description>
+    <rule id="28a0-7151-a0c5-9495" name="Scoot" book="BtGoA" page="88" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>Only affects infantry, mounted, weapon team, beast, and humongous beast, command, and bike mounted units with living crew. Affects scramble proof units. Any affected unit within 3&quot; canno tbe given any order except run or down. Cannot make any reaction apart from go down.</description>
     </rule>
-<rule id="94f5-4a4c-92ad-94f9" name="Scramble Proof" hidden="false" book="BtGoA" page="137">
+    <rule id="94f5-4a4c-92ad-94f9" name="Scramble Proof" book="BtGoA" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Not affected by scrambler munitions. Vehicles may be affected by scoot. Subverter matrixes cannot affect model.</description>
-      <modifiers/>
     </rule>
-<rule id="7a3b-74a5-3ced-dd88" name="Scrambler" hidden="false" book="BtGoA" page="88">
-      <description>Enemy units within 3" that are not scramble proof it loses Reflex Armor, Hyperlight Armor, and Phase Armor along with any bonuses. Units in Phase Armor cannot use their armor to go down.
+    <rule id="7a3b-74a5-3ced-dd88" name="Scrambler" book="BtGoA" page="88" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Enemy units within 3&quot; that are not scramble proof it loses Reflex Armor, Hyperlight Armor, and Phase Armor along with any bonuses. Units in Phase Armor cannot use their armor to go down.
 
-Weapon Drone and vehicles have Res reduced by 2 within 3". Buddy drones cease to function if the unit is within 3". Probes can do nothing at all while marker is within 3". Penalties are not cumulative.</description>
-      <modifiers/>
+Weapon Drone and vehicles have Res reduced by 2 within 3&quot;. Buddy drones cease to function if the unit is within 3&quot;. Probes can do nothing at all while marker is within 3&quot;. Penalties are not cumulative.</description>
     </rule>
-<rule id="3377-9408-33bb-6a02" name="Self Repair" hidden="false" book="BtGoA" page="137">
+    <rule id="3377-9408-33bb-6a02" name="Self Repair" book="BtGoA" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Give unit rally order. If no pins exist after order, may attempt one repair on  immobilisation or weapon. 1-5 = success, 6-10 failure. Success = that function is working again.</description>
-      <modifiers/>
     </rule>
-<rule id="00b8-b49c-4c61-2943" name="Shard" hidden="false" book="BtGoA" page="137">
+    <rule id="00b8-b49c-4c61-2943" name="Shard" book="BtGoA" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Every individual unit in the shard makes same action from order. Probes always run.
 
 Shard units never take pins. Always assumed to pass order tests. </description>
+    </rule>
+    <rule id="0c20-4983-db8a-0d56" name="Shared SV" book="BtGoA" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-<rule id="0c20-4983-db8a-0d56" name="Shared SV" hidden="false" book="BtGoA">
+    <rule id="b08d-74dd-1a32-8bdc" name="Shield Drone" book="BtGoA" page="114" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </rule>
-<rule id="b08d-74dd-1a32-8bdc" name="Shield Drone" hidden="false" book="BtGoA" page="114">
       <description>When unit is hit, shield drones may nullify one hit. Roll D10 on drone chart - 
 
 D10 Roll:
@@ -9267,54 +9625,90 @@ D10 Roll:
 10: Drone does not nullify the hit but is not removed.
 
 Shield drones may attempt to intercept lucky hits. Lucky hits can be allocated to them just like other drones - in that case the drone is removed with no roll. </description>
-      <modifiers/>
     </rule>
-<rule id="5bd0-9ab2-0523-cbc8" name="Slingnet Ammo" hidden="false" book="BtGoA" page="112">
+    <rule id="5bd0-9ab2-0523-cbc8" name="Slingnet Ammo" book="BtGoA" page="112" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Fired direct unless from Micro X Launcher. Targets hit suffer no damage but take +1 additional pin. Cannot affect units that cannot be pinned when hit.</description>
-      <modifiers/>
     </rule>
-<rule id="7c88-64d4-50ad-2313" name="Slow" hidden="false" book="BtGoA" page="137">
+    <rule id="7c88-64d4-50ad-2313" name="Slow" book="BtGoA" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Move at half pace.</description>
-      <modifiers/>
     </rule>
-<rule id="6f47-5038-573a-b225" name="Sniper" hidden="false" book="BtGoA" page="137">
-      <description>Deploy anywhere within player's half. Snipers may not be deployed within 20" of other snipers, enemy may not deploy within 10". </description>
+    <rule id="6f47-5038-573a-b225" name="Sniper" book="BtGoA" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>Deploy anywhere within player&apos;s half. Snipers may not be deployed within 20&quot; of other snipers, enemy may not deploy within 10&quot;. </description>
     </rule>
-<rule id="1253-ef5b-67d4-3e18" name="Soma Graft" hidden="false" book="BtGoA" page="121">
+    <rule id="1253-ef5b-67d4-3e18" name="Soma Graft" book="BtGoA" page="121" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>May activate when a unit takes a Co test. Will past any Co test on any score other than 10. If a 10 is rolled, unit goes out of control and must roll the order die to generate an order. The unit does not have to comply, but if it does an order that is the only one it can do.</description>
-      <modifiers/>
     </rule>
-<rule id="b996-131f-b84a-4724" name="Special Munition" hidden="false" book="BtGoA" page="87">
+    <rule id="b996-131f-b84a-4724" name="Special Munition" book="BtGoA" page="87" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Stays on the battlefield until it ceases to work p87. Use a marker to locate where shot lands.</description>
-      <modifiers/>
     </rule>
-<rule id="fdbd-254f-8dd7-b658" name="Spotter Drone" hidden="false" book="BtGoA" page="114">
+    <rule id="fdbd-254f-8dd7-b658" name="Spotter Drone" book="BtGoA" page="114" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Unit may re-roll one miss each time it shoots as long as drone has LOS to target. Units may fire OH using drone as spotter as long as it has LOS to target. 
 
-Spotter drones may spot through another spotter drone (within 20") with LOS to the target. Unit does not receive spotter re-roll as their spotter does not have LOS to target.</description>
+Spotter drones may spot through another spotter drone (within 20&quot;) with LOS to the target. Unit does not receive spotter re-roll as their spotter does not have LOS to target.</description>
+    </rule>
+    <rule id="cd8d-624c-ed86-e310" name="Subverter Matrix" book="BtGoA" page="122" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
     </rule>
-<rule id="cd8d-624c-ed86-e310" name="Subverter Matrix" hidden="false" book="BtGoA" page="122">
+    <rule id="d4f5-697e-dbf0-ced2" name="Superior Shard" page="159" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>At the start of the turn you can remove 1 of your opponent&apos;s Order Dice from the bag. This die isn&apos;t used that turn, and is returned to the dice bag at the start of the following turn. This means your opponent will have to fight without one of his dice that turn. Use once and discard. You can only buy ONE Superior Shard regardless of the eize of your army.</description>
     </rule>
-<rule id="d4f5-697e-dbf0-ced2" name="Superior Shard" hidden="false" page="159">
-      <description>At the start of the turn you can remove 1 of your opponent's Order Dice from the bag. This die isn't used that turn, and is returned to the dice bag at the start of the following turn. This means your opponent will have to fight without one of his dice that turn. Use once and discard. You can only buy ONE Superior Shard regardless of the eize of your army.</description>
+    <rule id="c526-9fd9-f1c5-6893" name="Synchroniser Drone" book="Battle for Xilos" page="79" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
+      <description>If a unit with a synchroniser drone is successfully issued an order, after it has completed all actions in that order it may attempt to synchronise with one other unit within 10&quot;. The unit nominated must take and pass a Command test made in the standard fashion. If successful, it may draw an Order Die and issue the same command as the Synchronising unit, treating the die as if it were drawn randomly for all game effects. If the Synchronising unit also has the Follow ability, the Drone extends the range of Follow to 10&quot; rather than 5&quot;. CANNOT be chained from one unit to another.</description>
     </rule>
-<rule id="c526-9fd9-f1c5-6893" name="Synchroniser Drone" hidden="false" book="Battle for Xilos" page="79">
-      <description>If a unit with a synchroniser drone is successfully issued an order, after it has completed all actions in that order it may attempt to synchronise with one other unit within 10". The unit nominated must take and pass a Command test made in the standard fashion. If successful, it may draw an Order Die and issue the same command as the Synchronising unit, treating the die as if it were drawn randomly for all game effects. If the Synchronising unit also has the Follow ability, the Drone extends the range of Follow to 10" rather than 5". CANNOT be chained from one unit to another.</description>
+    <rule id="ab37-33d8-41f3-7532" name="Transport 10" book="BtGoA" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </rule>
-<rule id="ab37-33d8-41f3-7532" name="Transport 10" hidden="false" book="BtGoA" page="137">
       <description>May transport 10 human sized models.</description>
-      <modifiers/>
     </rule>
-<rule id="99fd-f354-1703-5941" name="Variable Res/Strike" hidden="false" book="BtGoA" page="66">
+    <rule id="99fd-f354-1703-5941" name="Variable Res/Strike" book="BtGoA" page="66" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Use to boost Res +2 or give a SV +2 each round of fighting. If used as +2 SV, counts as Grenade. </description>
-      <modifiers/>
     </rule>
-<rule id="e167-a8e4-c26a-cafd" name="Weapon Drone" hidden="false" book="BtGoA" page="115">
+    <rule id="e167-a8e4-c26a-cafd" name="Weapon Drone" book="BtGoA" page="115" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>Always measure to model, not base. Not allowed to assault. Never take a break test, however auto-break if suffer pins equal to their Co stat. If drone fails a Res test, roll on Weapon Drone Damage Chart.
 
 D10 Result:
@@ -9324,581 +9718,736 @@ D10 Result:
 4: Take D3 additional pins and go down. Weapon malfunction.
 5: Take D6 additional pins and take a break test - destroyed if failed, go down if passed.
 6-10: Destroyed</description>
-      <modifiers/>
     </rule>
-<rule id="75d2-6efa-9640-61df" name="Well Prepared" hidden="false" page="159">
+    <rule id="75d2-6efa-9640-61df" name="Well Prepared" page="159" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <description>If you take any single re-roll, you can add plus one to the value tested against. For example instead of testing against a res of 7 you would test against a res of 8. Use once and discard. You can buy as many Well Prepared as you are allowed Auxiliary choices in your Army.</description>
-      <modifiers/>
     </rule>
-</sharedRules>
-<sharedProfiles>
-<profile id="2da6-e419-5126-a73b" profileTypeId="1650-77b3-10d1-6406" name="Attack Skimmer" hidden="false">
-      <characteristics>
-        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="11"/>
-        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="MOD2, Large"/>
-      </characteristics>
+  </sharedRules>
+  <sharedProfiles>
+    <profile id="2da6-e419-5126-a73b" name="Attack Skimmer" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
       <modifiers/>
-    </profile>
-<profile id="9fba-d6b7-c66d-99f0" profileTypeId="1650-77b3-10d1-6406" name="Bodyguard" hidden="false">
       <characteristics>
-        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="-"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="11"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="MOD2, Large"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="eb0f-0718-35d7-1a00" profileTypeId="1650-77b3-10d1-6406" name="Combat Drone" hidden="false">
+    <profile id="9fba-d6b7-c66d-99f0" name="Bodyguard" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="13"/>
-        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="MOD2, Large"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="b390-0002-e1ef-3999" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Bombard" hidden="false">
+    <profile id="eb0f-0718-35d7-1a00" name="Combat Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10-50"/>
-        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="150"/>
-        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="9/7/5"/>
-        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Cycle"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="13"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="MOD2, Large"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="2e88-78bb-e1ba-bf5c" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Cannon" hidden="false">
+    <profile id="b390-0002-e1ef-3999" name="Compression Bombard" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="7/4/2"/>
-        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Cycle"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-50"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="150"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="9/7/5"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Cycle"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="75cb-cf9b-dd3d-9177" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Carbine" hidden="false">
+    <profile id="2e88-78bb-e1ba-bf5c" name="Compression Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10-20"/>
-        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2/5/0"/>
-        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="7/4/2"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Cycle"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="2ae1-18d0-fbc8-21ad" profileTypeId="1650-77b3-10d1-6406" name="Feral Fighter" hidden="false">
+    <profile id="75cb-cf9b-dd3d-9177" name="Compression Carbine" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="7"/>
-        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="-"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2/5/0"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="f23b-60da-348a-e6db" profileTypeId="1650-77b3-10d1-6406" name="Feral Leader" hidden="false">
+    <profile id="2ae1-18d0-fbc8-21ad" name="Feral Fighter" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="7"/>
-        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Leader"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="1069-6287-7c2a-af01" profileTypeId="1650-77b3-10d1-6406" name="Ferel Skark Fighter" hidden="false">
+    <profile id="f23b-60da-348a-e6db" name="Feral Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Large, Fast, Skark3 Attacks SV1"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="41f2-0f61-9758-5e8d" profileTypeId="1650-77b3-10d1-6406" name="Ferel Skark Leader" hidden="false">
+    <profile id="1069-6287-7c2a-af01" name="Ferel Skark Fighter" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Large, Fast, Skark3 Attacks SV1, Leader"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Large, Fast, Skark3 Attacks SV1"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="bc52-cc32-73de-da9d" profileTypeId="ecae-8ac8-2c13-0dd3" name="Fractal Bombard" hidden="false">
+    <profile id="41f2-0f61-9758-5e8d" name="Ferel Skark Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="50"/>
-        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="200"/>
-        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="3 +2 max 10"/>
-        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Large, Fast, Skark3 Attacks SV1, Leader"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="4c7f-3ba3-d703-1255" profileTypeId="ecae-8ac8-2c13-0dd3" name="Fractal Cannon" hidden="false">
+    <profile id="bc52-cc32-73de-da9d" name="Fractal Bombard" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2 +1 max 10"/>
-        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="50"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="200"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3 +2 max 10"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="2d89-bcdb-b942-b900" profileTypeId="1650-77b3-10d1-6406" name="Freeborn Captain" hidden="false">
+    <profile id="4c7f-3ba3-d703-1255" name="Fractal Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Command, Hero, Follow, Leader 2"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2 +1 max 10"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="c245-fa49-1569-2f23" profileTypeId="1650-77b3-10d1-6406" name="Freeborn Crew" hidden="false">
+    <profile id="2d89-bcdb-b942-b900" name="Freeborn Captain" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="-"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Hero, Follow, Leader 2"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="a770-8327-b96d-b92e" profileTypeId="1650-77b3-10d1-6406" name="Freeborn Crew Leader" hidden="true">
+    <profile id="c245-fa49-1569-2f23" name="Freeborn Crew" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Leader"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="7267-3051-f1b4-0a88" profileTypeId="1650-77b3-10d1-6406" name="Freeborn Heavy Crew" hidden="false">
+    <profile id="a770-8327-b96d-b92e" name="Freeborn Crew Leader" hidden="true" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Large, Slow"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="87a3-460d-879a-92a5" profileTypeId="1650-77b3-10d1-6406" name="Freeborn Heavy Crew Leader" hidden="false">
+    <profile id="7267-3051-f1b4-0a88" name="Freeborn Heavy Crew" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Large, Slow"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Large, Slow"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="0c03-96a3-4833-bc67" profileTypeId="1650-77b3-10d1-6406" name="Freeborn NuHu Renegade" hidden="false">
+    <profile id="87a3-460d-879a-92a5" name="Freeborn Heavy Crew Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="4"/>
-        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="4(7)"/>
-        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="9"/>
-        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Command, Hero, Follow, Leader 3"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Large, Slow"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="68fe-17c2-2841-2cde" profileTypeId="1650-77b3-10d1-6406" name="Freeborn NuHu Renegade Meld" hidden="false">
+    <profile id="0c03-96a3-4833-bc67" name="Freeborn NuHu Renegade" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="4"/>
-        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="8(11)"/>
-        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="9"/>
-        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Command, Hero, Follow, Meld, Meld Damage, MOD2, Leader 3"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="4"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(7)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="9"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Hero, Follow, Leader 3"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="2dbd-14c5-219e-d37d" profileTypeId="1650-77b3-10d1-6406" name="GP Drone" hidden="false">
+    <profile id="68fe-17c2-2841-2cde" name="Freeborn NuHu Renegade Meld" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="7"/>
-        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="0"/>
-        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="8"/>
-        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="-"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="4"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="8(11)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="9"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Hero, Follow, Meld, Meld Damage, MOD2, Leader 3"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="9e2a-f076-d4df-b60a" profileTypeId="1650-77b3-10d1-6406" name="Heavy Combat Drone" hidden="false">
+    <profile id="2dbd-14c5-219e-d37d" name="GP Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="15"/>
-        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="MOD3, Slow, Large"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="7"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="0"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="8"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="d0a1-129b-f8e5-b1ad" profileTypeId="1650-77b3-10d1-6406" name="Hound Probe " hidden="false">
+    <profile id="9e2a-f076-d4df-b60a" name="Heavy Combat Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="-"/>
-        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
-        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="-"/>
-        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="-"/>
-        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="-"/>
-        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Shard"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="15"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="MOD3, Slow, Large"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="ed77-e875-0302-9bf4" profileTypeId="1650-77b3-10d1-6406" name="Household Leader" hidden="false">
+    <profile id="d0a1-129b-f8e5-b1ad" name="Hound Probe " hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Leader"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Shard"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="45dd-c1c8-46d5-0107" profileTypeId="1650-77b3-10d1-6406" name="Household Trooper" hidden="false">
+    <profile id="ed77-e875-0302-9bf4" name="Household Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="-"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="12c4-12f3-a601-7547" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Lash" hidden="false" book="BtGoA" page="67">
+    <profile id="45dd-c1c8-46d5-0107" name="Household Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="12fe-ec68-d3e2-79b9" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Mortar" hidden="false">
+    <profile id="12c4-12f3-a601-7547" name="Mag Lash" book="BtGoA" page="67" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="OHx2, Blast D10, No Cover"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="79c6-8556-6040-e975" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Pistol" hidden="false">
+    <profile id="12fe-ec68-d3e2-79b9" name="Mag Mortar" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="30"/>
-        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OHx2, Blast D10, No Cover"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="ac6c-7fd0-193a-7751" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Repeater" hidden="false" book="BtGoA" page="69">
+    <profile id="79c6-8556-6040-e975" name="Mag Pistol" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="3bc6-2260-1caa-db1c" profileTypeId="1650-77b3-10d1-6406" name="Meld Skark" hidden="false">
+    <profile id="ac6c-7fd0-193a-7751" name="Mag Repeater" book="BtGoA" page="69" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="8"/>
-        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="7(8)"/>
-        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Fast, Large, Savage Strike, Meld Skark 6 SV2, Leader"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="f504-4de7-23b9-2bad" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Bombard" hidden="false">
+    <profile id="3bc6-2260-1caa-db1c" name="Meld Skark" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="50"/>
-        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="200"/>
-        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="7"/>
-        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Plasma Fade"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="8"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="7(8)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Fast, Large, Savage Strike, Meld Skark 6 SV2, Leader"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="ed5d-2e1d-e51a-1f6a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Cannon" hidden="false">
+    <profile id="f504-4de7-23b9-2bad" name="Plasma Bombard" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="6"/>
-        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Plasma Fade"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="50"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="200"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="7"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Plasma Fade"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="ee9c-ada6-953a-b774" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Carbine - Scatter" hidden="false">
+    <profile id="ed5d-2e1d-e51a-1f6a" name="Plasma Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Plasma Fade"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="b56d-0f1d-de00-62c4" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Carbine - Single Shot" hidden="false">
+    <profile id="ee9c-ada6-953a-b774" name="Plasma Carbine - Scatter" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="8b37-5912-a988-22e9" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Grenade Bandolier" hidden="false">
+    <profile id="b56d-0f1d-de00-62c4" name="Plasma Carbine - Single Shot" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
-        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="-"/>
-        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="-"/>
-        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D4, Hazardous H2H"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="96f9-325b-69f7-13b4" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Grenades" hidden="false">
+    <profile id="8b37-5912-a988-22e9" name="Plasma Grenade Bandolier" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
-        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="-"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, Hazardous H2H"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="cc3a-cc3a-5a9e-616b" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Lance" hidden="false">
+    <profile id="96f9-325b-69f7-13b4" name="Plasma Grenades" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="4"/>
-        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Choose Target, Inaccurate"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="5463-10c1-cf72-c3f8" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Scatter" hidden="false">
+    <profile id="cc3a-cc3a-5a9e-616b" name="Plasma Lance - Lance" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="4"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Choose Target, Inaccurate"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="1112-0824-87c5-ae27" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Single Shot" hidden="false">
+    <profile id="5463-10c1-cf72-c3f8" name="Plasma Lance - Scatter" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="e44d-e4f0-3ad5-6528" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Light Support Gun" hidden="false">
+    <profile id="1112-0824-87c5-ae27" name="Plasma Lance - Single Shot" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="2e7c-b5f9-e3e5-9125" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Pistol" hidden="false">
+    <profile id="e44d-e4f0-3ad5-6528" name="Plasma Light Support Gun" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="30"/>
-        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="04ae-2947-a8ea-2c08" profileTypeId="1650-77b3-10d1-6406" name="Probe" hidden="false">
+    <profile id="2e7c-b5f9-e3e5-9125" name="Plasma Pistol" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="-"/>
-        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
-        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="-"/>
-        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="-"/>
-        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="-"/>
-        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Shard"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="45af-eec1-b29d-273f" profileTypeId="1650-77b3-10d1-6406" name="Rejects" hidden="false">
+    <profile id="04ae-2947-a8ea-2c08" name="Probe" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="7"/>
-        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Misgenic Abilities"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Shard"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="74dc-b388-dc1d-fb61" profileTypeId="1650-77b3-10d1-6406" name="Skyraider Captain" hidden="false">
+    <profile id="45af-eec1-b29d-273f" name="Rejects" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(7)"/>
-        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Command, Hero, Follow, Large, Fast, Leader 2"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Misgenic Abilities"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="e18f-34de-2624-4133" profileTypeId="1650-77b3-10d1-6406" name="Skyraider Leader" hidden="false">
+    <profile id="74dc-b388-dc1d-fb61" name="Skyraider Captain" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(7)"/>
-        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Large, Fast, Leader "/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Hero, Follow, Large, Fast, Leader 2"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="a654-5213-64f2-703a" profileTypeId="1650-77b3-10d1-6406" name="Skyraider Trooper" hidden="false">
+    <profile id="e18f-34de-2624-4133" name="Skyraider Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(7)"/>
-        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Large, Fast"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Large, Fast, Leader "/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="4d5f-ccb4-75c2-cbf2" profileTypeId="1650-77b3-10d1-6406" name="Targeter Probe" hidden="false">
+    <profile id="a654-5213-64f2-703a" name="Skyraider Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="-"/>
-        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
-        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="-"/>
-        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="-"/>
-        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="-"/>
-        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Shard"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Large, Fast"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="5425-1edf-f536-d5a1" profileTypeId="1650-77b3-10d1-6406" name="Transport Drone" hidden="false">
+    <profile id="4d5f-ccb4-75c2-cbf2" name="Targeter Probe" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="13"/>
-        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="MOD2, Transport 10, Large"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Shard"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="702f-c8a7-d8cf-01c1" profileTypeId="1650-77b3-10d1-6406" name="Vardanari Gaurd Trooper" hidden="false">
+    <profile id="5425-1edf-f536-d5a1" name="Transport Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="-"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="13"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="MOD2, Transport 10, Large"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="62fc-1d76-c6fd-a3eb" profileTypeId="1650-77b3-10d1-6406" name="Vardanari Leader" hidden="false">
+    <profile id="702f-c8a7-d8cf-01c1" name="Vardanari Gaurd Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Leader"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="27c9-718e-cee7-599d" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Launcher" hidden="false">
+    <profile id="62fc-1d76-c6fd-a3eb" name="Vardanari Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="60"/>
-        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="120"/>
-        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D5, No Cover"/>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(6)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader"/>
       </characteristics>
-      <modifiers/>
     </profile>
-<profile id="1298-3867-ea1e-c04c" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Sling" hidden="false" book="BtGoA" page="68">
+    <profile id="27c9-718e-cee7-599d" name="X-Launcher" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
       <characteristics>
-        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D3, Hand Weapon"/>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D5, No Cover"/>
       </characteristics>
-      <modifiers/>
     </profile>
-</sharedProfiles>
+    <profile id="1298-3867-ea1e-c04c" name="X-Sling" book="BtGoA" page="68" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D3, Hand Weapon"/>
+      </characteristics>
+    </profile>
+  </sharedProfiles>
 </catalogue>

--- a/Freeborn.cat
+++ b/Freeborn.cat
@@ -1,6092 +1,8970 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="64d6-1cd3-6226-4554" revision="6" gameSystemId="c339-677a-60db-4060" gameSystemRevision="0" battleScribeVersion="1.15" name="Freeborn" authorName="Michael Ovsenik / Vescarea" authorContact="FB" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
-  <entries>
-    <entry id="66a7-b2ec-cfcc-8359" name="&lt; Command Squad Options - Must choose first" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="c017-7f96-06bd-fd6b" name="Select one of the following option and the relevent selection will appear" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="3933-5e9f-f85c-ba75" name="1&lt; Add 2 extra bodygaurds" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-            <entry id="a400-34cd-f726-fbf6" name="9&lt; Add Batter Drone" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-            <entry id="ad0d-a741-67ad-5d5c" name="7&lt; Add up to 2 Gun Drones" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-            <entry id="d17a-ef4d-2148-25e8" name="8&lt; Add up to 2 shield Drones" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-            <entry id="6559-a8ba-d266-7c27" name="2&lt; HL Armour for unit" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-            <entry id="1ef5-d006-6a32-fddb" name="3&lt; Phase Armour for unit" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-            <entry id="a04c-3029-b790-0cdb" name="4&lt; Give Captain plasma Carbine" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-            <entry id="a90a-cec1-cd13-3c17" name="5&lt; Give Captain Compression Carbine" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-            <entry id="7f96-ddf7-af5d-958a" name="6&lt; Give Bodygaurds Compression carbines" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-            <entry id="39a7-bedc-c912-a9f0" name="0&lt; None" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers>
-                <modifier type="set" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="direct parent" childId="39a7-bedc-c912-a9f0" field="selections" type="equal to" value="0.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-            <entry id="ed16-8f24-873e-f6cd" name="Replace with Amano Harran and Bodyguards" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="7a95-8632-0c25-d086" name="Amano Harran and Bodyguards" points="126.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true" book="Battle for Xilos" page="115">
-      <entries>
-        <entry id="8fe8-c920-4357-5561" name="Amano Harran, Oszoni Freeborn Mercenary Captain" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="955c-f291-a035-8308" name="&lt;Weapons&gt;" minSelections="1" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="0197-c3d6-ee4b-351e" name="Zantu Plasma Duelling Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Battle for Xilos" page="115">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules>
-                    <rule id="a0dc-c29f-3f0d-da12" name="Dead Eye" hidden="false" book="Battle for Xilos" page="115">
+<?xml version="1.0" encoding="UTF-8"?><catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" battleScribeVersion="2.00" id="64d6-1cd3-6226-4554" revision="6" gameSystemId="c339-677a-60db-4060" gameSystemRevision="0" name="Freeborn" authorName="Michael Ovsenik / Vescarea" authorContact="FB">
+<selectionEntries>
+<selectionEntry id="66a7-b2ec-cfcc-8359" name="&lt; Command Squad Options - Must choose first" type="unit" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="1" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="c017-7f96-06bd-fd6b" name="Select one of the following option and the relevent selection will appear" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="3933-5e9f-f85c-ba75" name="1&lt; Add 2 extra bodygaurds" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="a400-34cd-f726-fbf6" name="9&lt; Add Batter Drone" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="ad0d-a741-67ad-5d5c" name="7&lt; Add up to 2 Gun Drones" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="d17a-ef4d-2148-25e8" name="8&lt; Add up to 2 shield Drones" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="6559-a8ba-d266-7c27" name="2&lt; HL Armour for unit" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="1ef5-d006-6a32-fddb" name="3&lt; Phase Armour for unit" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="a04c-3029-b790-0cdb" name="4&lt; Give Captain plasma Carbine" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="a90a-cec1-cd13-3c17" name="5&lt; Give Captain Compression Carbine" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="7f96-ddf7-af5d-958a" name="6&lt; Give Bodygaurds Compression carbines" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="39a7-bedc-c912-a9f0" name="0&lt; None" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers>
+<modifier type="set" field="minSelections" value="0.0">
+<conditions>
+<condition type="equalTo" value="0.0" field="selections" scope="parent" childId="39a7-bedc-c912-a9f0" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="ed16-8f24-873e-f6cd" name="Replace with Amano Harran and Bodyguards" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups/>
+<entryLinks/>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="7a95-8632-0c25-d086" name="Amano Harran and Bodyguards" type="unit" collective="false" hidden="true" book="Battle for Xilos" page="115" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe">
+<costs>
+<cost costTypeId="points" name="pts" value="126.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+</constraints>
+<modifiers>
+<modifier type="set" field="hidden" value="false">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="ed16-8f24-873e-f6cd" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+<selectionEntries>
+<selectionEntry id="8fe8-c920-4357-5561" name="Amano Harran, Oszoni Freeborn Mercenary Captain" type="model" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="955c-f291-a035-8308" name="&lt;Weapons&gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="0197-c3d6-ee4b-351e" name="Zantu Plasma Duelling Pistol" type="upgrade" collective="false" hidden="false" book="Battle for Xilos" page="115" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules>
+<rule id="a0dc-c29f-3f0d-da12" name="Dead Eye" hidden="false" book="Battle for Xilos" page="115">
                       <description>When shooting with a Fire order, add +2 to Acc value rather than standard +1</description>
                       <modifiers/>
                     </rule>
-                    <rule id="5ffd-287d-8644-d70c" name="Duellist" hidden="false" book="Battle for Xilos" page="115">
+<rule id="5ffd-287d-8644-d70c" name="Duellist" hidden="false" book="Battle for Xilos" page="115">
                       <description>When shooting simultaenously with an enemy unit, both sides roll 1d10. If the controlling player rolls higher, he shoots first and any result is applied to the target before it can fire back, including casualty removal and pinning.</description>
                       <modifiers/>
                     </rule>
-                  </rules>
-                  <profiles>
-                    <profile id="980e-e86b-7de6-4cff" profileTypeId="ecae-8ac8-2c13-0dd3" name="Zantu Plasma Duelling Pistol" hidden="false" book="Battle for Xilos" page="115">
+</rules>
+<profiles>
+<profile id="980e-e86b-7de6-4cff" profileTypeId="ecae-8ac8-2c13-0dd3" name="Zantu Plasma Duelling Pistol" hidden="false" book="Battle for Xilos" page="115">
                       <characteristics>
-                        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="40"/>
-                        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-                        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Dead Eye, Duellist"/>
+                        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
+                        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
+                        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="40"/>
+                        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
+                        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Dead Eye, Duellist"/>
                       </characteristics>
                       <modifiers/>
                     </profile>
-                  </profiles>
-                  <links/>
-                </entry>
-                <entry id="72ab-7a5e-1ef3-875a" name="Xilos Stasis Key" points="25.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Battle for Xilos" page="57">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules>
-                    <rule id="7ecb-bcba-21d4-a388" name="Stasis" hidden="false" book="Battle for Xilos" page="57">
+</profiles>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="72ab-7a5e-1ef3-875a" name="Xilos Stasis Key" type="upgrade" collective="false" hidden="false" book="Battle for Xilos" page="57" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="25.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules>
+<rule id="7ecb-bcba-21d4-a388" name="Stasis" hidden="false" book="Battle for Xilos" page="57">
                       <description>Weapon can ONLY be fired with a Fire order, applying normal +1 Acc bonus. If target unit is hit, either switch its current Order Die to a Down order, or if it does not yet have an order, retrieve an Order Die from the bag and issue it a down order. Then, add a Stasis marker to the unit.			If a unit is in stasis at the turn end phase, then instead of making a recovery test to recover the Down Order Die, make a recovery test to remove the Stasis marker. The unit then remains Down until the next chance to make a recovery test, at which point the test applies to the Down Order Die.</description>
                       <modifiers/>
                     </rule>
-                  </rules>
-                  <profiles>
-                    <profile id="ce34-6972-faf0-fc0e" profileTypeId="ecae-8ac8-2c13-0dd3" name="Xilos Stasis Key" hidden="false" book="Battle for Xilos" page="57">
+</rules>
+<profiles>
+<profile id="ce34-6972-faf0-fc0e" profileTypeId="ecae-8ac8-2c13-0dd3" name="Xilos Stasis Key" hidden="false" book="Battle for Xilos" page="57">
                       <characteristics>
-                        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-                        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long"/>
-                        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme"/>
-                        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value"/>
-                        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Stasis"/>
+                        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
+                        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long"/>
+                        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme"/>
+                        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value"/>
+                        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Stasis"/>
                       </characteristics>
                       <modifiers/>
                     </profile>
-                  </profiles>
-                  <links/>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules>
-            <rule id="4346-96cf-a909-9ab2" name="Fast Shot" hidden="false" book="Battle for Xilos" page="115">
+</profiles>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups/>
+<entryLinks/>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules>
+<rule id="4346-96cf-a909-9ab2" name="Fast Shot" hidden="false" book="Battle for Xilos" page="115">
               <description>With any hand or standard weapon, this model shoots twice instead of once using the same weapon at the same target. This ability CAN be used with the Xilos Stasis Key, but the key can still only fire with a Fire order.</description>
               <modifiers/>
             </rule>
-            <rule id="191b-64ea-3f8e-b6e2" name="Charismatic Aura" hidden="false" book="Battle for Xilos" page="115">
-              <description>If any enemy unit is within 10&quot; of the Amano Harran model then it cannot be given an order without taking an Order test against its Command, even if it has no pins, and both its Command and Initiative stat are reduced by -1 when making order and/or reaction tests.</description>
+<rule id="191b-64ea-3f8e-b6e2" name="Charismatic Aura" hidden="false" book="Battle for Xilos" page="115">
+              <description>If any enemy unit is within 10" of the Amano Harran model then it cannot be given an order without taking an Order test against its Command, even if it has no pins, and both its Command and Initiative stat are reduced by -1 when making order and/or reaction tests.</description>
               <modifiers/>
             </rule>
-            <rule id="1c55-16af-48d1-e10f" name="Wound" hidden="false" book="Battle for Xilos" page="115">
+<rule id="1c55-16af-48d1-e10f" name="Wound" hidden="false" book="Battle for Xilos" page="115">
               <description>If Amano Harran fails a Res test then instead of falling casualty he is wounded. Once wounded, if any further Res test is failed he is removed as a casualty. If Amano Harran is wounded then the unit cannot lose its last 1 pin. It can lose other pins as normal, but will always retain at least one.</description>
               <modifiers/>
             </rule>
-          </rules>
-          <profiles>
-            <profile id="ac61-5231-2810-84b0" profileTypeId="1650-77b3-10d1-6406" name="Amano Harran, Oszoni Freeborn Mercenary Captain" hidden="false" book="Battle for Xilos" page="115">
+</rules>
+<profiles>
+<profile id="ac61-5231-2810-84b0" profileTypeId="1650-77b3-10d1-6406" name="Amano Harran, Oszoni Freeborn Mercenary Captain" hidden="false" book="Battle for Xilos" page="115">
               <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="6"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="10"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="10"/>
-                <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Command, Follow, Hero, Leader 3, Wound, Fast Shot, Charismatic Aura"/>
+                <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="6"/>
+                <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
+                <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
+                <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
+                <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="10"/>
+                <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="10"/>
+                <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Command, Follow, Hero, Leader 3, Wound, Fast Shot, Charismatic Aura"/>
               </characteristics>
               <modifiers>
-                <modifier type="append" field="f214-abe8-c922-c51b" value="(7)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups>
-                    <conditionGroup type="or">
+                <modifier type="append" field="f214-abe8-c922-c51b" value="(7)">
+<conditions/>
+<conditionGroups>
+<conditionGroup type="or">
                       <conditions>
-                        <condition parentId="7a95-8632-0c25-d086" childId="ddb6-781a-85af-eeeb" field="selections" type="equal to" value="1.0"/>
-                        <condition parentId="7a95-8632-0c25-d086" childId="aa87-9d00-ec90-c775" field="selections" type="equal to" value="1.0"/>
+                        <condition type="equalTo" value="1.0" field="selections" scope="7a95-8632-0c25-d086" childId="ddb6-781a-85af-eeeb" shared="true"/>
+                        <condition type="equalTo" value="1.0" field="selections" scope="7a95-8632-0c25-d086" childId="aa87-9d00-ec90-c775" shared="true"/>
                       </conditions>
                       <conditionGroups/>
                     </conditionGroup>
-                  </conditionGroups>
-                </modifier>
+</conditionGroups>
+</modifier>
               </modifiers>
             </profile>
-          </profiles>
-          <links>
-            <link id="12e9-6e86-5af0-79e8" targetId="7bc9-5e98-2914-5abd" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="5cce-7f58-827d-5129" targetId="5c9b-1bde-ee01-04a4" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="eca5-0e3f-2e2f-371a" targetId="3c64-6022-a5f1-9c04" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="f56e-220b-8d8d-e9c7" targetId="05bb-4d34-70cd-25d2" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="dc88-b28b-0f31-61c9" name="Bodyguard" points="21.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="ceda-f66e-0469-f72a" targetId="9fba-d6b7-c66d-99f0" linkType="profile">
-              <modifiers>
-                <modifier type="append" field="f214-abe8-c922-c51b" value="(7)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups>
-                    <conditionGroup type="or">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="12e9-6e86-5af0-79e8" targetId="7bc9-5e98-2914-5abd" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="5cce-7f58-827d-5129" targetId="5c9b-1bde-ee01-04a4" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="eca5-0e3f-2e2f-371a" targetId="3c64-6022-a5f1-9c04" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="f56e-220b-8d8d-e9c7" targetId="05bb-4d34-70cd-25d2" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="dc88-b28b-0f31-61c9" name="Bodyguard" type="model" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="21.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="6"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks>
+<entryLink id="35f7-fede-27fa-da27" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+<infoLinks>
+<infoLink id="ceda-f66e-0469-f72a" targetId="9fba-d6b7-c66d-99f0" type="profile">
+<modifiers>
+<modifier type="append" field="f214-abe8-c922-c51b" value="(7)">
+<conditions/>
+<conditionGroups>
+<conditionGroup type="or">
                       <conditions>
-                        <condition parentId="7a95-8632-0c25-d086" childId="ddb6-781a-85af-eeeb" field="selections" type="equal to" value="1.0"/>
-                        <condition parentId="7a95-8632-0c25-d086" childId="aa87-9d00-ec90-c775" field="selections" type="equal to" value="1.0"/>
+                        <condition type="equalTo" value="1.0" field="selections" scope="7a95-8632-0c25-d086" childId="ddb6-781a-85af-eeeb" shared="true"/>
+                        <condition type="equalTo" value="1.0" field="selections" scope="7a95-8632-0c25-d086" childId="aa87-9d00-ec90-c775" shared="true"/>
                       </conditions>
                       <conditionGroups/>
                     </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="35f7-fede-27fa-da27" targetId="b018-6101-d2e3-b4ea" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="fa49-db82-4230-6855" name="&lt;Unit Armor&gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="ddb6-781a-85af-eeeb" targetId="eff8-bb0e-1b1d-bbb2" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="7a95-8632-0c25-d086" incrementChildId="8fe8-c920-4357-5561" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="7a95-8632-0c25-d086" incrementChildId="dc88-b28b-0f31-61c9" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="aa87-9d00-ec90-c775" targetId="eb94-d1e8-1084-71b3" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="7a95-8632-0c25-d086" incrementChildId="8fe8-c920-4357-5561" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="7a95-8632-0c25-d086" incrementChildId="dc88-b28b-0f31-61c9" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="5b9c-ebf8-2d76-ed50" targetId="03c2-174e-8617-cf04" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="ac48-df93-6a89-8648" name="&lt;Unit Options&gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="bf74-08ce-f02a-25d6" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="9ef5-e7d3-8f94-9a38" targetId="502c-9855-7269-eaa2" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="fae6-07a8-03bf-e759" targetId="573b-88bc-97d7-d890" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="4cf9-9568-6a33-5f18" targetId="d571-d584-85fc-9110" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="1b1b-5f67-48e7-b04d" targetId="4b9d-a0bf-396e-384b" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="81af-1353-1e75-955f" targetId="1707-586b-01df-0f80" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="1e83-2d30-37c1-f54f" targetId="d118-8115-df5f-2402" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="7a95-8632-0c25-d086" incrementChildId="8fe8-c920-4357-5561" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="7a95-8632-0c25-d086" incrementChildId="dc88-b28b-0f31-61c9" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="cad5-b340-7463-f360" targetId="059e-3ead-10ef-9fd5" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers>
-        <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-          <conditions>
-            <condition parentId="roster" childId="ed16-8f24-873e-f6cd" field="selections" type="equal to" value="1.0"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="1871-8acd-7ec8-8700" name="Block!" points="5.0" categoryId="50ba-cf77-3941-189c" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="aadf-c739-5770-7605" targetId="5d2e-45d2-1707-87db" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="a44f-4447-aff2-0dcd" name="Domari Squad (Household Troops)" points="22.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="192">
-      <entries>
-        <entry id="c61f-6de1-069d-821f" name="&lt; Household Leader" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="191">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="eeeb-14fc-3015-51fc" name="&lt; Leader Level &gt;" defaultEntryId="af81-32d2-905d-4525" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="5b49-8a4d-07d2-fb89" targetId="02f3-3134-ae39-afed" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="af81-32d2-905d-4525" targetId="fc7e-7c0e-65e0-8c33" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="614f-b64a-4c29-8d4f" name="&lt; Ranged Weapon &gt;" defaultEntryId="2bc1-4f6e-02ba-7d1c" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="2bc1-4f6e-02ba-7d1c" targetId="8690-3ab7-9fef-06ee" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="48df-d58e-e0d1-d8df" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-                <link id="526a-3475-ccc6-063a" targetId="9cd6-dbb8-bdcb-0299" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-                <link id="052b-0bbe-d078-8a35" targetId="1631-5857-2139-960a" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="6.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="c976-a3c2-48e7-a65d" targetId="ed77-e875-0302-9bf4" linkType="profile">
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="c61f-6de1-069d-821f" childId="5b49-8a4d-07d2-fb89" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="d441-f08b-6ae0-3ce1" name="Household Trooper" points="15.0" categoryId="(No Category)" type="model" minSelections="5" maxSelections="7" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="192">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="9c0c-e485-c447-84fb" name="Ranged Weapon" defaultEntryId="20d8-1c96-d87e-6005" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="20d8-1c96-d87e-6005" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="f4de-742c-31aa-3973" targetId="45dd-c1c8-46d5-0107" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="a960-249c-ef1d-5e8c" name="Micro-X Launcher" points="0.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="a9e5-f8a1-aadd-0667" name="SlingNet Ammo for Micro-X Launcher" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="eb51-606e-6b9f-6c33" targetId="e7b0-651a-cc7c-f27e" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="678a-8f30-acb7-0053" name="&lt; Unit Armor &gt;" defaultEntryId="a03c-46bd-0028-b43e" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="a03c-46bd-0028-b43e" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="e31c-0032-c416-8471" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="606b-c5e6-d436-9d3c" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="5163-e03b-fc25-9afe" targetId="d118-8115-df5f-2402" linkType="entry">
-              <modifiers>
-                <modifier type="set" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="a44f-4447-aff2-0dcd" incrementChildId="d441-f08b-6ae0-3ce1" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="a44f-4447-aff2-0dcd" incrementChildId="a960-249c-ef1d-5e8c" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="307c-9503-74f9-f4b3" name="Extra Shot" points="10.0" categoryId="50ba-cf77-3941-189c" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="4864-9551-d5ab-0fd1" targetId="e77b-02da-5143-229e" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="d05f-990a-ae91-4196" name="Feral Meld Skark (Mhagris)" points="115.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="193">
-      <entries>
-        <entry id="d398-8780-d6cb-1241" name="&gt; Feral Leader" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="193">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="fa1b-d08c-0a23-97f5" name="&lt; Leader Level &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="64c7-ce38-13a1-0a67" targetId="02f3-3134-ae39-afed" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="6230-3ae4-17d6-9052" targetId="5a4c-2f5e-40a2-91d4" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="1aa6-aff0-4b33-9f78" name="Ranged Weapon" defaultEntryId="43cf-0bae-d100-956c" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="43cf-0bae-d100-956c" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="ee88-cab4-5a29-66fe" targetId="b018-6101-d2e3-b4ea" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="fa1e-41af-d09a-4df9" profileTypeId="1650-77b3-10d1-6406" name="Feral Leader" hidden="false" book="BtGoA" page="193">
+</conditionGroups>
+</modifier>
+</modifiers>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups>
+<selectionEntryGroup id="fa49-db82-4230-6855" name="&lt;Unit Armor&gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="ddb6-781a-85af-eeeb" targetId="eff8-bb0e-1b1d-bbb2" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="1.0">
+<conditions/>
+<conditionGroups/>
+<repeats>
+<repeat repeats="1" value="1.0" field="selections" scope="7a95-8632-0c25-d086" childId="8fe8-c920-4357-5561" shared="true"/>
+</repeats>
+</modifier>
+<modifier type="increment" field="points" value="1.0">
+<conditions/>
+<conditionGroups/>
+<repeats>
+<repeat repeats="1" value="1.0" field="selections" scope="7a95-8632-0c25-d086" childId="dc88-b28b-0f31-61c9" shared="true"/>
+</repeats>
+</modifier>
+</modifiers>
+</entryLink>
+<entryLink id="aa87-9d00-ec90-c775" targetId="eb94-d1e8-1084-71b3" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="1.0">
+<conditions/>
+<conditionGroups/>
+<repeats>
+<repeat repeats="1" value="1.0" field="selections" scope="7a95-8632-0c25-d086" childId="8fe8-c920-4357-5561" shared="true"/>
+</repeats>
+</modifier>
+<modifier type="increment" field="points" value="1.0">
+<conditions/>
+<conditionGroups/>
+<repeats>
+<repeat repeats="1" value="1.0" field="selections" scope="7a95-8632-0c25-d086" childId="dc88-b28b-0f31-61c9" shared="true"/>
+</repeats>
+</modifier>
+</modifiers>
+</entryLink>
+<entryLink id="5b9c-ebf8-2d76-ed50" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="ac48-df93-6a89-8648" name="&lt;Unit Options&gt;" collective="false" hidden="false">
+<constraints/>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="bf74-08ce-f02a-25d6" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="9ef5-e7d3-8f94-9a38" targetId="502c-9855-7269-eaa2" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="fae6-07a8-03bf-e759" targetId="573b-88bc-97d7-d890" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="4cf9-9568-6a33-5f18" targetId="d571-d584-85fc-9110" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="1b1b-5f67-48e7-b04d" targetId="4b9d-a0bf-396e-384b" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="81af-1353-1e75-955f" targetId="1707-586b-01df-0f80" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="1e83-2d30-37c1-f54f" targetId="d118-8115-df5f-2402" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="2.0">
+<conditions/>
+<conditionGroups/>
+<repeats>
+<repeat repeats="1" value="1.0" field="selections" scope="7a95-8632-0c25-d086" childId="8fe8-c920-4357-5561" shared="true"/>
+</repeats>
+</modifier>
+<modifier type="increment" field="points" value="2.0">
+<conditions/>
+<conditionGroups/>
+<repeats>
+<repeat repeats="1" value="1.0" field="selections" scope="7a95-8632-0c25-d086" childId="dc88-b28b-0f31-61c9" shared="true"/>
+</repeats>
+</modifier>
+</modifiers>
+</entryLink>
+<entryLink id="cad5-b340-7463-f360" targetId="059e-3ead-10ef-9fd5" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="1871-8acd-7ec8-8700" name="Block!" type="upgrade" collective="false" hidden="false" categoryEntryId="50ba-cf77-3941-189c">
+<costs>
+<cost costTypeId="points" name="pts" value="5.0"/>
+</costs>
+<constraints/>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="aadf-c739-5770-7605" targetId="5d2e-45d2-1707-87db" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="a44f-4447-aff2-0dcd" name="Domari Squad (Household Troops)" type="unit" collective="false" hidden="false" book="BtGoA" page="192" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe">
+<costs>
+<cost costTypeId="points" name="pts" value="22.0"/>
+</costs>
+<constraints/>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="c61f-6de1-069d-821f" name="&lt; Household Leader" type="model" collective="false" hidden="false" book="BtGoA" page="191" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="eeeb-14fc-3015-51fc" name="&lt; Leader Level &gt;" collective="false" hidden="false" defaultSelectionEntryId="af81-32d2-905d-4525">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="5b49-8a4d-07d2-fb89" targetId="02f3-3134-ae39-afed" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="af81-32d2-905d-4525" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="614f-b64a-4c29-8d4f" name="&lt; Ranged Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="2bc1-4f6e-02ba-7d1c">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="2bc1-4f6e-02ba-7d1c" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="48df-d58e-e0d1-d8df" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="3.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+<entryLink id="526a-3475-ccc6-063a" targetId="9cd6-dbb8-bdcb-0299" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="1.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+<entryLink id="052b-0bbe-d078-8a35" targetId="1631-5857-2139-960a" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="6.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="c976-a3c2-48e7-a65d" targetId="ed77-e875-0302-9bf4" type="profile">
+<modifiers>
+<modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="c61f-6de1-069d-821f" childId="5b49-8a4d-07d2-fb89" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="d441-f08b-6ae0-3ce1" name="Household Trooper" type="model" collective="false" hidden="false" book="BtGoA" page="192" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="15.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="5"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="7"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="9c0c-e485-c447-84fb" name="Ranged Weapon" collective="false" hidden="false" defaultSelectionEntryId="20d8-1c96-d87e-6005">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="20d8-1c96-d87e-6005" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="f4de-742c-31aa-3973" targetId="45dd-c1c8-46d5-0107" type="profile">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="a960-249c-ef1d-5e8c" name="Micro-X Launcher" type="model" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="a9e5-f8a1-aadd-0667" name="SlingNet Ammo for Micro-X Launcher" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="5.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks>
+<entryLink id="eb51-606e-6b9f-6c33" targetId="e7b0-651a-cc7c-f27e" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+<infoLinks/>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups>
+<selectionEntryGroup id="678a-8f30-acb7-0053" name="&lt; Unit Armor &gt;" collective="false" hidden="false" defaultSelectionEntryId="a03c-46bd-0028-b43e">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="a03c-46bd-0028-b43e" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="e31c-0032-c416-8471" name="&lt; Unit Options &gt;" collective="false" hidden="false">
+<constraints/>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="606b-c5e6-d436-9d3c" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="5163-e03b-fc25-9afe" targetId="d118-8115-df5f-2402" type="selectionEntry">
+<modifiers>
+<modifier type="set" field="points" value="2.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+<modifier type="increment" field="points" value="2.0">
+<conditions/>
+<conditionGroups/>
+<repeats>
+<repeat repeats="1" value="1.0" field="selections" scope="a44f-4447-aff2-0dcd" childId="d441-f08b-6ae0-3ce1" shared="true"/>
+</repeats>
+</modifier>
+<modifier type="increment" field="points" value="2.0">
+<conditions/>
+<conditionGroups/>
+<repeats>
+<repeat repeats="1" value="1.0" field="selections" scope="a44f-4447-aff2-0dcd" childId="a960-249c-ef1d-5e8c" shared="true"/>
+</repeats>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="307c-9503-74f9-f4b3" name="Extra Shot" type="upgrade" collective="false" hidden="false" categoryEntryId="50ba-cf77-3941-189c">
+<costs>
+<cost costTypeId="points" name="pts" value="10.0"/>
+</costs>
+<constraints/>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="4864-9551-d5ab-0fd1" targetId="e77b-02da-5143-229e" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="d05f-990a-ae91-4196" name="Feral Meld Skark (Mhagris)" type="unit" collective="false" hidden="false" book="BtGoA" page="193" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5">
+<costs>
+<cost costTypeId="points" name="pts" value="115.0"/>
+</costs>
+<constraints/>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="d398-8780-d6cb-1241" name="&gt; Feral Leader" type="model" collective="false" hidden="false" book="BtGoA" page="193" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="fa1b-d08c-0a23-97f5" name="&lt; Leader Level &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="64c7-ce38-13a1-0a67" targetId="02f3-3134-ae39-afed" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="6230-3ae4-17d6-9052" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="1aa6-aff0-4b33-9f78" name="Ranged Weapon" collective="false" hidden="false" defaultSelectionEntryId="43cf-0bae-d100-956c">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="43cf-0bae-d100-956c" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="ee88-cab4-5a29-66fe" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="3.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles>
+<profile id="fa1e-41af-d09a-4df9" profileTypeId="1650-77b3-10d1-6406" name="Feral Leader" hidden="false" book="BtGoA" page="193">
               <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="8"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="7 (8)"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
+                <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
+                <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
+                <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="8"/>
+                <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="7 (8)"/>
+                <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
+                <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
               </characteristics>
               <modifiers/>
             </profile>
-          </profiles>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="0b29-d80a-20b5-7e35" name="Armor" defaultEntryId="6f2d-ec4e-ce5c-1488" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="6f2d-ec4e-ce5c-1488" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="199e-4b69-cffe-68a5" name="Close Combat Weapon" defaultEntryId="3f7a-4f46-1255-79ab" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="3f7a-4f46-1255-79ab" targetId="b5e9-5297-04d2-2bf8" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="375e-22a4-1200-b6c6" name="Meld Skark" defaultEntryId="ee4b-0b0e-386d-99b2" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="ee4b-0b0e-386d-99b2" targetId="eafe-29d5-1222-4155" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="bd78-00f6-6a00-c0c7" targetId="a221-d53c-b4bd-b52c" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="be9d-0689-3672-7135" targetId="b0ca-8e7d-d03f-f027" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="1196-e275-ef1a-7a7c" targetId="3878-9363-1705-9eda" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="c7f9-56fe-b1f2-8d86" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="ff01-5f28-c344-f670" targetId="f7af-59ec-acde-2f75" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="1044-b654-0ca0-e5ad" name="Feral Skark Squad (Mhagris)" points="115.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="193">
-      <entries>
-        <entry id="c7f9-56fe-b1f2-8d86" name="&lt; Feral Leader" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="193">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="fdfc-05ca-f8f0-d848" name="&lt; Leader Level &gt;" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="7938-5e37-03c2-36f9" name="Leader Two" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="3c91-9185-0302-3739" targetId="7850-89e7-bab8-86e9" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-                <entry id="86b4-5321-c678-9f8e" name="Leader Three" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="f1b2-17c3-5c01-f840" targetId="05bb-4d34-70cd-25d2" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-            <entryGroup id="4835-5cca-c5ab-b665" name="Ranged Weapon" defaultEntryId="a4b6-8b90-d408-47e6" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="a4b6-8b90-d408-47e6" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="ac42-4a97-d2ca-35a4" targetId="e6db-6ed3-1a26-ea56" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-                <link id="4ed0-25b7-d8a9-9620" targetId="790a-6841-6372-870b" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="249d-04f1-6637-584a" targetId="1631-5857-2139-960a" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="5.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="ef9d-4e79-290c-20bc" targetId="41f2-0f61-9758-5e8d" linkType="profile">
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Large, Fast, Skark 3 Attacks SV1, Leader 2" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="c7f9-56fe-b1f2-8d86" childId="7938-5e37-03c2-36f9" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Large, Fast, Skark 3 Attacks SV1, Leader 3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="c7f9-56fe-b1f2-8d86" childId="86b4-5321-c678-9f8e" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="66d4-fa07-1bbf-5da2" name="Feral Fighter" points="0.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="193">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="438b-90c8-d7c4-125e" targetId="1069-6287-7c2a-af01" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="6a38-a612-5d6b-f4b0" name="&lt; Unit Ranged Weapon &gt;" defaultEntryId="fe21-b7fd-711d-b2f5" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="fe21-b7fd-711d-b2f5" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="835f-70e0-eb3b-6fe3" name="&lt; Unit Armor&gt;" defaultEntryId="3555-0453-6307-704b" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="3555-0453-6307-704b" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="f1fd-e630-1832-069b" name="&lt; Unit Close Combat Weapon &gt;" defaultEntryId="ae29-c766-0fde-446c" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="ae29-c766-0fde-446c" targetId="b5e9-5297-04d2-2bf8" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="0d4c-9f77-f0bf-9e0c" targetId="a221-d53c-b4bd-b52c" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="fcbc-0bcd-8b26-fc45" targetId="b0ca-8e7d-d03f-f027" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="bfab-953d-8387-49ad" targetId="1e33-99fa-00fc-0a32" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="4426-94bd-2acc-1aff" targetId="3878-9363-1705-9eda" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="6.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="c7f9-56fe-b1f2-8d86" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="1044-b654-0ca0-e5ad" incrementChildId="66d4-fa07-1bbf-5da2" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-      </links>
-    </entry>
-    <entry id="5cda-2300-7dae-8090" name="Feral Squad (Mhagris)" points="18.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BTGOA" page="191">
-      <entries>
-        <entry id="060b-a9a7-c641-af07" name="&lt; Feral Leader" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="191">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="7bf3-7f8c-bb36-8056" name="&lt; Leader Level &gt;" defaultEntryId="02c0-bf97-34ab-30c2" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="cb7e-226f-de17-d52a" targetId="02f3-3134-ae39-afed" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="28b8-d291-d4ee-cb65" targetId="5a4c-2f5e-40a2-91d4" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="02c0-bf97-34ab-30c2" targetId="fc7e-7c0e-65e0-8c33" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="f6c4-adbe-a27d-129a" name="&lt; Ranged Weapon &gt;" defaultEntryId="b6be-4b77-ef52-cd3a" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="b6be-4b77-ef52-cd3a" targetId="8690-3ab7-9fef-06ee" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="f89e-fb57-67ee-cd21" targetId="9cd6-dbb8-bdcb-0299" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="1.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-                <link id="9f8e-1152-80b5-a7b3" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-                <link id="4a2f-9e80-09af-2aec" targetId="1631-5857-2139-960a" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="6.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="a390-861b-ce2b-149f" targetId="f23b-60da-348a-e6db" linkType="profile">
-              <modifiers>
-                <modifier type="append" field="f214-abe8-c922-c51b" value="(6)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="5cda-2300-7dae-8090" childId="7959-d3d0-3fa6-31d2" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="26dc-46a0-f598-e869" name="Feral Fighter" points="11.0" categoryId="(No Category)" type="model" minSelections="5" maxSelections="11" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="b699-14bd-4f42-6832" name="&lt; Ranged Weapon &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="7b8a-0e82-ab5e-59cb" targetId="8f47-408e-cc6e-7a19" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="63e8-7025-f4e9-e92d" targetId="2ae1-18d0-fbc8-21ad" linkType="profile">
-              <modifiers>
-                <modifier type="append" field="f214-abe8-c922-c51b" value="(6)" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="5cda-2300-7dae-8090" childId="7959-d3d0-3fa6-31d2" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="2223-cd79-2176-f186" name="Micro-X Launcher" points="0.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="aae4-047f-f2ad-3a9a" targetId="e7b0-651a-cc7c-f27e" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="13f2-f4e6-8cb9-000e" name="&lt; Unit Armor &gt;" defaultEntryId="0479-9c51-eb5f-7880" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="0479-9c51-eb5f-7880" name="None" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="7959-d3d0-3fa6-31d2" targetId="2396-4159-e26c-6c42" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="5cda-2300-7dae-8090" incrementChildId="060b-a9a7-c641-af07" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="5cda-2300-7dae-8090" incrementChildId="26dc-46a0-f598-e869" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="5cda-2300-7dae-8090" childId="2223-cd79-2176-f186" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="0587-e7a6-cccd-a152" name="Infantry Unit" hidden="false" book="">
+</profiles>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups>
+<selectionEntryGroup id="0b29-d80a-20b5-7e35" name="Armor" collective="false" hidden="false" defaultSelectionEntryId="6f2d-ec4e-ce5c-1488">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="6f2d-ec4e-ce5c-1488" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="199e-4b69-cffe-68a5" name="Close Combat Weapon" collective="false" hidden="false" defaultSelectionEntryId="3f7a-4f46-1255-79ab">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="3f7a-4f46-1255-79ab" targetId="b5e9-5297-04d2-2bf8" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="375e-22a4-1200-b6c6" name="Meld Skark" collective="false" hidden="false" defaultSelectionEntryId="ee4b-0b0e-386d-99b2">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="ee4b-0b0e-386d-99b2" targetId="eafe-29d5-1222-4155" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks>
+<entryLink id="1196-e275-ef1a-7a7c" targetId="3878-9363-1705-9eda" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="2.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+<infoLinks>
+<infoLink id="bd78-00f6-6a00-c0c7" targetId="a221-d53c-b4bd-b52c" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="be9d-0689-3672-7135" targetId="b0ca-8e7d-d03f-f027" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="ff01-5f28-c344-f670" targetId="f7af-59ec-acde-2f75" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="1044-b654-0ca0-e5ad" name="Feral Skark Squad (Mhagris)" type="unit" collective="false" hidden="false" book="BtGoA" page="193" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89">
+<costs>
+<cost costTypeId="points" name="pts" value="115.0"/>
+</costs>
+<constraints/>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="c7f9-56fe-b1f2-8d86" name="&lt; Feral Leader" type="model" collective="false" hidden="false" book="BtGoA" page="193" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="fdfc-05ca-f8f0-d848" name="&lt; Leader Level &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="7938-5e37-03c2-36f9" name="Leader Two" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="10.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="3c91-9185-0302-3739" targetId="7850-89e7-bab8-86e9" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="86b4-5321-c678-9f8e" name="Leader Three" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="20.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="f1b2-17c3-5c01-f840" targetId="05bb-4d34-70cd-25d2" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups/>
+<entryLinks/>
+</selectionEntryGroup>
+<selectionEntryGroup id="4835-5cca-c5ab-b665" name="Ranged Weapon" collective="false" hidden="false" defaultSelectionEntryId="a4b6-8b90-d408-47e6">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="a4b6-8b90-d408-47e6" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="ac42-4a97-d2ca-35a4" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="0.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+<entryLink id="4ed0-25b7-d8a9-9620" targetId="790a-6841-6372-870b" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="249d-04f1-6637-584a" targetId="1631-5857-2139-960a" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="5.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="ef9d-4e79-290c-20bc" targetId="41f2-0f61-9758-5e8d" type="profile">
+<modifiers>
+<modifier type="set" field="3baa-9cfd-f273-822d" value="Large, Fast, Skark 3 Attacks SV1, Leader 2">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="c7f9-56fe-b1f2-8d86" childId="7938-5e37-03c2-36f9" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+<modifier type="set" field="3baa-9cfd-f273-822d" value="Large, Fast, Skark 3 Attacks SV1, Leader 3">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="c7f9-56fe-b1f2-8d86" childId="86b4-5321-c678-9f8e" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="66d4-fa07-1bbf-5da2" name="Feral Fighter" type="model" collective="false" hidden="false" book="BtGoA" page="193" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="2"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="438b-90c8-d7c4-125e" targetId="1069-6287-7c2a-af01" type="profile">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups>
+<selectionEntryGroup id="6a38-a612-5d6b-f4b0" name="&lt; Unit Ranged Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="fe21-b7fd-711d-b2f5">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="fe21-b7fd-711d-b2f5" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="835f-70e0-eb3b-6fe3" name="&lt; Unit Armor&gt;" collective="false" hidden="false" defaultSelectionEntryId="3555-0453-6307-704b">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="3555-0453-6307-704b" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="f1fd-e630-1832-069b" name="&lt; Unit Close Combat Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="ae29-c766-0fde-446c">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="ae29-c766-0fde-446c" targetId="b5e9-5297-04d2-2bf8" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks>
+<entryLink id="bfab-953d-8387-49ad" targetId="1e33-99fa-00fc-0a32" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="4426-94bd-2acc-1aff" targetId="3878-9363-1705-9eda" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="6.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+<modifier type="increment" field="points" value="2.0">
+<conditions/>
+<conditionGroups/>
+<repeats>
+<repeat repeats="1" value="1.0" field="selections" scope="1044-b654-0ca0-e5ad" childId="66d4-fa07-1bbf-5da2" shared="true"/>
+</repeats>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+<infoLinks>
+<infoLink id="0d4c-9f77-f0bf-9e0c" targetId="a221-d53c-b4bd-b52c" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="fcbc-0bcd-8b26-fc45" targetId="b0ca-8e7d-d03f-f027" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="5cda-2300-7dae-8090" name="Feral Squad (Mhagris)" type="unit" collective="false" hidden="false" book="BTGOA" page="191" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe">
+<costs>
+<cost costTypeId="points" name="pts" value="18.0"/>
+</costs>
+<constraints/>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="060b-a9a7-c641-af07" name="&lt; Feral Leader" type="model" collective="false" hidden="false" book="BtGoA" page="191" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="7bf3-7f8c-bb36-8056" name="&lt; Leader Level &gt;" collective="false" hidden="false" defaultSelectionEntryId="02c0-bf97-34ab-30c2">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="cb7e-226f-de17-d52a" targetId="02f3-3134-ae39-afed" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="28b8-d291-d4ee-cb65" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="02c0-bf97-34ab-30c2" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="f6c4-adbe-a27d-129a" name="&lt; Ranged Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="b6be-4b77-ef52-cd3a">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="b6be-4b77-ef52-cd3a" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="f89e-fb57-67ee-cd21" targetId="9cd6-dbb8-bdcb-0299" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="1.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+<entryLink id="9f8e-1152-80b5-a7b3" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="3.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+<entryLink id="4a2f-9e80-09af-2aec" targetId="1631-5857-2139-960a" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="6.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="a390-861b-ce2b-149f" targetId="f23b-60da-348a-e6db" type="profile">
+<modifiers>
+<modifier type="append" field="f214-abe8-c922-c51b" value="(6)">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="5cda-2300-7dae-8090" childId="7959-d3d0-3fa6-31d2" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="26dc-46a0-f598-e869" name="Feral Fighter" type="model" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="11.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="5"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="11"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="b699-14bd-4f42-6832" name="&lt; Ranged Weapon &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="7b8a-0e82-ab5e-59cb" targetId="8f47-408e-cc6e-7a19" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="63e8-7025-f4e9-e92d" targetId="2ae1-18d0-fbc8-21ad" type="profile">
+<modifiers>
+<modifier type="append" field="f214-abe8-c922-c51b" value="(6)">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="5cda-2300-7dae-8090" childId="7959-d3d0-3fa6-31d2" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="2223-cd79-2176-f186" name="Micro-X Launcher" type="model" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks>
+<entryLink id="aae4-047f-f2ad-3a9a" targetId="e7b0-651a-cc7c-f27e" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+<infoLinks/>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups>
+<selectionEntryGroup id="13f2-f4e6-8cb9-000e" name="&lt; Unit Armor &gt;" collective="false" hidden="false" defaultSelectionEntryId="0479-9c51-eb5f-7880">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="0479-9c51-eb5f-7880" name="None" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="7959-d3d0-3fa6-31d2" targetId="2396-4159-e26c-6c42" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="2.0">
+<conditions/>
+<conditionGroups/>
+<repeats>
+<repeat repeats="1" value="1.0" field="selections" scope="5cda-2300-7dae-8090" childId="060b-a9a7-c641-af07" shared="true"/>
+</repeats>
+</modifier>
+<modifier type="increment" field="points" value="2.0">
+<conditions/>
+<conditionGroups/>
+<repeats>
+<repeat repeats="1" value="1.0" field="selections" scope="5cda-2300-7dae-8090" childId="26dc-46a0-f598-e869" shared="true"/>
+</repeats>
+</modifier>
+<modifier type="increment" field="points" value="2.0">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="5cda-2300-7dae-8090" childId="2223-cd79-2176-f186" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules>
+<rule id="0587-e7a6-cccd-a152" name="Infantry Unit" hidden="false" book="">
           <modifiers/>
         </rule>
-      </rules>
-      <profiles/>
-      <links>
-        <link id="0e45-6566-b04a-b718" targetId="3878-9363-1705-9eda" linkType="entry">
-          <modifiers>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="5cda-2300-7dae-8090" incrementChildId="060b-a9a7-c641-af07" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="5cda-2300-7dae-8090" incrementChildId="26dc-46a0-f598-e869" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions>
-                <condition parentId="5cda-2300-7dae-8090" childId="2223-cd79-2176-f186" field="selections" type="equal to" value="1.0"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-        <link id="49e8-198a-92af-6784" targetId="d118-8115-df5f-2402" linkType="entry">
-          <modifiers>
-            <modifier type="set" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="5cda-2300-7dae-8090" incrementChildId="26dc-46a0-f598-e869" incrementField="selections" incrementValue="1.0">
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions>
-                <condition parentId="5cda-2300-7dae-8090" childId="2223-cd79-2176-f186" field="selections" type="equal to" value="1.0"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-        </link>
-      </links>
-    </entry>
-    <entry id="04d7-b8fa-d20d-5a98" name="Freeborn Attack Skimmer (Striker)" points="148.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="193">
-      <entries>
-        <entry id="c30a-e7b6-bb84-7bb5" name="Striker" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="193">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="c647-b28b-df13-6d30" name="&lt; Unit Weapon &gt;" defaultEntryId="b030-5851-0170-e80b" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="b030-5851-0170-e80b" targetId="cf3a-e6a9-bdc0-e0ae" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="2691-8987-ab1a-2617" targetId="c2bf-0272-30c6-dd20" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="5.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="204f-7870-70cd-0175" targetId="2da6-e419-5126-a73b" linkType="profile">
-              <modifiers>
-                <modifier type="increment" field="f214-abe8-c922-c51b" value="1" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="04d7-b8fa-d20d-5a98" childId="d788-9457-e43f-3692" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="d788-9457-e43f-3692" name="HL Booster (adds +1 res)" points="24.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="eb1e-c626-334f-2865" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="a72d-0f8c-e2c5-99f2" targetId="d571-d584-85fc-9110" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="2979-eed7-b244-aefc" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="3282-4fa8-4571-f511" name="Vehicle Unit" hidden="false">
+</rules>
+<profiles/>
+<entryLinks>
+<entryLink id="0e45-6566-b04a-b718" targetId="3878-9363-1705-9eda" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="2.0">
+<conditions/>
+<conditionGroups/>
+<repeats>
+<repeat repeats="1" value="1.0" field="selections" scope="5cda-2300-7dae-8090" childId="060b-a9a7-c641-af07" shared="true"/>
+</repeats>
+</modifier>
+<modifier type="increment" field="points" value="2.0">
+<conditions/>
+<conditionGroups/>
+<repeats>
+<repeat repeats="1" value="1.0" field="selections" scope="5cda-2300-7dae-8090" childId="26dc-46a0-f598-e869" shared="true"/>
+</repeats>
+</modifier>
+<modifier type="increment" field="points" value="2.0">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="5cda-2300-7dae-8090" childId="2223-cd79-2176-f186" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+<entryLink id="49e8-198a-92af-6784" targetId="d118-8115-df5f-2402" type="selectionEntry">
+<modifiers>
+<modifier type="set" field="points" value="2.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+<modifier type="increment" field="points" value="2.0">
+<conditions/>
+<conditionGroups/>
+<repeats>
+<repeat repeats="1" value="1.0" field="selections" scope="5cda-2300-7dae-8090" childId="26dc-46a0-f598-e869" shared="true"/>
+</repeats>
+</modifier>
+<modifier type="increment" field="points" value="2.0">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="5cda-2300-7dae-8090" childId="2223-cd79-2176-f186" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="04d7-b8fa-d20d-5a98" name="Freeborn Attack Skimmer (Striker)" type="unit" collective="false" hidden="false" book="BtGoA" page="193" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89">
+<costs>
+<cost costTypeId="points" name="pts" value="148.0"/>
+</costs>
+<constraints/>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="c30a-e7b6-bb84-7bb5" name="Striker" type="upgrade" collective="false" hidden="false" book="BtGoA" page="193" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="c647-b28b-df13-6d30" name="&lt; Unit Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="b030-5851-0170-e80b">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="b030-5851-0170-e80b" targetId="cf3a-e6a9-bdc0-e0ae" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="2691-8987-ab1a-2617" targetId="c2bf-0272-30c6-dd20" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="5.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="204f-7870-70cd-0175" targetId="2da6-e419-5126-a73b" type="profile">
+<modifiers>
+<modifier type="increment" field="f214-abe8-c922-c51b" value="1">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="04d7-b8fa-d20d-5a98" childId="d788-9457-e43f-3692" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="d788-9457-e43f-3692" name="HL Booster (adds +1 res)" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="24.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups>
+<selectionEntryGroup id="eb1e-c626-334f-2865" name="&lt; Unit Options &gt;" collective="false" hidden="false">
+<constraints/>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="a72d-0f8c-e2c5-99f2" targetId="d571-d584-85fc-9110" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="2979-eed7-b244-aefc" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules>
+<rule id="3282-4fa8-4571-f511" name="Vehicle Unit" hidden="false">
           <modifiers/>
         </rule>
-      </rules>
-      <profiles/>
-      <links>
-        <link id="b3ea-1e90-ad90-ee02" targetId="5565-ce10-1c78-1ee7" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="48a7-1194-3630-6d90" targetId="a221-d53c-b4bd-b52c" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="b73b-6140-e2ca-f0c1" name="Freeborn Command Squad" points="69.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true">
-      <entries>
-        <entry id="b36d-f9f6-80eb-6f8a" name="&lt; Freeborn Captain" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="ee93-85a8-a748-3858" name="&lt; Leader Level &gt;" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="3a47-103d-769c-3d59" targetId="5a4c-2f5e-40a2-91d4" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="0c11-a12d-3376-0b4b" name="&lt;Freeborn Captain Equipment &gt;" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups>
-                <entryGroup id="d72b-f17d-2842-5908" name="&lt; Armour &gt;" defaultEntryId="d821-bfad-6e70-be4a" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="d821-bfad-6e70-be4a" targetId="03c2-174e-8617-cf04" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-                <entryGroup id="6343-7996-c9c2-e583" name="&lt; Weapons &gt;" defaultEntryId="c38c-46e0-0457-f57d" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="c38c-46e0-0457-f57d" targetId="e6db-6ed3-1a26-ea56" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-              </entryGroups>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="75cc-7baf-4390-4597" targetId="2d89-bcdb-b942-b900" linkType="profile">
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="b73b-6140-e2ca-f0c1" childId="3a47-103d-769c-3d59" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="6b48-ec12-ab6c-2063" name="Bodyguards" points="21.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="c9a4-5ee7-f187-8235" name="&lt; Armour &gt;" defaultEntryId="5b9a-d663-bb0e-6480" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="5b9a-d663-bb0e-6480" targetId="03c2-174e-8617-cf04" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="ce36-0f86-ad2b-2de0" name="&lt; Weapons &gt;" defaultEntryId="ffe5-b36e-981d-67c8" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="ffe5-b36e-981d-67c8" targetId="b018-6101-d2e3-b4ea" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers>
-            <modifier type="increment" field="maxSelections" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
+</rules>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="b3ea-1e90-ad90-ee02" targetId="5565-ce10-1c78-1ee7" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="48a7-1194-3630-6d90" targetId="a221-d53c-b4bd-b52c" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="b73b-6140-e2ca-f0c1" name="Freeborn Command Squad" type="unit" collective="false" hidden="true" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe">
+<costs>
+<cost costTypeId="points" name="pts" value="69.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+</constraints>
+<modifiers>
+<modifier type="set" field="hidden" value="false">
+<conditions/>
+<conditionGroups>
+<conditionGroup type="or">
               <conditions>
-                <condition parentId="roster" childId="3933-5e9f-f85c-ba75" field="selections" type="equal to" value="1.0"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="16f3-2f8c-3e35-5557" targetId="9fba-d6b7-c66d-99f0" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="87b2-db05-700b-2ce2" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="4e48-b0be-38f0-fb84" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="25ec-bc01-1917-42a1" targetId="502c-9855-7269-eaa2" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="e804-8e7c-7660-6271" targetId="573b-88bc-97d7-d890" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="19db-d0e1-8415-81fa" targetId="d118-8115-df5f-2402" linkType="entry">
-              <modifiers>
-                <modifier type="set" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="b73b-6140-e2ca-f0c1" incrementChildId="6b48-ec12-ab6c-2063" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="3b4d-27c4-5549-02cb" targetId="4b9d-a0bf-396e-384b" linkType="entry">
-              <modifiers>
-                <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="roster" childId="ad0d-a741-67ad-5d5c" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="2c36-464a-243b-0e55" targetId="1707-586b-01df-0f80" linkType="entry">
-              <modifiers>
-                <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="roster" childId="d17a-ef4d-2148-25e8" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="8de0-52be-784c-00ce" targetId="d571-d584-85fc-9110" linkType="entry">
-              <modifiers>
-                <modifier type="hide" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="roster" childId="a400-34cd-f726-fbf6" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers>
-        <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition parentId="roster" childId="3933-5e9f-f85c-ba75" field="selections" type="equal to" value="1.0"/>
-                <condition parentId="roster" childId="a400-34cd-f726-fbf6" field="selections" type="equal to" value="1.0"/>
-                <condition parentId="roster" childId="ad0d-a741-67ad-5d5c" field="selections" type="equal to" value="1.0"/>
-                <condition parentId="roster" childId="d17a-ef4d-2148-25e8" field="selections" type="equal to" value="1.0"/>
-                <condition parentId="roster" childId="39a7-bedc-c912-a9f0" field="selections" type="equal to" value="1.0"/>
+                <condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="3933-5e9f-f85c-ba75" shared="true"/>
+                <condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="a400-34cd-f726-fbf6" shared="true"/>
+                <condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="ad0d-a741-67ad-5d5c" shared="true"/>
+                <condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="d17a-ef4d-2148-25e8" shared="true"/>
+                <condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="39a7-bedc-c912-a9f0" shared="true"/>
               </conditions>
               <conditionGroups/>
             </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="15e4-e4af-15f1-94c3" name="Freeborn Command Squad" points="70.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true">
-      <entries>
-        <entry id="8b00-b972-e10d-1390" name="&lt; Freeborn Captain" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="b997-071f-1f47-aee8" name="&lt; Leader Level &gt;" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="ed96-be90-06f3-0beb" targetId="5a4c-2f5e-40a2-91d4" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="992a-ced2-9419-513c" name="&lt;Freeborn Captain Equipment &gt;" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups>
-                <entryGroup id="f80a-cee4-23df-5b8d" name="&lt; Armour &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="0ca1-9662-209b-eb0d" targetId="03c2-174e-8617-cf04" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-                <entryGroup id="a5f8-02a4-689a-510f" name="&lt; Weapons &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="c1d9-84de-92d6-cb72" targetId="e6db-6ed3-1a26-ea56" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-              </entryGroups>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="5545-8414-45f3-4c97" targetId="2d89-bcdb-b942-b900" linkType="profile">
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="15e4-e4af-15f1-94c3" childId="ed96-be90-06f3-0beb" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="16e2-4b59-8a36-351a" name="Bodygaurds" points="26.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="70fa-1e75-d60b-2e16" name="&lt; Armour &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="f41b-1c7d-c117-325d" targetId="03c2-174e-8617-cf04" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="05c5-0dc8-f360-2012" name="&lt; Weapons &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="b106-d8e7-67b5-3daf" targetId="059b-38f7-0313-5ae4" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers>
-            <modifier type="increment" field="maxSelections" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions>
-                <condition parentId="roster" childId="3933-5e9f-f85c-ba75" field="selections" type="equal to" value="1.0"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="5e80-a56f-41a7-b337" targetId="9fba-d6b7-c66d-99f0" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="4fd9-336f-cb2a-74cb" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="5c84-6fcb-23cb-c531" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="0534-209c-6e63-b751" targetId="502c-9855-7269-eaa2" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="3cc5-bd4f-f987-bb96" targetId="573b-88bc-97d7-d890" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="9289-3ce8-ce3b-c398" targetId="d118-8115-df5f-2402" linkType="entry">
-              <modifiers>
-                <modifier type="set" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="15e4-e4af-15f1-94c3" incrementChildId="16e2-4b59-8a36-351a" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers>
-        <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-          <conditions>
-            <condition parentId="roster" childId="7f96-ddf7-af5d-958a" field="selections" type="equal to" value="1.0"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="4224-b512-8e27-a7ae" name="Freeborn Command Squad" points="70.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true">
-      <entries>
-        <entry id="8166-8ae2-85a7-d508" name="&lt; Freeborn Captain" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="ec55-a3a6-79d2-3d8d" name="&lt; Leader Level &gt;" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="7539-56fe-d7c4-3436" targetId="5a4c-2f5e-40a2-91d4" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="bc83-ae90-8685-ec61" name="&lt;Freeborn Captain Equipment &gt;" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups>
-                <entryGroup id="8610-880b-d363-2842" name="&lt; Armour &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="9413-43f9-5e3c-0e39" targetId="03c2-174e-8617-cf04" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-                <entryGroup id="b05f-e970-7acf-b5c2" name="&lt; Weapons &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="dc7e-0219-458d-80af" targetId="e6db-6ed3-1a26-ea56" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-              </entryGroups>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="74c9-0721-edb2-fe31" targetId="2d89-bcdb-b942-b900" linkType="profile">
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="4224-b512-8e27-a7ae" childId="ec55-a3a6-79d2-3d8d" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="733f-d5cf-9ed2-cd37" name="Bodygaurds" points="26.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="2a25-debf-a112-08f8" name="&lt; Armour &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="94d8-34e0-0bd0-2f8f" targetId="03c2-174e-8617-cf04" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="64e2-25c4-0a20-fd6f" name="&lt; Weapons &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="f2d1-fbb0-ae51-637a" targetId="059b-38f7-0313-5ae4" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers>
-            <modifier type="increment" field="maxSelections" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions>
-                <condition parentId="roster" childId="3933-5e9f-f85c-ba75" field="selections" type="equal to" value="1.0"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="433d-17af-98e2-e708" targetId="9fba-d6b7-c66d-99f0" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="01c0-de81-eb4f-6520" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="2313-6b51-b6fc-4334" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="55b3-8e97-1f9f-99c1" targetId="502c-9855-7269-eaa2" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="6334-02c5-fe28-46b2" targetId="573b-88bc-97d7-d890" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="94a7-abc4-e849-288a" targetId="d118-8115-df5f-2402" linkType="entry">
-              <modifiers>
-                <modifier type="set" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="4224-b512-8e27-a7ae" incrementChildId="733f-d5cf-9ed2-cd37" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers>
-        <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-          <conditions>
-            <condition parentId="roster" childId="a90a-cec1-cd13-3c17" field="selections" type="equal to" value="1.0"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="0f65-b8ed-b8b2-294a" name="Freeborn Command Squad" points="70.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true">
-      <entries>
-        <entry id="6f3f-e7de-8b1f-9a45" name="&lt; Freeborn Captain" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="3f21-c5d0-9056-3513" name="&lt; Leader Level &gt;" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="6ef1-5f41-d717-8432" targetId="5a4c-2f5e-40a2-91d4" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="eba6-42f4-e601-d9d4" name="&lt;Freeborn Captain Equipment &gt;" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups>
-                <entryGroup id="0c25-94d1-2ee1-8f97" name="&lt; Armour &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="fd6b-8d29-bb72-1f1a" targetId="03c2-174e-8617-cf04" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-                <entryGroup id="1d89-7fac-a8ca-dea9" name="&lt; Weapons &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="bfcd-6dc1-7032-9eca" targetId="059b-38f7-0313-5ae4" linkType="entry">
-                      <modifiers>
-                        <modifier type="set" field="points" value="8.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                          <conditions/>
-                          <conditionGroups/>
-                        </modifier>
-                      </modifiers>
-                    </link>
-                  </links>
-                </entryGroup>
-              </entryGroups>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="9559-7359-c187-35e7" targetId="2d89-bcdb-b942-b900" linkType="profile">
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="0f65-b8ed-b8b2-294a" childId="6ef1-5f41-d717-8432" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="f539-7c50-1fed-c0fe" name="Bodygaurds" points="26.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="db1b-d74c-4488-f114" name="&lt; Armour &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="9dbd-a1b9-f7e2-b802" targetId="03c2-174e-8617-cf04" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="da8e-2b95-0031-818a" name="&lt; Weapons &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="bcc8-515f-8cbc-7a6c" targetId="b018-6101-d2e3-b4ea" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers>
-            <modifier type="increment" field="maxSelections" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-              <conditions>
-                <condition parentId="roster" childId="3933-5e9f-f85c-ba75" field="selections" type="equal to" value="1.0"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="c830-2ab1-3be7-3427" targetId="9fba-d6b7-c66d-99f0" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="6c4b-1586-3d8b-dbda" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="712a-24b1-dd4d-c34e" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="7484-dc39-dbc9-ced2" targetId="502c-9855-7269-eaa2" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="2981-4427-c93a-87d1" targetId="573b-88bc-97d7-d890" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="7113-0a49-238b-ccc3" targetId="d118-8115-df5f-2402" linkType="entry">
-              <modifiers>
-                <modifier type="set" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="0f65-b8ed-b8b2-294a" incrementChildId="f539-7c50-1fed-c0fe" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers>
-        <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-          <conditions>
-            <condition parentId="roster" childId="a04c-3029-b790-0cdb" field="selections" type="equal to" value="1.0"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="ff83-951c-1523-67b4" name="Freeborn Command Squad" points="70.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true">
-      <entries>
-        <entry id="0b68-b15d-4f21-400d" name="&lt; Freeborn Captain" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="4f77-859f-d36f-3f51" name="&lt; Leader Level &gt;" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="fab0-fb87-4db4-b758" targetId="5a4c-2f5e-40a2-91d4" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="534d-0cc6-dc8f-0e4a" name="&lt;Freeborn Captain Equipment &gt;" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups>
-                <entryGroup id="6168-628e-5ed2-eaa9" name="&lt; Armour &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="be23-8e40-689c-4584" targetId="eff8-bb0e-1b1d-bbb2" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-                <entryGroup id="5ec4-d224-e3cc-e5a6" name="&lt; Weapons &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="bff1-9762-306f-171b" targetId="b018-6101-d2e3-b4ea" linkType="entry">
-                      <modifiers>
-                        <modifier type="set" field="points" value="8.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                          <conditions/>
-                          <conditionGroups/>
-                        </modifier>
-                      </modifiers>
-                    </link>
-                  </links>
-                </entryGroup>
-              </entryGroups>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="865b-5fee-3347-eedb" targetId="2d89-bcdb-b942-b900" linkType="profile">
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="ff83-951c-1523-67b4" childId="fab0-fb87-4db4-b758" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="b52c-6be6-7a76-ba77" name="Bodygaurds" points="26.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="48ac-19f4-04e6-2834" name="&lt; Armour &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="f1f4-b68d-48a0-6c7f" targetId="eff8-bb0e-1b1d-bbb2" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="1095-6dad-810d-ff4f" name="&lt; Weapons &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="dde5-232c-c035-35fa" targetId="b018-6101-d2e3-b4ea" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="248c-567b-902f-d5d5" targetId="9fba-d6b7-c66d-99f0" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="4329-ec3b-739b-0050" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="9bc9-cab0-4841-6c2c" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="c86a-f1fe-6d59-873f" targetId="502c-9855-7269-eaa2" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="e0aa-ee5e-c24a-c338" targetId="573b-88bc-97d7-d890" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="0aac-c5ca-badb-4434" targetId="d118-8115-df5f-2402" linkType="entry">
-              <modifiers>
-                <modifier type="set" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="ff83-951c-1523-67b4" incrementChildId="b52c-6be6-7a76-ba77" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers>
-        <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-          <conditions>
-            <condition parentId="roster" childId="6559-a8ba-d266-7c27" field="selections" type="equal to" value="1.0"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="d603-36ff-a2eb-312f" name="Freeborn Command Squad" points="70.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true">
-      <entries>
-        <entry id="3c30-80dd-c936-7ccf" name="&lt; Freeborn Captain" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="6111-3b3b-a2ef-bdbc" name="&lt; Leader Level &gt;" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="7671-d1cb-8583-32f9" targetId="5a4c-2f5e-40a2-91d4" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="c091-1c08-a4c1-1e30" name="&lt;Freeborn Captain Equipment &gt;" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups>
-                <entryGroup id="90d1-c02b-6791-3678" name="&lt; Armour &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="ef1a-0b88-41e9-520f" targetId="eb94-d1e8-1084-71b3" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-                <entryGroup id="954d-9823-9e71-fdb2" name="&lt; Weapons &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="9620-1c29-bbc5-277d" targetId="e6db-6ed3-1a26-ea56" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-              </entryGroups>
-              <modifiers/>
-              <links/>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="86ad-520b-f8d8-0b4d" targetId="2d89-bcdb-b942-b900" linkType="profile">
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="d603-36ff-a2eb-312f" childId="7671-d1cb-8583-32f9" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="70ef-17b0-4cc6-59d6" name="Bodygaurds" points="26.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="190">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="b2b0-8472-6f6f-b03b" name="&lt; Armour &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="4966-a136-1d34-1648" targetId="eb94-d1e8-1084-71b3" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="cd16-bf68-6808-737f" name="&lt; Weapons &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="7c24-c3ed-edef-f97d" targetId="b018-6101-d2e3-b4ea" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="8523-7e21-40bd-02f6" targetId="9fba-d6b7-c66d-99f0" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="1359-b8c0-aedb-1bbe" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="3c36-c80e-c93c-f6a4" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="9092-1d24-81d4-4b37" targetId="502c-9855-7269-eaa2" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="e184-cee5-0fd5-9e41" targetId="573b-88bc-97d7-d890" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="6f0c-0da4-1e67-2635" targetId="d118-8115-df5f-2402" linkType="entry">
-              <modifiers>
-                <modifier type="set" field="points" value="2.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="d603-36ff-a2eb-312f" incrementChildId="70ef-17b0-4cc6-59d6" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers>
-        <modifier type="show" field="minSelections" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-          <conditions>
-            <condition parentId="roster" childId="1ef5-d006-6a32-fddb" field="selections" type="equal to" value="1.0"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="6a1d-c668-c7e8-ed9f" name="Freeborn Heavy Support Team" points="25.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="194">
-      <entries>
-        <entry id="d45c-a6e2-b912-4bcd" name="Freeborn Crew" points="12.0" categoryId="(No Category)" type="upgrade" minSelections="3" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="193">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="8b71-ca9c-1ca2-0abc" name="&lt; Unit Weapon &gt;" defaultEntryId="42ad-31e5-60a7-9e01" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="42ad-31e5-60a7-9e01" targetId="8690-3ab7-9fef-06ee" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="d718-d349-ce44-fe7e" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="9dd0-b9bb-59a6-5f05" name="&lt; Unit Armor &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="7632-f6c2-622d-6f3a" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="4d7b-6ff6-c6f1-e988" targetId="7267-3051-f1b4-0a88" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="e688-49e6-a2dd-5f3f" targetId="87a3-460d-879a-92a5" linkType="profile">
-              <modifiers>
-                <modifier type="show" field="None" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="6a1d-c668-c7e8-ed9f" childId="5afb-493a-f716-72df" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="a4e6-016c-c52f-4548" name="&lt; Support Weapon &gt;" defaultEntryId="f434-b021-4e80-826a" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="f434-b021-4e80-826a" targetId="cea7-8511-2208-1b1f" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="a076-8dc7-3360-7f97" targetId="b9f1-a313-3e59-57ab" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="9d3d-0bdc-592a-8e5a" targetId="9733-7039-e306-26b5" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="a2ac-6dfc-f14e-fcab" targetId="5149-5183-64d5-feaf" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="16f8-cbcf-1527-66e2" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="5afb-493a-f716-72df" name="Promote Crew Member to Leader" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="fb3e-d593-1cf1-ad9d" targetId="fc7e-7c0e-65e0-8c33" linkType="entry">
-                  <modifiers>
-                    <modifier type="set" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <links>
-            <link id="b8ea-0f50-8af5-3fec" targetId="d571-d584-85fc-9110" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="97c0-d505-6d11-a769" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="b771-d383-4d92-ea6b" targetId="4364-45ee-ee83-ca30" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="6a1d-c668-c7e8-ed9f" incrementChildId="d45c-a6e2-b912-4bcd" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="99d8-ad33-bc0e-0a91" name="Weapon Team Unit" hidden="false">
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links>
-        <link id="b8d9-62b2-a114-98f3" targetId="e329-9443-6cb2-bc53" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="1405-a43b-534b-ab05" name="Freeborn Nuhu Renegade" points="114.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="191">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="a2f4-4dc6-77ae-47c3" name="&lt; Freeborn Renegade Option &gt;" defaultEntryId="df76-0766-2149-0a05" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="df76-0766-2149-0a05" name="Freeborn Nuhu Renegade" points="0.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="191">
-              <entries/>
-              <entryGroups>
-                <entryGroup id="b8fc-7c31-a28e-2734" name="&lt; Close Combat Weapon &gt;" defaultEntryId="6411-27f7-6c9d-41d5" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="6411-27f7-6c9d-41d5" targetId="b357-a997-60e5-053e" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-                <entryGroup id="dfa1-9c18-5508-8d84" name="&lt; Ranged Weapon &gt;" defaultEntryId="5252-b85f-713e-89e3" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="5252-b85f-713e-89e3" targetId="e6db-6ed3-1a26-ea56" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-              </entryGroups>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="c045-a625-7025-1578" targetId="5c9b-1bde-ee01-04a4" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="4078-9939-a810-38ce" targetId="7bc9-5e98-2914-5abd" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="0cec-0def-8aec-1297" targetId="05bb-4d34-70cd-25d2" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="dfe4-8f70-63fd-fcb2" targetId="3c64-6022-a5f1-9c04" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="70d1-ee75-ecc4-1c5e" targetId="0c03-96a3-4833-bc67" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="1b3e-6788-9f9a-5ed5" name="Freeborn NuHu Renegade Meld" points="163.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups>
-                <entryGroup id="7f1e-6fe3-4c0d-1835" name="&lt; Close Combat Weapon &gt;" defaultEntryId="4e50-184a-086b-ddf4" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="4e50-184a-086b-ddf4" targetId="b357-a997-60e5-053e" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-                <entryGroup id="71f0-8ea7-438d-6aaf" name="&lt; Ranged Weapon &gt;" defaultEntryId="7123-c19b-8cec-f0c7" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <links>
-                    <link id="7123-c19b-8cec-f0c7" targetId="e6db-6ed3-1a26-ea56" linkType="entry">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entryGroup>
-              </entryGroups>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="a00c-80d5-2a22-dfbf" targetId="5c9b-1bde-ee01-04a4" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="1773-4ee5-6db6-6430" targetId="7bc9-5e98-2914-5abd" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="10a2-0000-14c0-e073" targetId="3c64-6022-a5f1-9c04" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="79d1-47e4-312e-04d3" targetId="05bb-4d34-70cd-25d2" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="b9b0-d17f-a96e-d0c3" targetId="5565-ce10-1c78-1ee7" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="6355-4d83-0120-3b82" targetId="a97f-4540-de7b-5734" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="6792-be66-d3a6-276b" targetId="5e3d-6905-2b14-8cd1" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="062e-3dd5-efd6-8a93" targetId="68fe-17c2-2841-2cde" linkType="profile">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="b2d5-107a-301c-db27" name="Limited Choice" hidden="false" book="">
-          <modifiers/>
-        </rule>
-        <rule id="05ad-d2b8-2f3f-67e1" name="Infantry Command Unit" hidden="false" book="">
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links>
-        <link id="11d3-ea88-2582-dbc0" targetId="a1c9-551b-1532-ef5a" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="8c9e-c5c0-4339-2c9e" targetId="1707-586b-01df-0f80" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="b557-70e8-d27c-aa9d" targetId="cadc-e1ce-3615-ac4b" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="0223-7d39-0a7c-f8a9" name="Freeborn Skyraider Squad" points="121.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="174">
-      <entries>
-        <entry id="cffa-15d6-0631-ed32" name="&lt; Skyraider Leader" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="192">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="6fb4-5cba-7e48-83e2" name="Leader Level" defaultEntryId="e5fb-0118-831e-f517" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="86cc-1a90-418d-75d5" targetId="02f3-3134-ae39-afed" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="e5fb-0118-831e-f517" targetId="fc7e-7c0e-65e0-8c33" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="7e77-cac2-feab-67d6" targetId="5c9b-1bde-ee01-04a4" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="a17a-173b-6907-b7ee" targetId="7bc9-5e98-2914-5abd" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="1491-1d08-a7c9-d0f4" targetId="e18f-34de-2624-4133" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="212a-5750-9cf2-9c7a" targetId="e18f-34de-2624-4133" linkType="profile">
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Large, Fast, Leader 2" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="cffa-15d6-0631-ed32" childId="86cc-1a90-418d-75d5" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="b5b1-72ee-b28c-ed4a" name="Skyraider Trooper" points="0.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="192">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="d042-54cc-962c-5c4e" name="&lt; Ranged Weapon &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="60da-034a-d954-5cfc" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="7303-1648-6de4-25ea" targetId="a654-5213-64f2-703a" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="84fe-b5cd-ab19-23e4" name="&lt; Skyraider &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="87a0-db4c-17e6-d240" targetId="a1a8-ba0b-2e45-8020" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="46d3-88f8-ecac-204c" name="&lt; Special Weapon Option &gt;" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="e34a-7c57-c72d-b20e" targetId="47d9-8149-9744-9849" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="8a5a-b8d3-b9f7-cffb" targetId="a00c-0542-f2a5-8124" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="f5d5-4b78-eab5-56a2" name="&lt; Unit Armor &gt;" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="3304-35c1-b35b-5a16" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="41f4-516b-6edc-fa24" targetId="2e3d-bbaa-3f5c-ac53" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="d56e-be22-258f-698c" name="&lt; Unit Options &gt; " minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="a434-7a9b-75cb-d4be" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="a61b-d8b1-c4a3-6102" name="Mounted Command Unit" hidden="false">
-          <modifiers/>
-        </rule>
-        <rule id="572f-a685-c7aa-3d42" name="Limited Choice" hidden="false">
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links>
-        <link id="c8b0-00c2-4509-d681" targetId="b0ca-8e7d-d03f-f027" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="3fb0-934a-d1a8-ed1e" targetId="a221-d53c-b4bd-b52c" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="5db6-c261-8463-2fde" name="Freeborn Specialist Heavy Support Team" points="45.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="194">
-      <entries>
-        <entry id="bb44-58f4-62b7-989d" name="Freeborn Crew" points="12.0" categoryId="(No Category)" type="upgrade" minSelections="3" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="193">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="da65-0295-8e02-4356" name="&lt; Unit Weapon &gt;" defaultEntryId="e081-6f9b-47f1-8d2e" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="e081-6f9b-47f1-8d2e" targetId="8690-3ab7-9fef-06ee" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="1af1-0c6d-46fc-9a90" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="8003-fecb-500b-a2f1" name="&lt; Unit Armor &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="76fe-447d-63af-8c97" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="7e69-7f6d-660b-ada8" targetId="7267-3051-f1b4-0a88" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="f359-8e60-9b6c-caf8" targetId="87a3-460d-879a-92a5" linkType="profile">
-              <modifiers>
-                <modifier type="show" field="None" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="5db6-c261-8463-2fde" childId="4117-a3fe-bf51-e9fe" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="7b8f-9d4d-fe28-010d" name="&lt; Support Weapon &gt;" defaultEntryId="c4cb-5ad3-29f5-e064" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="1d83-6417-d5ba-71b0" targetId="2cec-e1d7-c680-7ca0" linkType="entry">
-              <modifiers>
-                <modifier type="set" field="points" value="15.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="c4cb-5ad3-29f5-e064" targetId="67b6-d6f5-5ba3-e50d" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="8ae5-cb57-4392-b6d3" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="4117-a3fe-bf51-e9fe" name="Promote one crew to Leader" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="6735-38dd-ba7c-0697" targetId="d571-d584-85fc-9110" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="58d6-220a-a277-4d27" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="1bed-3774-e8f1-9891" targetId="4364-45ee-ee83-ca30" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="2.0" repeat="true" numRepeats="1" incrementParentId="5db6-c261-8463-2fde" incrementChildId="bb44-58f4-62b7-989d" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="cfca-4aa7-d6d4-b77e" name="Weapon Team Unit" hidden="false">
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links>
-        <link id="a700-75fe-fedc-4a1d" targetId="e329-9443-6cb2-bc53" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="e040-74bb-81d2-742f" name="Freeborn Specialist Heavy Support Team w/ Compression Bombard" points="45.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Battle for Xilos" page="19483">
-      <entries>
-        <entry id="3f02-0f65-aa87-f29b" name="Freeborn Crew" points="12.0" categoryId="(No Category)" type="upgrade" minSelections="3" maxSelections="4" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="193">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="e24b-2ff8-7c27-8ba7" name="&lt; Unit Weapon &gt;" defaultEntryId="ff3e-645a-e8d0-d896" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="ff3e-645a-e8d0-d896" targetId="8690-3ab7-9fef-06ee" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="b5d8-4f59-792a-5aa0" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="a0b8-45f2-80c2-2e6f" name="&lt; Unit Armor &gt;" defaultEntryId="9db6-ea3f-f9ce-9280" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="9db6-ea3f-f9ce-9280" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="2e53-4fbd-d21f-0ff4" targetId="7267-3051-f1b4-0a88" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="a311-98bd-dc31-1e18" targetId="87a3-460d-879a-92a5" linkType="profile">
-              <modifiers>
-                <modifier type="show" field="None" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="e040-74bb-81d2-742f" childId="30cb-c08e-9c00-1db2" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="10be-7777-50bb-0438" name="&lt; Support Weapon &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="1f73-aed3-4502-cebb" targetId="af24-45f9-4669-bf98" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="b980-251d-2639-9888" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="30cb-c08e-9c00-1db2" name="Promote one crew to Leader" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="cdac-db4e-1fea-369a" targetId="d571-d584-85fc-9110" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="2daa-0c1c-11a8-0cb0" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="de04-6777-8685-d52a" targetId="4364-45ee-ee83-ca30" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="e040-74bb-81d2-742f" incrementChildId="3f02-0f65-aa87-f29b" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="b131-f742-1197-dc55" name="Weapon Team Unit" hidden="false">
+</conditionGroups>
+</modifier>
+</modifiers>
+<selectionEntries>
+<selectionEntry id="b36d-f9f6-80eb-6f8a" name="&lt; Freeborn Captain" type="model" collective="false" hidden="false" book="BtGoA" page="190" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="ee93-85a8-a748-3858" name="&lt; Leader Level &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="3a47-103d-769c-3d59" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="0c11-a12d-3376-0b4b" name="&lt;Freeborn Captain Equipment &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="d72b-f17d-2842-5908" name="&lt; Armour &gt;" collective="false" hidden="false" defaultSelectionEntryId="d821-bfad-6e70-be4a">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="d821-bfad-6e70-be4a" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="6343-7996-c9c2-e583" name="&lt; Weapons &gt;" collective="false" hidden="false" defaultSelectionEntryId="c38c-46e0-0457-f57d">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="c38c-46e0-0457-f57d" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<entryLinks/>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="75cc-7baf-4390-4597" targetId="2d89-bcdb-b942-b900" type="profile">
+<modifiers>
+<modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="b73b-6140-e2ca-f0c1" childId="3a47-103d-769c-3d59" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="6b48-ec12-ab6c-2063" name="Bodyguards" type="model" collective="false" hidden="false" book="BtGoA" page="190" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="21.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="2"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="4"/>
+</constraints>
+<modifiers>
+<modifier type="increment" field="maxSelections" value="2.0">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="3933-5e9f-f85c-ba75" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="c9a4-5ee7-f187-8235" name="&lt; Armour &gt;" collective="false" hidden="false" defaultSelectionEntryId="5b9a-d663-bb0e-6480">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="5b9a-d663-bb0e-6480" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="ce36-0f86-ad2b-2de0" name="&lt; Weapons &gt;" collective="false" hidden="false" defaultSelectionEntryId="ffe5-b36e-981d-67c8">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="ffe5-b36e-981d-67c8" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="16f3-2f8c-3e35-5557" targetId="9fba-d6b7-c66d-99f0" type="profile">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups>
+<selectionEntryGroup id="87b2-db05-700b-2ce2" name="&lt; Unit Options &gt;" collective="false" hidden="false">
+<constraints/>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="4e48-b0be-38f0-fb84" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="25ec-bc01-1917-42a1" targetId="502c-9855-7269-eaa2" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="e804-8e7c-7660-6271" targetId="573b-88bc-97d7-d890" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="19db-d0e1-8415-81fa" targetId="d118-8115-df5f-2402" type="selectionEntry">
+<modifiers>
+<modifier type="set" field="points" value="2.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+<modifier type="increment" field="points" value="2.0">
+<conditions/>
+<conditionGroups/>
+<repeats>
+<repeat repeats="1" value="1.0" field="selections" scope="b73b-6140-e2ca-f0c1" childId="6b48-ec12-ab6c-2063" shared="true"/>
+</repeats>
+</modifier>
+</modifiers>
+</entryLink>
+<entryLink id="3b4d-27c4-5549-02cb" targetId="4b9d-a0bf-396e-384b" type="selectionEntry">
+<modifiers>
+<modifier type="set" field="hidden" value="true">
+<conditions/>
+<conditionGroups/>
+</modifier>
+<modifier type="set" field="hidden" value="false">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="ad0d-a741-67ad-5d5c" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+<entryLink id="2c36-464a-243b-0e55" targetId="1707-586b-01df-0f80" type="selectionEntry">
+<modifiers>
+<modifier type="set" field="hidden" value="true">
+<conditions/>
+<conditionGroups/>
+</modifier>
+<modifier type="set" field="hidden" value="false">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="d17a-ef4d-2148-25e8" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+<entryLink id="8de0-52be-784c-00ce" targetId="d571-d584-85fc-9110" type="selectionEntry">
+<modifiers>
+<modifier type="set" field="hidden" value="true">
+<conditions/>
+<conditionGroups/>
+</modifier>
+<modifier type="set" field="hidden" value="false">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="a400-34cd-f726-fbf6" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="15e4-e4af-15f1-94c3" name="Freeborn Command Squad" type="unit" collective="false" hidden="true" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe">
+<costs>
+<cost costTypeId="points" name="pts" value="70.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+</constraints>
+<modifiers>
+<modifier type="set" field="hidden" value="false">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="7f96-ddf7-af5d-958a" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+<selectionEntries>
+<selectionEntry id="8b00-b972-e10d-1390" name="&lt; Freeborn Captain" type="model" collective="false" hidden="false" book="BtGoA" page="190" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="b997-071f-1f47-aee8" name="&lt; Leader Level &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="ed96-be90-06f3-0beb" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="992a-ced2-9419-513c" name="&lt;Freeborn Captain Equipment &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="f80a-cee4-23df-5b8d" name="&lt; Armour &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="0ca1-9662-209b-eb0d" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="a5f8-02a4-689a-510f" name="&lt; Weapons &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="c1d9-84de-92d6-cb72" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<entryLinks/>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="5545-8414-45f3-4c97" targetId="2d89-bcdb-b942-b900" type="profile">
+<modifiers>
+<modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="15e4-e4af-15f1-94c3" childId="ed96-be90-06f3-0beb" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="16e2-4b59-8a36-351a" name="Bodygaurds" type="model" collective="false" hidden="false" book="BtGoA" page="190" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="26.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="2"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="4"/>
+</constraints>
+<modifiers>
+<modifier type="increment" field="maxSelections" value="2.0">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="3933-5e9f-f85c-ba75" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="70fa-1e75-d60b-2e16" name="&lt; Armour &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="f41b-1c7d-c117-325d" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="05c5-0dc8-f360-2012" name="&lt; Weapons &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="b106-d8e7-67b5-3daf" targetId="059b-38f7-0313-5ae4" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="5e80-a56f-41a7-b337" targetId="9fba-d6b7-c66d-99f0" type="profile">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups>
+<selectionEntryGroup id="4fd9-336f-cb2a-74cb" name="&lt; Unit Options &gt;" collective="false" hidden="false">
+<constraints/>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="5c84-6fcb-23cb-c531" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="0534-209c-6e63-b751" targetId="502c-9855-7269-eaa2" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="3cc5-bd4f-f987-bb96" targetId="573b-88bc-97d7-d890" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="9289-3ce8-ce3b-c398" targetId="d118-8115-df5f-2402" type="selectionEntry">
+<modifiers>
+<modifier type="set" field="points" value="2.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+<modifier type="increment" field="points" value="2.0">
+<conditions/>
+<conditionGroups/>
+<repeats>
+<repeat repeats="1" value="1.0" field="selections" scope="15e4-e4af-15f1-94c3" childId="16e2-4b59-8a36-351a" shared="true"/>
+</repeats>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="4224-b512-8e27-a7ae" name="Freeborn Command Squad" type="unit" collective="false" hidden="true" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe">
+<costs>
+<cost costTypeId="points" name="pts" value="70.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+</constraints>
+<modifiers>
+<modifier type="set" field="hidden" value="false">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="a90a-cec1-cd13-3c17" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+<selectionEntries>
+<selectionEntry id="8166-8ae2-85a7-d508" name="&lt; Freeborn Captain" type="model" collective="false" hidden="false" book="BtGoA" page="190" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="ec55-a3a6-79d2-3d8d" name="&lt; Leader Level &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="7539-56fe-d7c4-3436" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="bc83-ae90-8685-ec61" name="&lt;Freeborn Captain Equipment &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="8610-880b-d363-2842" name="&lt; Armour &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="9413-43f9-5e3c-0e39" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="b05f-e970-7acf-b5c2" name="&lt; Weapons &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="dc7e-0219-458d-80af" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<entryLinks/>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="74c9-0721-edb2-fe31" targetId="2d89-bcdb-b942-b900" type="profile">
+<modifiers>
+<modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="4224-b512-8e27-a7ae" childId="ec55-a3a6-79d2-3d8d" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="733f-d5cf-9ed2-cd37" name="Bodygaurds" type="model" collective="false" hidden="false" book="BtGoA" page="190" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="26.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="2"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="4"/>
+</constraints>
+<modifiers>
+<modifier type="increment" field="maxSelections" value="2.0">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="3933-5e9f-f85c-ba75" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="2a25-debf-a112-08f8" name="&lt; Armour &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="94d8-34e0-0bd0-2f8f" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="64e2-25c4-0a20-fd6f" name="&lt; Weapons &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="f2d1-fbb0-ae51-637a" targetId="059b-38f7-0313-5ae4" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="433d-17af-98e2-e708" targetId="9fba-d6b7-c66d-99f0" type="profile">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups>
+<selectionEntryGroup id="01c0-de81-eb4f-6520" name="&lt; Unit Options &gt;" collective="false" hidden="false">
+<constraints/>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="2313-6b51-b6fc-4334" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="55b3-8e97-1f9f-99c1" targetId="502c-9855-7269-eaa2" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="6334-02c5-fe28-46b2" targetId="573b-88bc-97d7-d890" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="94a7-abc4-e849-288a" targetId="d118-8115-df5f-2402" type="selectionEntry">
+<modifiers>
+<modifier type="set" field="points" value="2.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+<modifier type="increment" field="points" value="2.0">
+<conditions/>
+<conditionGroups/>
+<repeats>
+<repeat repeats="1" value="1.0" field="selections" scope="4224-b512-8e27-a7ae" childId="733f-d5cf-9ed2-cd37" shared="true"/>
+</repeats>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="0f65-b8ed-b8b2-294a" name="Freeborn Command Squad" type="unit" collective="false" hidden="true" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe">
+<costs>
+<cost costTypeId="points" name="pts" value="70.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+</constraints>
+<modifiers>
+<modifier type="set" field="hidden" value="false">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="a04c-3029-b790-0cdb" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+<selectionEntries>
+<selectionEntry id="6f3f-e7de-8b1f-9a45" name="&lt; Freeborn Captain" type="model" collective="false" hidden="false" book="BtGoA" page="190" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="3f21-c5d0-9056-3513" name="&lt; Leader Level &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="6ef1-5f41-d717-8432" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="eba6-42f4-e601-d9d4" name="&lt;Freeborn Captain Equipment &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="0c25-94d1-2ee1-8f97" name="&lt; Armour &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="fd6b-8d29-bb72-1f1a" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="1d89-7fac-a8ca-dea9" name="&lt; Weapons &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="bfcd-6dc1-7032-9eca" targetId="059b-38f7-0313-5ae4" type="selectionEntry">
+<modifiers>
+<modifier type="set" field="points" value="8.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<entryLinks/>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="9559-7359-c187-35e7" targetId="2d89-bcdb-b942-b900" type="profile">
+<modifiers>
+<modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="0f65-b8ed-b8b2-294a" childId="6ef1-5f41-d717-8432" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="f539-7c50-1fed-c0fe" name="Bodygaurds" type="model" collective="false" hidden="false" book="BtGoA" page="190" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="26.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="2"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="4"/>
+</constraints>
+<modifiers>
+<modifier type="increment" field="maxSelections" value="2.0">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="3933-5e9f-f85c-ba75" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="db1b-d74c-4488-f114" name="&lt; Armour &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="9dbd-a1b9-f7e2-b802" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="da8e-2b95-0031-818a" name="&lt; Weapons &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="bcc8-515f-8cbc-7a6c" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="c830-2ab1-3be7-3427" targetId="9fba-d6b7-c66d-99f0" type="profile">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups>
+<selectionEntryGroup id="6c4b-1586-3d8b-dbda" name="&lt; Unit Options &gt;" collective="false" hidden="false">
+<constraints/>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="712a-24b1-dd4d-c34e" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="7484-dc39-dbc9-ced2" targetId="502c-9855-7269-eaa2" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="2981-4427-c93a-87d1" targetId="573b-88bc-97d7-d890" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="7113-0a49-238b-ccc3" targetId="d118-8115-df5f-2402" type="selectionEntry">
+<modifiers>
+<modifier type="set" field="points" value="2.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+<modifier type="increment" field="points" value="2.0">
+<conditions/>
+<conditionGroups/>
+<repeats>
+<repeat repeats="1" value="1.0" field="selections" scope="0f65-b8ed-b8b2-294a" childId="f539-7c50-1fed-c0fe" shared="true"/>
+</repeats>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="ff83-951c-1523-67b4" name="Freeborn Command Squad" type="unit" collective="false" hidden="true" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe">
+<costs>
+<cost costTypeId="points" name="pts" value="70.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+</constraints>
+<modifiers>
+<modifier type="set" field="hidden" value="false">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="6559-a8ba-d266-7c27" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+<selectionEntries>
+<selectionEntry id="0b68-b15d-4f21-400d" name="&lt; Freeborn Captain" type="model" collective="false" hidden="false" book="BtGoA" page="190" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="4f77-859f-d36f-3f51" name="&lt; Leader Level &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="fab0-fb87-4db4-b758" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="534d-0cc6-dc8f-0e4a" name="&lt;Freeborn Captain Equipment &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="6168-628e-5ed2-eaa9" name="&lt; Armour &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="be23-8e40-689c-4584" targetId="eff8-bb0e-1b1d-bbb2" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="5ec4-d224-e3cc-e5a6" name="&lt; Weapons &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="bff1-9762-306f-171b" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+<modifiers>
+<modifier type="set" field="points" value="8.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<entryLinks/>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="865b-5fee-3347-eedb" targetId="2d89-bcdb-b942-b900" type="profile">
+<modifiers>
+<modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="ff83-951c-1523-67b4" childId="fab0-fb87-4db4-b758" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="b52c-6be6-7a76-ba77" name="Bodygaurds" type="model" collective="false" hidden="false" book="BtGoA" page="190" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="26.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="2"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="4"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="48ac-19f4-04e6-2834" name="&lt; Armour &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="f1f4-b68d-48a0-6c7f" targetId="eff8-bb0e-1b1d-bbb2" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="1095-6dad-810d-ff4f" name="&lt; Weapons &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="dde5-232c-c035-35fa" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="248c-567b-902f-d5d5" targetId="9fba-d6b7-c66d-99f0" type="profile">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups>
+<selectionEntryGroup id="4329-ec3b-739b-0050" name="&lt; Unit Options &gt;" collective="false" hidden="false">
+<constraints/>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="9bc9-cab0-4841-6c2c" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="c86a-f1fe-6d59-873f" targetId="502c-9855-7269-eaa2" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="e0aa-ee5e-c24a-c338" targetId="573b-88bc-97d7-d890" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="0aac-c5ca-badb-4434" targetId="d118-8115-df5f-2402" type="selectionEntry">
+<modifiers>
+<modifier type="set" field="points" value="2.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+<modifier type="increment" field="points" value="2.0">
+<conditions/>
+<conditionGroups/>
+<repeats>
+<repeat repeats="1" value="1.0" field="selections" scope="ff83-951c-1523-67b4" childId="b52c-6be6-7a76-ba77" shared="true"/>
+</repeats>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="d603-36ff-a2eb-312f" name="Freeborn Command Squad" type="unit" collective="false" hidden="true" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe">
+<costs>
+<cost costTypeId="points" name="pts" value="70.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+</constraints>
+<modifiers>
+<modifier type="set" field="hidden" value="false">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="roster" includeChildSelections="true" childId="1ef5-d006-6a32-fddb" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+<selectionEntries>
+<selectionEntry id="3c30-80dd-c936-7ccf" name="&lt; Freeborn Captain" type="model" collective="false" hidden="false" book="BtGoA" page="190" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="6111-3b3b-a2ef-bdbc" name="&lt; Leader Level &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="7671-d1cb-8583-32f9" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="c091-1c08-a4c1-1e30" name="&lt;Freeborn Captain Equipment &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="90d1-c02b-6791-3678" name="&lt; Armour &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="ef1a-0b88-41e9-520f" targetId="eb94-d1e8-1084-71b3" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="954d-9823-9e71-fdb2" name="&lt; Weapons &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="9620-1c29-bbc5-277d" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<entryLinks/>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="86ad-520b-f8d8-0b4d" targetId="2d89-bcdb-b942-b900" type="profile">
+<modifiers>
+<modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="d603-36ff-a2eb-312f" childId="7671-d1cb-8583-32f9" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="70ef-17b0-4cc6-59d6" name="Bodygaurds" type="model" collective="false" hidden="false" book="BtGoA" page="190" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="26.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="2"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="4"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="b2b0-8472-6f6f-b03b" name="&lt; Armour &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="4966-a136-1d34-1648" targetId="eb94-d1e8-1084-71b3" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="cd16-bf68-6808-737f" name="&lt; Weapons &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="7c24-c3ed-edef-f97d" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="8523-7e21-40bd-02f6" targetId="9fba-d6b7-c66d-99f0" type="profile">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups>
+<selectionEntryGroup id="1359-b8c0-aedb-1bbe" name="&lt; Unit Options &gt;" collective="false" hidden="false">
+<constraints/>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="3c36-c80e-c93c-f6a4" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="9092-1d24-81d4-4b37" targetId="502c-9855-7269-eaa2" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="e184-cee5-0fd5-9e41" targetId="573b-88bc-97d7-d890" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="6f0c-0da4-1e67-2635" targetId="d118-8115-df5f-2402" type="selectionEntry">
+<modifiers>
+<modifier type="set" field="points" value="2.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+<modifier type="increment" field="points" value="2.0">
+<conditions/>
+<conditionGroups/>
+<repeats>
+<repeat repeats="1" value="1.0" field="selections" scope="d603-36ff-a2eb-312f" childId="70ef-17b0-4cc6-59d6" shared="true"/>
+</repeats>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="6a1d-c668-c7e8-ed9f" name="Freeborn Heavy Support Team" type="unit" collective="false" hidden="false" book="BtGoA" page="194" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5">
+<costs>
+<cost costTypeId="points" name="pts" value="25.0"/>
+</costs>
+<constraints/>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="d45c-a6e2-b912-4bcd" name="Freeborn Crew" type="upgrade" collective="false" hidden="false" book="BtGoA" page="193" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="12.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="3"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="4"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="8b71-ca9c-1ca2-0abc" name="&lt; Unit Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="42ad-31e5-60a7-9e01">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="42ad-31e5-60a7-9e01" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="d718-d349-ce44-fe7e" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="3.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="9dd0-b9bb-59a6-5f05" name="&lt; Unit Armor &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="7632-f6c2-622d-6f3a" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="4d7b-6ff6-c6f1-e988" targetId="7267-3051-f1b4-0a88" type="profile">
+<modifiers/>
+</infoLink>
+<infoLink id="e688-49e6-a2dd-5f3f" targetId="87a3-460d-879a-92a5" type="profile">
+<modifiers>
+<modifier type="set" field="hidden" value="false">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="6a1d-c668-c7e8-ed9f" childId="5afb-493a-f716-72df" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups>
+<selectionEntryGroup id="a4e6-016c-c52f-4548" name="&lt; Support Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="f434-b021-4e80-826a">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="f434-b021-4e80-826a" targetId="cea7-8511-2208-1b1f" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="a076-8dc7-3360-7f97" targetId="b9f1-a313-3e59-57ab" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="10.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+<entryLink id="9d3d-0bdc-592a-8e5a" targetId="9733-7039-e306-26b5" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="10.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+<entryLink id="a2ac-6dfc-f14e-fcab" targetId="5149-5183-64d5-feaf" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="10.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="16f8-cbcf-1527-66e2" name="&lt; Unit Options &gt;" collective="false" hidden="false">
+<constraints/>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="5afb-493a-f716-72df" name="Promote Crew Member to Leader" collective="false" hidden="false">
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="fb3e-d593-1cf1-ad9d" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
+<modifiers>
+<modifier type="set" field="points" value="10.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<entryLinks>
+<entryLink id="b8ea-0f50-8af5-3fec" targetId="d571-d584-85fc-9110" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="97c0-d505-6d11-a769" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="b771-d383-4d92-ea6b" targetId="4364-45ee-ee83-ca30" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="1.0">
+<conditions/>
+<conditionGroups/>
+<repeats>
+<repeat repeats="1" value="1.0" field="selections" scope="6a1d-c668-c7e8-ed9f" childId="d45c-a6e2-b912-4bcd" shared="true"/>
+</repeats>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules>
+<rule id="99d8-ad33-bc0e-0a91" name="Weapon Team Unit" hidden="false">
           <modifiers/>
         </rule>
-      </rules>
-      <profiles/>
-      <links>
-        <link id="9ba6-236f-73dc-a81d" targetId="e329-9443-6cb2-bc53" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="0f2b-5fd2-86c3-563b" name="Freeborn Support Team" points="10.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="193">
-      <entries>
-        <entry id="3b68-a4c9-03bb-dd68" name="Freeborn Crew" points="12.0" categoryId="(No Category)" type="upgrade" minSelections="2" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="193">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="09ce-fa1f-63c6-0dee" name="&lt; Unit Weapon &gt;" defaultEntryId="e022-953c-7321-fa34" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="e022-953c-7321-fa34" targetId="8690-3ab7-9fef-06ee" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="af1b-11cd-5a0f-d758" name="&lt; Unit Armor &gt;" defaultEntryId="20cd-dacc-9c25-5545" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="20cd-dacc-9c25-5545" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="6f07-d1a0-a27b-5ab4" targetId="c245-fa49-1569-2f23" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="0ced-d327-0411-d442" targetId="a770-8327-b96d-b92e" linkType="profile">
-              <modifiers>
-                <modifier type="show" field="None" value="0.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="0f2b-5fd2-86c3-563b" childId="8943-c8c6-eaa4-c959" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="85a1-9aa5-986c-0134" name="Weapon" defaultEntryId="5764-6087-e7b6-4c73" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="7198-55af-d564-f2fd" targetId="6a2b-50c5-9a33-b756" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="4711-a1d0-8193-4ddf" targetId="eed0-b68f-b5fb-92c7" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="5764-6087-e7b6-4c73" targetId="a00c-0542-f2a5-8124" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="8c57-5f05-54c3-3b50" targetId="93db-3751-fdd4-08f9" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="40.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="0bef-09de-cda1-001e" targetId="c2bf-0272-30c6-dd20" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="35.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="3f8a-3a73-e583-707c" targetId="cf3a-e6a9-bdc0-e0ae" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="30.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="a7eb-103f-f984-c4f9" targetId="71c9-4382-01cf-c737" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="52c4-3f29-7cff-341f" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="3860-7352-2507-b377" name="Promote Crew Member to Leader" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="8943-c8c6-eaa4-c959" targetId="fc7e-7c0e-65e0-8c33" linkType="entry">
-                  <modifiers>
-                    <modifier type="set" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <links>
-            <link id="d6e9-f088-ecba-53b8" targetId="d571-d584-85fc-9110" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="e4a1-35cb-9989-c083" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="22d3-07af-fc6e-749c" targetId="4364-45ee-ee83-ca30" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="1.0" repeat="true" numRepeats="1" incrementParentId="0f2b-5fd2-86c3-563b" incrementChildId="3b68-a4c9-03bb-dd68" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="a6d0-fc64-ad5d-674a" name="Weapon Team Unit" hidden="false">
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="cff3-e0da-411a-cbd9" name="Get Up!" points="10.0" categoryId="50ba-cf77-3941-189c" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="8563-f338-4ece-a2d7" targetId="2afe-05bf-268b-84c2" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="4881-30cd-5020-cf21" name="Hound Probe shard" points="0.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="196">
-      <entries>
-        <entry id="b84e-d168-f074-70e9" name="&gt; Hound Probe" points="5.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="de6a-8e84-305b-6721" targetId="00b8-b49c-4c61-2943" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="8bc7-33a7-b05c-29d5" targetId="d0a1-129b-f8e5-b1ad" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules>
-        <rule id="a2c9-24be-fc58-b2ce" name="Probe Unit" hidden="false" book="">
+</rules>
+<profiles/>
+<entryLinks>
+<entryLink id="b8d9-62b2-a114-98f3" targetId="e329-9443-6cb2-bc53" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="1405-a43b-534b-ab05" name="Freeborn Nuhu Renegade" type="unit" collective="false" hidden="false" book="BtGoA" page="191" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe">
+<costs>
+<cost costTypeId="points" name="pts" value="114.0"/>
+</costs>
+<constraints/>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="a2f4-4dc6-77ae-47c3" name="&lt; Freeborn Renegade Option &gt;" collective="false" hidden="false" defaultSelectionEntryId="df76-0766-2149-0a05">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="df76-0766-2149-0a05" name="Freeborn Nuhu Renegade" type="model" collective="false" hidden="false" book="BtGoA" page="191" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="b8fc-7c31-a28e-2734" name="&lt; Close Combat Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="6411-27f7-6c9d-41d5">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="6411-27f7-6c9d-41d5" targetId="b357-a997-60e5-053e" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="dfa1-9c18-5508-8d84" name="&lt; Ranged Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="5252-b85f-713e-89e3">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="5252-b85f-713e-89e3" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="c045-a625-7025-1578" targetId="5c9b-1bde-ee01-04a4" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="4078-9939-a810-38ce" targetId="7bc9-5e98-2914-5abd" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="0cec-0def-8aec-1297" targetId="05bb-4d34-70cd-25d2" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="dfe4-8f70-63fd-fcb2" targetId="3c64-6022-a5f1-9c04" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="70d1-ee75-ecc4-1c5e" targetId="0c03-96a3-4833-bc67" type="profile">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="1b3e-6788-9f9a-5ed5" name="Freeborn NuHu Renegade Meld" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="163.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="7f1e-6fe3-4c0d-1835" name="&lt; Close Combat Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="4e50-184a-086b-ddf4">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="4e50-184a-086b-ddf4" targetId="b357-a997-60e5-053e" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="71f0-8ea7-438d-6aaf" name="&lt; Ranged Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="7123-c19b-8cec-f0c7">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="7123-c19b-8cec-f0c7" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="a00c-80d5-2a22-dfbf" targetId="5c9b-1bde-ee01-04a4" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="1773-4ee5-6db6-6430" targetId="7bc9-5e98-2914-5abd" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="10a2-0000-14c0-e073" targetId="3c64-6022-a5f1-9c04" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="79d1-47e4-312e-04d3" targetId="05bb-4d34-70cd-25d2" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="b9b0-d17f-a96e-d0c3" targetId="5565-ce10-1c78-1ee7" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="6355-4d83-0120-3b82" targetId="a97f-4540-de7b-5734" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="6792-be66-d3a6-276b" targetId="5e3d-6905-2b14-8cd1" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="062e-3dd5-efd6-8a93" targetId="68fe-17c2-2841-2cde" type="profile">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups/>
+<entryLinks/>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules>
+<rule id="b2d5-107a-301c-db27" name="Limited Choice" hidden="false" book="">
           <modifiers/>
         </rule>
-      </rules>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="bd58-a73b-e17b-89ae" name="Light General Purpose Drone" points="20.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="196">
-      <entries>
-        <entry id="136e-670b-fde8-eb08" name="GP Drone" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="ee6d-c97a-5f05-6da2" targetId="2dbd-14c5-219e-d37d" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="3dc6-b2b7-80a4-d6db" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="7189-205b-e43f-4b47" name="Self Repair" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="4f3f-a904-dfd8-30e0" targetId="3377-9408-33bb-6a02" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="9c14-af40-c4a6-8c01" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="8fc1-59dc-574d-d478" targetId="d571-d584-85fc-9110" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="b30a-6adc-e0b9-35b5" targetId="1707-586b-01df-0f80" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="ee36-d310-391a-5a23" targetId="fb8b-7402-c5a9-8644" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="ae83-e15b-aca4-e246" name="Weapon Drone Unit" hidden="false" book="BtGoA">
+<rule id="05ad-d2b8-2f3f-67e1" name="Infantry Command Unit" hidden="false" book="">
           <modifiers/>
         </rule>
-      </rules>
-      <profiles/>
-      <links>
-        <link id="bd92-cca5-ea64-865d" targetId="e167-a8e4-c26a-cafd" linkType="rule">
+</rules>
+<profiles/>
+<entryLinks>
+<entryLink id="11d3-ea88-2582-dbc0" targetId="a1c9-551b-1532-ef5a" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="8c9e-c5c0-4339-2c9e" targetId="1707-586b-01df-0f80" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="b557-70e8-d27c-aa9d" targetId="cadc-e1ce-3615-ac4b" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="0223-7d39-0a7c-f8a9" name="Freeborn Skyraider Squad" type="unit" collective="false" hidden="false" book="BtGoA" page="174" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89">
+<costs>
+<cost costTypeId="points" name="pts" value="121.0"/>
+</costs>
+<constraints/>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="cffa-15d6-0631-ed32" name="&lt; Skyraider Leader" type="model" collective="false" hidden="false" book="BtGoA" page="192" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="6fb4-5cba-7e48-83e2" name="Leader Level" collective="false" hidden="false" defaultSelectionEntryId="e5fb-0118-831e-f517">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="86cc-1a90-418d-75d5" targetId="02f3-3134-ae39-afed" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="e5fb-0118-831e-f517" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="7e77-cac2-feab-67d6" targetId="5c9b-1bde-ee01-04a4" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="a17a-173b-6907-b7ee" targetId="7bc9-5e98-2914-5abd" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="1491-1d08-a7c9-d0f4" targetId="e18f-34de-2624-4133" type="profile">
+<modifiers/>
+</infoLink>
+<infoLink id="212a-5750-9cf2-9c7a" targetId="e18f-34de-2624-4133" type="profile">
+<modifiers>
+<modifier type="set" field="3baa-9cfd-f273-822d" value="Large, Fast, Leader 2">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="cffa-15d6-0631-ed32" childId="86cc-1a90-418d-75d5" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="b5b1-72ee-b28c-ed4a" name="Skyraider Trooper" type="model" collective="false" hidden="false" book="BtGoA" page="192" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="2"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="d042-54cc-962c-5c4e" name="&lt; Ranged Weapon &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="60da-034a-d954-5cfc" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="7303-1648-6de4-25ea" targetId="a654-5213-64f2-703a" type="profile">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups>
+<selectionEntryGroup id="84fe-b5cd-ab19-23e4" name="&lt; Skyraider &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="87a0-db4c-17e6-d240" targetId="a1a8-ba0b-2e45-8020" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="46d3-88f8-ecac-204c" name="&lt; Special Weapon Option &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="e34a-7c57-c72d-b20e" targetId="47d9-8149-9744-9849" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="8a5a-b8d3-b9f7-cffb" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="f5d5-4b78-eab5-56a2" name="&lt; Unit Armor &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="2"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="3304-35c1-b35b-5a16" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="41f4-516b-6edc-fa24" targetId="2e3d-bbaa-3f5c-ac53" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="d56e-be22-258f-698c" name="&lt; Unit Options &gt; " collective="false" hidden="false">
+<constraints/>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="a434-7a9b-75cb-d4be" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules>
+<rule id="a61b-d8b1-c4a3-6102" name="Mounted Command Unit" hidden="false">
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="9cfb-19e0-05ac-1e47" name="M25 Type Heavy Combat Drone" points="418.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="195">
-      <entries>
-        <entry id="01f5-c3d0-42de-8d99" name="&gt; Transporter Drone" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="195">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="0bd6-01b0-8347-296b" name="&lt; Weapon &gt;" defaultEntryId="dd0c-d323-b658-fa67" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="dd0c-d323-b658-fa67" targetId="67b6-d6f5-5ba3-e50d" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="62ea-7660-3ccf-313c" targetId="af24-45f9-4669-bf98" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="25.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
+        </rule>
+<rule id="572f-a685-c7aa-3d42" name="Limited Choice" hidden="false">
           <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="2c9f-5d67-5f75-022c" targetId="5425-1edf-f536-d5a1" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="bcac-a955-0a97-bdb0" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="e39c-f576-faa5-f1da" name="Self Repair" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="ee9f-3fa4-0af8-ce9e" targetId="3377-9408-33bb-6a02" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
+        </rule>
+</rules>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="c8b0-00c2-4509-d681" targetId="b0ca-8e7d-d03f-f027" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="3fb0-934a-d1a8-ed1e" targetId="a221-d53c-b4bd-b52c" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="5db6-c261-8463-2fde" name="Freeborn Specialist Heavy Support Team" type="unit" collective="false" hidden="false" book="BtGoA" page="194" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5">
+<costs>
+<cost costTypeId="points" name="pts" value="45.0"/>
+</costs>
+<constraints/>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="bb44-58f4-62b7-989d" name="Freeborn Crew" type="upgrade" collective="false" hidden="false" book="BtGoA" page="193" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="12.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="3"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="4"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="da65-0295-8e02-4356" name="&lt; Unit Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="e081-6f9b-47f1-8d2e">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="e081-6f9b-47f1-8d2e" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="1af1-0c6d-46fc-9a90" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="3.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="8003-fecb-500b-a2f1" name="&lt; Unit Armor &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="76fe-447d-63af-8c97" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="7e69-7f6d-660b-ada8" targetId="7267-3051-f1b4-0a88" type="profile">
+<modifiers/>
+</infoLink>
+<infoLink id="f359-8e60-9b6c-caf8" targetId="87a3-460d-879a-92a5" type="profile">
+<modifiers>
+<modifier type="set" field="hidden" value="false">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="5db6-c261-8463-2fde" childId="4117-a3fe-bf51-e9fe" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups>
+<selectionEntryGroup id="7b8f-9d4d-fe28-010d" name="&lt; Support Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="c4cb-5ad3-29f5-e064">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="1d83-6417-d5ba-71b0" targetId="2cec-e1d7-c680-7ca0" type="selectionEntry">
+<modifiers>
+<modifier type="set" field="points" value="15.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+<entryLink id="c4cb-5ad3-29f5-e064" targetId="67b6-d6f5-5ba3-e50d" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="8ae5-cb57-4392-b6d3" name="&lt; Unit Options &gt;" collective="false" hidden="false">
+<constraints/>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="4117-a3fe-bf51-e9fe" name="Promote one crew to Leader" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="10.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="6735-38dd-ba7c-0697" targetId="d571-d584-85fc-9110" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="58d6-220a-a277-4d27" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="1bed-3774-e8f1-9891" targetId="4364-45ee-ee83-ca30" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="2.0">
+<conditions/>
+<conditionGroups/>
+<repeats>
+<repeat repeats="1" value="1.0" field="selections" scope="5db6-c261-8463-2fde" childId="bb44-58f4-62b7-989d" shared="true"/>
+</repeats>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules>
+<rule id="cfca-4aa7-d6d4-b77e" name="Weapon Team Unit" hidden="false">
           <modifiers/>
-          <links>
-            <link id="f37d-a025-3c15-4abf" targetId="1707-586b-01df-0f80" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="80cd-1a9a-13f7-0d35" targetId="8f68-d09d-6e26-c6ea" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="ecf7-a64a-293a-de72" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="3edb-e997-53e8-ad4a" targetId="e329-9443-6cb2-bc53" linkType="entry">
+        </rule>
+</rules>
+<profiles/>
+<entryLinks>
+<entryLink id="a700-75fe-fedc-4a1d" targetId="e329-9443-6cb2-bc53" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="e040-74bb-81d2-742f" name="Freeborn Specialist Heavy Support Team w/ Compression Bombard" type="unit" collective="false" hidden="false" book="Battle for Xilos" page="19483" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5">
+<costs>
+<cost costTypeId="points" name="pts" value="45.0"/>
+</costs>
+<constraints/>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="3f02-0f65-aa87-f29b" name="Freeborn Crew" type="upgrade" collective="false" hidden="false" book="BtGoA" page="193" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="12.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="3"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="4"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="e24b-2ff8-7c27-8ba7" name="&lt; Unit Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="ff3e-645a-e8d0-d896">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="ff3e-645a-e8d0-d896" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="b5d8-4f59-792a-5aa0" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="3.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="a0b8-45f2-80c2-2e6f" name="&lt; Unit Armor &gt;" collective="false" hidden="false" defaultSelectionEntryId="9db6-ea3f-f9ce-9280">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="9db6-ea3f-f9ce-9280" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="2e53-4fbd-d21f-0ff4" targetId="7267-3051-f1b4-0a88" type="profile">
+<modifiers/>
+</infoLink>
+<infoLink id="a311-98bd-dc31-1e18" targetId="87a3-460d-879a-92a5" type="profile">
+<modifiers>
+<modifier type="set" field="hidden" value="false">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="e040-74bb-81d2-742f" childId="30cb-c08e-9c00-1db2" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups>
+<selectionEntryGroup id="10be-7777-50bb-0438" name="&lt; Support Weapon &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="1f73-aed3-4502-cebb" targetId="af24-45f9-4669-bf98" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="b980-251d-2639-9888" name="&lt; Unit Options &gt;" collective="false" hidden="false">
+<constraints/>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="30cb-c08e-9c00-1db2" name="Promote one crew to Leader" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="10.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="cdac-db4e-1fea-369a" targetId="d571-d584-85fc-9110" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="2daa-0c1c-11a8-0cb0" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="de04-6777-8685-d52a" targetId="4364-45ee-ee83-ca30" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="1.0">
+<conditions/>
+<conditionGroups/>
+<repeats>
+<repeat repeats="1" value="1.0" field="selections" scope="e040-74bb-81d2-742f" childId="3f02-0f65-aa87-f29b" shared="true"/>
+</repeats>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules>
+<rule id="b131-f742-1197-dc55" name="Weapon Team Unit" hidden="false">
           <modifiers/>
-        </link>
-        <link id="27e0-0043-07dc-ece0" targetId="a221-d53c-b4bd-b52c" linkType="rule">
+        </rule>
+</rules>
+<profiles/>
+<entryLinks>
+<entryLink id="9ba6-236f-73dc-a81d" targetId="e329-9443-6cb2-bc53" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="0f2b-5fd2-86c3-563b" name="Freeborn Support Team" type="unit" collective="false" hidden="false" book="BtGoA" page="193" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89">
+<costs>
+<cost costTypeId="points" name="pts" value="10.0"/>
+</costs>
+<constraints/>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="3b68-a4c9-03bb-dd68" name="Freeborn Crew" type="upgrade" collective="false" hidden="false" book="BtGoA" page="193" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="12.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="2"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="3"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="09ce-fa1f-63c6-0dee" name="&lt; Unit Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="e022-953c-7321-fa34">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="e022-953c-7321-fa34" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="af1b-11cd-5a0f-d758" name="&lt; Unit Armor &gt;" collective="false" hidden="false" defaultSelectionEntryId="20cd-dacc-9c25-5545">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="20cd-dacc-9c25-5545" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="6f07-d1a0-a27b-5ab4" targetId="c245-fa49-1569-2f23" type="profile">
+<modifiers/>
+</infoLink>
+<infoLink id="0ced-d327-0411-d442" targetId="a770-8327-b96d-b92e" type="profile">
+<modifiers>
+<modifier type="set" field="hidden" value="false">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="0f2b-5fd2-86c3-563b" childId="8943-c8c6-eaa4-c959" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups>
+<selectionEntryGroup id="85a1-9aa5-986c-0134" name="Weapon" collective="false" hidden="false" defaultSelectionEntryId="5764-6087-e7b6-4c73">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="7198-55af-d564-f2fd" targetId="6a2b-50c5-9a33-b756" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="10.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+<entryLink id="4711-a1d0-8193-4ddf" targetId="eed0-b68f-b5fb-92c7" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="5764-6087-e7b6-4c73" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="8c57-5f05-54c3-3b50" targetId="93db-3751-fdd4-08f9" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="40.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+<entryLink id="0bef-09de-cda1-001e" targetId="c2bf-0272-30c6-dd20" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="35.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+<entryLink id="3f8a-3a73-e583-707c" targetId="cf3a-e6a9-bdc0-e0ae" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="30.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+<entryLink id="a7eb-103f-f984-c4f9" targetId="71c9-4382-01cf-c737" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="10.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="52c4-3f29-7cff-341f" name="&lt; Unit Options &gt;" collective="false" hidden="false">
+<constraints/>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="3860-7352-2507-b377" name="Promote Crew Member to Leader" collective="false" hidden="false">
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="8943-c8c6-eaa4-c959" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
+<modifiers>
+<modifier type="set" field="points" value="10.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<entryLinks>
+<entryLink id="d6e9-f088-ecba-53b8" targetId="d571-d584-85fc-9110" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="e4a1-35cb-9989-c083" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="22d3-07af-fc6e-749c" targetId="4364-45ee-ee83-ca30" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="1.0">
+<conditions/>
+<conditionGroups/>
+<repeats>
+<repeat repeats="1" value="1.0" field="selections" scope="0f2b-5fd2-86c3-563b" childId="3b68-a4c9-03bb-dd68" shared="true"/>
+</repeats>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules>
+<rule id="a6d0-fc64-ad5d-674a" name="Weapon Team Unit" hidden="false">
           <modifiers/>
-        </link>
-        <link id="9d1c-1cca-ed53-b1b0" targetId="7c88-64d4-50ad-2313" linkType="rule">
+        </rule>
+</rules>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="cff3-e0da-411a-cbd9" name="Get Up!" type="upgrade" collective="false" hidden="false" categoryEntryId="50ba-cf77-3941-189c">
+<costs>
+<cost costTypeId="points" name="pts" value="10.0"/>
+</costs>
+<constraints/>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="8563-f338-4ece-a2d7" targetId="2afe-05bf-268b-84c2" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="4881-30cd-5020-cf21" name="Hound Probe shard" type="unit" collective="false" hidden="false" book="BtGoA" page="196" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints/>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="b84e-d168-f074-70e9" name="&gt; Hound Probe" type="model" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="5.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="4"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="6"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="de6a-8e84-305b-6721" targetId="00b8-b49c-4c61-2943" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="8bc7-33a7-b05c-29d5" targetId="d0a1-129b-f8e5-b1ad" type="profile">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups/>
+<rules>
+<rule id="a2c9-24be-fc58-b2ce" name="Probe Unit" hidden="false" book="">
           <modifiers/>
-        </link>
-        <link id="04b2-5695-d4ce-6256" targetId="8151-2e24-94ee-0477" linkType="rule">
+        </rule>
+</rules>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="bd58-a73b-e17b-89ae" name="Light General Purpose Drone" type="unit" collective="false" hidden="false" book="BtGoA" page="196" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d">
+<costs>
+<cost costTypeId="points" name="pts" value="20.0"/>
+</costs>
+<constraints/>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="136e-670b-fde8-eb08" name="GP Drone" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="ee6d-c97a-5f05-6da2" targetId="2dbd-14c5-219e-d37d" type="profile">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups>
+<selectionEntryGroup id="3dc6-b2b7-80a4-d6db" name="&lt; Unit Options &gt;" collective="false" hidden="false">
+<constraints/>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="7189-205b-e43f-4b47" name="Self Repair" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers>
+<modifier type="increment" field="points" value="10.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="4f3f-a904-dfd8-30e0" targetId="3377-9408-33bb-6a02" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="9c14-af40-c4a6-8c01" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="8fc1-59dc-574d-d478" targetId="d571-d584-85fc-9110" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="b30a-6adc-e0b9-35b5" targetId="1707-586b-01df-0f80" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="ee36-d310-391a-5a23" targetId="fb8b-7402-c5a9-8644" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules>
+<rule id="ae83-e15b-aca4-e246" name="Weapon Drone Unit" hidden="false" book="BtGoA">
           <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="530f-c210-1c10-4819" name="M4 Type Combat Drone" points="249.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="195">
-      <entries>
-        <entry id="30bd-b309-a7e2-ce17" name="&gt; Combat Drone" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="195">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="e349-a387-3011-cdb4" name="&lt; Main Weapon &gt;" defaultEntryId="64cd-d0a7-af3d-bd56" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="64cd-d0a7-af3d-bd56" targetId="c2bf-0272-30c6-dd20" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="905e-efa8-94c5-0f56" targetId="93db-3751-fdd4-08f9" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="5.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-                <link id="c54e-bd52-591e-31d6" targetId="71c9-4382-01cf-c737" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="5.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="e4b6-ff25-d3f7-7d36" targetId="0f97-9dbe-566a-5ab0" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="a8b4-2c55-d8de-de72" targetId="eb0f-0718-35d7-1a00" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="42d3-0396-7538-2afe" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="3d7b-8b6c-0bc7-2176" name="Self Repair" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="50db-2d5d-b0d3-7ab6" targetId="3377-9408-33bb-6a02" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="5b5a-646b-cdc9-70c6" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="6b3d-030d-2e2f-db4e" targetId="8f68-d09d-6e26-c6ea" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="c15c-7bd3-0f3e-e876" targetId="1707-586b-01df-0f80" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="b25f-8a2f-5932-bb6a" targetId="5565-ce10-1c78-1ee7" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="1334-f2ea-a5eb-674c" targetId="a221-d53c-b4bd-b52c" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="1504-b595-21a5-1772" targetId="e329-9443-6cb2-bc53" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="3df6-b3d9-248f-350b" name="M50 Type Heavy Combat Drone" points="418.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="195">
-      <entries>
-        <entry id="aaf8-6738-2b45-c252" name="&gt; Heavy Support Drone" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="195">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="5086-9f66-b442-f987" name="&lt; Weapon &gt;" defaultEntryId="1e4a-57fb-e968-6982" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="1e4a-57fb-e968-6982" targetId="b9f1-a313-3e59-57ab" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="2b26-87e7-1e8f-ea79" targetId="9733-7039-e306-26b5" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="7053-b744-1b1a-bbeb" targetId="2cec-e1d7-c680-7ca0" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="25.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="250a-e588-2f82-7123" targetId="9e2a-f076-d4df-b60a" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="c089-dc26-6ac4-a9e0" targetId="0f97-9dbe-566a-5ab0" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="8226-5f69-098e-16a2" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="b1c4-3032-4af5-5874" name="Self Repair" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="dc4e-ba2d-8399-9b36" targetId="3377-9408-33bb-6a02" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="92d7-f414-c1e1-175b" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="7a1a-41e1-fcdc-3390" targetId="8f68-d09d-6e26-c6ea" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="a7a7-9da8-ef6f-2592" targetId="1707-586b-01df-0f80" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="2e55-1966-d767-c4f5" targetId="a221-d53c-b4bd-b52c" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="b56d-83bb-8c53-a2ee" targetId="7c88-64d4-50ad-2313" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="8342-2c8c-460a-7d1d" targetId="8151-2e24-94ee-0477" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="6d78-6ff1-689b-45b9" targetId="e329-9443-6cb2-bc53" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="68e5-824d-8e72-1018" name="Marksman" points="15.0" categoryId="50ba-cf77-3941-189c" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="1054-eaa0-48d3-3dfa" targetId="5741-af68-9dc0-519f" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="771e-7953-547e-2082" name="Misgenic Rejects" points="0.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="196">
-      <entries>
-        <entry id="6098-b5c2-1d8a-a1b6" name="Misgenic Rejects" points="5.0" categoryId="(No Category)" type="model" minSelections="6" maxSelections="12" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="196">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="7079-9c86-12a0-461d" profileTypeId="1650-77b3-10d1-6406" name="Misgenic Rejects" hidden="false" book="BtGoA" page="196">
+        </rule>
+</rules>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="bd92-cca5-ea64-865d" targetId="e167-a8e4-c26a-cafd" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="9cfb-19e0-05ac-1e47" name="M25 Type Heavy Combat Drone" type="unit" collective="false" hidden="false" book="BtGoA" page="195" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5">
+<costs>
+<cost costTypeId="points" name="pts" value="418.0"/>
+</costs>
+<constraints/>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="01f5-c3d0-42de-8d99" name="&gt; Transporter Drone" type="model" collective="false" hidden="false" book="BtGoA" page="195" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="0bd6-01b0-8347-296b" name="&lt; Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="dd0c-d323-b658-fa67">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="dd0c-d323-b658-fa67" targetId="67b6-d6f5-5ba3-e50d" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="62ea-7660-3ccf-313c" targetId="af24-45f9-4669-bf98" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="25.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="2c9f-5d67-5f75-022c" targetId="5425-1edf-f536-d5a1" type="profile">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups>
+<selectionEntryGroup id="bcac-a955-0a97-bdb0" name="&lt; Unit Options &gt;" collective="false" hidden="false">
+<constraints/>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="e39c-f576-faa5-f1da" name="Self Repair" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers>
+<modifier type="increment" field="points" value="10.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="ee9f-3fa4-0af8-ce9e" targetId="3377-9408-33bb-6a02" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="f37d-a025-3c15-4abf" targetId="1707-586b-01df-0f80" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="80cd-1a9a-13f7-0d35" targetId="8f68-d09d-6e26-c6ea" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="ecf7-a64a-293a-de72" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks>
+<entryLink id="3edb-e997-53e8-ad4a" targetId="e329-9443-6cb2-bc53" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+<infoLinks>
+<infoLink id="27e0-0043-07dc-ece0" targetId="a221-d53c-b4bd-b52c" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="9d1c-1cca-ed53-b1b0" targetId="7c88-64d4-50ad-2313" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="04b2-5695-d4ce-6256" targetId="8151-2e24-94ee-0477" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="530f-c210-1c10-4819" name="M4 Type Combat Drone" type="unit" collective="false" hidden="false" book="BtGoA" page="195" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5">
+<costs>
+<cost costTypeId="points" name="pts" value="249.0"/>
+</costs>
+<constraints/>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="30bd-b309-a7e2-ce17" name="&gt; Combat Drone" type="model" collective="false" hidden="false" book="BtGoA" page="195" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="e349-a387-3011-cdb4" name="&lt; Main Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="64cd-d0a7-af3d-bd56">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="64cd-d0a7-af3d-bd56" targetId="c2bf-0272-30c6-dd20" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="905e-efa8-94c5-0f56" targetId="93db-3751-fdd4-08f9" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="5.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+<entryLink id="c54e-bd52-591e-31d6" targetId="71c9-4382-01cf-c737" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="5.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks>
+<entryLink id="e4b6-ff25-d3f7-7d36" targetId="0f97-9dbe-566a-5ab0" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+<infoLinks>
+<infoLink id="a8b4-2c55-d8de-de72" targetId="eb0f-0718-35d7-1a00" type="profile">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups>
+<selectionEntryGroup id="42d3-0396-7538-2afe" name="&lt; Unit Options &gt;" collective="false" hidden="false">
+<constraints/>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="3d7b-8b6c-0bc7-2176" name="Self Repair" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers>
+<modifier type="increment" field="points" value="10.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="50db-2d5d-b0d3-7ab6" targetId="3377-9408-33bb-6a02" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="5b5a-646b-cdc9-70c6" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="6b3d-030d-2e2f-db4e" targetId="8f68-d09d-6e26-c6ea" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="c15c-7bd3-0f3e-e876" targetId="1707-586b-01df-0f80" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks>
+<entryLink id="1504-b595-21a5-1772" targetId="e329-9443-6cb2-bc53" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+<infoLinks>
+<infoLink id="b25f-8a2f-5932-bb6a" targetId="5565-ce10-1c78-1ee7" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="1334-f2ea-a5eb-674c" targetId="a221-d53c-b4bd-b52c" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="3df6-b3d9-248f-350b" name="M50 Type Heavy Combat Drone" type="unit" collective="false" hidden="false" book="BtGoA" page="195" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5">
+<costs>
+<cost costTypeId="points" name="pts" value="418.0"/>
+</costs>
+<constraints/>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="aaf8-6738-2b45-c252" name="&gt; Heavy Support Drone" type="model" collective="false" hidden="false" book="BtGoA" page="195" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="5086-9f66-b442-f987" name="&lt; Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="1e4a-57fb-e968-6982">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="1e4a-57fb-e968-6982" targetId="b9f1-a313-3e59-57ab" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="2b26-87e7-1e8f-ea79" targetId="9733-7039-e306-26b5" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="7053-b744-1b1a-bbeb" targetId="2cec-e1d7-c680-7ca0" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="25.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks>
+<entryLink id="c089-dc26-6ac4-a9e0" targetId="0f97-9dbe-566a-5ab0" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+<infoLinks>
+<infoLink id="250a-e588-2f82-7123" targetId="9e2a-f076-d4df-b60a" type="profile">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups>
+<selectionEntryGroup id="8226-5f69-098e-16a2" name="&lt; Unit Options &gt;" collective="false" hidden="false">
+<constraints/>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="b1c4-3032-4af5-5874" name="Self Repair" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers>
+<modifier type="increment" field="points" value="10.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="dc4e-ba2d-8399-9b36" targetId="3377-9408-33bb-6a02" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="92d7-f414-c1e1-175b" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="7a1a-41e1-fcdc-3390" targetId="8f68-d09d-6e26-c6ea" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="a7a7-9da8-ef6f-2592" targetId="1707-586b-01df-0f80" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks>
+<entryLink id="6d78-6ff1-689b-45b9" targetId="e329-9443-6cb2-bc53" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+<infoLinks>
+<infoLink id="2e55-1966-d767-c4f5" targetId="a221-d53c-b4bd-b52c" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="b56d-83bb-8c53-a2ee" targetId="7c88-64d4-50ad-2313" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="8342-2c8c-460a-7d1d" targetId="8151-2e24-94ee-0477" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="68e5-824d-8e72-1018" name="Marksman" type="upgrade" collective="false" hidden="false" categoryEntryId="50ba-cf77-3941-189c">
+<costs>
+<cost costTypeId="points" name="pts" value="15.0"/>
+</costs>
+<constraints>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="1" includeChildSelections="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="1" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="1054-eaa0-48d3-3dfa" targetId="5741-af68-9dc0-519f" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="771e-7953-547e-2082" name="Misgenic Rejects" type="unit" collective="false" hidden="false" book="BtGoA" page="196" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints/>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="6098-b5c2-1d8a-a1b6" name="Misgenic Rejects" type="model" collective="false" hidden="false" book="BtGoA" page="196" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="5.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="6"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="12"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="7079-9c86-12a0-461d" profileTypeId="1650-77b3-10d1-6406" name="Misgenic Rejects" hidden="false" book="BtGoA" page="196">
               <characteristics>
-                <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-                <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-                <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-                <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-                <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-                <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="7"/>
+                <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
+                <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
+                <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
+                <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5"/>
+                <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
+                <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="7"/>
               </characteristics>
               <modifiers/>
             </profile>
-          </profiles>
-          <links/>
-        </entry>
-        <entry id="523a-c675-bb65-766b" name="Promote one reject to Leader" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="85a6-e9d0-03ac-593c" name="Leader One" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="5b45-20ce-68b0-7e0c" targetId="e441-c3a6-7d61-2c63" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-        <entry id="e3fa-3d4f-d370-193c" name="More Misgenic Abilities" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="196">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="627d-95ce-0cb7-067d" targetId="db7a-5bd4-6400-f6d1" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="e1f2-aa77-1cf5-d89f" name="Pull Yourself Together!" points="15.0" categoryId="50ba-cf77-3941-189c" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="96ff-949d-ec39-33e0" targetId="8056-104a-5a5d-2089" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="969a-8139-9654-9cdf" name="Skyraider Command Squad" points="164.0" categoryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="174">
-      <entries>
-        <entry id="d40e-0a4d-13fa-863b" name="&lt; Skyraider Captain" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="192">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="e0b2-8c3a-7575-9736" name="Leader Level" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="4ac0-b84e-687f-e73b" targetId="5a4c-2f5e-40a2-91d4" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="0b4f-18e9-64d4-1bc8" targetId="5c9b-1bde-ee01-04a4" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="7780-1ba7-1b1c-b4c2" targetId="7bc9-5e98-2914-5abd" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="f186-3a30-6680-477f" targetId="e18f-34de-2624-4133" linkType="profile">
-              <modifiers/>
-            </link>
-            <link id="8ac3-35e0-d064-d5b0" targetId="74dc-b388-dc1d-fb61" linkType="profile">
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command, Hero, Follow, Large, Fast, Leader 3" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions>
-                    <condition parentId="d40e-0a4d-13fa-863b" childId="4ac0-b84e-687f-e73b" field="selections" type="equal to" value="1.0"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="2c42-d94f-83c4-fb4f" name="Skyraider Trooper" points="0.0" categoryId="(No Category)" type="model" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="192">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="62da-827c-1a4c-bfef" name="&lt; Ranged Weapon &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="5c2c-6873-9857-0546" targetId="84ac-0f31-c388-d0bd" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="a18a-ce88-b9af-89e7" targetId="a654-5213-64f2-703a" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="2996-96fd-31e3-fe8c" name="&lt; Skyraider &gt;" defaultEntryId="92a3-2543-174e-504b" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="92a3-2543-174e-504b" targetId="a1a8-ba0b-2e45-8020" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="5f94-8423-056d-5f54" name="&lt; Special Weapon Option &gt;" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="b3cb-790e-d4ae-710a" targetId="47d9-8149-9744-9849" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="0f9b-216d-3f08-d82e" targetId="a00c-0542-f2a5-8124" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="2d2f-4f61-9b31-50b5" name="&lt; Unit Armor &gt;" defaultEntryId="6df8-de07-b4b9-201f" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="6df8-de07-b4b9-201f" targetId="9cdf-f068-bbde-2d0c" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="0eff-479f-05c9-7f65" targetId="2e3d-bbaa-3f5c-ac53" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="1858-3233-777b-6a0f" name="&lt; Unit Options &gt; " minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="8350-a307-4835-3176" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules>
-        <rule id="76be-d990-01b2-40b5" name="Mounted Command Unit" hidden="false">
-          <modifiers/>
-        </rule>
-        <rule id="801f-37d3-aeef-35ef" name="Limited Choice" hidden="false">
-          <modifiers/>
-        </rule>
-      </rules>
-      <profiles/>
-      <links>
-        <link id="8ada-48df-990a-b1c6" targetId="b0ca-8e7d-d03f-f027" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="0026-0fee-242b-f524" targetId="a221-d53c-b4bd-b52c" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="1fc7-db89-4652-3c98" name="Superior Shard" points="15.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="1" minInRoster="0" maxInRoster="1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="661d-86ab-a747-8bb5" targetId="d4f5-697e-dbf0-ced2" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="859c-f6ff-bc8a-74cf" name="T7 Type Transporter Drone" points="164.0" categoryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="195">
-      <entries>
-        <entry id="e215-3b85-89ba-1fc8" name="&gt; Transporter Drone" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="195">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="8a07-2ee4-8417-4ab3" name="&lt; Weapon &gt;" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="4ff7-f2df-7ced-d8f0" targetId="a00c-0542-f2a5-8124" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="d2cf-994c-12f0-9c5b" targetId="6a2b-50c5-9a33-b756" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-                <link id="5a7f-0ae6-6b32-4321" targetId="cf3a-e6a9-bdc0-e0ae" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="30.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-                <link id="439c-15d6-48b7-16d2" targetId="ac1e-a740-57b7-cc64" linkType="entry">
-                  <modifiers>
-                    <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="a5f0-4afc-16c4-72f9" targetId="5425-1edf-f536-d5a1" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="48a3-5d25-ade2-1097" name="&lt; Unit Options &gt;" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="ad46-f5e3-e9f3-a7de" name="Self Repair" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="4565-ded9-505e-aced" targetId="3377-9408-33bb-6a02" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="064d-4c81-4e23-79d4" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="b2ad-61e0-f7fe-f5d0" targetId="d571-d584-85fc-9110" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="6f20-1361-0577-c4cf" targetId="1707-586b-01df-0f80" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="c985-b014-70bf-635d" targetId="5565-ce10-1c78-1ee7" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="40c3-e6f7-a42a-fd30" targetId="a221-d53c-b4bd-b52c" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="8eaf-ef10-dfe5-8f3a" targetId="ab37-33d8-41f3-7532" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="aa6c-67b7-3d3b-2a61" name="Targeter Probe Shard" points="0.0" categoryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="196">
-      <entries>
-        <entry id="31ff-3d6d-2a30-3b5a" name="&gt; Targeter Probe" points="5.0" categoryId="(No Category)" type="model" minSelections="4" maxSelections="6" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="58b0-e470-5c3a-0e30" targetId="00b8-b49c-4c61-2943" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="6620-e65c-9afa-7ed9" targetId="4d5f-ccb4-75c2-cbf2" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules>
-        <rule id="8104-2eac-f495-21f9" name="Probe Unit" hidden="false" book="">
+</profiles>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="523a-c675-bb65-766b" name="Promote one reject to Leader" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="85a6-e9d0-03ac-593c" name="Leader One" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="10.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="5b45-20ce-68b0-7e0c" targetId="e441-c3a6-7d61-2c63" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="e3fa-3d4f-d370-193c" name="More Misgenic Abilities" type="upgrade" collective="false" hidden="false" book="BtGoA" page="196" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="10.0"/>
+</costs>
+<constraints/>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="627d-95ce-0cb7-067d" targetId="db7a-5bd4-6400-f6d1" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="e1f2-aa77-1cf5-d89f" name="Pull Yourself Together!" type="upgrade" collective="false" hidden="false" categoryEntryId="50ba-cf77-3941-189c">
+<costs>
+<cost costTypeId="points" name="pts" value="15.0"/>
+</costs>
+<constraints/>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="96ff-949d-ec39-33e0" targetId="8056-104a-5a5d-2089" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="969a-8139-9654-9cdf" name="Skyraider Command Squad" type="unit" collective="false" hidden="false" book="BtGoA" page="174" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89">
+<costs>
+<cost costTypeId="points" name="pts" value="164.0"/>
+</costs>
+<constraints/>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="d40e-0a4d-13fa-863b" name="&lt; Skyraider Captain" type="model" collective="false" hidden="false" book="BtGoA" page="192" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="e0b2-8c3a-7575-9736" name="Leader Level" collective="false" hidden="false">
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="4ac0-b84e-687f-e73b" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="0b4f-18e9-64d4-1bc8" targetId="5c9b-1bde-ee01-04a4" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="7780-1ba7-1b1c-b4c2" targetId="7bc9-5e98-2914-5abd" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="f186-3a30-6680-477f" targetId="e18f-34de-2624-4133" type="profile">
+<modifiers/>
+</infoLink>
+<infoLink id="8ac3-35e0-d064-d5b0" targetId="74dc-b388-dc1d-fb61" type="profile">
+<modifiers>
+<modifier type="set" field="3baa-9cfd-f273-822d" value="Command, Hero, Follow, Large, Fast, Leader 3">
+<conditions>
+<condition type="equalTo" value="1.0" field="selections" scope="d40e-0a4d-13fa-863b" childId="4ac0-b84e-687f-e73b" shared="true"/>
+</conditions>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="2c42-d94f-83c4-fb4f" name="Skyraider Trooper" type="model" collective="false" hidden="false" book="BtGoA" page="192" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="2"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="62da-827c-1a4c-bfef" name="&lt; Ranged Weapon &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="5c2c-6873-9857-0546" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="a18a-ce88-b9af-89e7" targetId="a654-5213-64f2-703a" type="profile">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups>
+<selectionEntryGroup id="2996-96fd-31e3-fe8c" name="&lt; Skyraider &gt;" collective="false" hidden="false" defaultSelectionEntryId="92a3-2543-174e-504b">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="92a3-2543-174e-504b" targetId="a1a8-ba0b-2e45-8020" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="5f94-8423-056d-5f54" name="&lt; Special Weapon Option &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="b3cb-790e-d4ae-710a" targetId="47d9-8149-9744-9849" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="0f9b-216d-3f08-d82e" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="2d2f-4f61-9b31-50b5" name="&lt; Unit Armor &gt;" collective="false" hidden="false" defaultSelectionEntryId="6df8-de07-b4b9-201f">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="2"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="6df8-de07-b4b9-201f" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="0eff-479f-05c9-7f65" targetId="2e3d-bbaa-3f5c-ac53" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="1858-3233-777b-6a0f" name="&lt; Unit Options &gt; " collective="false" hidden="false">
+<constraints/>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="8350-a307-4835-3176" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules>
+<rule id="76be-d990-01b2-40b5" name="Mounted Command Unit" hidden="false">
           <modifiers/>
         </rule>
-      </rules>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="40ad-08b6-fa6a-0171" name="Vardanari Squad (Guards)" points="42.0" categoryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="191">
-      <entries>
-        <entry id="c3fa-7787-a4d1-50f8" name="&lt; Vardanari Leader" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="191">
-          <entries/>
-          <entryGroups>
-            <entryGroup id="189f-239f-cc54-f496" name="&lt; Leader Level &gt;" defaultEntryId="7ea8-bf13-37df-8acf" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries>
-                <entry id="6cd8-052e-b9da-e94e" name="Leader 2" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-                  <entries/>
-                  <entryGroups/>
-                  <modifiers/>
-                  <rules/>
-                  <profiles/>
-                  <links>
-                    <link id="f2ac-6316-75a8-0504" targetId="7850-89e7-bab8-86e9" linkType="rule">
-                      <modifiers/>
-                    </link>
-                  </links>
-                </entry>
-              </entries>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="7ea8-bf13-37df-8acf" targetId="fc7e-7c0e-65e0-8c33" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-            <entryGroup id="f5ed-8cd5-154e-1987" name="&lt; Ranged Weapon &gt;" defaultEntryId="c12f-a100-2c77-940b" minSelections="2" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <links>
-                <link id="c12f-a100-2c77-940b" targetId="b018-6101-d2e3-b4ea" linkType="entry">
-                  <modifiers/>
-                </link>
-                <link id="02d9-18d6-822b-c297" targetId="179a-c0cc-49cc-c946" linkType="entry">
-                  <modifiers/>
-                </link>
-              </links>
-            </entryGroup>
-          </entryGroups>
+<rule id="801f-37d3-aeef-35ef" name="Limited Choice" hidden="false">
           <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="dbcb-5feb-24da-acaf" targetId="8de3-1e72-72ef-e7a3" linkType="entry">
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-            <link id="1a89-bc54-c850-a7a0" targetId="62fc-1d76-c6fd-a3eb" linkType="profile">
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2" repeat="false" numRepeats="1" incrementParentId="roster" incrementChildId="no child" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </link>
-          </links>
-        </entry>
-        <entry id="97e8-d8ef-1bec-906d" name="Vardanari Guard" points="19.0" categoryId="(No Category)" type="model" minSelections="5" maxSelections="7" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="191">
-          <entries/>
-          <entryGroups/>
+        </rule>
+</rules>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="8ada-48df-990a-b1c6" targetId="b0ca-8e7d-d03f-f027" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="0026-0fee-242b-f524" targetId="a221-d53c-b4bd-b52c" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="1fc7-db89-4652-3c98" name="Superior Shard" type="upgrade" collective="false" hidden="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d">
+<costs>
+<cost costTypeId="points" name="pts" value="15.0"/>
+</costs>
+<constraints>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="1" includeChildSelections="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="1" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="661d-86ab-a747-8bb5" targetId="d4f5-697e-dbf0-ced2" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="859c-f6ff-bc8a-74cf" name="T7 Type Transporter Drone" type="unit" collective="false" hidden="false" book="BtGoA" page="195" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5">
+<costs>
+<cost costTypeId="points" name="pts" value="164.0"/>
+</costs>
+<constraints/>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="e215-3b85-89ba-1fc8" name="&gt; Transporter Drone" type="model" collective="false" hidden="false" book="BtGoA" page="195" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="8a07-2ee4-8417-4ab3" name="&lt; Weapon &gt;" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="4ff7-f2df-7ced-d8f0" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="d2cf-994c-12f0-9c5b" targetId="6a2b-50c5-9a33-b756" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="10.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+<entryLink id="5a7f-0ae6-6b32-4321" targetId="cf3a-e6a9-bdc0-e0ae" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="30.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+<entryLink id="439c-15d6-48b7-16d2" targetId="ac1e-a740-57b7-cc64" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="10.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="a5f0-4afc-16c4-72f9" targetId="5425-1edf-f536-d5a1" type="profile">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups>
+<selectionEntryGroup id="48a3-5d25-ade2-1097" name="&lt; Unit Options &gt;" collective="false" hidden="false">
+<constraints/>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="ad46-f5e3-e9f3-a7de" name="Self Repair" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers>
+<modifier type="increment" field="points" value="10.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="4565-ded9-505e-aced" targetId="3377-9408-33bb-6a02" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="064d-4c81-4e23-79d4" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="b2ad-61e0-f7fe-f5d0" targetId="d571-d584-85fc-9110" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="6f20-1361-0577-c4cf" targetId="1707-586b-01df-0f80" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="c985-b014-70bf-635d" targetId="5565-ce10-1c78-1ee7" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="40c3-e6f7-a42a-fd30" targetId="a221-d53c-b4bd-b52c" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="8eaf-ef10-dfe5-8f3a" targetId="ab37-33d8-41f3-7532" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="aa6c-67b7-3d3b-2a61" name="Targeter Probe Shard" type="unit" collective="false" hidden="false" book="BtGoA" page="196" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints/>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="31ff-3d6d-2a30-3b5a" name="&gt; Targeter Probe" type="model" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="5.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="4"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="6"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="58b0-e470-5c3a-0e30" targetId="00b8-b49c-4c61-2943" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="6620-e65c-9afa-7ed9" targetId="4d5f-ccb4-75c2-cbf2" type="profile">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups/>
+<rules>
+<rule id="8104-2eac-f495-21f9" name="Probe Unit" hidden="false" book="">
           <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="4ca6-7e89-8b59-f1d5" targetId="702f-c8a7-d8cf-01c1" linkType="profile">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups>
-        <entryGroup id="fff7-d85d-7713-194d" name="Ranged Weapon" defaultEntryId="1b32-6cc9-8dc9-64b3" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="1b32-6cc9-8dc9-64b3" targetId="b018-6101-d2e3-b4ea" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="8836-8c4d-3a4f-5d40" name="Armor" defaultEntryId="a575-c942-e1b2-0d29" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="a575-c942-e1b2-0d29" targetId="03c2-174e-8617-cf04" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="7876-6071-860a-2b8f" targetId="f3aa-148a-0460-c7e5" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="a7b4-9779-24e9-b2a7" targetId="573b-88bc-97d7-d890" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="4e0f-95bb-f4f1-6030" name="Well Prepared" points="5.0" categoryId="50ba-cf77-3941-189c" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="69f3-3470-5212-8eaa" targetId="75d2-6efa-9640-61df" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-  </entries>
-  <rules/>
-  <links/>
-  <sharedEntries>
-    <entry id="e9dd-1dc6-3c92-4305" name="AG Chute" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="120">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="54c4-0df3-268c-9fe1" targetId="7daf-414b-c030-7626" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="828e-3aa2-3dbf-f2cb" name="Auto-Workshop" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="120">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="2aa0-3909-ff3b-5bfe" targetId="b7c6-fc7c-d48b-aae4" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="d571-d584-85fc-9110" name="Batter Drone" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="11">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="2686-6df4-4601-e99f" targetId="f0d9-1e5a-ec20-b27c" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="8f68-d09d-6e26-c6ea" name="Batter Drone (2)" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="11">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="0a02-46cc-7e6f-28b0" targetId="f0d9-1e5a-ec20-b27c" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="af35-43cb-665c-f896" name="Booster Drone" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="111">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="77b8-dc0d-36ff-0f1d" name="Borer Drone" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="111">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="f67e-b103-c5e0-7d92" targetId="4e34-753f-b082-2e00" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="4933-25f0-2896-ac60" name="Camo Drone" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="0235-7440-f324-d8e9" targetId="5f48-f41c-fd96-6a1a" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="babd-f951-933b-1254" name="Compactor Drone" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="d5b5-2649-62fd-e305" targetId="3995-c066-c957-5ffe" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="666e-aa69-6e72-f168" name="Compactor Drone with Mag Cannon" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="9c4f-f6de-c09c-eab2" targetId="6a2b-50c5-9a33-b756" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="663f-33f4-57b5-7a11" targetId="3995-c066-c957-5ffe" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="2144-e450-c8f2-af26" name="Compactor Drone with Mag Light Support" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="d525-3a93-38f1-7e4e" targetId="a00c-0542-f2a5-8124" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="4e01-7b13-2e6c-0f97" targetId="3995-c066-c957-5ffe" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="0299-39fc-32bd-8ac2" name="Compactor Drone with Plasma Cannon" points="0.0" categoryId="(No Category)" type="unit" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="e506-bd0d-b513-7050" targetId="c2bf-0272-30c6-dd20" linkType="entry">
-          <modifiers/>
-        </link>
-        <link id="ae6e-0698-5ad9-8d26" targetId="3995-c066-c957-5ffe" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="af24-45f9-4669-bf98" name="Compression Bombard" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="84">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="f3f6-794b-82b3-a39a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Bombard" hidden="false" book="BtGoA" page="84">
+        </rule>
+</rules>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="40ad-08b6-fa6a-0171" name="Vardanari Squad (Guards)" type="unit" collective="false" hidden="false" book="BtGoA" page="191" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe">
+<costs>
+<cost costTypeId="points" name="pts" value="42.0"/>
+</costs>
+<constraints/>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="c3fa-7787-a4d1-50f8" name="&lt; Vardanari Leader" type="model" collective="false" hidden="false" book="BtGoA" page="191" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="189f-239f-cc54-f496" name="&lt; Leader Level &gt;" collective="false" hidden="false" defaultSelectionEntryId="7ea8-bf13-37df-8acf">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="6cd8-052e-b9da-e94e" name="Leader 2" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="10.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="f2ac-6316-75a8-0504" targetId="7850-89e7-bab8-86e9" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="7ea8-bf13-37df-8acf" targetId="fc7e-7c0e-65e0-8c33" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="f5ed-8cd5-154e-1987" name="&lt; Ranged Weapon &gt;" collective="false" hidden="false" defaultSelectionEntryId="c12f-a100-2c77-940b">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="2"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="c12f-a100-2c77-940b" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="02d9-18d6-822b-c297" targetId="179a-c0cc-49cc-c946" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks>
+<entryLink id="dbcb-5feb-24da-acaf" targetId="8de3-1e72-72ef-e7a3" type="selectionEntry">
+<modifiers>
+<modifier type="increment" field="points" value="5.0">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</entryLink>
+</entryLinks>
+<infoLinks>
+<infoLink id="1a89-bc54-c850-a7a0" targetId="62fc-1d76-c6fd-a3eb" type="profile">
+<modifiers>
+<modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2">
+<conditions/>
+<conditionGroups/>
+</modifier>
+</modifiers>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="97e8-d8ef-1bec-906d" name="Vardanari Guard" type="model" collective="false" hidden="false" book="BtGoA" page="191" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="19.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="5"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="7"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="4ca6-7e89-8b59-f1d5" targetId="702f-c8a7-d8cf-01c1" type="profile">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups>
+<selectionEntryGroup id="fff7-d85d-7713-194d" name="Ranged Weapon" collective="false" hidden="false" defaultSelectionEntryId="1b32-6cc9-8dc9-64b3">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="1b32-6cc9-8dc9-64b3" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="8836-8c4d-3a4f-5d40" name="Armor" collective="false" hidden="false" defaultSelectionEntryId="a575-c942-e1b2-0d29">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="a575-c942-e1b2-0d29" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks>
+<entryLink id="7876-6071-860a-2b8f" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="a7b4-9779-24e9-b2a7" targetId="573b-88bc-97d7-d890" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="4e0f-95bb-f4f1-6030" name="Well Prepared" type="upgrade" collective="false" hidden="false" categoryEntryId="50ba-cf77-3941-189c">
+<costs>
+<cost costTypeId="points" name="pts" value="5.0"/>
+</costs>
+<constraints/>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="69f3-3470-5212-8eaa" targetId="75d2-6efa-9640-61df" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<rules/>
+<entryLinks/>
+<infoLinks/>
+<sharedSelectionEntries>
+<selectionEntry id="e9dd-1dc6-3c92-4305" name="AG Chute" type="upgrade" collective="true" hidden="false" book="BtGoA" page="120" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="54c4-0df3-268c-9fe1" targetId="7daf-414b-c030-7626" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="828e-3aa2-3dbf-f2cb" name="Auto-Workshop" type="upgrade" collective="false" hidden="false" book="BtGoA" page="120" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="-1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="2aa0-3909-ff3b-5bfe" targetId="b7c6-fc7c-d48b-aae4" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="d571-d584-85fc-9110" name="Batter Drone" type="upgrade" collective="false" hidden="false" book="BtGoA" page="11" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="20.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="2686-6df4-4601-e99f" targetId="f0d9-1e5a-ec20-b27c" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="8f68-d09d-6e26-c6ea" name="Batter Drone (2)" type="upgrade" collective="false" hidden="false" book="BtGoA" page="11" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="20.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="0a02-46cc-7e6f-28b0" targetId="f0d9-1e5a-ec20-b27c" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="af35-43cb-665c-f896" name="Booster Drone" type="upgrade" collective="true" hidden="false" book="BtGoA" page="111" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="77b8-dc0d-36ff-0f1d" name="Borer Drone" type="upgrade" collective="false" hidden="false" book="BtGoA" page="111" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="-1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="f67e-b103-c5e0-7d92" targetId="4e34-753f-b082-2e00" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="4933-25f0-2896-ac60" name="Camo Drone" type="upgrade" collective="false" hidden="false" book="BtGoA" page="112" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="0235-7440-f324-d8e9" targetId="5f48-f41c-fd96-6a1a" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="babd-f951-933b-1254" name="Compactor Drone" type="unit" collective="false" hidden="false" book="BtGoA" page="112" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="d5b5-2649-62fd-e305" targetId="3995-c066-c957-5ffe" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="666e-aa69-6e72-f168" name="Compactor Drone with Mag Cannon" type="unit" collective="false" hidden="false" book="BtGoA" page="112" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks>
+<entryLink id="9c4f-f6de-c09c-eab2" targetId="6a2b-50c5-9a33-b756" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+<infoLinks>
+<infoLink id="663f-33f4-57b5-7a11" targetId="3995-c066-c957-5ffe" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="2144-e450-c8f2-af26" name="Compactor Drone with Mag Light Support" type="unit" collective="false" hidden="false" book="BtGoA" page="112" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks>
+<entryLink id="d525-3a93-38f1-7e4e" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+<infoLinks>
+<infoLink id="4e01-7b13-2e6c-0f97" targetId="3995-c066-c957-5ffe" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="0299-39fc-32bd-8ac2" name="Compactor Drone with Plasma Cannon" type="unit" collective="false" hidden="false" book="BtGoA" page="112" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks>
+<entryLink id="e506-bd0d-b513-7050" targetId="c2bf-0272-30c6-dd20" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+<infoLinks>
+<infoLink id="ae6e-0698-5ad9-8d26" targetId="3995-c066-c957-5ffe" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="af24-45f9-4669-bf98" name="Compression Bombard" type="upgrade" collective="false" hidden="false" book="BtGoA" page="84" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="f3f6-794b-82b3-a39a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Bombard" hidden="false" book="BtGoA" page="84">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-50"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="150"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="9/7/5"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Cycle, Heavy Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10-50"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="150"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="9/7/5"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Cycle, Heavy Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="d318-c320-5b7c-b089" targetId="7db4-2d14-3984-37d9" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="a2f7-528d-dd59-9d00" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="b53d-32d6-c4fc-cefc" targetId="cf7f-6f85-e64e-0363" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="71c9-4382-01cf-c737" name="Compression Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="78">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="b626-3a7f-ecf5-ea69" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Cannon" hidden="false" book="BtGoA" page="78">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="d318-c320-5b7c-b089" targetId="7db4-2d14-3984-37d9" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="a2f7-528d-dd59-9d00" targetId="a41d-d55e-6d97-049d" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="b53d-32d6-c4fc-cefc" targetId="cf7f-6f85-e64e-0363" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="71c9-4382-01cf-c737" name="Compression Cannon" type="upgrade" collective="false" hidden="false" book="BtGoA" page="78" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="b626-3a7f-ecf5-ea69" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Cannon" hidden="false" book="BtGoA" page="78">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="7/4/2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Cycle,  Light Support Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="7/4/2"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Cycle,  Light Support Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="a6f9-23ce-e99d-7c15" targetId="7db4-2d14-3984-37d9" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="3003-31fb-fb6c-3084" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="70d5-a230-ba57-ead0" targetId="cf7f-6f85-e64e-0363" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="059b-38f7-0313-5ae4" name="Compression Carbine" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="72">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="e580-6389-7ec6-d445" targetId="7db4-2d14-3984-37d9" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="b230-6dc2-fc21-9332" targetId="75cb-cf9b-dd3d-9177" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="72ba-15e7-dbf7-816c" name="D-Spinner" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="66">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="bc08-23ff-215d-d442" profileTypeId="ecae-8ac8-2c13-0dd3" name="D-Spinner" hidden="false" book="BtGoA" page="66">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="a6f9-23ce-e99d-7c15" targetId="7db4-2d14-3984-37d9" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="3003-31fb-fb6c-3084" targetId="a41d-d55e-6d97-049d" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="70d5-a230-ba57-ead0" targetId="cf7f-6f85-e64e-0363" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="059b-38f7-0313-5ae4" name="Compression Carbine" type="upgrade" collective="true" hidden="false" book="BtGoA" page="72" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="e580-6389-7ec6-d445" targetId="7db4-2d14-3984-37d9" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="b230-6dc2-fc21-9332" targetId="75cb-cf9b-dd3d-9177" type="profile">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="72ba-15e7-dbf7-816c" name="D-Spinner" type="upgrade" collective="true" hidden="false" book="BtGoA" page="66" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="bc08-23ff-215d-d442" profileTypeId="ecae-8ac8-2c13-0dd3" name="D-Spinner" hidden="false" book="BtGoA" page="66">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="Varies"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks, Variable Res/Strike, Grenade, Hand Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="Varies"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks, Variable Res/Strike, Grenade, Hand Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="bf1e-fb77-9e71-f9fe" targetId="2cbd-47c9-de87-ec2a" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="363c-73f0-41ad-dfb8" targetId="99fd-f354-1703-5941" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="91a4-fa2b-910b-b8f8" targetId="b466-7990-db34-55b1" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="ff6c-f8d8-94e6-57bc" name="Disruptor Bomber" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="77">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="c100-99b7-2ff6-24a0" profileTypeId="ecae-8ac8-2c13-0dd3" name="Disruptor Bomber" hidden="false" book="BtGoA" page="77">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="bf1e-fb77-9e71-f9fe" targetId="2cbd-47c9-de87-ec2a" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="363c-73f0-41ad-dfb8" targetId="99fd-f354-1703-5941" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="91a4-fa2b-910b-b8f8" targetId="b466-7990-db34-55b1" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="ff6c-f8d8-94e6-57bc" name="Disruptor Bomber" type="upgrade" collective="false" hidden="false" book="BtGoA" page="77" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="c100-99b7-2ff6-24a0" profileTypeId="ecae-8ac8-2c13-0dd3" name="Disruptor Bomber" hidden="false" book="BtGoA" page="77">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="60"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="120"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D5, No Crew, Limited Ammo, No Cover, Disruptor,  Light Support Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="60"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="120"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D5, No Crew, Limited Ammo, No Cover, Disruptor,  Light Support Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="5bfd-e568-cff9-ff1b" targetId="c3bc-87fd-fa5d-5055" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="ada8-a0a5-d314-27a6" targetId="b050-496a-ed16-2b2a" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="c9a5-e124-997c-44ea" targetId="f502-611e-9704-97bb" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="b3e6-5aa3-ef1f-f7b1" targetId="5efa-64a9-bbc9-3dba" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="df53-3436-c62e-c73e" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="7fb2-1ffe-610d-7f33" targetId="6305-72fa-da02-235b" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="f771-f4b5-0047-de53" name="Disruptor Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="79">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="17db-4b84-9d1b-122d" profileTypeId="ecae-8ac8-2c13-0dd3" name="Disruptor Cannon" hidden="false" book="BtGoA" page="79">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="5bfd-e568-cff9-ff1b" targetId="c3bc-87fd-fa5d-5055" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="ada8-a0a5-d314-27a6" targetId="b050-496a-ed16-2b2a" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="c9a5-e124-997c-44ea" targetId="f502-611e-9704-97bb" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="b3e6-5aa3-ef1f-f7b1" targetId="5efa-64a9-bbc9-3dba" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="df53-3436-c62e-c73e" targetId="a41d-d55e-6d97-049d" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="7fb2-1ffe-610d-7f33" targetId="6305-72fa-da02-235b" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="f771-f4b5-0047-de53" name="Disruptor Cannon" type="upgrade" collective="false" hidden="false" book="BtGoA" page="79" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="17db-4b84-9d1b-122d" profileTypeId="ecae-8ac8-2c13-0dd3" name="Disruptor Cannon" hidden="false" book="BtGoA" page="79">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D4, No Cover, Disruptor, Light Support Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D4, No Cover, Disruptor, Light Support Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="48bb-4c87-e0f2-08b4" targetId="ca96-58c9-9551-d4fe" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="3b06-bc9e-4002-8aeb" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="8e03-d6b4-1fab-5cd2" targetId="6305-72fa-da02-235b" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="396e-b157-b3bb-a5e7" name="Disruptor Discharger" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="86">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="de01-ba7b-11ee-55ca" profileTypeId="ecae-8ac8-2c13-0dd3" name="Disruptor Discharger" hidden="false" book="BtGoA" page="86">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="48bb-4c87-e0f2-08b4" targetId="ca96-58c9-9551-d4fe" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="3b06-bc9e-4002-8aeb" targetId="a41d-d55e-6d97-049d" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="8e03-d6b4-1fab-5cd2" targetId="6305-72fa-da02-235b" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="396e-b157-b3bb-a5e7" name="Disruptor Discharger" type="upgrade" collective="false" hidden="false" book="BtGoA" page="86" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="-1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="de01-ba7b-11ee-55ca" profileTypeId="ecae-8ac8-2c13-0dd3" name="Disruptor Discharger" hidden="false" book="BtGoA" page="86">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="Point blank shooting only"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="Point blank shooting only"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="Point blank shooting only"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D4, No Cover, Disruptor, Grenade"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="Point blank shooting only"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="Point blank shooting only"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="Point blank shooting only"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D4, No Cover, Disruptor, Grenade"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="e755-a7a2-1343-d27a" targetId="5d64-4bf5-e947-95d1" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="b2cb-0542-2c44-9f1b" targetId="ca96-58c9-9551-d4fe" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="049f-1e26-3f5d-a4f9" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="adad-ebe2-3953-6510" targetId="6305-72fa-da02-235b" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="2cec-e1d7-c680-7ca0" name="Fractal Bombard" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="83">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="279b-22b3-c3ff-1320" profileTypeId="ecae-8ac8-2c13-0dd3" name="Fractal Bombard" hidden="false" book="BtGoA" page="83">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="e755-a7a2-1343-d27a" targetId="5d64-4bf5-e947-95d1" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="b2cb-0542-2c44-9f1b" targetId="ca96-58c9-9551-d4fe" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="049f-1e26-3f5d-a4f9" targetId="a41d-d55e-6d97-049d" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="adad-ebe2-3953-6510" targetId="6305-72fa-da02-235b" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="2cec-e1d7-c680-7ca0" name="Fractal Bombard" type="upgrade" collective="false" hidden="false" book="BtGoA" page="83" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="279b-22b3-c3ff-1320" profileTypeId="ecae-8ac8-2c13-0dd3" name="Fractal Bombard" hidden="false" book="BtGoA" page="83">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="50"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="200"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3 + 2 Max 10"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock, Heavy Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="50"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="200"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="3 + 2 Max 10"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock, Heavy Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="fe6a-32a9-1211-b766" targetId="d50c-3bbe-c62d-34c3" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="93db-3751-fdd4-08f9" name="Fractal Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="76">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="cb47-aad3-9a1b-1266" profileTypeId="ecae-8ac8-2c13-0dd3" name="Fractal Cannon" hidden="false" book="BtGoA" page="76">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="fe6a-32a9-1211-b766" targetId="d50c-3bbe-c62d-34c3" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="93db-3751-fdd4-08f9" name="Fractal Cannon" type="upgrade" collective="false" hidden="false" book="BtGoA" page="76" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="cb47-aad3-9a1b-1266" profileTypeId="ecae-8ac8-2c13-0dd3" name="Fractal Cannon" hidden="false" book="BtGoA" page="76">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2 + 1 Max 10"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock,  Light Support Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2 + 1 Max 10"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock,  Light Support Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="b7b4-01fa-5f1f-ebee" targetId="d50c-3bbe-c62d-34c3" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="aac7-43b0-4a5c-05bb" name="Frag Borer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="77">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="5cb2-9abf-ed28-03ff" profileTypeId="ecae-8ac8-2c13-0dd3" name="Frag Borer" hidden="false" book="BtGoA" page="77">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="b7b4-01fa-5f1f-ebee" targetId="d50c-3bbe-c62d-34c3" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="aac7-43b0-4a5c-05bb" name="Frag Borer" type="upgrade" collective="false" hidden="false" book="BtGoA" page="77" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="5cb2-9abf-ed28-03ff" profileTypeId="ecae-8ac8-2c13-0dd3" name="Frag Borer" hidden="false" book="BtGoA" page="77">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="60"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3 + 1 Max 10"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock,  Light Support Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="60"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="3 + 1 Max 10"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock,  Light Support Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="eac9-8b04-b66c-5db6" targetId="d50c-3bbe-c62d-34c3" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="3975-3892-22f2-0c8e" name="Ghar Plasma Claw" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="66">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="57de-9415-94c2-a9cd" profileTypeId="ecae-8ac8-2c13-0dd3" name="Ghar Plasma Claw" hidden="false" book="BtGoA" page="66">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="eac9-8b04-b66c-5db6" targetId="d50c-3bbe-c62d-34c3" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="3975-3892-22f2-0c8e" name="Ghar Plasma Claw" type="upgrade" collective="false" hidden="false" book="BtGoA" page="66" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="57de-9415-94c2-a9cd" profileTypeId="ecae-8ac8-2c13-0dd3" name="Ghar Plasma Claw" hidden="false" book="BtGoA" page="66">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="D4"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Random SV,  Hand Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="D4"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Random SV,  Hand Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="7eb4-a0e1-1e61-3d82" targetId="b6e3-9cf0-1a9f-a941" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="f319-5d36-f853-9d45" name="Gouger Gun" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="74">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="5caa-0eb3-a2c8-d79c" profileTypeId="ecae-8ac8-2c13-0dd3" name="Gouger Gun" hidden="false" book="BtGoA" page="74">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="7eb4-a0e1-1e61-3d82" targetId="b6e3-9cf0-1a9f-a941" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="f319-5d36-f853-9d45" name="Gouger Gun" type="upgrade" collective="false" hidden="false" book="BtGoA" page="74" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="5caa-0eb3-a2c8-d79c" profileTypeId="ecae-8ac8-2c13-0dd3" name="Gouger Gun" hidden="false" book="BtGoA" page="74">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Down, Inaccurate, Standard Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10-20"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Down, Inaccurate, Standard Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="6c43-9149-1b89-35e5" targetId="9444-e2a0-8048-5ce9" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="aa66-a1ad-73f1-8bd2" targetId="3b84-9d0e-a3c1-6c1f" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="b8d1-46be-c623-ad68" name="Gun Drone" points="14.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="4b9d-a0bf-396e-384b" name="Gun Drone (2)" points="14.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="f9cf-568d-998b-c3ca" name="Heavy Disruptor Bomber" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="80">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="a9a7-e90e-e54a-e37c" profileTypeId="ecae-8ac8-2c13-0dd3" name="Heavy Disruptor Bomber" hidden="false" book="BtGoA" page="80">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="6c43-9149-1b89-35e5" targetId="9444-e2a0-8048-5ce9" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="aa66-a1ad-73f1-8bd2" targetId="3b84-9d0e-a3c1-6c1f" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="b8d1-46be-c623-ad68" name="Gun Drone" type="upgrade" collective="false" hidden="false" book="BtGoA" page="112" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="14.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="4b9d-a0bf-396e-384b" name="Gun Drone (2)" type="upgrade" collective="true" hidden="false" book="BtGoA" page="112" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="14.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="f9cf-568d-998b-c3ca" name="Heavy Disruptor Bomber" type="upgrade" collective="false" hidden="false" book="BtGoA" page="80" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="a9a7-e90e-e54a-e37c" profileTypeId="ecae-8ac8-2c13-0dd3" name="Heavy Disruptor Bomber" hidden="false" book="BtGoA" page="80">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="60"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="120"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH x2, Blast D10, Limited Ammo, No Cover, Disruptor, Heavy Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="60"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="120"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="OH x2, Blast D10, Limited Ammo, No Cover, Disruptor, Heavy Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="baaa-0b37-7581-545a" targetId="aef6-6934-1dee-6fa0" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="ad5f-454c-b4ec-0b29" targetId="04d9-a48d-7b25-4dd3" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="3dc5-ce4c-aaf4-7bc4" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="1d69-8270-126c-b660" targetId="6305-72fa-da02-235b" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="564d-3561-f5e4-783d" name="Heavy Frag Borer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="83">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="4001-9da2-86d1-6b80" profileTypeId="ecae-8ac8-2c13-0dd3" name="Heavy Frag Borer" hidden="false" book="BtGoA" page="83">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="baaa-0b37-7581-545a" targetId="aef6-6934-1dee-6fa0" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="ad5f-454c-b4ec-0b29" targetId="04d9-a48d-7b25-4dd3" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="3dc5-ce4c-aaf4-7bc4" targetId="a41d-d55e-6d97-049d" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="1d69-8270-126c-b660" targetId="6305-72fa-da02-235b" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="564d-3561-f5e4-783d" name="Heavy Frag Borer" type="upgrade" collective="false" hidden="false" book="BtGoA" page="83" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="4001-9da2-86d1-6b80" profileTypeId="ecae-8ac8-2c13-0dd3" name="Heavy Frag Borer" hidden="false" book="BtGoA" page="83">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="60"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="6 + 1 Max 10"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock, Heavy Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="60"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="6 + 1 Max 10"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock, Heavy Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="174d-fb91-0ee1-de89" targetId="d50c-3bbe-c62d-34c3" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="5149-5183-64d5-feaf" name="Heavy Mag Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="81">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="49f7-05c7-8536-e088" profileTypeId="ecae-8ac8-2c13-0dd3" name="Heavy Mag Cannon" hidden="false" book="BtGoA" page="81">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="174d-fb91-0ee1-de89" targetId="d50c-3bbe-c62d-34c3" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="5149-5183-64d5-feaf" name="Heavy Mag Cannon" type="upgrade" collective="false" hidden="false" book="BtGoA" page="81" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="49f7-05c7-8536-e088" profileTypeId="ecae-8ac8-2c13-0dd3" name="Heavy Mag Cannon" hidden="false" book="BtGoA" page="81">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="50"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="10"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="250"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="6"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Massive Damage, Heavy Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="50"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="10"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="250"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="6"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Massive Damage, Heavy Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="2226-327b-9cef-5629" targetId="c863-510b-e239-be92" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="4fbe-feab-de05-5312" name="Heavy Tractor Maul" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="65">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="05cc-6d3b-93d8-0b0e" profileTypeId="ecae-8ac8-2c13-0dd3" name="Heavy Tractor Maul" hidden="false" book="BtGoA" page="65">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="2226-327b-9cef-5629" targetId="c863-510b-e239-be92" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="4fbe-feab-de05-5312" name="Heavy Tractor Maul" type="upgrade" collective="false" hidden="false" book="BtGoA" page="65" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="05cc-6d3b-93d8-0b0e" profileTypeId="ecae-8ac8-2c13-0dd3" name="Heavy Tractor Maul" hidden="false" book="BtGoA" page="65">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks, Hand Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks, Hand Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="c401-a6db-93c9-69e0" targetId="2cbd-47c9-de87-ec2a" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="eff8-bb0e-1b1d-bbb2" name="HL armor" points="0.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="93">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="2a6f-a102-e7b6-54c7" targetId="b436-1f8a-5d3a-2d7d" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="2e3d-bbaa-3f5c-ac53" name="HL Booster (Eq)" points="1.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="b458-ac53-f980-4960" targetId="56ab-52fc-9557-2586" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="573b-88bc-97d7-d890" name="HL Booster Drone" points="20.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="121">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="68d9-bb11-1862-acca" targetId="56ab-52fc-9557-2586" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="1b16-412b-662a-5467" name="Homer Drone" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="112">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="e015-e1a0-3cd3-a350" targetId="ca2b-9550-eb1e-77c8" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="4364-45ee-ee83-ca30" name="Impact Cloak " points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="93">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules>
-        <rule id="5da7-d6db-a841-0ff0" name="Impact Cloak" hidden="false" book="BtGoA" page="93">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="c401-a6db-93c9-69e0" targetId="2cbd-47c9-de87-ec2a" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="eff8-bb0e-1b1d-bbb2" name="HL armor" type="model" collective="true" hidden="false" book="BtGoA" page="93" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="2a6f-a102-e7b6-54c7" targetId="b436-1f8a-5d3a-2d7d" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="2e3d-bbaa-3f5c-ac53" name="HL Booster (Eq)" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="1.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="-1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="b458-ac53-f980-4960" targetId="56ab-52fc-9557-2586" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="573b-88bc-97d7-d890" name="HL Booster Drone" type="model" collective="false" hidden="false" book="BtGoA" page="121" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="20.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="68d9-bb11-1862-acca" targetId="56ab-52fc-9557-2586" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="1b16-412b-662a-5467" name="Homer Drone" type="upgrade" collective="false" hidden="false" book="BtGoA" page="112" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="e015-e1a0-3cd3-a350" targetId="ca2b-9550-eb1e-77c8" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="4364-45ee-ee83-ca30" name="Impact Cloak " type="upgrade" collective="true" hidden="false" book="BtGoA" page="93" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules>
+<rule id="5da7-d6db-a841-0ff0" name="Impact Cloak" hidden="false" book="BtGoA" page="93">
           <description>Add +2 to Res in hand to hand combat.</description>
           <modifiers/>
         </rule>
-      </rules>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="74e7-3e15-6b19-94e8" name="Impact Cloak (Eq)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="93">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules>
-        <rule id="a94d-f3ac-90df-d53a" name="Impact Cloak" hidden="false" book="BtGoA" page="93">
+</rules>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="74e7-3e15-6b19-94e8" name="Impact Cloak (Eq)" type="upgrade" collective="true" hidden="false" book="BtGoA" page="93" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules>
+<rule id="a94d-f3ac-90df-d53a" name="Impact Cloak" hidden="false" book="BtGoA" page="93">
           <description>Add +2 to Res in hand to hand combat.</description>
           <modifiers/>
         </rule>
-      </rules>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="f99c-daab-b3d7-9c61" name="Implosion Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="85">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="50ac-e85f-6480-9e2e" profileTypeId="ecae-8ac8-2c13-0dd3" name="Implosion Grenades" hidden="false" book="BtGoA" page="85">
+</rules>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="f99c-daab-b3d7-9c61" name="Implosion Grenades" type="upgrade" collective="false" hidden="false" book="BtGoA" page="85" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="-1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="50ac-e85f-6480-9e2e" profileTypeId="ecae-8ac8-2c13-0dd3" name="Implosion Grenades" hidden="false" book="BtGoA" page="85">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Hazardous H2H, Grenade"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Hazardous H2H, Grenade"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="9868-0703-9743-d4b5" targetId="1c2c-6574-0a17-f90c" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="b357-a997-60e5-053e" name="IMTel Stave" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="67">
-      <entries>
-        <entry id="d6be-b9a8-1ea3-d1ee" name="IMTel Stave - Standard" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="9cc5-5341-3598-a655" profileTypeId="ecae-8ac8-2c13-0dd3" name="IMTel Stave - Standard" hidden="false" book="BtGoA" page="67">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="9868-0703-9743-d4b5" targetId="1c2c-6574-0a17-f90c" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="b357-a997-60e5-053e" name="IMTel Stave" type="upgrade" collective="false" hidden="false" book="BtGoA" page="67" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="d6be-b9a8-1ea3-d1ee" name="IMTel Stave - Standard" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="9cc5-5341-3598-a655" profileTypeId="ecae-8ac8-2c13-0dd3" name="IMTel Stave - Standard" hidden="false" book="BtGoA" page="67">
               <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="3 Attacks, Hand Weapon"/>
+                <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
+                <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
+                <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
+                <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
+                <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="3 Attacks, Hand Weapon"/>
               </characteristics>
               <modifiers/>
             </profile>
-          </profiles>
-          <links>
-            <link id="051e-0412-fe0f-16d2" targetId="61e2-3707-ade3-c9ad" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="da2f-6bd2-fb0e-5e5e" name="IMTel Stave - Nano Drone Boost" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="cf0b-c836-c681-d9c0" profileTypeId="ecae-8ac8-2c13-0dd3" name="IMTel Stave - Nano Drone Boost" hidden="false" book="BtGoA" page="67">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="051e-0412-fe0f-16d2" targetId="61e2-3707-ade3-c9ad" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="da2f-6bd2-fb0e-5e5e" name="IMTel Stave - Nano Drone Boost" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="cf0b-c836-c681-d9c0" profileTypeId="ecae-8ac8-2c13-0dd3" name="IMTel Stave - Nano Drone Boost" hidden="false" book="BtGoA" page="67">
               <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="6"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="3 Attacks, Blast D3, Exhausted, Hand Weapon"/>
+                <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
+                <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
+                <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
+                <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="6"/>
+                <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="3 Attacks, Blast D3, Exhausted, Hand Weapon"/>
               </characteristics>
               <modifiers/>
             </profile>
-          </profiles>
-          <links>
-            <link id="8918-00b1-258e-5005" targetId="61e2-3707-ade3-c9ad" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="a14f-0f5e-7b8f-63f5" targetId="1acd-39d3-94e7-48e1" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="e461-67a4-a88e-a136" targetId="4232-2801-36cf-704c" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="5346-a420-8994-c5ed" name="Interceptor Bike" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="100">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="c7d2-5723-e428-dd5a" name="Ranged Weapon" minSelections="3" maxSelections="3" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="fa7c-b456-730f-167f" targetId="47d9-8149-9744-9849" linkType="entry">
-              <modifiers/>
-            </link>
-            <link id="ec8f-9506-26e0-53ec" targetId="78dd-7840-1210-fb35" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="d3a3-d3e0-1480-e349" name="Intruder Skimmer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="9">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="e102-2c84-66f5-fba9" name="Ranged Weapon" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="ed95-b0bc-1c54-77ce" name="Twin Mag Repeaters" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links/>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="3aa7-ded4-1810-f136" targetId="f31c-6e5c-19c0-ada7" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="fc7e-7c0e-65e0-8c33" name="Leader" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="b121-6dcc-8053-c5a2" targetId="e441-c3a6-7d61-2c63" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="02f3-3134-ae39-afed" name="Leader 2" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="135">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="0240-940c-2896-fe6d" targetId="7850-89e7-bab8-86e9" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="5a4c-2f5e-40a2-91d4" name="Leader 3" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="135">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="0722-f7c8-1f58-524e" targetId="05bb-4d34-70cd-25d2" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="222a-c399-636e-c285" name="Lectro Lance" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="66">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="1194-e016-79d8-8f37" profileTypeId="ecae-8ac8-2c13-0dd3" name="Lectro Lance" hidden="false" book="BtGoA" page="66">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="8918-00b1-258e-5005" targetId="61e2-3707-ade3-c9ad" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="a14f-0f5e-7b8f-63f5" targetId="1acd-39d3-94e7-48e1" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="e461-67a4-a88e-a136" targetId="4232-2801-36cf-704c" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="5346-a420-8994-c5ed" name="Interceptor Bike" type="upgrade" collective="false" hidden="false" book="BtGoA" page="100" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="c7d2-5723-e428-dd5a" name="Ranged Weapon" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="3"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="3"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="fa7c-b456-730f-167f" targetId="47d9-8149-9744-9849" type="selectionEntry">
+<modifiers/>
+</entryLink>
+<entryLink id="ec8f-9506-26e0-53ec" targetId="78dd-7840-1210-fb35" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="d3a3-d3e0-1480-e349" name="Intruder Skimmer" type="upgrade" collective="true" hidden="false" book="BtGoA" page="9" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="e102-2c84-66f5-fba9" name="Ranged Weapon" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="ed95-b0bc-1c54-77ce" name="Twin Mag Repeaters" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="3aa7-ded4-1810-f136" targetId="f31c-6e5c-19c0-ada7" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="fc7e-7c0e-65e0-8c33" name="Leader" type="upgrade" collective="false" hidden="false" book="" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="b121-6dcc-8053-c5a2" targetId="e441-c3a6-7d61-2c63" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="02f3-3134-ae39-afed" name="Leader 2" type="upgrade" collective="false" hidden="false" book="BtGoA" page="135" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="10.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="0240-940c-2896-fe6d" targetId="7850-89e7-bab8-86e9" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="5a4c-2f5e-40a2-91d4" name="Leader 3" type="upgrade" collective="false" hidden="false" book="BtGoA" page="135" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="20.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="0722-f7c8-1f58-524e" targetId="05bb-4d34-70cd-25d2" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="222a-c399-636e-c285" name="Lectro Lance" type="upgrade" collective="false" hidden="false" book="BtGoA" page="66" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="1194-e016-79d8-8f37" profileTypeId="ecae-8ac8-2c13-0dd3" name="Lectro Lance" hidden="false" book="BtGoA" page="66">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Hand Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Hand Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="10e4-842d-bb66-6204" name="Lectro Lash" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="65">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="0e1a-a803-d9c9-9f0a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Lectro Lash" hidden="false" book="BtGoA" page="65">
+</profiles>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="10e4-842d-bb66-6204" name="Lectro Lash" type="upgrade" collective="false" hidden="false" book="BtGoA" page="65" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="0e1a-a803-d9c9-9f0a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Lectro Lash" hidden="false" book="BtGoA" page="65">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="3 Attacks, Hand Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="3 Attacks, Hand Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="485e-5cd5-458a-5b01" targetId="61e2-3707-ade3-c9ad" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="3ad3-bfdd-6120-7c29" name="Lugger Gun" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="73">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="5c6f-c4ef-b4a1-32eb" profileTypeId="ecae-8ac8-2c13-0dd3" name="Lugger Gun" hidden="false" book="BtGoA" page="73">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="485e-5cd5-458a-5b01" targetId="61e2-3707-ade3-c9ad" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="3ad3-bfdd-6120-7c29" name="Lugger Gun" type="upgrade" collective="false" hidden="false" book="BtGoA" page="73" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="5c6f-c4ef-b4a1-32eb" profileTypeId="ecae-8ac8-2c13-0dd3" name="Lugger Gun" hidden="false" book="BtGoA" page="73">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2, Limited Ammo, Standard Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2, Limited Ammo, Standard Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="a5ed-7915-9221-076b" targetId="0cb1-ea91-e5bc-4f75" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="cc2c-1225-57ca-f1ed" targetId="5efa-64a9-bbc9-3dba" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="6a2b-50c5-9a33-b756" name="Mag Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="75">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="295a-d623-e2d2-c684" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Cannon" hidden="false" book="BtGoA" page="75">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="a5ed-7915-9221-076b" targetId="0cb1-ea91-e5bc-4f75" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="cc2c-1225-57ca-f1ed" targetId="5efa-64a9-bbc9-3dba" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="6a2b-50c5-9a33-b756" name="Mag Cannon" type="upgrade" collective="false" hidden="false" book="BtGoA" page="75" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="295a-d623-e2d2-c684" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Cannon" hidden="false" book="BtGoA" page="75">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="5"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="5"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Massive Damage, Light Support Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="5"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="5"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Massive Damage, Light Support Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="ba14-c26b-33c6-8283" targetId="c863-510b-e239-be92" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="84ac-0f31-c388-d0bd" name="Mag Gun" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="69">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="d809-b3af-7007-a7b3" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Gun" hidden="false" book="BtGoA" page="69">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="ba14-c26b-33c6-8283" targetId="c863-510b-e239-be92" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="84ac-0f31-c388-d0bd" name="Mag Gun" type="upgrade" collective="true" hidden="false" book="BtGoA" page="69" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="d809-b3af-7007-a7b3" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Gun" hidden="false" book="BtGoA" page="69">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="60"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="60"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="8f47-408e-cc6e-7a19" name="Mag Gun (Eq)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="69">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="33ca-cc05-d33e-3d00" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Gun" hidden="false" book="BtGoA" page="69">
+</profiles>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="8f47-408e-cc6e-7a19" name="Mag Gun (Eq)" type="upgrade" collective="true" hidden="false" book="BtGoA" page="69" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="33ca-cc05-d33e-3d00" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Gun" hidden="false" book="BtGoA" page="69">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="60"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="60"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="cea7-8511-2208-1b1f" name="Mag Heavy Support" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="81">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="c318-2375-d610-2950" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Heavy Support" hidden="false" book="BtGoA" page="81">
+</profiles>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="cea7-8511-2208-1b1f" name="Mag Heavy Support" type="upgrade" collective="false" hidden="false" book="BtGoA" page="81" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="c318-2375-d610-2950" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Heavy Support" hidden="false" book="BtGoA" page="81">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="5"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF5, Heavy Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="5"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="RF5, Heavy Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="d752-3c59-1096-f66d" targetId="b0cb-c022-0531-4852" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="b5e9-5297-04d2-2bf8" name="Mag Lash" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="67">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="f404-2eda-272f-57cf" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Lash" hidden="false" book="BtGoA" page="67">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="d752-3c59-1096-f66d" targetId="b0cb-c022-0531-4852" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="b5e9-5297-04d2-2bf8" name="Mag Lash" type="upgrade" collective="true" hidden="false" book="BtGoA" page="67" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="f404-2eda-272f-57cf" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Lash" hidden="false" book="BtGoA" page="67">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="a97e-ddef-2a97-6023" targetId="2cbd-47c9-de87-ec2a" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="a00c-0542-f2a5-8124" name="Mag Light Support" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="75">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="df5b-35ce-669c-6aee" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Light Support" hidden="false" book="BtGoA" page="75">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="a97e-ddef-2a97-6023" targetId="2cbd-47c9-de87-ec2a" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="a00c-0542-f2a5-8124" name="Mag Light Support" type="upgrade" collective="false" hidden="false" book="BtGoA" page="75" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="df5b-35ce-669c-6aee" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Light Support" hidden="false" book="BtGoA" page="75">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="50"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3, Light Support Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="50"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3, Light Support Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="1edc-0547-c0b3-df09" targetId="97d4-67cb-2671-ca29" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="9733-7039-e306-26b5" name="Mag Mortar" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="81">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="d461-69b8-c506-322a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Mortar" hidden="false" book="BtGoA" page="81">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="1edc-0547-c0b3-df09" targetId="97d4-67cb-2671-ca29" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="9733-7039-e306-26b5" name="Mag Mortar" type="upgrade" collective="false" hidden="false" book="BtGoA" page="81" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="d461-69b8-c506-322a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Mortar" hidden="false" book="BtGoA" page="81">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH x2, Blast D10, No Cover, Heavy Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="OH x2, Blast D10, No Cover, Heavy Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="f42c-7e9e-5b27-6658" targetId="aef6-6934-1dee-6fa0" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="bfd1-e214-1717-c121" targetId="04d9-a48d-7b25-4dd3" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="f78e-6fd2-fff5-58e2" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="3203-24a2-4083-bc0d" targetId="bc4e-7cd8-4017-d911" linkType="entry group">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="8690-3ab7-9fef-06ee" name="Mag Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="68">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="57f9-ac99-e46c-2757" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Pistol" hidden="false" book="BtGoA" page="68">
+</profiles>
+<entryLinks>
+<entryLink id="3203-24a2-4083-bc0d" targetId="bc4e-7cd8-4017-d911" type="selectionEntryGroup">
+<modifiers/>
+</entryLink>
+</entryLinks>
+<infoLinks>
+<infoLink id="f42c-7e9e-5b27-6658" targetId="aef6-6934-1dee-6fa0" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="bfd1-e214-1717-c121" targetId="04d9-a48d-7b25-4dd3" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="f78e-6fd2-fff5-58e2" targetId="a41d-d55e-6d97-049d" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="8690-3ab7-9fef-06ee" name="Mag Pistol" type="upgrade" collective="true" hidden="false" book="BtGoA" page="68" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="57f9-ac99-e46c-2757" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Pistol" hidden="false" book="BtGoA" page="68">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="30"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Hand Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="30"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Hand Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links/>
-    </entry>
-    <entry id="790a-6841-6372-870b" name="Mag Repeater" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="69">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="1c20-93a8-d402-9d61" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Repeater" hidden="false" book="BtGoA" page="69">
+</profiles>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="790a-6841-6372-870b" name="Mag Repeater" type="upgrade" collective="true" hidden="false" book="BtGoA" page="69" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="1c20-93a8-d402-9d61" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Repeater" hidden="false" book="BtGoA" page="69">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2, Standard Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2, Standard Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="af4a-bed9-243c-993e" targetId="0cb1-ea91-e5bc-4f75" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="3ecf-d559-4559-c1bb" name="Mass Compactor" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="71">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="b468-06b2-1a5d-2ec0" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mass Compactor" hidden="false" book="BtGoA" page="71">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="af4a-bed9-243c-993e" targetId="0cb1-ea91-e5bc-4f75" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="3ecf-d559-4559-c1bb" name="Mass Compactor" type="upgrade" collective="false" hidden="false" book="BtGoA" page="71" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="b468-06b2-1a5d-2ec0" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mass Compactor" hidden="false" book="BtGoA" page="71">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="30"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3/2/1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Standard Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="30"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="3/2/1"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Standard Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="068c-0048-aa5f-9906" targetId="7db4-2d14-3984-37d9" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="af50-5808-cb3e-2ec9" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="502c-9855-7269-eaa2" name="Medi-Drone" points="20.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="113">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="a034-e97d-eddd-d272" targetId="4039-88e8-9f6d-bfb3" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="eafe-29d5-1222-4155" name="Meld Skark" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules>
-        <rule id="68b7-72bd-610b-2ae3" name="Meld Skark" hidden="false" book="BtGoA" page="194">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="068c-0048-aa5f-9906" targetId="7db4-2d14-3984-37d9" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="af50-5808-cb3e-2ec9" targetId="a41d-d55e-6d97-049d" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="502c-9855-7269-eaa2" name="Medi-Drone" type="model" collective="false" hidden="false" book="BtGoA" page="113" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="20.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="a034-e97d-eddd-d272" targetId="4039-88e8-9f6d-bfb3" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="eafe-29d5-1222-4155" name="Meld Skark" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="-1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules>
+<rule id="68b7-72bd-610b-2ae3" name="Meld Skark" hidden="false" book="BtGoA" page="194">
           <description>6 Attacks, SV1</description>
           <modifiers/>
         </rule>
-      </rules>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="1a9d-01a2-ee09-883c" name="Micro-X Launcher" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="71">
-      <entries>
-        <entry id="756b-b4d4-8824-056b" name="Micro X-Launcher - Overhead" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="b067-87fe-65b4-6bd8" profileTypeId="ecae-8ac8-2c13-0dd3" name="Micro X-Launcher Overhead" hidden="false" book="BtGoA" page="71">
+</rules>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="1a9d-01a2-ee09-883c" name="Micro-X Launcher" type="upgrade" collective="false" hidden="false" book="BtGoA" page="71" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="756b-b4d4-8824-056b" name="Micro X-Launcher - Overhead" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="b067-87fe-65b4-6bd8" profileTypeId="ecae-8ac8-2c13-0dd3" name="Micro X-Launcher Overhead" hidden="false" book="BtGoA" page="71">
               <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D4, No Cover, Standard Weapon"/>
+                <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10-20"/>
+                <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
+                <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
+                <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
+                <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D4, No Cover, Standard Weapon"/>
               </characteristics>
               <modifiers/>
             </profile>
-          </profiles>
-          <links>
-            <link id="29b1-77a8-eac1-dcb8" targetId="c3bc-87fd-fa5d-5055" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="5888-4d4d-b427-d1f3" targetId="ca96-58c9-9551-d4fe" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="de68-1314-0e93-bc44" targetId="a41d-d55e-6d97-049d" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="b484-5b5d-96fb-e628" name="Micro X-Launcher - Direct Fire" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="c0c1-ee5f-5c1f-77a0" profileTypeId="ecae-8ac8-2c13-0dd3" name="Micro X-Launcher - Direct Fire" hidden="false" book="BtGoA" page="71">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="29b1-77a8-eac1-dcb8" targetId="c3bc-87fd-fa5d-5055" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="5888-4d4d-b427-d1f3" targetId="ca96-58c9-9551-d4fe" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="de68-1314-0e93-bc44" targetId="a41d-d55e-6d97-049d" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="b484-5b5d-96fb-e628" name="Micro X-Launcher - Direct Fire" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="c0c1-ee5f-5c1f-77a0" profileTypeId="ecae-8ac8-2c13-0dd3" name="Micro X-Launcher - Direct Fire" hidden="false" book="BtGoA" page="71">
               <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
+                <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
+                <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
+                <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
+                <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
+                <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
               </characteristics>
               <modifiers/>
             </profile>
-          </profiles>
-          <links/>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="e7b0-651a-cc7c-f27e" name="Micro-X Launcher (Eq)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="71">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="3bdc-c653-a2ab-de1c" profileTypeId="ecae-8ac8-2c13-0dd3" name="Micro X-Launcher - Direct Fire" hidden="false" book="BtGoA" page="71">
+</profiles>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="e7b0-651a-cc7c-f27e" name="Micro-X Launcher (Eq)" type="upgrade" collective="false" hidden="false" book="BtGoA" page="71" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="3bdc-c653-a2ab-de1c" profileTypeId="ecae-8ac8-2c13-0dd3" name="Micro X-Launcher - Direct Fire" hidden="false" book="BtGoA" page="71">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-        <profile id="7649-e5a8-d706-0d24" profileTypeId="ecae-8ac8-2c13-0dd3" name="Micro X-Launcher Overhead" hidden="false" book="BtGoA" page="71">
+<profile id="7649-e5a8-d706-0d24" profileTypeId="ecae-8ac8-2c13-0dd3" name="Micro X-Launcher Overhead" hidden="false" book="BtGoA" page="71">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="5"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D4, No Cover, Standard Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10-20"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="5"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D4, No Cover, Standard Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="ede2-e3e5-c94d-4378" targetId="ca96-58c9-9551-d4fe" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="c25b-badb-e157-f945" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="83cb-eec9-94c0-8fc1" targetId="c3bc-87fd-fa5d-5055" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="7849-7fc2-0006-8fbd" name="Munitions" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="cf32-46fd-cdce-80dd" name="Munitions" minSelections="0" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries>
-            <entry id="2f9e-d8b5-f1a8-6e4c" name="Scrambler" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-              <entries/>
-              <entryGroups/>
-              <modifiers>
-                <modifier type="hide" field="maxSelections" value="0.0" repeat="true" numRepeats="1" incrementParentId="cf32-46fd-cdce-80dd" incrementChildId="057c-a217-e792-8ef7" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="c2fb-c9db-5e9c-dcfe" targetId="7a3b-74a5-3ced-dd88" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="9622-01bf-0303-e5f7" targetId="b996-131f-b84a-4724" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="47c5-9ed0-b50a-45b7" name="Arc" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-              <entries/>
-              <entryGroups/>
-              <modifiers>
-                <modifier type="hide" field="maxSelections" value="0.0" repeat="true" numRepeats="1" incrementParentId="cf32-46fd-cdce-80dd" incrementChildId="057c-a217-e792-8ef7" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="1838-cbe5-7c85-395d" targetId="c1ba-c745-22a8-e2d7" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="6568-0044-8497-b002" targetId="b996-131f-b84a-4724" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="876b-029d-8c49-cf28" name="Blur" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-              <entries/>
-              <entryGroups/>
-              <modifiers>
-                <modifier type="hide" field="maxSelections" value="0.0" repeat="true" numRepeats="1" incrementParentId="cf32-46fd-cdce-80dd" incrementChildId="057c-a217-e792-8ef7" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="8a68-f508-7c9e-1ee4" targetId="117a-a2aa-4be7-dffe" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="1fe7-d90c-fd8b-2777" targetId="b996-131f-b84a-4724" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="2f18-3173-0eea-f19f" name="Scoot" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-              <entries/>
-              <entryGroups/>
-              <modifiers>
-                <modifier type="hide" field="maxSelections" value="0.0" repeat="true" numRepeats="1" incrementParentId="cf32-46fd-cdce-80dd" incrementChildId="057c-a217-e792-8ef7" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="a787-c45e-8df6-7cdb" targetId="28a0-7151-a0c5-9495" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="4acd-4d6e-c5ce-c202" targetId="b996-131f-b84a-4724" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="99d6-3f14-a1e9-779b" name="Net" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-              <entries/>
-              <entryGroups/>
-              <modifiers>
-                <modifier type="hide" field="maxSelections" value="0.0" repeat="true" numRepeats="1" incrementParentId="cf32-46fd-cdce-80dd" incrementChildId="057c-a217-e792-8ef7" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="c8d2-16b3-5523-a9b1" targetId="ac33-af99-2d76-c981" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="e014-fd16-bd43-6ead" name="Grip" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-              <entries/>
-              <entryGroups/>
-              <modifiers>
-                <modifier type="hide" field="maxSelections" value="0.0" repeat="true" numRepeats="1" incrementParentId="cf32-46fd-cdce-80dd" incrementChildId="057c-a217-e792-8ef7" incrementField="selections" incrementValue="1.0">
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="6ffa-8857-9b93-35b5" targetId="1045-95cb-5504-9050" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="3eba-9eb4-bf44-4b04" targetId="b996-131f-b84a-4724" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-            <entry id="057c-a217-e792-8ef7" name="All" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-              <entries/>
-              <entryGroups/>
-              <modifiers/>
-              <rules/>
-              <profiles/>
-              <links>
-                <link id="7fae-ff88-b94e-934e" targetId="c1ba-c745-22a8-e2d7" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="49a1-2fba-ff8f-c1b0" targetId="117a-a2aa-4be7-dffe" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="7acb-0144-9a6a-9840" targetId="1045-95cb-5504-9050" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="878e-a6f2-d2ce-4e02" targetId="ac33-af99-2d76-c981" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="ed06-0ab3-bc83-05de" targetId="28a0-7151-a0c5-9495" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="03ee-325f-d6f1-fd20" targetId="7a3b-74a5-3ced-dd88" linkType="rule">
-                  <modifiers/>
-                </link>
-                <link id="8d63-0835-da60-a624" targetId="b996-131f-b84a-4724" linkType="rule">
-                  <modifiers/>
-                </link>
-              </links>
-            </entry>
-          </entries>
-          <entryGroups/>
-          <modifiers/>
-          <links/>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="bf0f-913b-e028-8891" name="Nano Drone" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="113">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="4173-19e8-aa99-3e22" targetId="c1c6-f9c7-c84f-d57d" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="cadc-e1ce-3615-ac4b" name="Nano Drones (2)" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="113">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="ce7f-8e3d-c50c-b636" targetId="c1c6-f9c7-c84f-d57d" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="6b54-c223-3c4a-5de7" name="Overload Ammo" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="89">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="6edf-03c1-417f-13e8" targetId="3559-4b87-980d-f90d" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="eb94-d1e8-1084-71b3" name="Phase Armor" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="93">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="3da3-80ac-dc11-6809" targetId="b28d-571e-af69-4582" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="5725-5e4d-d4f2-1dd0" name="Phase Rifle" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="72">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="d2b1-2482-5f97-a4e4" profileTypeId="ecae-8ac8-2c13-0dd3" name="Phase Rifle" hidden="false" book="BtGoA" page="72">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="ede2-e3e5-c94d-4378" targetId="ca96-58c9-9551-d4fe" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="c25b-badb-e157-f945" targetId="a41d-d55e-6d97-049d" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="83cb-eec9-94c0-8fc1" targetId="c3bc-87fd-fa5d-5055" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="7849-7fc2-0006-8fbd" name="Munitions" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="cf32-46fd-cdce-80dd" name="Munitions" collective="false" hidden="false">
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="5"/>
+</constraints>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="2f9e-d8b5-f1a8-6e4c" name="Scrambler" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="5.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers>
+<modifier type="set" field="hidden" value="true">
+<conditions/>
+<conditionGroups/>
+<repeats>
+<repeat repeats="1" value="1.0" field="selections" scope="cf32-46fd-cdce-80dd" childId="057c-a217-e792-8ef7" shared="true"/>
+</repeats>
+</modifier>
+</modifiers>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="c2fb-c9db-5e9c-dcfe" targetId="7a3b-74a5-3ced-dd88" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="9622-01bf-0303-e5f7" targetId="b996-131f-b84a-4724" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="47c5-9ed0-b50a-45b7" name="Arc" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="5.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers>
+<modifier type="set" field="hidden" value="true">
+<conditions/>
+<conditionGroups/>
+<repeats>
+<repeat repeats="1" value="1.0" field="selections" scope="cf32-46fd-cdce-80dd" childId="057c-a217-e792-8ef7" shared="true"/>
+</repeats>
+</modifier>
+</modifiers>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="1838-cbe5-7c85-395d" targetId="c1ba-c745-22a8-e2d7" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="6568-0044-8497-b002" targetId="b996-131f-b84a-4724" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="876b-029d-8c49-cf28" name="Blur" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="5.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers>
+<modifier type="set" field="hidden" value="true">
+<conditions/>
+<conditionGroups/>
+<repeats>
+<repeat repeats="1" value="1.0" field="selections" scope="cf32-46fd-cdce-80dd" childId="057c-a217-e792-8ef7" shared="true"/>
+</repeats>
+</modifier>
+</modifiers>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="8a68-f508-7c9e-1ee4" targetId="117a-a2aa-4be7-dffe" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="1fe7-d90c-fd8b-2777" targetId="b996-131f-b84a-4724" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="2f18-3173-0eea-f19f" name="Scoot" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="5.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers>
+<modifier type="set" field="hidden" value="true">
+<conditions/>
+<conditionGroups/>
+<repeats>
+<repeat repeats="1" value="1.0" field="selections" scope="cf32-46fd-cdce-80dd" childId="057c-a217-e792-8ef7" shared="true"/>
+</repeats>
+</modifier>
+</modifiers>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="a787-c45e-8df6-7cdb" targetId="28a0-7151-a0c5-9495" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="4acd-4d6e-c5ce-c202" targetId="b996-131f-b84a-4724" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="99d6-3f14-a1e9-779b" name="Net" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="5.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers>
+<modifier type="set" field="hidden" value="true">
+<conditions/>
+<conditionGroups/>
+<repeats>
+<repeat repeats="1" value="1.0" field="selections" scope="cf32-46fd-cdce-80dd" childId="057c-a217-e792-8ef7" shared="true"/>
+</repeats>
+</modifier>
+</modifiers>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="c8d2-16b3-5523-a9b1" targetId="ac33-af99-2d76-c981" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="e014-fd16-bd43-6ead" name="Grip" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="5.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers>
+<modifier type="set" field="hidden" value="true">
+<conditions/>
+<conditionGroups/>
+<repeats>
+<repeat repeats="1" value="1.0" field="selections" scope="cf32-46fd-cdce-80dd" childId="057c-a217-e792-8ef7" shared="true"/>
+</repeats>
+</modifier>
+</modifiers>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="6ffa-8857-9b93-35b5" targetId="1045-95cb-5504-9050" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="3eba-9eb4-bf44-4b04" targetId="b996-131f-b84a-4724" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="057c-a217-e792-8ef7" name="All" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="15.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="7fae-ff88-b94e-934e" targetId="c1ba-c745-22a8-e2d7" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="49a1-2fba-ff8f-c1b0" targetId="117a-a2aa-4be7-dffe" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="7acb-0144-9a6a-9840" targetId="1045-95cb-5504-9050" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="878e-a6f2-d2ce-4e02" targetId="ac33-af99-2d76-c981" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="ed06-0ab3-bc83-05de" targetId="28a0-7151-a0c5-9495" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="03ee-325f-d6f1-fd20" targetId="7a3b-74a5-3ced-dd88" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="8d63-0835-da60-a624" targetId="b996-131f-b84a-4724" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups/>
+<entryLinks/>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="bf0f-913b-e028-8891" name="Nano Drone" type="upgrade" collective="false" hidden="false" book="BtGoA" page="113" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="20.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="4173-19e8-aa99-3e22" targetId="c1c6-f9c7-c84f-d57d" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="cadc-e1ce-3615-ac4b" name="Nano Drones (2)" type="upgrade" collective="false" hidden="false" book="BtGoA" page="113" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="20.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="ce7f-8e3d-c50c-b636" targetId="c1c6-f9c7-c84f-d57d" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="6b54-c223-3c4a-5de7" name="Overload Ammo" type="upgrade" collective="true" hidden="false" book="BtGoA" page="89" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="6edf-03c1-417f-13e8" targetId="3559-4b87-980d-f90d" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="eb94-d1e8-1084-71b3" name="Phase Armor" type="upgrade" collective="true" hidden="false" book="BtGoA" page="93" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="3da3-80ac-dc11-6809" targetId="b28d-571e-af69-4582" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="5725-5e4d-d4f2-1dd0" name="Phase Rifle" type="upgrade" collective="false" hidden="false" book="BtGoA" page="72" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="d2b1-2482-5f97-a4e4" profileTypeId="ecae-8ac8-2c13-0dd3" name="Phase Rifle" hidden="false" book="BtGoA" page="72">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="No Cover, RF D6 Fire Only, Concentrated Fire, Standard Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="100"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="No Cover, RF D6 Fire Only, Concentrated Fire, Standard Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="0d4d-4f3f-c86d-9dbe" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="b46e-26ca-aad6-e64b" targetId="1863-c041-6dc4-c62d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="6fea-ec6b-df33-2abe" targetId="5fb8-4f09-d496-4ea9" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="a18f-8d16-f879-e590" name="Phaseshift Shield" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="122">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="67b6-d6f5-5ba3-e50d" name="Plasma Bombard" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="82">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="a5d1-11c5-eb13-f676" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Bombard" hidden="false" book="BtGoA" page="82">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="0d4d-4f3f-c86d-9dbe" targetId="a41d-d55e-6d97-049d" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="b46e-26ca-aad6-e64b" targetId="1863-c041-6dc4-c62d" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="6fea-ec6b-df33-2abe" targetId="5fb8-4f09-d496-4ea9" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="a18f-8d16-f879-e590" name="Phaseshift Shield" type="upgrade" collective="false" hidden="false" book="BtGoA" page="122" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="-1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="67b6-d6f5-5ba3-e50d" name="Plasma Bombard" type="upgrade" collective="false" hidden="false" book="BtGoA" page="82" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="a5d1-11c5-eb13-f676" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Bombard" hidden="false" book="BtGoA" page="82">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="200"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="7"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Plasma Fade, Heavy Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="200"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="7"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Plasma Fade, Heavy Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="7388-9f57-6e2a-eadb" targetId="6b03-2ad4-34c1-7f73" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="c2bf-0272-30c6-dd20" name="Plasma Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="76">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="dce6-92d7-7812-820a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Cannon" hidden="false" book="BtGoA" page="76">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="7388-9f57-6e2a-eadb" targetId="6b03-2ad4-34c1-7f73" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="c2bf-0272-30c6-dd20" name="Plasma Cannon" type="upgrade" collective="false" hidden="false" book="BtGoA" page="76" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="dce6-92d7-7812-820a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Cannon" hidden="false" book="BtGoA" page="76">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="4"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="6"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Plasma Fade, Light Support Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="4"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="6"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Plasma Fade, Light Support Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="3c39-3d6d-7a5a-f2f5" targetId="6b03-2ad4-34c1-7f73" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="1631-5857-2139-960a" name="Plasma Carbine " points="0.0" categoryId="(No Category)" type="model" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="70">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="0212-5213-7d18-d37f" targetId="ee9c-ada6-953a-b774" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="d572-ea69-f6bd-9b8f" targetId="b56d-0f1d-de00-62c4" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="b55d-3878-89ca-fb86" targetId="0cb1-ea91-e5bc-4f75" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="b018-6101-d2e3-b4ea" name="Plasma Carbine (Eq)" points="0.0" categoryId="(No Category)" type="model" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="70">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="7c09-db8c-68d9-485b" targetId="ee9c-ada6-953a-b774" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="8179-73ab-e5c7-065c" targetId="b56d-0f1d-de00-62c4" linkType="profile">
-          <modifiers/>
-        </link>
-        <link id="f29e-ac68-7310-1db0" targetId="0cb1-ea91-e5bc-4f75" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="d118-8115-df5f-2402" name="Plasma Grenades" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="8771-f173-82cd-3509" targetId="96f9-325b-69f7-13b4" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="47d9-8149-9744-9849" name="Plasma Lance" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="70">
-      <entries>
-        <entry id="b6e9-addd-c005-4547" name="Plasma Lance - Single Shot" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="70">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="3799-96cf-d949-da4e" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Single Shot" hidden="false" book="BtGoA" page="70">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="3c39-3d6d-7a5a-f2f5" targetId="6b03-2ad4-34c1-7f73" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="1631-5857-2139-960a" name="Plasma Carbine " type="model" collective="true" hidden="false" book="BtGoA" page="70" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="0212-5213-7d18-d37f" targetId="ee9c-ada6-953a-b774" type="profile">
+<modifiers/>
+</infoLink>
+<infoLink id="d572-ea69-f6bd-9b8f" targetId="b56d-0f1d-de00-62c4" type="profile">
+<modifiers/>
+</infoLink>
+<infoLink id="b55d-3878-89ca-fb86" targetId="0cb1-ea91-e5bc-4f75" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="b018-6101-d2e3-b4ea" name="Plasma Carbine (Eq)" type="model" collective="true" hidden="false" book="BtGoA" page="70" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="7c09-db8c-68d9-485b" targetId="ee9c-ada6-953a-b774" type="profile">
+<modifiers/>
+</infoLink>
+<infoLink id="8179-73ab-e5c7-065c" targetId="b56d-0f1d-de00-62c4" type="profile">
+<modifiers/>
+</infoLink>
+<infoLink id="f29e-ac68-7310-1db0" targetId="0cb1-ea91-e5bc-4f75" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="d118-8115-df5f-2402" name="Plasma Grenades" type="upgrade" collective="false" hidden="false" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="8771-f173-82cd-3509" targetId="96f9-325b-69f7-13b4" type="profile">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="47d9-8149-9744-9849" name="Plasma Lance" type="upgrade" collective="false" hidden="false" book="BtGoA" page="70" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="b6e9-addd-c005-4547" name="Plasma Lance - Single Shot" type="upgrade" collective="false" hidden="false" book="BtGoA" page="70" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="3799-96cf-d949-da4e" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Single Shot" hidden="false" book="BtGoA" page="70">
               <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
+                <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
+                <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
+                <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
+                <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
+                <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
               </characteristics>
               <modifiers/>
             </profile>
-          </profiles>
-          <links/>
-        </entry>
-        <entry id="80ed-e766-57b1-3d2a" name="Plasma Lance - Scatter" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="70">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="9ad5-3648-6628-2caa" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Scatter" hidden="false" book="BtGoA" page="70">
+</profiles>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="80ed-e766-57b1-3d2a" name="Plasma Lance - Scatter" type="upgrade" collective="false" hidden="false" book="BtGoA" page="70" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="9ad5-3648-6628-2caa" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Scatter" hidden="false" book="BtGoA" page="70">
               <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2, Standard Weapon"/>
+                <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
+                <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
+                <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
+                <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
+                <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2, Standard Weapon"/>
               </characteristics>
               <modifiers/>
             </profile>
-          </profiles>
-          <links>
-            <link id="3f8e-ffa3-e1eb-fde7" targetId="0cb1-ea91-e5bc-4f75" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="4069-4420-c5b5-56af" name="Plasma Lance - Lance" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="70">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="f44f-9fdb-7e3c-bf9e" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Lance" hidden="false" book="BtGoA" page="70">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="3f8e-ffa3-e1eb-fde7" targetId="0cb1-ea91-e5bc-4f75" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="4069-4420-c5b5-56af" name="Plasma Lance - Lance" type="upgrade" collective="false" hidden="false" book="BtGoA" page="70" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="f44f-9fdb-7e3c-bf9e" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Lance" hidden="false" book="BtGoA" page="70">
               <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="4"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Choose Target, Inaccurate, Standard Weapon"/>
+                <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
+                <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
+                <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
+                <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="4"/>
+                <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Choose Target, Inaccurate, Standard Weapon"/>
               </characteristics>
               <modifiers/>
             </profile>
-          </profiles>
-          <links>
-            <link id="7213-775a-deac-dce8" targetId="fd72-d48c-e8af-4883" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="9752-310b-98a1-37af" targetId="3b84-9d0e-a3c1-6c1f" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="cf3a-e6a9-bdc0-e0ae" name="Plasma Light Support" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="76">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="d429-b8cc-aca0-aac9" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Light Support" hidden="false" book="BtGoA" page="76">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="7213-775a-deac-dce8" targetId="fd72-d48c-e8af-4883" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="9752-310b-98a1-37af" targetId="3b84-9d0e-a3c1-6c1f" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="cf3a-e6a9-bdc0-e0ae" name="Plasma Light Support" type="upgrade" collective="false" hidden="false" book="BtGoA" page="76" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="d429-b8cc-aca0-aac9" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Light Support" hidden="false" book="BtGoA" page="76">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3, Light Support Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3, Light Support Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="9e8b-6ee9-56f0-aedf" targetId="97d4-67cb-2671-ca29" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="0f97-9dbe-566a-5ab0" name="Plasma Light Support (Eq)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="76">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="4477-6aca-5fe1-2d03" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Light Support" hidden="false" book="BtGoA" page="76">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="9e8b-6ee9-56f0-aedf" targetId="97d4-67cb-2671-ca29" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="0f97-9dbe-566a-5ab0" name="Plasma Light Support (Eq)" type="upgrade" collective="false" hidden="false" book="BtGoA" page="76" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="4477-6aca-5fe1-2d03" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Light Support" hidden="false" book="BtGoA" page="76">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="4"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3, Light Support Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="4"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3, Light Support Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="61c1-b16a-8335-9497" targetId="97d4-67cb-2671-ca29" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="9cd6-dbb8-bdcb-0299" name="Plasma Pistol" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="68">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="3d5e-ab8a-1859-49b2" targetId="2e7c-b5f9-e3e5-9125" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="e6db-6ed3-1a26-ea56" name="Plasma Pistol (Eq)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="68">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="d7c4-2e9d-b85d-2cda" targetId="2e7c-b5f9-e3e5-9125" linkType="profile">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="2396-4159-e26c-6c42" name="Reflex Armor" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="93">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="6826-c718-8070-65a3" targetId="18c0-c86d-0b2c-23af" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="9cdf-f068-bbde-2d0c" name="Reflex Armor (Eq)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="93">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="fead-bc73-7559-09fc" targetId="18c0-c86d-0b2c-23af" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="03c2-174e-8617-cf04" name="Reflex Armor/ Impact Cloak (Eq)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="93">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="a445-3a2a-b5dc-dff6" targetId="18c0-c86d-0b2c-23af" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="abe2-ce1e-271f-5a85" name="Scourer Cannon" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="73">
-      <entries>
-        <entry id="ccbf-d756-25d7-40f4" name="Scourer Cannon - Dispersed" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="true" book="BtGoA" page="73">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="03b8-44da-840d-df59" profileTypeId="ecae-8ac8-2c13-0dd3" name="Scourer Cannon - Dispersed" hidden="false" book="BtGoA" page="73">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="61c1-b16a-8335-9497" targetId="97d4-67cb-2671-ca29" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="9cd6-dbb8-bdcb-0299" name="Plasma Pistol" type="upgrade" collective="false" hidden="false" book="BtGoA" page="68" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="3d5e-ab8a-1859-49b2" targetId="2e7c-b5f9-e3e5-9125" type="profile">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="e6db-6ed3-1a26-ea56" name="Plasma Pistol (Eq)" type="upgrade" collective="true" hidden="false" book="BtGoA" page="68" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="d7c4-2e9d-b85d-2cda" targetId="2e7c-b5f9-e3e5-9125" type="profile">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="2396-4159-e26c-6c42" name="Reflex Armor" type="upgrade" collective="true" hidden="false" book="BtGoA" page="93" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="6826-c718-8070-65a3" targetId="18c0-c86d-0b2c-23af" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="9cdf-f068-bbde-2d0c" name="Reflex Armor (Eq)" type="upgrade" collective="true" hidden="false" book="BtGoA" page="93" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="fead-bc73-7559-09fc" targetId="18c0-c86d-0b2c-23af" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="03c2-174e-8617-cf04" name="Reflex Armor/ Impact Cloak (Eq)" type="upgrade" collective="true" hidden="false" book="BtGoA" page="93" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="a445-3a2a-b5dc-dff6" targetId="18c0-c86d-0b2c-23af" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="abe2-ce1e-271f-5a85" name="Scourer Cannon" type="upgrade" collective="false" hidden="false" book="BtGoA" page="73" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="ccbf-d756-25d7-40f4" name="Scourer Cannon - Dispersed" type="upgrade" collective="false" hidden="true" book="BtGoA" page="73" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="03b8-44da-840d-df59" profileTypeId="ecae-8ac8-2c13-0dd3" name="Scourer Cannon - Dispersed" hidden="false" book="BtGoA" page="73">
               <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3, Standard Weapon"/>
+                <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
+                <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
+                <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
+                <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
+                <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3, Standard Weapon"/>
               </characteristics>
               <modifiers/>
             </profile>
-          </profiles>
-          <links>
-            <link id="6631-7298-fd9d-ce64" targetId="97d4-67cb-2671-ca29" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="713c-944f-32ee-fe55" name="Scourer Cannon - Concentrated" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="73">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="0f28-d6ef-0f10-6e8f" profileTypeId="ecae-8ac8-2c13-0dd3" name="Scourer Cannon - Concentrated" hidden="false" book="BtGoA" page="73">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="6631-7298-fd9d-ce64" targetId="97d4-67cb-2671-ca29" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="713c-944f-32ee-fe55" name="Scourer Cannon - Concentrated" type="upgrade" collective="false" hidden="false" book="BtGoA" page="73" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints/>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="0f28-d6ef-0f10-6e8f" profileTypeId="ecae-8ac8-2c13-0dd3" name="Scourer Cannon - Concentrated" hidden="false" book="BtGoA" page="73">
               <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="40"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="4"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
+                <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
+                <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
+                <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="40"/>
+                <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="4"/>
+                <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Standard Weapon"/>
               </characteristics>
               <modifiers/>
             </profile>
-          </profiles>
-          <links/>
-        </entry>
-        <entry id="9a2e-529c-2e81-0d99" name="Scourer Cannon - Disruptor" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="-1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="73">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles>
-            <profile id="1b2e-f75a-2b45-9cde" profileTypeId="ecae-8ac8-2c13-0dd3" name="Scourer Cannon - Disruptor" hidden="false" book="BtGoA" page="73">
+</profiles>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="9a2e-529c-2e81-0d99" name="Scourer Cannon - Disruptor" type="upgrade" collective="false" hidden="false" book="BtGoA" page="73" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints/>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="1b2e-f75a-2b45-9cde" profileTypeId="ecae-8ac8-2c13-0dd3" name="Scourer Cannon - Disruptor" hidden="false" book="BtGoA" page="73">
               <characteristics>
-                <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-                <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
-                <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-                <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-                <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D4, No Cover, Disruptor, Standard Weapon"/>
+                <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
+                <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="3"/>
+                <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
+                <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
+                <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D4, No Cover, Disruptor, Standard Weapon"/>
               </characteristics>
               <modifiers/>
             </profile>
-          </profiles>
-          <links>
-            <link id="393a-a871-9061-745a" targetId="ca96-58c9-9551-d4fe" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="dee2-529a-c466-8b1e" targetId="a41d-d55e-6d97-049d" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="1a7e-03a3-9055-86c1" targetId="6305-72fa-da02-235b" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="b145-19b3-baae-ff39" name="Shield Drone" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="114">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="65a3-4c38-417c-cc9f" targetId="b08d-74dd-1a32-8bdc" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="1707-586b-01df-0f80" name="Shield Drone (2)" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="114">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="b2fa-ba86-d0d2-1a30" targetId="b08d-74dd-1a32-8bdc" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="1e33-99fa-00fc-0a32" name="Skark" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="131">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules>
-        <rule id="3983-4050-5e06-8fd3" name="Skark" hidden="false" book="BtGoA" page="131">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="393a-a871-9061-745a" targetId="ca96-58c9-9551-d4fe" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="dee2-529a-c466-8b1e" targetId="a41d-d55e-6d97-049d" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="1a7e-03a3-9055-86c1" targetId="6305-72fa-da02-235b" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="b145-19b3-baae-ff39" name="Shield Drone" type="upgrade" collective="false" hidden="false" book="BtGoA" page="114" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="10.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="65a3-4c38-417c-cc9f" targetId="b08d-74dd-1a32-8bdc" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="1707-586b-01df-0f80" name="Shield Drone (2)" type="upgrade" collective="false" hidden="false" book="BtGoA" page="114" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="10.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="b2fa-ba86-d0d2-1a30" targetId="b08d-74dd-1a32-8bdc" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="1e33-99fa-00fc-0a32" name="Skark" type="upgrade" collective="true" hidden="false" book="BtGoA" page="131" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules>
+<rule id="3983-4050-5e06-8fd3" name="Skark" hidden="false" book="BtGoA" page="131">
           <description>Three attacks at SV1.</description>
           <modifiers/>
         </rule>
-      </rules>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="a1a8-ba0b-2e45-8020" name="Skyraider" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="192">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="d918-4412-0ae1-6f74" name="Weapon" defaultEntryId="467e-1407-3119-60ef" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="467e-1407-3119-60ef" targetId="f31c-6e5c-19c0-ada7" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="8de3-1e72-72ef-e7a3" name="SlingNet Ammo" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="27d6-5dd8-337d-1005" targetId="5bd0-9ab2-0523-cbc8" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="db03-7794-daeb-fef6" name="Solar Charges" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="85">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="457b-abde-ffd5-bb14" profileTypeId="ecae-8ac8-2c13-0dd3" name="Solar Charges" hidden="false" book="BtGoA" page="85">
+</rules>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="a1a8-ba0b-2e45-8020" name="Skyraider" type="upgrade" collective="true" hidden="false" book="BtGoA" page="192" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="d918-4412-0ae1-6f74" name="Weapon" collective="false" hidden="false" defaultSelectionEntryId="467e-1407-3119-60ef">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="467e-1407-3119-60ef" targetId="f31c-6e5c-19c0-ada7" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="8de3-1e72-72ef-e7a3" name="SlingNet Ammo" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="27d6-5dd8-337d-1005" targetId="5bd0-9ab2-0523-cbc8" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="db03-7794-daeb-fef6" name="Solar Charges" type="upgrade" collective="true" hidden="false" book="BtGoA" page="85" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="457b-abde-ffd5-bb14" profileTypeId="ecae-8ac8-2c13-0dd3" name="Solar Charges" hidden="false" book="BtGoA" page="85">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D3, Hazardhous H2H, Grenade"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D3, Hazardhous H2H, Grenade"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="7a23-290e-0678-0165" targetId="1acd-39d3-94e7-48e1" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="7cdc-f9ef-85bc-947a" targetId="1c2c-6574-0a17-f90c" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="3878-9363-1705-9eda" name="Soma Graft" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="121">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="3d50-6009-476b-2dd3" targetId="1253-ef5b-67d4-3e18" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="f3aa-148a-0460-c7e5" name="Spotter Drone" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="114">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="b096-0158-02cc-ad91" targetId="fdbd-254f-8dd7-b658" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="a1c9-551b-1532-ef5a" name="Spotter Drone (2)" points="10.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="2" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="114">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="af19-89d3-df23-32fc" targetId="fdbd-254f-8dd7-b658" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="e329-9443-6cb2-bc53" name="Spotter Drone (Eq)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="114">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="65b9-8262-6f60-281e" targetId="fdbd-254f-8dd7-b658" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="6bfe-ff47-b61c-afd2" name="Sub-mounted X-Sling" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="a9af-f28d-4e65-6d1b" targetId="b08e-548a-fda7-0a4e" linkType="entry">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="fb8b-7402-c5a9-8644" name="Subverter Matrix" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="122">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="24bd-bd70-2f6b-0434" targetId="cd8d-624c-ed86-e310" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="059e-3ead-10ef-9fd5" name="Synchroniser Drone" points="20.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="Battle for Xilos" page="79">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links>
-        <link id="f848-9ddf-c5b7-7291" targetId="c526-9fd9-f1c5-6893" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="02f1-fd15-ca9d-ad79" name="Tractor Maul" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="65">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="0f4d-9895-e878-29ea" profileTypeId="ecae-8ac8-2c13-0dd3" name="Tractor Maul" hidden="false" book="BtGoA" page="65">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="7a23-290e-0678-0165" targetId="1acd-39d3-94e7-48e1" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="7cdc-f9ef-85bc-947a" targetId="1c2c-6574-0a17-f90c" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="3878-9363-1705-9eda" name="Soma Graft" type="upgrade" collective="false" hidden="false" book="BtGoA" page="121" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="3d50-6009-476b-2dd3" targetId="1253-ef5b-67d4-3e18" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="f3aa-148a-0460-c7e5" name="Spotter Drone" type="upgrade" collective="false" hidden="false" book="BtGoA" page="114" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="10.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="b096-0158-02cc-ad91" targetId="fdbd-254f-8dd7-b658" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="a1c9-551b-1532-ef5a" name="Spotter Drone (2)" type="upgrade" collective="false" hidden="false" book="BtGoA" page="114" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="10.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="2"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="af19-89d3-df23-32fc" targetId="fdbd-254f-8dd7-b658" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="e329-9443-6cb2-bc53" name="Spotter Drone (Eq)" type="upgrade" collective="false" hidden="false" book="BtGoA" page="114" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="65b9-8262-6f60-281e" targetId="fdbd-254f-8dd7-b658" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="6bfe-ff47-b61c-afd2" name="Sub-mounted X-Sling" type="upgrade" collective="true" hidden="false" book="BtGoA" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks>
+<entryLink id="a9af-f28d-4e65-6d1b" targetId="b08e-548a-fda7-0a4e" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="fb8b-7402-c5a9-8644" name="Subverter Matrix" type="upgrade" collective="false" hidden="false" book="BtGoA" page="122" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="24bd-bd70-2f6b-0434" targetId="cd8d-624c-ed86-e310" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="059e-3ead-10ef-9fd5" name="Synchroniser Drone" type="upgrade" collective="false" hidden="false" book="Battle for Xilos" page="79" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="20.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="f848-9ddf-c5b7-7291" targetId="c526-9fd9-f1c5-6893" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="02f1-fd15-ca9d-ad79" name="Tractor Maul" type="upgrade" collective="false" hidden="false" book="BtGoA" page="65" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="0f4d-9895-e878-29ea" profileTypeId="ecae-8ac8-2c13-0dd3" name="Tractor Maul" hidden="false" book="BtGoA" page="65">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks, Hand Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="H2H Only"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="H2H Only"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="H2H Only"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks, Hand Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="311e-56e1-d1bc-36a1" targetId="2cbd-47c9-de87-ec2a" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="ac1e-a740-57b7-cc64" name="Twin Mag Light Support" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="75">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="25d4-13e2-3977-4bd4" name="Mag Light Support" defaultEntryId="d17e-2eae-cc33-8d46" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="d17e-2eae-cc33-8d46" targetId="a00c-0542-f2a5-8124" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="c10e-6e9c-dabb-e6f1" name="Mag Light Support" defaultEntryId="b385-bf67-9722-e7f9" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="b385-bf67-9722-e7f9" targetId="a00c-0542-f2a5-8124" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="f31c-6e5c-19c0-ada7" name="Twin Mag Repeaters" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="69">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="4e5a-4594-d2da-527c" name="Mag Repeater" defaultEntryId="513b-6ec0-e655-02cd" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="513b-6ec0-e655-02cd" targetId="790a-6841-6372-870b" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-        <entryGroup id="273a-5de1-c9e1-5310" name="Mag Repeater" defaultEntryId="6e82-7e87-0e72-610f" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="6e82-7e87-0e72-610f" targetId="790a-6841-6372-870b" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="78dd-7840-1210-fb35" name="Twin Plasma Carbines" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA">
-      <entries/>
-      <entryGroups>
-        <entryGroup id="306b-df6b-34af-a65f" name="Plasma Carbine" defaultEntryId="50f5-f0eb-d9cb-a569" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <links>
-            <link id="50f5-f0eb-d9cb-a569" targetId="b018-6101-d2e3-b4ea" linkType="entry">
-              <modifiers/>
-            </link>
-          </links>
-        </entryGroup>
-      </entryGroups>
-      <modifiers/>
-      <rules/>
-      <profiles/>
-      <links/>
-    </entry>
-    <entry id="b9f1-a313-3e59-57ab" name="X-Howitzer" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="82">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="acf4-2a5f-e9a1-6d3c" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Howitzer" hidden="false" book="BtGoA" page="82">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="311e-56e1-d1bc-36a1" targetId="2cbd-47c9-de87-ec2a" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="ac1e-a740-57b7-cc64" name="Twin Mag Light Support" type="upgrade" collective="false" hidden="false" book="BtGoA" page="75" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="25d4-13e2-3977-4bd4" name="Mag Light Support" collective="false" hidden="false" defaultSelectionEntryId="d17e-2eae-cc33-8d46">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="d17e-2eae-cc33-8d46" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="c10e-6e9c-dabb-e6f1" name="Mag Light Support" collective="false" hidden="false" defaultSelectionEntryId="b385-bf67-9722-e7f9">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="b385-bf67-9722-e7f9" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="f31c-6e5c-19c0-ada7" name="Twin Mag Repeaters" type="upgrade" collective="false" hidden="false" book="BtGoA" page="69" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="4e5a-4594-d2da-527c" name="Mag Repeater" collective="false" hidden="false" defaultSelectionEntryId="513b-6ec0-e655-02cd">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="513b-6ec0-e655-02cd" targetId="790a-6841-6372-870b" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+<selectionEntryGroup id="273a-5de1-c9e1-5310" name="Mag Repeater" collective="false" hidden="false" defaultSelectionEntryId="6e82-7e87-0e72-610f">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="6e82-7e87-0e72-610f" targetId="790a-6841-6372-870b" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="78dd-7840-1210-fb35" name="Twin Plasma Carbines" type="upgrade" collective="false" hidden="false" book="BtGoA" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups>
+<selectionEntryGroup id="306b-df6b-34af-a65f" name="Plasma Carbine" collective="false" hidden="false" defaultSelectionEntryId="50f5-f0eb-d9cb-a569">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<entryLinks>
+<entryLink id="50f5-f0eb-d9cb-a569" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+<modifiers/>
+</entryLink>
+</entryLinks>
+</selectionEntryGroup>
+</selectionEntryGroups>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks/>
+</selectionEntry>
+<selectionEntry id="b9f1-a313-3e59-57ab" name="X-Howitzer" type="upgrade" collective="false" hidden="false" book="BtGoA" page="82" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="acf4-2a5f-e9a1-6d3c" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Howitzer" hidden="false" book="BtGoA" page="82">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-50"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="250"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D10, No Cover, Heavy Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10-50"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="250"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D10, No Cover, Heavy Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="6f40-42de-4957-1df4" targetId="c3bc-87fd-fa5d-5055" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="b631-2638-986b-4611" targetId="04d9-a48d-7b25-4dd3" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="7c8b-6880-8593-4b52" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="92e5-9a8f-2921-8280" targetId="bc4e-7cd8-4017-d911" linkType="entry group">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="eed0-b68f-b5fb-92c7" name="X-Launcher" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="78">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="2489-100b-d116-96c6" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Launcher" hidden="false" book="BtGoA" page="78">
+</profiles>
+<entryLinks>
+<entryLink id="92e5-9a8f-2921-8280" targetId="bc4e-7cd8-4017-d911" type="selectionEntryGroup">
+<modifiers/>
+</entryLink>
+</entryLinks>
+<infoLinks>
+<infoLink id="6f40-42de-4957-1df4" targetId="c3bc-87fd-fa5d-5055" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="b631-2638-986b-4611" targetId="04d9-a48d-7b25-4dd3" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="7c8b-6880-8593-4b52" targetId="a41d-d55e-6d97-049d" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="eed0-b68f-b5fb-92c7" name="X-Launcher" type="upgrade" collective="false" hidden="false" book="BtGoA" page="78" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="2489-100b-d116-96c6" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Launcher" hidden="false" book="BtGoA" page="78">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="60"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="120"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D5, No Cover,  Light Support Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="60"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="120"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D5, No Cover,  Light Support Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="cbba-ff32-112c-3173" targetId="c3bc-87fd-fa5d-5055" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="57ac-1f50-9d13-b33b" targetId="b050-496a-ed16-2b2a" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="613e-43c3-a036-e997" targetId="a41d-d55e-6d97-049d" linkType="rule">
-          <modifiers/>
-        </link>
-        <link id="7bb9-56de-ae51-c52b" targetId="bc4e-7cd8-4017-d911" linkType="entry group">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="b08e-548a-fda7-0a4e" name="X-Sling" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="68">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="3cec-d2e0-b0ed-7856" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Sling" hidden="false" book="BtGoA" page="68">
+</profiles>
+<entryLinks>
+<entryLink id="7bb9-56de-ae51-c52b" targetId="bc4e-7cd8-4017-d911" type="selectionEntryGroup">
+<modifiers/>
+</entryLink>
+</entryLinks>
+<infoLinks>
+<infoLink id="cbba-ff32-112c-3173" targetId="c3bc-87fd-fa5d-5055" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="57ac-1f50-9d13-b33b" targetId="b050-496a-ed16-2b2a" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="613e-43c3-a036-e997" targetId="a41d-d55e-6d97-049d" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="b08e-548a-fda7-0a4e" name="X-Sling" type="upgrade" collective="true" hidden="false" book="BtGoA" page="68" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="3cec-d2e0-b0ed-7856" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Sling" hidden="false" book="BtGoA" page="68">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D3, Hand Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D3, Hand Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="ff22-4293-45d6-b483" targetId="1acd-39d3-94e7-48e1" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-    <entry id="179a-c0cc-49cc-c946" name="X-Sling (Eq)" points="0.0" categoryId="(No Category)" type="upgrade" minSelections="1" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="true" hidden="false" book="BtGoA" page="68">
-      <entries/>
-      <entryGroups/>
-      <modifiers/>
-      <rules/>
-      <profiles>
-        <profile id="8977-826a-5f65-6907" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Sling" hidden="false" book="BtGoA" page="68">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="ff22-4293-45d6-b483" targetId="1acd-39d3-94e7-48e1" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="179a-c0cc-49cc-c946" name="X-Sling (Eq)" type="upgrade" collective="true" hidden="false" book="BtGoA" page="68" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="0.0"/>
+</costs>
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="1"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles>
+<profile id="8977-826a-5f65-6907" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Sling" hidden="false" book="BtGoA" page="68">
           <characteristics>
-            <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-            <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-            <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-            <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-            <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D3, Hand Weapon"/>
+            <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
+            <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
+            <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
+            <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
+            <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D3, Hand Weapon"/>
           </characteristics>
           <modifiers/>
         </profile>
-      </profiles>
-      <links>
-        <link id="f51f-aab5-2da1-d5d0" targetId="1acd-39d3-94e7-48e1" linkType="rule">
-          <modifiers/>
-        </link>
-      </links>
-    </entry>
-  </sharedEntries>
-  <sharedEntryGroups>
-    <entryGroup id="bc4e-7cd8-4017-d911" name="Munitions" minSelections="0" maxSelections="5" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false">
-      <entries>
-        <entry id="c816-58ed-3726-86b5" name="Scrambler" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="55f1-0e9f-4b69-56c1" targetId="7a3b-74a5-3ced-dd88" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="69e5-ef01-7a5e-3f24" targetId="b996-131f-b84a-4724" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="e0bc-ff63-7ed9-9768" name="Arc" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="6614-fd6d-aecf-1070" targetId="c1ba-c745-22a8-e2d7" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="6979-177c-42e8-27bf" targetId="b996-131f-b84a-4724" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="d6cb-2428-f1b5-0f11" name="Blur" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="a019-91dd-3b84-e72e" targetId="117a-a2aa-4be7-dffe" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="b4a9-0df0-5149-5785" targetId="b996-131f-b84a-4724" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="bbac-d335-536a-e63d" name="Scoot" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="0e1e-3e34-5c36-4bbf" targetId="28a0-7151-a0c5-9495" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="cc03-4929-b882-43a6" targetId="b996-131f-b84a-4724" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="2a9e-c888-1e5a-ea11" name="Net" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="f4bd-099a-19ab-8138" targetId="ac33-af99-2d76-c981" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="b932-f489-37e5-e6b4" name="Grip" points="5.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="eee1-31e1-599c-0bd8" targetId="1045-95cb-5504-9050" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="df1a-7d7c-9316-5794" targetId="b996-131f-b84a-4724" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-        <entry id="f766-367d-f5c0-fc59" name="All" points="15.0" categoryId="(No Category)" type="upgrade" minSelections="0" maxSelections="1" minInForce="0" maxInForce="-1" minInRoster="0" maxInRoster="-1" minPoints="0.0" maxPoints="-1.0" collective="false" hidden="false" book="BtGoA" page="87">
-          <entries/>
-          <entryGroups/>
-          <modifiers/>
-          <rules/>
-          <profiles/>
-          <links>
-            <link id="1874-10fd-bc26-7005" targetId="c1ba-c745-22a8-e2d7" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="0234-4b9e-9342-68f7" targetId="117a-a2aa-4be7-dffe" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="6234-ec86-062c-0073" targetId="1045-95cb-5504-9050" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="a285-cf7f-7fac-f9ab" targetId="ac33-af99-2d76-c981" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="11d8-fdb9-76ff-2c4c" targetId="28a0-7151-a0c5-9495" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="9abb-2789-75c0-d3a8" targetId="7a3b-74a5-3ced-dd88" linkType="rule">
-              <modifiers/>
-            </link>
-            <link id="1492-b598-eb64-0ea0" targetId="b996-131f-b84a-4724" linkType="rule">
-              <modifiers/>
-            </link>
-          </links>
-        </entry>
-      </entries>
-      <entryGroups/>
-      <modifiers/>
-      <links/>
-    </entryGroup>
-  </sharedEntryGroups>
-  <sharedRules>
-    <rule id="2cbd-47c9-de87-ec2a" name="2 Attacks" hidden="false" book="BtGoA" page="133">
+</profiles>
+<entryLinks/>
+<infoLinks>
+<infoLink id="f51f-aab5-2da1-d5d0" targetId="1acd-39d3-94e7-48e1" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</sharedSelectionEntries>
+<sharedSelectionEntryGroups>
+<selectionEntryGroup id="bc4e-7cd8-4017-d911" name="Munitions" collective="false" hidden="false">
+<constraints>
+<constraint id="minSelections" type="min" field="selections" scope="parent" value="0"/>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="5"/>
+<constraint id="minInForce" type="min" field="selections" scope="force" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInForce" type="max" field="selections" scope="force" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minInRoster" type="min" field="selections" scope="roster" value="0" includeChildSelections="true" shared="true"/>
+<constraint id="maxInRoster" type="max" field="selections" scope="roster" value="-1" includeChildSelections="true" shared="true"/>
+<constraint id="minPoints" type="min" field="points" scope="parent" value="0.0" includeChildSelections="true"/>
+<constraint id="maxPoints" type="max" field="points" scope="parent" value="-1.0" includeChildSelections="true"/>
+</constraints>
+<modifiers/>
+<selectionEntries>
+<selectionEntry id="c816-58ed-3726-86b5" name="Scrambler" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="5.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="55f1-0e9f-4b69-56c1" targetId="7a3b-74a5-3ced-dd88" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="69e5-ef01-7a5e-3f24" targetId="b996-131f-b84a-4724" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="e0bc-ff63-7ed9-9768" name="Arc" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="5.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="6614-fd6d-aecf-1070" targetId="c1ba-c745-22a8-e2d7" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="6979-177c-42e8-27bf" targetId="b996-131f-b84a-4724" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="d6cb-2428-f1b5-0f11" name="Blur" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="5.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="a019-91dd-3b84-e72e" targetId="117a-a2aa-4be7-dffe" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="b4a9-0df0-5149-5785" targetId="b996-131f-b84a-4724" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="bbac-d335-536a-e63d" name="Scoot" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="5.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="0e1e-3e34-5c36-4bbf" targetId="28a0-7151-a0c5-9495" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="cc03-4929-b882-43a6" targetId="b996-131f-b84a-4724" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="2a9e-c888-1e5a-ea11" name="Net" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="5.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="f4bd-099a-19ab-8138" targetId="ac33-af99-2d76-c981" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="b932-f489-37e5-e6b4" name="Grip" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="5.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="eee1-31e1-599c-0bd8" targetId="1045-95cb-5504-9050" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="df1a-7d7c-9316-5794" targetId="b996-131f-b84a-4724" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+<selectionEntry id="f766-367d-f5c0-fc59" name="All" type="upgrade" collective="false" hidden="false" book="BtGoA" page="87" categoryEntryId="(No Category)">
+<costs>
+<cost costTypeId="points" name="pts" value="15.0"/>
+</costs>
+<constraints>
+<constraint id="maxSelections" type="max" field="selections" scope="parent" value="1"/>
+</constraints>
+<modifiers/>
+<selectionEntries/>
+<selectionEntryGroups/>
+<rules/>
+<profiles/>
+<entryLinks/>
+<infoLinks>
+<infoLink id="1874-10fd-bc26-7005" targetId="c1ba-c745-22a8-e2d7" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="0234-4b9e-9342-68f7" targetId="117a-a2aa-4be7-dffe" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="6234-ec86-062c-0073" targetId="1045-95cb-5504-9050" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="a285-cf7f-7fac-f9ab" targetId="ac33-af99-2d76-c981" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="11d8-fdb9-76ff-2c4c" targetId="28a0-7151-a0c5-9495" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="9abb-2789-75c0-d3a8" targetId="7a3b-74a5-3ced-dd88" type="rule">
+<modifiers/>
+</infoLink>
+<infoLink id="1492-b598-eb64-0ea0" targetId="b996-131f-b84a-4724" type="rule">
+<modifiers/>
+</infoLink>
+</infoLinks>
+</selectionEntry>
+</selectionEntries>
+<selectionEntryGroups/>
+<entryLinks/>
+</selectionEntryGroup>
+</sharedSelectionEntryGroups>
+<sharedRules>
+<rule id="2cbd-47c9-de87-ec2a" name="2 Attacks" hidden="false" book="BtGoA" page="133">
       <description>Two attacks in close combat.</description>
       <modifiers/>
     </rule>
-    <rule id="61e2-3707-ade3-c9ad" name="3 Attacks" hidden="false" book="BtGoA" page="133">
+<rule id="61e2-3707-ade3-c9ad" name="3 Attacks" hidden="false" book="BtGoA" page="133">
       <description>Three attacks in close combat.</description>
       <modifiers/>
     </rule>
-    <rule id="7daf-414b-c030-7626" name="AG Chute" hidden="false" book="BtGoA" page="120">
+<rule id="7daf-414b-c030-7626" name="AG Chute" hidden="false" book="BtGoA" page="120">
       <description>May make 2M move and shoot when given advance order. +1 Ag. Treat difficult ground as suspensored vehicle. </description>
       <modifiers/>
     </rule>
-    <rule id="c1ba-c745-22a8-e2d7" name="Arc" hidden="false" book="BtGoA" page="88">
-      <description>Creates 3&quot; sink area. Affects any shooter attemping to draw LOS and shoot through the arc. Roll a D10 if LOS goes through - 1-5 the shot is normal, 6-10 the shot automatically misses. Make test before rolling Acc to hit. 
+<rule id="c1ba-c745-22a8-e2d7" name="Arc" hidden="false" book="BtGoA" page="88">
+      <description>Creates 3" sink area. Affects any shooter attemping to draw LOS and shoot through the arc. Roll a D10 if LOS goes through - 1-5 the shot is normal, 6-10 the shot automatically misses. Make test before rolling Acc to hit. 
 
-OH shots are affected if the target is within 3&quot; of the marker. </description>
+OH shots are affected if the target is within 3" of the marker. </description>
       <modifiers/>
     </rule>
-    <rule id="b7c6-fc7c-d48b-aae4" name="Auto-Workshop" hidden="false" book="BtGoA" page="121">
-      <description>Activated from any order to the unit. Affects every vehicle, weapon drone, weapon team, and machine mounted unit within 5&quot; of the unit, and itself. Roll D10 - on 1-5, nothing happens, 6-10 each unit removes a pin.</description>
+<rule id="b7c6-fc7c-d48b-aae4" name="Auto-Workshop" hidden="false" book="BtGoA" page="121">
+      <description>Activated from any order to the unit. Affects every vehicle, weapon drone, weapon team, and machine mounted unit within 5" of the unit, and itself. Roll D10 - on 1-5, nothing happens, 6-10 each unit removes a pin.</description>
       <modifiers/>
     </rule>
-    <rule id="f0d9-1e5a-ec20-b27c" name="Batter Drone" hidden="false" book="BtGoA" page="110">
-      <description>Projects curved shield as template - must be positioned with outer side facing away from drone, no part of template more than 5&quot; from drone base. Template may be repositioned any time unit receives an order die.
+<rule id="f0d9-1e5a-ec20-b27c" name="Batter Drone" hidden="false" book="BtGoA" page="110">
+      <description>Projects curved shield as template - must be positioned with outer side facing away from drone, no part of template more than 5" from drone base. Template may be repositioned any time unit receives an order die.
 
 Enemy units shooting through shield suffer -2 ACC. Models positioned inside the shield do not receive the -2 ACC protection. Troops shooting from the inside convex side of the shield do not suffer the ACC penalty. 
 
 No protection is offered for OH shots.</description>
       <modifiers/>
     </rule>
-    <rule id="04d9-a48d-7b25-4dd3" name="Blast D10" hidden="false" book="BtGoA">
+<rule id="04d9-a48d-7b25-4dd3" name="Blast D10" hidden="false" book="BtGoA">
       <description>Inflicts D10 hits on a successful shooting attack.</description>
       <modifiers/>
     </rule>
-    <rule id="1acd-39d3-94e7-48e1" name="Blast D3" hidden="false" book="BtGoA">
+<rule id="1acd-39d3-94e7-48e1" name="Blast D3" hidden="false" book="BtGoA">
       <description>Inflicts D3 hits on a successful shooting attack.</description>
       <modifiers/>
     </rule>
-    <rule id="ca96-58c9-9551-d4fe" name="Blast D4" hidden="false" book="BtGoA">
+<rule id="ca96-58c9-9551-d4fe" name="Blast D4" hidden="false" book="BtGoA">
       <description>Inflicts D4 hits on a successful shooting attack.</description>
       <modifiers/>
     </rule>
-    <rule id="b050-496a-ed16-2b2a" name="Blast D5" hidden="false" book="BtGoA">
+<rule id="b050-496a-ed16-2b2a" name="Blast D5" hidden="false" book="BtGoA">
       <description>Inflicts D5 hits on a successful shooting attack.</description>
       <modifiers/>
     </rule>
-    <rule id="5d2e-45d2-1707-87db" name="Block!" hidden="false" page="159">
+<rule id="5d2e-45d2-1707-87db" name="Block!" hidden="false" page="159">
       <description>The Order Die drawn from the bag is returned and another random die is drawn. This dice stands and cannot be blocked. Use once and discard. You can buy as many Blocks as you are allowed Auxiliary choices in your Army</description>
       <modifiers/>
     </rule>
-    <rule id="117a-a2aa-4be7-dffe" name="Blur" hidden="false" book="BtGoA" page="89">
-      <description>Any unit within 3&quot; reduces Acc by D3 each time it shoots. If within two or more blur markers, roll a D3 for each and take highest.</description>
+<rule id="117a-a2aa-4be7-dffe" name="Blur" hidden="false" book="BtGoA" page="89">
+      <description>Any unit within 3" reduces Acc by D3 each time it shoots. If within two or more blur markers, roll a D3 for each and take highest.</description>
       <modifiers/>
     </rule>
-    <rule id="c3e6-4e9b-858c-80d3" name="Booster Drone" hidden="false" book="BtGoA" page="92">
+<rule id="c3e6-4e9b-858c-80d3" name="Booster Drone" hidden="false" book="BtGoA" page="92">
       <description>Infantry, Weapon Team, or Command unit gains +1 armor bonus from reflex, hyperlight, and phase armor. Cannot benefit units with HL boosters.</description>
       <modifiers/>
     </rule>
-    <rule id="4e34-753f-b082-2e00" name="Borer Drone" hidden="false" book="BtGoA" page="111">
+<rule id="4e34-753f-b082-2e00" name="Borer Drone" hidden="false" book="BtGoA" page="111">
       <description>Every model in the owning unit gains +1 Str for all Strength tests and H2H. 
 
 Unit may put up temporary cover by making any action without a move. May result from order or reaction and can include a down action from failed order check. Unit benefits from 2+ Res as long as it does not move. Is not cumulative with other cover bonuses.</description>
       <modifiers/>
     </rule>
-    <rule id="5f48-f41c-fd96-6a1a" name="Camo Drone" hidden="false" book="BtGoA" page="111">
-      <description>If unit goes down it cannot be targeted at ranges of more than 10&quot;. If a unit with the drone goes down as reaction to enemy shooting from more than 10&quot; away then the unit can no longer be targeted. OH shots will miss and have no effect. Scout probes can compromise this effect within 10&quot;.
+<rule id="5f48-f41c-fd96-6a1a" name="Camo Drone" hidden="false" book="BtGoA" page="111">
+      <description>If unit goes down it cannot be targeted at ranges of more than 10". If a unit with the drone goes down as reaction to enemy shooting from more than 10" away then the unit can no longer be targeted. OH shots will miss and have no effect. Scout probes can compromise this effect within 10".
 
 </description>
       <modifiers/>
     </rule>
-    <rule id="fd72-d48c-e8af-4883" name="Choose Target" hidden="false" book="BtGoA" page="70">
+<rule id="fd72-d48c-e8af-4883" name="Choose Target" hidden="false" book="BtGoA" page="70">
       <description>May fire at a different target from the test of the unit. If more than one model has a weapon with Choose Target, all weapons with Choose Target must shoot at same target.</description>
       <modifiers/>
     </rule>
-    <rule id="5c9b-1bde-ee01-04a4" name="Command" hidden="false" book="BtGoA" page="133">
-      <description>Friendly units within 10&quot; can use this model&apos;s Co value for any Co based test instead of their own. Pins still affect this Co value.</description>
+<rule id="5c9b-1bde-ee01-04a4" name="Command" hidden="false" book="BtGoA" page="133">
+      <description>Friendly units within 10" can use this model's Co value for any Co based test instead of their own. Pins still affect this Co value.</description>
       <modifiers/>
     </rule>
-    <rule id="3995-c066-c957-5ffe" name="Compactor Drone" hidden="false" book="BtGoA" page="112">
-      <description>May carry one of the following: all of a mounted unit&apos;s bikes, a unit&apos;s support weapon, an entire weapon drone unit complete with any associated buddy drones other than compactor drones, or an entire probe shard.
+<rule id="3995-c066-c957-5ffe" name="Compactor Drone" hidden="false" book="BtGoA" page="112">
+      <description>May carry one of the following: all of a mounted unit's bikes, a unit's support weapon, an entire weapon drone unit complete with any associated buddy drones other than compactor drones, or an entire probe shard.
 
 May load or unload when their unit makes an action, even down order following failed order test. </description>
       <modifiers/>
     </rule>
-    <rule id="7db4-2d14-3984-37d9" name="Compressor" hidden="false" book="BtGoA" page="71">
+<rule id="7db4-2d14-3984-37d9" name="Compressor" hidden="false" book="BtGoA" page="71">
       <description>SV value varies with range band.</description>
       <modifiers/>
     </rule>
-    <rule id="5fb8-4f09-d496-4ea9" name="Concentrated Fire" hidden="false" book="BtGoA" page="72">
+<rule id="5fb8-4f09-d496-4ea9" name="Concentrated Fire" hidden="false" book="BtGoA" page="72">
       <description>Any lucky hits can be allocated to the same model, do not have to be distributed evenly.</description>
       <modifiers/>
     </rule>
-    <rule id="c34f-bbca-9bfc-6874" name="Crawler" hidden="false" book="BtGoA" page="133">
+<rule id="c34f-bbca-9bfc-6874" name="Crawler" hidden="false" book="BtGoA" page="133">
       <description>Crawlers are restricted when moving over certain terrain types as described in the terrain section. They cross obstacles in the same manner as a heavy weapon team. They cannot cross at a run and must test to cross at advance rate. Crossing obstacles, p22</description>
       <modifiers/>
     </rule>
-    <rule id="cf7f-6f85-e64e-0363" name="Cycle" hidden="false" book="BtGoA" page="78">
+<rule id="cf7f-6f85-e64e-0363" name="Cycle" hidden="false" book="BtGoA" page="78">
       <description>On the Acc roll of a 10 shot misses and weapon team goes down.</description>
       <modifiers/>
     </rule>
-    <rule id="6305-72fa-da02-235b" name="Disruptor" hidden="false" book="BtGoA" page="79">
+<rule id="6305-72fa-da02-235b" name="Disruptor" hidden="false" book="BtGoA" page="79">
       <description>A target hit by a disruptor weapon gets no cover bonus to its Res roll against the hit.
 
 A non-Ghar target hit by a disruptor weapon takes 2 pins rather than the usual 1 pin. If the target has Res &gt; 10, it takes these pins even if the hit is successfully resisted. Ghar do not suffer these pins. 
@@ -6096,138 +8974,138 @@ Buddy drones can be allocated hits from this weapon by the shooter from any hits
 If the target is a probe it only passes Res tests on a 1.</description>
       <modifiers/>
     </rule>
-    <rule id="9444-e2a0-8048-5ce9" name="Down" hidden="false" book="BtGoA" page="74">
+<rule id="9444-e2a0-8048-5ce9" name="Down" hidden="false" book="BtGoA" page="74">
       <description>Unit hit automatically goes down after shooting has been worked out whether casualties are caused or not. </description>
       <modifiers/>
     </rule>
-    <rule id="4232-2801-36cf-704c" name="Exhausted" hidden="false" book="BtGoA" page="67">
+<rule id="4232-2801-36cf-704c" name="Exhausted" hidden="false" book="BtGoA" page="67">
       <description>Rolls of 10 on Str or Acc to-hit rolls cannot be re-rolled and stave has become exhausted. Make a test at the turn end phase - 1-5 it is still exhausted, 6-10 it is replenished.</description>
       <modifiers/>
     </rule>
-    <rule id="e77b-02da-5143-229e" name="Extra Shot" hidden="false" page="159">
+<rule id="e77b-02da-5143-229e" name="Extra Shot" hidden="false" page="159">
       <description>If you score a Lucky Hit with any shot you can make one more shot with that model using the same weapon with exactly the same score required to hit the same target. Roll one more shot to score a hit. Use once and discard. You can buy as many Extra Shots as you are allowed Auxiliary choices in your Army.</description>
       <modifiers/>
     </rule>
-    <rule id="b0ca-8e7d-d03f-f027" name="Fast" hidden="false" book="BtGoA" page="133">
-      <description>Move at double pace - 10&quot; per advance, 20&quot; for run. Shots fired at fast targets with a run order must re-roll hits. 
+<rule id="b0ca-8e7d-d03f-f027" name="Fast" hidden="false" book="BtGoA" page="133">
+      <description>Move at double pace - 10" per advance, 20" for run. Shots fired at fast targets with a run order must re-roll hits. 
 Fast units may break off of assault after point blank shooting has been conducted. They may move through the enemy during this move.</description>
       <modifiers/>
     </rule>
-    <rule id="7bc9-5e98-2914-5abd" name="Follow" hidden="false" book="BtGoA" page="13">
-      <description>When a leader with follow gives his unit an order, any other friendly units within 5&quot; may make the same action as long as they have no pins and are otherwise able to make the action.</description>
+<rule id="7bc9-5e98-2914-5abd" name="Follow" hidden="false" book="BtGoA" page="13">
+      <description>When a leader with follow gives his unit an order, any other friendly units within 5" may make the same action as long as they have no pins and are otherwise able to make the action.</description>
       <modifiers/>
     </rule>
-    <rule id="d50c-3bbe-c62d-34c3" name="Fractal Lock" hidden="false" book="BtGoA" page="83">
+<rule id="d50c-3bbe-c62d-34c3" name="Fractal Lock" hidden="false" book="BtGoA" page="83">
       <description>If the weapon hits, it locks on. If the target does not move and the unit receives a fire order it automatically hits. Each time it auto-hits the SV value goes up by 2.</description>
       <modifiers/>
     </rule>
-    <rule id="2afe-05bf-268b-84c2" name="Get Up!" hidden="false" page="159">
+<rule id="2afe-05bf-268b-84c2" name="Get Up!" hidden="false" page="159">
       <description>When making a Recovery Test (to recover a Down order die) you will succeed on a roll of anything but a 10 regardless of the value you would normally test against. A roll of a 10 is still a failure, and no pin markers are removed, as standard. Use once and discard. You can buy as many Get Up!(s) as you are allowed Auxiliary choices in your Army.</description>
       <modifiers/>
     </rule>
-    <rule id="b466-7990-db34-55b1" name="Grenade" hidden="false" book="BtGoA" page="85">
+<rule id="b466-7990-db34-55b1" name="Grenade" hidden="false" book="BtGoA" page="85">
       <description>In H2H counts as hand weapon +1 Str bonus. Grenade hits compound in H2H - if a model takes suffers two or more hits from grenades, add all SVs together and take one Res test.</description>
       <modifiers/>
     </rule>
-    <rule id="1045-95cb-5504-9050" name="Grip" hidden="false" book="BtGoA" page="87">
-      <description>Unit beginning its move within 3&quot; must take and pass an Ag test. If failed it may not move, if passed it can move half rate, failed on a 10 it takes a pin and cannot move.
+<rule id="1045-95cb-5504-9050" name="Grip" hidden="false" book="BtGoA" page="87">
+      <description>Unit beginning its move within 3" must take and pass an Ag test. If failed it may not move, if passed it can move half rate, failed on a 10 it takes a pin and cannot move.
 
-If a unit moves within 3&quot; it must take the Ag test as above. </description>
+If a unit moves within 3" it must take the Ag test as above. </description>
       <modifiers/>
     </rule>
-    <rule id="5f6c-7c20-3cbc-bcc8" name="Gun Drone" hidden="false" book="BtGoA" page="112">
+<rule id="5f6c-7c20-3cbc-bcc8" name="Gun Drone" hidden="false" book="BtGoA" page="112">
       <description>Shoots as if it were an ordinary member of its unit with the same Acc value. Draw LOS in the same way as other models in the unit.</description>
       <modifiers/>
     </rule>
-    <rule id="1c2c-6574-0a17-f90c" name="Hazardous H2H" hidden="false" book="BtGoA" page="85">
+<rule id="1c2c-6574-0a17-f90c" name="Hazardous H2H" hidden="false" book="BtGoA" page="85">
       <description>Any H2H Str roll of 10 hits the user, not enemy.</description>
       <modifiers/>
     </rule>
-    <rule id="a846-6829-3398-bac1" name="Heavy" hidden="false" book="BtGoA" page="134">
+<rule id="a846-6829-3398-bac1" name="Heavy" hidden="false" book="BtGoA" page="134">
       <description>Movement restricted across obstacles per p22. Cannot cross obstacles at a run. Agility test required to cross at advance. When rolling resistance checks only fail on a 10, roll on damage chart p37.</description>
       <modifiers/>
     </rule>
-    <rule id="3c64-6022-a5f1-9c04" name="Hero" hidden="false" book="BtGoA" page="134">
-      <description>Friendly units within 10&quot; may use this model&apos;s Init stat. </description>
+<rule id="3c64-6022-a5f1-9c04" name="Hero" hidden="false" book="BtGoA" page="134">
+      <description>Friendly units within 10" may use this model's Init stat. </description>
       <modifiers/>
     </rule>
-    <rule id="34e0-c5a3-3998-5d0b" name="High Commander" hidden="false" book="BtGoA" page="134">
+<rule id="34e0-c5a3-3998-5d0b" name="High Commander" hidden="false" book="BtGoA" page="134">
       <description>May re-roll every failed resist test once. May use command, hero, and follow special rules on any units.</description>
       <modifiers/>
     </rule>
-    <rule id="b436-1f8a-5d3a-2d7d" name="HL Armor" hidden="false" book="BtGoA" page="93">
-      <description>Ranges of 10&quot; or less, +1 to Res. Ranges of greater than 10&quot; +2 Res. Against any Blast hits, +3 Res. </description>
+<rule id="b436-1f8a-5d3a-2d7d" name="HL Armor" hidden="false" book="BtGoA" page="93">
+      <description>Ranges of 10" or less, +1 to Res. Ranges of greater than 10" +2 Res. Against any Blast hits, +3 Res. </description>
       <modifiers/>
     </rule>
-    <rule id="56ab-52fc-9557-2586" name="HL Booster" hidden="false" book="BtGoA" page="93">
+<rule id="56ab-52fc-9557-2586" name="HL Booster" hidden="false" book="BtGoA" page="93">
       <description>+1 Res on top of all other bonuses.</description>
       <modifiers/>
     </rule>
-    <rule id="ca2b-9550-eb1e-77c8" name="Homer Drone" hidden="false" book="BtGoA" page="112">
+<rule id="ca2b-9550-eb1e-77c8" name="Homer Drone" hidden="false" book="BtGoA" page="112">
       <description>Unit may be transported off the table by using a Run order. If taking an order test and failed on a 10, homer drone is destroyed. Once removed from the battlefield unit cannot return. Only the unit and equipment may be transported - not objectives.</description>
       <modifiers/>
     </rule>
-    <rule id="3b84-9d0e-a3c1-6c1f" name="Inaccurate" hidden="false" book="BtGoA" page="70">
+<rule id="3b84-9d0e-a3c1-6c1f" name="Inaccurate" hidden="false" book="BtGoA" page="70">
       <description>Additional -1 Acc penalty.</description>
       <modifiers/>
     </rule>
-    <rule id="96c4-7a43-2a4c-d7d3" name="Infiltrator" hidden="false" book="BtGoA" page="134">
-      <description>May make a special pre-game run action. May sprint, test for exhaustion. May not move within 10&quot; of enemy. May lay a minefield before game starts.</description>
+<rule id="96c4-7a43-2a4c-d7d3" name="Infiltrator" hidden="false" book="BtGoA" page="134">
+      <description>May make a special pre-game run action. May sprint, test for exhaustion. May not move within 10" of enemy. May lay a minefield before game starts.</description>
       <modifiers/>
     </rule>
-    <rule id="a221-d53c-b4bd-b52c" name="Large" hidden="false" book="BtGoA" page="134">
+<rule id="a221-d53c-b4bd-b52c" name="Large" hidden="false" book="BtGoA" page="134">
       <description>Cannot sprint unless also fast. Passes when testing Ag to move through dense terrain reduce movement to half. Passes on a one mean unit can move at full rate. Failure means unit cannot move, failure on a 10 gains one pin. 
 
 Units may fire over regular sized units at no penalty. Large targets never gain cover bonuses to their Res stat. May not enter buildings. </description>
       <modifiers/>
     </rule>
-    <rule id="7cfb-9874-dfe0-b136" name="Lava Spit" hidden="false" book="BtGoA" page="135">
+<rule id="7cfb-9874-dfe0-b136" name="Lava Spit" hidden="false" book="BtGoA" page="135">
       <description>Lavamites may shoot during point blank shooting at SV 2.</description>
       <modifiers/>
     </rule>
-    <rule id="e441-c3a6-7d61-2c63" name="Leader" hidden="false" book="BtGoA" page="135">
+<rule id="e441-c3a6-7d61-2c63" name="Leader" hidden="false" book="BtGoA" page="135">
       <description>May re-roll one failed res test per leader level. </description>
       <modifiers/>
     </rule>
-    <rule id="7850-89e7-bab8-86e9" name="Leader 2" hidden="false" book="BtGoA">
+<rule id="7850-89e7-bab8-86e9" name="Leader 2" hidden="false" book="BtGoA">
       <description>May re-roll one failed res test per leader level.</description>
       <modifiers/>
     </rule>
-    <rule id="05bb-4d34-70cd-25d2" name="Leader 3" hidden="false" book="BtGoA">
+<rule id="05bb-4d34-70cd-25d2" name="Leader 3" hidden="false" book="BtGoA">
       <description>May re-roll one failed res test per leader level.</description>
       <modifiers/>
     </rule>
-    <rule id="5efa-64a9-bbc9-3dba" name="Limited Ammo" hidden="false" book="BtGoA" page="73,77">
+<rule id="5efa-64a9-bbc9-3dba" name="Limited Ammo" hidden="false" book="BtGoA" page="73,77">
       <description>Risks running out of ammunition.</description>
       <modifiers/>
     </rule>
-    <rule id="d8dc-cf25-ef95-c94b" name="Limited Choice" hidden="false" book="BtGoA">
+<rule id="d8dc-cf25-ef95-c94b" name="Limited Choice" hidden="false" book="BtGoA">
       <description>May only be taken as 1 in 4 choices of entire force.</description>
       <modifiers/>
     </rule>
-    <rule id="5741-af68-9dc0-519f" name="Marksman" hidden="false" page="159">
+<rule id="5741-af68-9dc0-519f" name="Marksman" hidden="false" page="159">
       <description>When rolling to-hit against a unit with a shooting attack, you may re-roll all of the shots. If you choose to do this you must take ALL of the shots again regardless of whether they hit or miss, and whatever result you roll the second time stands, with no further re-rolls allowed. You can only buy ONE Marksman regardless of Army size.</description>
       <modifiers/>
     </rule>
-    <rule id="c863-510b-e239-be92" name="Massive Damage" hidden="false" book="BtGoA" page="75">
-      <description>If the mag cannon&apos;s target rolls for damage on a damage table it suffers Massive Damage - page 37.</description>
+<rule id="c863-510b-e239-be92" name="Massive Damage" hidden="false" book="BtGoA" page="75">
+      <description>If the mag cannon's target rolls for damage on a damage table it suffers Massive Damage - page 37.</description>
       <modifiers/>
     </rule>
-    <rule id="4039-88e8-9f6d-bfb3" name="Medi-Drone" hidden="false" book="BtGoA" page="113">
-      <description>Can only attend humans - not machines or Skarks. Any friendly unit within 5&quot; may re-roll one failed Res test each time it is shot at, fights H2H, or otherwise suffers damage. Units within 5&quot; of more than one medi-drone may re-roll one failed Res test for each medi-drone. </description>
+<rule id="4039-88e8-9f6d-bfb3" name="Medi-Drone" hidden="false" book="BtGoA" page="113">
+      <description>Can only attend humans - not machines or Skarks. Any friendly unit within 5" may re-roll one failed Res test each time it is shot at, fights H2H, or otherwise suffers damage. Units within 5" of more than one medi-drone may re-roll one failed Res test for each medi-drone. </description>
       <modifiers/>
     </rule>
-    <rule id="137e-c2b6-65b7-ecc3" name="Medic" hidden="false" book="BtGoA" page="135">
-      <description>Units within 5&quot; of a medic unit may re-roll one failed Res test each time it is shot at. Medi-probes and drones may add their re-rolls to total number of re-rolls.
+<rule id="137e-c2b6-65b7-ecc3" name="Medic" hidden="false" book="BtGoA" page="135">
+      <description>Units within 5" of a medic unit may re-roll one failed Res test each time it is shot at. Medi-probes and drones may add their re-rolls to total number of re-rolls.
 
 Cannot be used on non-humans. </description>
       <modifiers/>
     </rule>
-    <rule id="a97f-4540-de7b-5734" name="Meld" hidden="false" book="BtGoA" page="128">
+<rule id="a97f-4540-de7b-5734" name="Meld" hidden="false" book="BtGoA" page="128">
       <description>Single unit of two NuHu but only has one Res value. If a Res test is failed, roll on Meld Damage Chart. </description>
       <modifiers/>
     </rule>
-    <rule id="5e3d-6905-2b14-8cd1" name="Meld Damage" hidden="false" book="BtGoA" page="128">
+<rule id="5e3d-6905-2b14-8cd1" name="Meld Damage" hidden="false" book="BtGoA" page="128">
       <description>D10 Result
 1	No effect
 2-3 	Take one additional pin and Go Down
@@ -6237,7 +9115,7 @@ Cannot be used on non-humans. </description>
 10 	Destroyed. The unit is destroyed, and both NuHu are removed as casualties.</description>
       <modifiers/>
     </rule>
-    <rule id="db7a-5bd4-6400-f6d1" name="Misgenic Abilities" hidden="false" book="BtGoA" page="196">
+<rule id="db7a-5bd4-6400-f6d1" name="Misgenic Abilities" hidden="false" book="BtGoA" page="196">
       <description>Set after deployment. May choose one of the following before the game and pay 10 points to gain any further qualities on a D10 roll. Duplicates may be added together or treated as a 10 roll.
 
 D10 Result:
@@ -6245,27 +9123,27 @@ D10 Result:
 2 Gnarly Hide: +1 Resist
 3 Bulging Muscles: +1 Str
 4 Lightning Reflexes: +1 Init
-5 Piercing Scream: gains a shooting attack with 10&quot; effective range and SV 0
+5 Piercing Scream: gains a shooting attack with 10" effective range and SV 0
 6 Belches Acid: SV 1 in H2H
 7 Exudes Noxious Vapors: H2H enemies must re-roll successful hits
-8 Mesmerising: any enemy unit within 5&quot; must pass command test at -1 to do anything, even with no pins.
+8 Mesmerising: any enemy unit within 5" must pass command test at -1 to do anything, even with no pins.
 9 Cunning Leader: unit leader gains command and Init 8. If unit has no leader, it gains a leader with base Co and Init.
 10 Choose one of the above qualities.</description>
       <modifiers/>
     </rule>
-    <rule id="5565-ce10-1c78-1ee7" name="MOD2" hidden="false" book="BtGoA" page="136">
+<rule id="5565-ce10-1c78-1ee7" name="MOD2" hidden="false" book="BtGoA" page="136">
       <description>Unit contributes two die to the dice pool and may act twice per turn. Always treated as having used the most recent action.</description>
       <modifiers/>
     </rule>
-    <rule id="8151-2e24-94ee-0477" name="MOD3" hidden="false" book="BtGoA">
+<rule id="8151-2e24-94ee-0477" name="MOD3" hidden="false" book="BtGoA">
       <description>Unit contributes three die to the dice pool and may act thrice per turn. Always treated as having used the most recent action.</description>
       <modifiers/>
     </rule>
-    <rule id="c1c6-f9c7-c84f-d57d" name="Nano Drone" hidden="false" book="BtGoA" page="113">
+<rule id="c1c6-f9c7-c84f-d57d" name="Nano Drone" hidden="false" book="BtGoA" page="113">
       <description>Shots against the unit suffer -2 Acc. Cannot be combined with a Batter drone. Unit counts as having HL armor. IMtel stave may be boosted by Nano Drone.</description>
       <modifiers/>
     </rule>
-    <rule id="ac33-af99-2d76-c981" name="Net" hidden="false" book="BtGoA" page="88">
+<rule id="ac33-af99-2d76-c981" name="Net" hidden="false" book="BtGoA" page="88">
       <description>Roll to hit as normal for a blast weapon. Target does not suffer blast damage, rather suffers pins:
 
 X-Launcher: D3+1 pin
@@ -6275,112 +9153,112 @@ Mag Mortar: D10+1 pin
 Targets that would normally force an Acc re-roll suffer half the number of pins rounded down. Divide pins equally between two or more units as normal.</description>
       <modifiers/>
     </rule>
-    <rule id="a41d-d55e-6d97-049d" name="No Cover" hidden="false" book="BtGoA" page="71">
+<rule id="a41d-d55e-6d97-049d" name="No Cover" hidden="false" book="BtGoA" page="71">
       <description>No cover bonus to Res roll.</description>
       <modifiers/>
     </rule>
-    <rule id="f502-611e-9704-97bb" name="No Crew" hidden="false" book="BtGoA" page="7">
+<rule id="f502-611e-9704-97bb" name="No Crew" hidden="false" book="BtGoA" page="7">
       <description>When carried by a model in battle armor it counts as having full crew.</description>
       <modifiers/>
     </rule>
-    <rule id="c3bc-87fd-fa5d-5055" name="OH" hidden="false" book="BtGoA" page="34">
+<rule id="c3bc-87fd-fa5d-5055" name="OH" hidden="false" book="BtGoA" page="34">
       <description>Fires as an Overhead weapon.</description>
       <modifiers/>
     </rule>
-    <rule id="aef6-6934-1dee-6fa0" name="OHx2" hidden="false" book="BtGoA">
+<rule id="aef6-6934-1dee-6fa0" name="OHx2" hidden="false" book="BtGoA">
       <modifiers/>
     </rule>
-    <rule id="7db4-6bd3-fb59-706d" name="Outcast" hidden="false" book="BtGoA" page="136">
+<rule id="7db4-6bd3-fb59-706d" name="Outcast" hidden="false" book="BtGoA" page="136">
       <description>Command, hero, and follow rules only work on Outcast units. Cannot benefit from command, hero, or follow from non-Outcast unless it is a High Commander.</description>
       <modifiers/>
     </rule>
-    <rule id="3559-4b87-980d-f90d" name="Overload Ammo" hidden="false" book="BtGoA" page="89">
+<rule id="3559-4b87-980d-f90d" name="Overload Ammo" hidden="false" book="BtGoA" page="89">
       <description>Can only be used with direct fire. SV = 3, single hit. If a 10 is rolled on Acc roll, shot misses, cannot be re-rolled, and overload ammo cannot be used again.</description>
       <modifiers/>
     </rule>
-    <rule id="b28d-571e-af69-4582" name="Phase Armor" hidden="false" book="BtGoA" page="93">
-      <description>10&quot; or less, +1 Res. Greater than 10&quot;, +2 Res. May make a down reaction even if it already has order die - flip to down if so. </description>
+<rule id="b28d-571e-af69-4582" name="Phase Armor" hidden="false" book="BtGoA" page="93">
+      <description>10" or less, +1 Res. Greater than 10", +2 Res. May make a down reaction even if it already has order die - flip to down if so. </description>
       <modifiers/>
     </rule>
-    <rule id="6b03-2ad4-34c1-7f73" name="Plasma Fade" hidden="false" book="BtGoA" page="76">
+<rule id="6b03-2ad4-34c1-7f73" name="Plasma Fade" hidden="false" book="BtGoA" page="76">
       <description>On the Acc roll of a 10 to hit the shot is a miss and the unit goes down.</description>
       <modifiers/>
     </rule>
-    <rule id="0f12-545e-1c86-f482" name="Plasma Reactor" hidden="false" book="BtGoA" page="1367">
+<rule id="0f12-545e-1c86-f482" name="Plasma Reactor" hidden="false" book="BtGoA" page="1367">
       <description>Lucky hits are allocated by shooter and hit plasma reactor. On a Res failure of 10, roll for every other model in unit and on a 10 they are removed as well.</description>
       <modifiers/>
     </rule>
-    <rule id="5d64-4bf5-e947-95d1" name="Point Blank Shooting Only" hidden="false" book="BtGoA" page="86">
+<rule id="5d64-4bf5-e947-95d1" name="Point Blank Shooting Only" hidden="false" book="BtGoA" page="86">
       <description>May only be used for point blank shooting. Cannot be used for H2H.</description>
       <modifiers/>
     </rule>
-    <rule id="8056-104a-5a5d-2089" name="Pull Yourself Together!" hidden="false" page="159">
-      <description>At the end of any turn you can expend a &quot;Pull Yourself Together!&quot; to remove one pin from one unit. Use once and discard. You can buy as many as you are allowed Auxiliary choices in your Army but can only use ONE per turn.</description>
+<rule id="8056-104a-5a5d-2089" name="Pull Yourself Together!" hidden="false" page="159">
+      <description>At the end of any turn you can expend a "Pull Yourself Together!" to remove one pin from one unit. Use once and discard. You can buy as many as you are allowed Auxiliary choices in your Army but can only use ONE per turn.</description>
       <modifiers/>
     </rule>
-    <rule id="b6e3-9cf0-1a9f-a941" name="Random SV" hidden="false" book="BtGoA" page="66">
+<rule id="b6e3-9cf0-1a9f-a941" name="Random SV" hidden="false" book="BtGoA" page="66">
       <description>Roll every round for entire unit to determine SV. </description>
       <modifiers/>
     </rule>
-    <rule id="9ad5-9fc3-726e-852a" name="Rapid Sprint" hidden="false" book="BtGoA" page="136">
+<rule id="9ad5-9fc3-726e-852a" name="Rapid Sprint" hidden="false" book="BtGoA" page="136">
       <description>May sprint at 4M. </description>
       <modifiers/>
     </rule>
-    <rule id="18c0-c86d-0b2c-23af" name="Reflex Armour" hidden="false" book="BtGoA" page="93">
+<rule id="18c0-c86d-0b2c-23af" name="Reflex Armour" hidden="false" book="BtGoA" page="93">
       <description>-Troops with Reflex Armour Shield add +1 to their Res value.
 -Troops with Reflex Armour and Impact Cloaks add +2 to their Res value, in hand to hand fighting.
 -Troops mounted on bikes with Reflex Armour and HL Boosters add +2 to their Res value.
 </description>
       <modifiers/>
     </rule>
-    <rule id="1863-c041-6dc4-c62d" name="RF D6 Fire Only" hidden="false" book="BtGoA" page="72">
+<rule id="1863-c041-6dc4-c62d" name="RF D6 Fire Only" hidden="false" book="BtGoA" page="72">
       <description>Rapid Fire D6 when making a fire action. When shooting with advance action weapon has one shot. If issued in multiples, roll D6 for all weapons in unit.</description>
       <modifiers/>
     </rule>
-    <rule id="0cb1-ea91-e5bc-4f75" name="RF2" hidden="false" book="BtGoA">
+<rule id="0cb1-ea91-e5bc-4f75" name="RF2" hidden="false" book="BtGoA">
       <description>May fire two shots at rapid fire. Suffers additional -1 ACC at Long or Extreme Ranges.</description>
       <modifiers/>
     </rule>
-    <rule id="97d4-67cb-2671-ca29" name="RF3" hidden="false" book="BtGoA">
+<rule id="97d4-67cb-2671-ca29" name="RF3" hidden="false" book="BtGoA">
       <description>May fire three shots at rapid fire. Suffers additional -1 ACC at Long or Extreme Ranges.</description>
       <modifiers/>
     </rule>
-    <rule id="b0cb-c022-0531-4852" name="RF5" hidden="false" book="BtGoA">
+<rule id="b0cb-c022-0531-4852" name="RF5" hidden="false" book="BtGoA">
       <description>May fire five shots at rapid fire. Suffers additional -1 ACC at Long or Extreme Ranges.</description>
       <modifiers/>
     </rule>
-    <rule id="f7af-59ec-acde-2f75" name="Savage Strike" hidden="false" book="BtGoA" page="136">
+<rule id="f7af-59ec-acde-2f75" name="Savage Strike" hidden="false" book="BtGoA" page="136">
       <description>Passes order check to assault on any roll except a 10, regardless of modifiers.</description>
       <modifiers/>
     </rule>
-    <rule id="28a0-7151-a0c5-9495" name="Scoot" hidden="false" book="BtGoA" page="88">
-      <description>Only affects infantry, mounted, weapon team, beast, and humongous beast, command, and bike mounted units with living crew. Affects scramble proof units. Any affected unit within 3&quot; canno tbe given any order except run or down. Cannot make any reaction apart from go down.</description>
+<rule id="28a0-7151-a0c5-9495" name="Scoot" hidden="false" book="BtGoA" page="88">
+      <description>Only affects infantry, mounted, weapon team, beast, and humongous beast, command, and bike mounted units with living crew. Affects scramble proof units. Any affected unit within 3" canno tbe given any order except run or down. Cannot make any reaction apart from go down.</description>
       <modifiers/>
     </rule>
-    <rule id="94f5-4a4c-92ad-94f9" name="Scramble Proof" hidden="false" book="BtGoA" page="137">
+<rule id="94f5-4a4c-92ad-94f9" name="Scramble Proof" hidden="false" book="BtGoA" page="137">
       <description>Not affected by scrambler munitions. Vehicles may be affected by scoot. Subverter matrixes cannot affect model.</description>
       <modifiers/>
     </rule>
-    <rule id="7a3b-74a5-3ced-dd88" name="Scrambler" hidden="false" book="BtGoA" page="88">
-      <description>Enemy units within 3&quot; that are not scramble proof it loses Reflex Armor, Hyperlight Armor, and Phase Armor along with any bonuses. Units in Phase Armor cannot use their armor to go down.
+<rule id="7a3b-74a5-3ced-dd88" name="Scrambler" hidden="false" book="BtGoA" page="88">
+      <description>Enemy units within 3" that are not scramble proof it loses Reflex Armor, Hyperlight Armor, and Phase Armor along with any bonuses. Units in Phase Armor cannot use their armor to go down.
 
-Weapon Drone and vehicles have Res reduced by 2 within 3&quot;. Buddy drones cease to function if the unit is within 3&quot;. Probes can do nothing at all while marker is within 3&quot;. Penalties are not cumulative.</description>
+Weapon Drone and vehicles have Res reduced by 2 within 3". Buddy drones cease to function if the unit is within 3". Probes can do nothing at all while marker is within 3". Penalties are not cumulative.</description>
       <modifiers/>
     </rule>
-    <rule id="3377-9408-33bb-6a02" name="Self Repair" hidden="false" book="BtGoA" page="137">
+<rule id="3377-9408-33bb-6a02" name="Self Repair" hidden="false" book="BtGoA" page="137">
       <description>Give unit rally order. If no pins exist after order, may attempt one repair on  immobilisation or weapon. 1-5 = success, 6-10 failure. Success = that function is working again.</description>
       <modifiers/>
     </rule>
-    <rule id="00b8-b49c-4c61-2943" name="Shard" hidden="false" book="BtGoA" page="137">
+<rule id="00b8-b49c-4c61-2943" name="Shard" hidden="false" book="BtGoA" page="137">
       <description>Every individual unit in the shard makes same action from order. Probes always run.
 
 Shard units never take pins. Always assumed to pass order tests. </description>
       <modifiers/>
     </rule>
-    <rule id="0c20-4983-db8a-0d56" name="Shared SV" hidden="false" book="BtGoA">
+<rule id="0c20-4983-db8a-0d56" name="Shared SV" hidden="false" book="BtGoA">
       <modifiers/>
     </rule>
-    <rule id="b08d-74dd-1a32-8bdc" name="Shield Drone" hidden="false" book="BtGoA" page="114">
+<rule id="b08d-74dd-1a32-8bdc" name="Shield Drone" hidden="false" book="BtGoA" page="114">
       <description>When unit is hit, shield drones may nullify one hit. Roll D10 on drone chart - 
 
 D10 Roll:
@@ -6391,52 +9269,52 @@ D10 Roll:
 Shield drones may attempt to intercept lucky hits. Lucky hits can be allocated to them just like other drones - in that case the drone is removed with no roll. </description>
       <modifiers/>
     </rule>
-    <rule id="5bd0-9ab2-0523-cbc8" name="Slingnet Ammo" hidden="false" book="BtGoA" page="112">
+<rule id="5bd0-9ab2-0523-cbc8" name="Slingnet Ammo" hidden="false" book="BtGoA" page="112">
       <description>Fired direct unless from Micro X Launcher. Targets hit suffer no damage but take +1 additional pin. Cannot affect units that cannot be pinned when hit.</description>
       <modifiers/>
     </rule>
-    <rule id="7c88-64d4-50ad-2313" name="Slow" hidden="false" book="BtGoA" page="137">
+<rule id="7c88-64d4-50ad-2313" name="Slow" hidden="false" book="BtGoA" page="137">
       <description>Move at half pace.</description>
       <modifiers/>
     </rule>
-    <rule id="6f47-5038-573a-b225" name="Sniper" hidden="false" book="BtGoA" page="137">
-      <description>Deploy anywhere within player&apos;s half. Snipers may not be deployed within 20&quot; of other snipers, enemy may not deploy within 10&quot;. </description>
+<rule id="6f47-5038-573a-b225" name="Sniper" hidden="false" book="BtGoA" page="137">
+      <description>Deploy anywhere within player's half. Snipers may not be deployed within 20" of other snipers, enemy may not deploy within 10". </description>
       <modifiers/>
     </rule>
-    <rule id="1253-ef5b-67d4-3e18" name="Soma Graft" hidden="false" book="BtGoA" page="121">
+<rule id="1253-ef5b-67d4-3e18" name="Soma Graft" hidden="false" book="BtGoA" page="121">
       <description>May activate when a unit takes a Co test. Will past any Co test on any score other than 10. If a 10 is rolled, unit goes out of control and must roll the order die to generate an order. The unit does not have to comply, but if it does an order that is the only one it can do.</description>
       <modifiers/>
     </rule>
-    <rule id="b996-131f-b84a-4724" name="Special Munition" hidden="false" book="BtGoA" page="87">
+<rule id="b996-131f-b84a-4724" name="Special Munition" hidden="false" book="BtGoA" page="87">
       <description>Stays on the battlefield until it ceases to work p87. Use a marker to locate where shot lands.</description>
       <modifiers/>
     </rule>
-    <rule id="fdbd-254f-8dd7-b658" name="Spotter Drone" hidden="false" book="BtGoA" page="114">
+<rule id="fdbd-254f-8dd7-b658" name="Spotter Drone" hidden="false" book="BtGoA" page="114">
       <description>Unit may re-roll one miss each time it shoots as long as drone has LOS to target. Units may fire OH using drone as spotter as long as it has LOS to target. 
 
-Spotter drones may spot through another spotter drone (within 20&quot;) with LOS to the target. Unit does not receive spotter re-roll as their spotter does not have LOS to target.</description>
+Spotter drones may spot through another spotter drone (within 20") with LOS to the target. Unit does not receive spotter re-roll as their spotter does not have LOS to target.</description>
       <modifiers/>
     </rule>
-    <rule id="cd8d-624c-ed86-e310" name="Subverter Matrix" hidden="false" book="BtGoA" page="122">
+<rule id="cd8d-624c-ed86-e310" name="Subverter Matrix" hidden="false" book="BtGoA" page="122">
       <modifiers/>
     </rule>
-    <rule id="d4f5-697e-dbf0-ced2" name="Superior Shard" hidden="false" page="159">
-      <description>At the start of the turn you can remove 1 of your opponent&apos;s Order Dice from the bag. This die isn&apos;t used that turn, and is returned to the dice bag at the start of the following turn. This means your opponent will have to fight without one of his dice that turn. Use once and discard. You can only buy ONE Superior Shard regardless of the eize of your army.</description>
+<rule id="d4f5-697e-dbf0-ced2" name="Superior Shard" hidden="false" page="159">
+      <description>At the start of the turn you can remove 1 of your opponent's Order Dice from the bag. This die isn't used that turn, and is returned to the dice bag at the start of the following turn. This means your opponent will have to fight without one of his dice that turn. Use once and discard. You can only buy ONE Superior Shard regardless of the eize of your army.</description>
       <modifiers/>
     </rule>
-    <rule id="c526-9fd9-f1c5-6893" name="Synchroniser Drone" hidden="false" book="Battle for Xilos" page="79">
-      <description>If a unit with a synchroniser drone is successfully issued an order, after it has completed all actions in that order it may attempt to synchronise with one other unit within 10&quot;. The unit nominated must take and pass a Command test made in the standard fashion. If successful, it may draw an Order Die and issue the same command as the Synchronising unit, treating the die as if it were drawn randomly for all game effects. If the Synchronising unit also has the Follow ability, the Drone extends the range of Follow to 10&quot; rather than 5&quot;. CANNOT be chained from one unit to another.</description>
+<rule id="c526-9fd9-f1c5-6893" name="Synchroniser Drone" hidden="false" book="Battle for Xilos" page="79">
+      <description>If a unit with a synchroniser drone is successfully issued an order, after it has completed all actions in that order it may attempt to synchronise with one other unit within 10". The unit nominated must take and pass a Command test made in the standard fashion. If successful, it may draw an Order Die and issue the same command as the Synchronising unit, treating the die as if it were drawn randomly for all game effects. If the Synchronising unit also has the Follow ability, the Drone extends the range of Follow to 10" rather than 5". CANNOT be chained from one unit to another.</description>
       <modifiers/>
     </rule>
-    <rule id="ab37-33d8-41f3-7532" name="Transport 10" hidden="false" book="BtGoA" page="137">
+<rule id="ab37-33d8-41f3-7532" name="Transport 10" hidden="false" book="BtGoA" page="137">
       <description>May transport 10 human sized models.</description>
       <modifiers/>
     </rule>
-    <rule id="99fd-f354-1703-5941" name="Variable Res/Strike" hidden="false" book="BtGoA" page="66">
+<rule id="99fd-f354-1703-5941" name="Variable Res/Strike" hidden="false" book="BtGoA" page="66">
       <description>Use to boost Res +2 or give a SV +2 each round of fighting. If used as +2 SV, counts as Grenade. </description>
       <modifiers/>
     </rule>
-    <rule id="e167-a8e4-c26a-cafd" name="Weapon Drone" hidden="false" book="BtGoA" page="115">
+<rule id="e167-a8e4-c26a-cafd" name="Weapon Drone" hidden="false" book="BtGoA" page="115">
       <description>Always measure to model, not base. Not allowed to assault. Never take a break test, however auto-break if suffer pins equal to their Co stat. If drone fails a Res test, roll on Weapon Drone Damage Chart.
 
 D10 Result:
@@ -6448,579 +9326,579 @@ D10 Result:
 6-10: Destroyed</description>
       <modifiers/>
     </rule>
-    <rule id="75d2-6efa-9640-61df" name="Well Prepared" hidden="false" page="159">
+<rule id="75d2-6efa-9640-61df" name="Well Prepared" hidden="false" page="159">
       <description>If you take any single re-roll, you can add plus one to the value tested against. For example instead of testing against a res of 7 you would test against a res of 8. Use once and discard. You can buy as many Well Prepared as you are allowed Auxiliary choices in your Army.</description>
       <modifiers/>
     </rule>
-  </sharedRules>
-  <sharedProfiles>
-    <profile id="2da6-e419-5126-a73b" profileTypeId="1650-77b3-10d1-6406" name="Attack Skimmer" hidden="false">
+</sharedRules>
+<sharedProfiles>
+<profile id="2da6-e419-5126-a73b" profileTypeId="1650-77b3-10d1-6406" name="Attack Skimmer" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="11"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="MOD2, Large"/>
+        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
+        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
+        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
+        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="11"/>
+        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
+        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
+        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="MOD2, Large"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="9fba-d6b7-c66d-99f0" profileTypeId="1650-77b3-10d1-6406" name="Bodyguard" hidden="false">
+<profile id="9fba-d6b7-c66d-99f0" profileTypeId="1650-77b3-10d1-6406" name="Bodyguard" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="-"/>
+        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
+        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
+        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
+        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
+        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
+        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
+        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="-"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="eb0f-0718-35d7-1a00" profileTypeId="1650-77b3-10d1-6406" name="Combat Drone" hidden="false">
+<profile id="eb0f-0718-35d7-1a00" profileTypeId="1650-77b3-10d1-6406" name="Combat Drone" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="13"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="MOD2, Large"/>
+        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
+        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
+        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="1"/>
+        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="13"/>
+        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="8"/>
+        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
+        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="MOD2, Large"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="b390-0002-e1ef-3999" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Bombard" hidden="false">
+<profile id="b390-0002-e1ef-3999" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Bombard" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-50"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="150"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="9/7/5"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Cycle"/>
+        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10-50"/>
+        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
+        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="150"/>
+        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="9/7/5"/>
+        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Cycle"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="2e88-78bb-e1ba-bf5c" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Cannon" hidden="false">
+<profile id="2e88-78bb-e1ba-bf5c" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Cannon" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="7/4/2"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Cycle"/>
+        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
+        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
+        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
+        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="7/4/2"/>
+        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover, Cycle"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="75cb-cf9b-dd3d-9177" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Carbine" hidden="false">
+<profile id="75cb-cf9b-dd3d-9177" profileTypeId="ecae-8ac8-2c13-0dd3" name="Compression Carbine" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2/5/0"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover"/>
+        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10-20"/>
+        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
+        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
+        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2/5/0"/>
+        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Compressor, No Cover"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="2ae1-18d0-fbc8-21ad" profileTypeId="1650-77b3-10d1-6406" name="Feral Fighter" hidden="false">
+<profile id="2ae1-18d0-fbc8-21ad" profileTypeId="1650-77b3-10d1-6406" name="Feral Fighter" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="7"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="-"/>
+        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
+        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
+        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
+        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5"/>
+        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
+        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="7"/>
+        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="-"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="f23b-60da-348a-e6db" profileTypeId="1650-77b3-10d1-6406" name="Feral Leader" hidden="false">
+<profile id="f23b-60da-348a-e6db" profileTypeId="1650-77b3-10d1-6406" name="Feral Leader" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="7"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Leader"/>
+        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
+        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
+        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
+        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5"/>
+        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
+        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="7"/>
+        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Leader"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="1069-6287-7c2a-af01" profileTypeId="1650-77b3-10d1-6406" name="Ferel Skark Fighter" hidden="false">
+<profile id="1069-6287-7c2a-af01" profileTypeId="1650-77b3-10d1-6406" name="Ferel Skark Fighter" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Large, Fast, Skark3 Attacks SV1"/>
+        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
+        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
+        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
+        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
+        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
+        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
+        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Large, Fast, Skark3 Attacks SV1"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="41f2-0f61-9758-5e8d" profileTypeId="1650-77b3-10d1-6406" name="Ferel Skark Leader" hidden="false">
+<profile id="41f2-0f61-9758-5e8d" profileTypeId="1650-77b3-10d1-6406" name="Ferel Skark Leader" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Large, Fast, Skark3 Attacks SV1, Leader"/>
+        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
+        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
+        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
+        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
+        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
+        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
+        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Large, Fast, Skark3 Attacks SV1, Leader"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="bc52-cc32-73de-da9d" profileTypeId="ecae-8ac8-2c13-0dd3" name="Fractal Bombard" hidden="false">
+<profile id="bc52-cc32-73de-da9d" profileTypeId="ecae-8ac8-2c13-0dd3" name="Fractal Bombard" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="50"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="200"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3 +2 max 10"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock"/>
+        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="50"/>
+        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
+        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="200"/>
+        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="3 +2 max 10"/>
+        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="4c7f-3ba3-d703-1255" profileTypeId="ecae-8ac8-2c13-0dd3" name="Fractal Cannon" hidden="false">
+<profile id="4c7f-3ba3-d703-1255" profileTypeId="ecae-8ac8-2c13-0dd3" name="Fractal Cannon" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2 +1 max 10"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock"/>
+        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
+        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
+        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
+        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2 +1 max 10"/>
+        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Fractal Lock"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="2d89-bcdb-b942-b900" profileTypeId="1650-77b3-10d1-6406" name="Freeborn Captain" hidden="false">
+<profile id="2d89-bcdb-b942-b900" profileTypeId="1650-77b3-10d1-6406" name="Freeborn Captain" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Command, Hero, Follow, Leader 2"/>
+        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
+        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
+        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
+        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
+        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="8"/>
+        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="9"/>
+        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Command, Hero, Follow, Leader 2"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="c245-fa49-1569-2f23" profileTypeId="1650-77b3-10d1-6406" name="Freeborn Crew" hidden="false">
+<profile id="c245-fa49-1569-2f23" profileTypeId="1650-77b3-10d1-6406" name="Freeborn Crew" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="-"/>
+        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
+        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
+        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
+        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
+        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
+        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
+        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="-"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="a770-8327-b96d-b92e" profileTypeId="1650-77b3-10d1-6406" name="Freeborn Crew Leader" hidden="true">
+<profile id="a770-8327-b96d-b92e" profileTypeId="1650-77b3-10d1-6406" name="Freeborn Crew Leader" hidden="true">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Leader"/>
+        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
+        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
+        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
+        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
+        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
+        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
+        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Leader"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="7267-3051-f1b4-0a88" profileTypeId="1650-77b3-10d1-6406" name="Freeborn Heavy Crew" hidden="false">
+<profile id="7267-3051-f1b4-0a88" profileTypeId="1650-77b3-10d1-6406" name="Freeborn Heavy Crew" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Large, Slow"/>
+        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
+        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
+        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
+        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
+        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
+        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
+        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Large, Slow"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="87a3-460d-879a-92a5" profileTypeId="1650-77b3-10d1-6406" name="Freeborn Heavy Crew Leader" hidden="false">
+<profile id="87a3-460d-879a-92a5" profileTypeId="1650-77b3-10d1-6406" name="Freeborn Heavy Crew Leader" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Large, Slow"/>
+        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
+        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
+        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
+        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
+        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
+        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
+        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Large, Slow"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="0c03-96a3-4833-bc67" profileTypeId="1650-77b3-10d1-6406" name="Freeborn NuHu Renegade" hidden="false">
+<profile id="0c03-96a3-4833-bc67" profileTypeId="1650-77b3-10d1-6406" name="Freeborn NuHu Renegade" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="4"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="4(7)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="9"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Command, Hero, Follow, Leader 3"/>
+        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
+        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
+        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="4"/>
+        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="4(7)"/>
+        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="9"/>
+        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="9"/>
+        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Command, Hero, Follow, Leader 3"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="68fe-17c2-2841-2cde" profileTypeId="1650-77b3-10d1-6406" name="Freeborn NuHu Renegade Meld" hidden="false">
+<profile id="68fe-17c2-2841-2cde" profileTypeId="1650-77b3-10d1-6406" name="Freeborn NuHu Renegade Meld" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="4"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="8(11)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="9"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Command, Hero, Follow, Meld, Meld Damage, MOD2, Leader 3"/>
+        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
+        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
+        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="4"/>
+        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="8(11)"/>
+        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="9"/>
+        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="9"/>
+        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Command, Hero, Follow, Meld, Meld Damage, MOD2, Leader 3"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="2dbd-14c5-219e-d37d" profileTypeId="1650-77b3-10d1-6406" name="GP Drone" hidden="false">
+<profile id="2dbd-14c5-219e-d37d" profileTypeId="1650-77b3-10d1-6406" name="GP Drone" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="7"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="0"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="8"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="-"/>
+        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="7"/>
+        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="0"/>
+        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="1"/>
+        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="8"/>
+        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="8"/>
+        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
+        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="-"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="9e2a-f076-d4df-b60a" profileTypeId="1650-77b3-10d1-6406" name="Heavy Combat Drone" hidden="false">
+<profile id="9e2a-f076-d4df-b60a" profileTypeId="1650-77b3-10d1-6406" name="Heavy Combat Drone" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="15"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="MOD3, Slow, Large"/>
+        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
+        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
+        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="1"/>
+        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="15"/>
+        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="8"/>
+        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
+        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="MOD3, Slow, Large"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="d0a1-129b-f8e5-b1ad" profileTypeId="1650-77b3-10d1-6406" name="Hound Probe " hidden="false">
+<profile id="d0a1-129b-f8e5-b1ad" profileTypeId="1650-77b3-10d1-6406" name="Hound Probe " hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="-"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="-"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="-"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="-"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Shard"/>
+        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="-"/>
+        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
+        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="-"/>
+        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5"/>
+        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="-"/>
+        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="-"/>
+        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Shard"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="ed77-e875-0302-9bf4" profileTypeId="1650-77b3-10d1-6406" name="Household Leader" hidden="false">
+<profile id="ed77-e875-0302-9bf4" profileTypeId="1650-77b3-10d1-6406" name="Household Leader" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Leader"/>
+        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
+        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
+        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
+        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
+        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
+        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
+        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Leader"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="45dd-c1c8-46d5-0107" profileTypeId="1650-77b3-10d1-6406" name="Household Trooper" hidden="false">
+<profile id="45dd-c1c8-46d5-0107" profileTypeId="1650-77b3-10d1-6406" name="Household Trooper" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="-"/>
+        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
+        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
+        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
+        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
+        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
+        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
+        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="-"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="12c4-12f3-a601-7547" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Lash" hidden="false" book="BtGoA" page="67">
+<profile id="12c4-12f3-a601-7547" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Lash" hidden="false" book="BtGoA" page="67">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks"/>
+        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
+        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
+        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
+        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
+        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="2 Attacks"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="12fe-ec68-d3e2-79b9" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Mortar" hidden="false">
+<profile id="12fe-ec68-d3e2-79b9" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Mortar" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OHx2, Blast D10, No Cover"/>
+        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
+        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
+        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
+        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
+        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="OHx2, Blast D10, No Cover"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="79c6-8556-6040-e975" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Pistol" hidden="false">
+<profile id="79c6-8556-6040-e975" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Pistol" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="30"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
+        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
+        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
+        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="30"/>
+        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
+        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="ac6c-7fd0-193a-7751" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Repeater" hidden="false" book="BtGoA" page="69">
+<profile id="ac6c-7fd0-193a-7751" profileTypeId="ecae-8ac8-2c13-0dd3" name="Mag Repeater" hidden="false" book="BtGoA" page="69">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2"/>
+        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
+        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
+        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
+        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
+        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="3bc6-2260-1caa-db1c" profileTypeId="1650-77b3-10d1-6406" name="Meld Skark" hidden="false">
+<profile id="3bc6-2260-1caa-db1c" profileTypeId="1650-77b3-10d1-6406" name="Meld Skark" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="8"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="7(8)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Fast, Large, Savage Strike, Meld Skark 6 SV2, Leader"/>
+        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
+        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
+        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="8"/>
+        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="7(8)"/>
+        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
+        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
+        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Fast, Large, Savage Strike, Meld Skark 6 SV2, Leader"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="f504-4de7-23b9-2bad" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Bombard" hidden="false">
+<profile id="f504-4de7-23b9-2bad" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Bombard" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="50"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="200"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="7"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Plasma Fade"/>
+        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="50"/>
+        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="100"/>
+        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="200"/>
+        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="7"/>
+        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Plasma Fade"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="ed5d-2e1d-e51a-1f6a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Cannon" hidden="false">
+<profile id="ed5d-2e1d-e51a-1f6a" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Cannon" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="6"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Plasma Fade"/>
+        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
+        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
+        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
+        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="6"/>
+        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Plasma Fade"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="ee9c-ada6-953a-b774" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Carbine - Scatter" hidden="false">
+<profile id="ee9c-ada6-953a-b774" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Carbine - Scatter" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2"/>
+        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
+        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
+        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
+        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
+        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="b56d-0f1d-de00-62c4" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Carbine - Single Shot" hidden="false">
+<profile id="b56d-0f1d-de00-62c4" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Carbine - Single Shot" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
+        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
+        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
+        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
+        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
+        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="8b37-5912-a988-22e9" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Grenade Bandolier" hidden="false">
+<profile id="8b37-5912-a988-22e9" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Grenade Bandolier" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="-"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="-"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D4, Hazardous H2H"/>
+        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
+        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="-"/>
+        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="-"/>
+        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
+        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D4, Hazardous H2H"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="96f9-325b-69f7-13b4" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Grenades" hidden="false">
+<profile id="96f9-325b-69f7-13b4" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Grenades" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
+        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="5"/>
+        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="None"/>
+        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
+        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
+        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="cc3a-cc3a-5a9e-616b" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Lance" hidden="false">
+<profile id="cc3a-cc3a-5a9e-616b" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Lance" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="4"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Choose Target, Inaccurate"/>
+        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
+        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
+        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
+        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="4"/>
+        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Choose Target, Inaccurate"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="5463-10c1-cf72-c3f8" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Scatter" hidden="false">
+<profile id="5463-10c1-cf72-c3f8" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Scatter" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2"/>
+        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
+        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
+        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
+        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
+        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="RF2"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="1112-0824-87c5-ae27" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Single Shot" hidden="false">
+<profile id="1112-0824-87c5-ae27" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Lance - Single Shot" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
+        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="20"/>
+        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="30"/>
+        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="50"/>
+        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
+        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="e44d-e4f0-3ad5-6528" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Light Support Gun" hidden="false">
+<profile id="e44d-e4f0-3ad5-6528" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Light Support Gun" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3"/>
+        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="30"/>
+        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="40"/>
+        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="80"/>
+        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="3"/>
+        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="RF3"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="2e7c-b5f9-e3e5-9125" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Pistol" hidden="false">
+<profile id="2e7c-b5f9-e3e5-9125" profileTypeId="ecae-8ac8-2c13-0dd3" name="Plasma Pistol" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="30"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
+        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
+        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
+        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="30"/>
+        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="2"/>
+        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="-"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="04ae-2947-a8ea-2c08" profileTypeId="1650-77b3-10d1-6406" name="Probe" hidden="false">
+<profile id="04ae-2947-a8ea-2c08" profileTypeId="1650-77b3-10d1-6406" name="Probe" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="-"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="-"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="-"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="-"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Shard"/>
+        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="-"/>
+        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
+        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="-"/>
+        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5"/>
+        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="-"/>
+        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="-"/>
+        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Shard"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="45af-eec1-b29d-273f" profileTypeId="1650-77b3-10d1-6406" name="Rejects" hidden="false">
+<profile id="45af-eec1-b29d-273f" profileTypeId="1650-77b3-10d1-6406" name="Rejects" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="7"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Misgenic Abilities"/>
+        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
+        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
+        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
+        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5"/>
+        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
+        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="7"/>
+        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Misgenic Abilities"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="74dc-b388-dc1d-fb61" profileTypeId="1650-77b3-10d1-6406" name="Skyraider Captain" hidden="false">
+<profile id="74dc-b388-dc1d-fb61" profileTypeId="1650-77b3-10d1-6406" name="Skyraider Captain" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(7)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Command, Hero, Follow, Large, Fast, Leader 2"/>
+        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
+        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
+        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
+        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(7)"/>
+        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="8"/>
+        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="9"/>
+        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Command, Hero, Follow, Large, Fast, Leader 2"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="e18f-34de-2624-4133" profileTypeId="1650-77b3-10d1-6406" name="Skyraider Leader" hidden="false">
+<profile id="e18f-34de-2624-4133" profileTypeId="1650-77b3-10d1-6406" name="Skyraider Leader" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(7)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="9"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Large, Fast, Leader "/>
+        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
+        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
+        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
+        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(7)"/>
+        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="8"/>
+        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="9"/>
+        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Large, Fast, Leader "/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="a654-5213-64f2-703a" profileTypeId="1650-77b3-10d1-6406" name="Skyraider Trooper" hidden="false">
+<profile id="a654-5213-64f2-703a" profileTypeId="1650-77b3-10d1-6406" name="Skyraider Trooper" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(7)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Large, Fast"/>
+        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
+        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
+        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
+        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(7)"/>
+        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
+        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
+        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Large, Fast"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="4d5f-ccb4-75c2-cbf2" profileTypeId="1650-77b3-10d1-6406" name="Targeter Probe" hidden="false">
+<profile id="4d5f-ccb4-75c2-cbf2" profileTypeId="1650-77b3-10d1-6406" name="Targeter Probe" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="-"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="-"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="-"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="-"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Shard"/>
+        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="-"/>
+        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="-"/>
+        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="-"/>
+        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5"/>
+        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="-"/>
+        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="-"/>
+        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Shard"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="5425-1edf-f536-d5a1" profileTypeId="1650-77b3-10d1-6406" name="Transport Drone" hidden="false">
+<profile id="5425-1edf-f536-d5a1" profileTypeId="1650-77b3-10d1-6406" name="Transport Drone" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="1"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="13"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="8"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="MOD2, Transport 10, Large"/>
+        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
+        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="6"/>
+        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="1"/>
+        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="13"/>
+        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="8"/>
+        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
+        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="MOD2, Transport 10, Large"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="702f-c8a7-d8cf-01c1" profileTypeId="1650-77b3-10d1-6406" name="Vardanari Gaurd Trooper" hidden="false">
+<profile id="702f-c8a7-d8cf-01c1" profileTypeId="1650-77b3-10d1-6406" name="Vardanari Gaurd Trooper" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="-"/>
+        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
+        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
+        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
+        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
+        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
+        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
+        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="-"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="62fc-1d76-c6fd-a3eb" profileTypeId="1650-77b3-10d1-6406" name="Vardanari Leader" hidden="false">
+<profile id="62fc-1d76-c6fd-a3eb" profileTypeId="1650-77b3-10d1-6406" name="Vardanari Leader" hidden="false">
       <characteristics>
-        <characteristic characteristicId="cf30-f234-691c-47bd" name="Ag" value="5"/>
-        <characteristic characteristicId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
-        <characteristic characteristicId="8294-36f1-6431-2145" name="Str" value="5"/>
-        <characteristic characteristicId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
-        <characteristic characteristicId="08b9-e038-7ba6-488e" name="Init" value="7"/>
-        <characteristic characteristicId="3993-27b0-c3d9-de20" name="Co" value="8"/>
-        <characteristic characteristicId="3baa-9cfd-f273-822d" name="Special" value="Leader"/>
+        <characteristic characteristicTypeId="cf30-f234-691c-47bd" name="Ag" value="5"/>
+        <characteristic characteristicTypeId="017a-9b43-b7b3-030d" name="Acc" value="5"/>
+        <characteristic characteristicTypeId="8294-36f1-6431-2145" name="Str" value="5"/>
+        <characteristic characteristicTypeId="f214-abe8-c922-c51b" name="Res" value="5(6)"/>
+        <characteristic characteristicTypeId="08b9-e038-7ba6-488e" name="Init" value="7"/>
+        <characteristic characteristicTypeId="3993-27b0-c3d9-de20" name="Co" value="8"/>
+        <characteristic characteristicTypeId="3baa-9cfd-f273-822d" name="Special" value="Leader"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="27c9-718e-cee7-599d" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Launcher" hidden="false">
+<profile id="27c9-718e-cee7-599d" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Launcher" hidden="false">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="60"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="120"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D5, No Cover"/>
+        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10-30"/>
+        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="60"/>
+        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="120"/>
+        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="1"/>
+        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="OH, Blast D5, No Cover"/>
       </characteristics>
       <modifiers/>
     </profile>
-    <profile id="1298-3867-ea1e-c04c" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Sling" hidden="false" book="BtGoA" page="68">
+<profile id="1298-3867-ea1e-c04c" profileTypeId="ecae-8ac8-2c13-0dd3" name="X-Sling" hidden="false" book="BtGoA" page="68">
       <characteristics>
-        <characteristic characteristicId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
-        <characteristic characteristicId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
-        <characteristic characteristicId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
-        <characteristic characteristicId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
-        <characteristic characteristicId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D3, Hand Weapon"/>
+        <characteristic characteristicTypeId="c2de-17f1-10e2-2c0a" name="Effective" value="10"/>
+        <characteristic characteristicTypeId="995e-b5e6-4c63-0baa" name="Long" value="20"/>
+        <characteristic characteristicTypeId="bf58-0ad5-c7ee-3fd9" name="Extreme" value="None"/>
+        <characteristic characteristicTypeId="897c-d3c4-3983-896a" name="Strike Value" value="0"/>
+        <characteristic characteristicTypeId="7e87-2586-653f-d6ec" name="Special Rules" value="Blast D3, Hand Weapon"/>
       </characteristics>
       <modifiers/>
     </profile>
-  </sharedProfiles>
+</sharedProfiles>
 </catalogue>

--- a/Freeborn_Adventurers.cat
+++ b/Freeborn_Adventurers.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="5e8e-3fa7-98ab-9b96" name="Freeborn Adventurers" book="Battle for Xilos" revision="3" battleScribeVersion="2.00" authorName="Christopher Wailes" authorContact="email" authorUrl="http://cwailes1987@gmail.com" gameSystemId="c339-677a-60db-4060" gameSystemRevision="0" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="5e8e-3fa7-98ab-9b96" name="Freeborn Adventurers" book="Battle for Xilos" revision="4" battleScribeVersion="2.00" authorName="Christopher Wailes" authorContact="email" authorUrl="http://cwailes1987@gmail.com" gameSystemId="c339-677a-60db-4060" gameSystemRevision="0" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -7,223 +7,11 @@
   <profileTypes/>
   <forceEntries/>
   <selectionEntries>
-    <selectionEntry id="66a7-b2ec-cfcc-8359" name="&lt; Command Squad Options - Must choose first" hidden="false" collective="false" categoryEntryId="(No Category)" type="unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-      </constraints>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="c017-7f96-06bd-fd6b" name="Select one of the following option and the relevent selection will appear" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="3933-5e9f-f85c-ba75" name="1&lt; Add 2 extra bodygaurds" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a400-34cd-f726-fbf6" name="9&lt; Add Batter Drone" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="ad0d-a741-67ad-5d5c" name="7&lt; Add up to 2 Gun Drones" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="d17a-ef4d-2148-25e8" name="8&lt; Add up to 2 shield Drones" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="6559-a8ba-d266-7c27" name="2&lt; HL Armour for unit" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="1ef5-d006-6a32-fddb" name="3&lt; Phase Armour for unit" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a04c-3029-b790-0cdb" name="4&lt; Give Captain plasma Carbine" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a90a-cec1-cd13-3c17" name="5&lt; Give Captain Compression Carbine" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="7f96-ddf7-af5d-958a" name="6&lt; Give Bodygaurds Compression carbines" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="39a7-bedc-c912-a9f0" name="0&lt; None" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="minSelections" value="0.0">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="39a7-bedc-c912-a9f0" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="3596-fdfb-c997-4a56" name="Replace with Amano Harran and Bodyguards" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="f2dd-4a37-dae9-7560" name="Amano Harran and Bodyguards" book="Battle for Xilos" page="115" hidden="true" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
       <profiles/>
       <rules/>
       <infoLinks/>
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3596-fdfb-c997-4a56" type="equalTo"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
+      <modifiers/>
       <constraints>
         <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
         <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
@@ -451,7 +239,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="e34f-0193-f3d5-05b5" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+            <entryLink id="e34f-0193-f3d5-05b5" hidden="false" targetId="1631-5857-2139-960a" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -484,14 +272,14 @@
               <modifiers>
                 <modifier type="increment" field="points" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="f2dd-4a37-dae9-7560" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cf2e-47f5-d441-4c5b" repeats="1"/>
+                    <repeat field="selections" scope="f2dd-4a37-dae9-7560" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cf2e-47f5-d441-4c5b" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="increment" field="points" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="f2dd-4a37-dae9-7560" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c172-9fe8-32cc-31d8" repeats="1"/>
+                    <repeat field="selections" scope="f2dd-4a37-dae9-7560" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c172-9fe8-32cc-31d8" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -506,14 +294,14 @@
               <modifiers>
                 <modifier type="increment" field="points" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="f2dd-4a37-dae9-7560" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c172-9fe8-32cc-31d8" repeats="1"/>
+                    <repeat field="selections" scope="f2dd-4a37-dae9-7560" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c172-9fe8-32cc-31d8" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="increment" field="points" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="f2dd-4a37-dae9-7560" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cf2e-47f5-d441-4c5b" repeats="1"/>
+                    <repeat field="selections" scope="f2dd-4a37-dae9-7560" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cf2e-47f5-d441-4c5b" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -595,14 +383,14 @@
               <modifiers>
                 <modifier type="increment" field="points" value="2.0">
                   <repeats>
-                    <repeat field="selections" scope="f2dd-4a37-dae9-7560" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c172-9fe8-32cc-31d8" repeats="1"/>
+                    <repeat field="selections" scope="f2dd-4a37-dae9-7560" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c172-9fe8-32cc-31d8" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="increment" field="points" value="2.0">
                   <repeats>
-                    <repeat field="selections" scope="f2dd-4a37-dae9-7560" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cf2e-47f5-d441-4c5b" repeats="1"/>
+                    <repeat field="selections" scope="f2dd-4a37-dae9-7560" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cf2e-47f5-d441-4c5b" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -873,7 +661,7 @@
                   <modifiers/>
                   <constraints/>
                 </entryLink>
-                <entryLink id="48df-d58e-e0d1-d8df" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+                <entryLink id="48df-d58e-e0d1-d8df" hidden="false" targetId="8f47-408e-cc6e-7a19" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -937,30 +725,19 @@
             <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="9c0c-e485-c447-84fb" name="Ranged Weapon" hidden="false" collective="false">
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="ef34-3a97-17d4-0285" hidden="false" targetId="8f47-408e-cc6e-7a19" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5f4c-f7d8-2378-45b8" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="981e-e76e-039d-b344" type="min"/>
               </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="20d8-1c96-d87e-6005" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="pts" costTypeId="points" value="15.0"/>
           </costs>
@@ -1055,14 +832,14 @@
                 </modifier>
                 <modifier type="increment" field="points" value="2.0">
                   <repeats>
-                    <repeat field="selections" scope="a44f-4447-aff2-0dcd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d441-f08b-6ae0-3ce1" repeats="1"/>
+                    <repeat field="selections" scope="a44f-4447-aff2-0dcd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d441-f08b-6ae0-3ce1" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="increment" field="points" value="2.0">
                   <repeats>
-                    <repeat field="selections" scope="a44f-4447-aff2-0dcd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a960-249c-ef1d-5e8c" repeats="1"/>
+                    <repeat field="selections" scope="a44f-4447-aff2-0dcd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a960-249c-ef1d-5e8c" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -1098,1384 +875,14 @@
         <cost name="pts" costTypeId="points" value="10.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b73b-6140-e2ca-f0c1" name="Freeborn Command Squad" hidden="true" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+    <selectionEntry id="d603-36ff-a2eb-312f" name="Freeborn Command Squad" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
       <profiles/>
       <rules/>
       <infoLinks/>
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <repeats/>
-          <conditions/>
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3933-5e9f-f85c-ba75" type="equalTo"/>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a400-34cd-f726-fbf6" type="equalTo"/>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad0d-a741-67ad-5d5c" type="equalTo"/>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d17a-ef4d-2148-25e8" type="equalTo"/>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="39a7-bedc-c912-a9f0" type="equalTo"/>
-              </conditions>
-              <conditionGroups/>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
+      <modifiers/>
       <constraints>
         <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-      </constraints>
-      <selectionEntries>
-        <selectionEntry id="b36d-f9f6-80eb-6f8a" name="&lt; Freeborn Captain" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="75cc-7baf-4390-4597" hidden="false" targetId="2d89-bcdb-b942-b900" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="b73b-6140-e2ca-f0c1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3a47-103d-769c-3d59" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="ee93-85a8-a748-3858" name="&lt; Leader Level &gt;" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="3a47-103d-769c-3d59" hidden="false" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="0c11-a12d-3376-0b4b" name="&lt;Freeborn Captain Equipment &gt;" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="d72b-f17d-2842-5908" name="&lt; Armour &gt;" hidden="false" collective="false" defaultSelectionEntryId="d821-bfad-6e70-be4a">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="d821-bfad-6e70-be4a" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="6343-7996-c9c2-e583" name="&lt; Weapons &gt;" hidden="false" collective="false" defaultSelectionEntryId="c38c-46e0-0457-f57d">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="c38c-46e0-0457-f57d" hidden="false" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <entryLinks/>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="6b48-ec12-ab6c-2063" name="Bodyguards" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="16f3-2f8c-3e35-5557" hidden="false" targetId="9fba-d6b7-c66d-99f0" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers>
-            <modifier type="increment" field="maxSelections" value="2.0">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3933-5e9f-f85c-ba75" type="equalTo"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="c9a4-5ee7-f187-8235" name="&lt; Armour &gt;" hidden="false" collective="false" defaultSelectionEntryId="5b9a-d663-bb0e-6480">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="5b9a-d663-bb0e-6480" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="ce36-0f86-ad2b-2de0" name="&lt; Weapons &gt;" hidden="false" collective="false" defaultSelectionEntryId="ffe5-b36e-981d-67c8">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="ffe5-b36e-981d-67c8" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="21.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="87b2-db05-700b-2ce2" name="&lt; Unit Options &gt;" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="4e48-b0be-38f0-fb84" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="25ec-bc01-1917-42a1" hidden="false" targetId="502c-9855-7269-eaa2" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="e804-8e7c-7660-6271" hidden="false" targetId="573b-88bc-97d7-d890" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="19db-d0e1-8415-81fa" hidden="false" targetId="d118-8115-df5f-2402" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="points" value="2.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0">
-                  <repeats>
-                    <repeat field="selections" scope="b73b-6140-e2ca-f0c1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6b48-ec12-ab6c-2063" repeats="1"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-            </entryLink>
-            <entryLink id="3b4d-27c4-5549-02cb" hidden="false" targetId="4b9d-a0bf-396e-384b" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="set" field="hidden" value="false">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ad0d-a741-67ad-5d5c" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-            </entryLink>
-            <entryLink id="2c36-464a-243b-0e55" hidden="false" targetId="1707-586b-01df-0f80" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="set" field="hidden" value="false">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d17a-ef4d-2148-25e8" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-            </entryLink>
-            <entryLink id="8de0-52be-784c-00ce" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="set" field="hidden" value="false">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a400-34cd-f726-fbf6" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="69.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="15e4-e4af-15f1-94c3" name="Freeborn Command Squad" hidden="true" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f96-ddf7-af5d-958a" type="equalTo"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-      </constraints>
-      <selectionEntries>
-        <selectionEntry id="8b00-b972-e10d-1390" name="&lt; Freeborn Captain" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="5545-8414-45f3-4c97" hidden="false" targetId="2d89-bcdb-b942-b900" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="15e4-e4af-15f1-94c3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ed96-be90-06f3-0beb" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="b997-071f-1f47-aee8" name="&lt; Leader Level &gt;" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="ed96-be90-06f3-0beb" hidden="false" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="992a-ced2-9419-513c" name="&lt;Freeborn Captain Equipment &gt;" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="f80a-cee4-23df-5b8d" name="&lt; Armour &gt;" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="0ca1-9662-209b-eb0d" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="a5f8-02a4-689a-510f" name="&lt; Weapons &gt;" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="c1d9-84de-92d6-cb72" hidden="false" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <entryLinks/>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="16e2-4b59-8a36-351a" name="Bodygaurds" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="5e80-a56f-41a7-b337" hidden="false" targetId="9fba-d6b7-c66d-99f0" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers>
-            <modifier type="increment" field="maxSelections" value="2.0">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3933-5e9f-f85c-ba75" type="equalTo"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="70fa-1e75-d60b-2e16" name="&lt; Armour &gt;" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="f41b-1c7d-c117-325d" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="05c5-0dc8-f360-2012" name="&lt; Weapons &gt;" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="b106-d8e7-67b5-3daf" hidden="false" targetId="059b-38f7-0313-5ae4" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="26.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="4fd9-336f-cb2a-74cb" name="&lt; Unit Options &gt;" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="5c84-6fcb-23cb-c531" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="0534-209c-6e63-b751" hidden="false" targetId="502c-9855-7269-eaa2" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="3cc5-bd4f-f987-bb96" hidden="false" targetId="573b-88bc-97d7-d890" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="9289-3ce8-ce3b-c398" hidden="false" targetId="d118-8115-df5f-2402" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="points" value="2.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0">
-                  <repeats>
-                    <repeat field="selections" scope="15e4-e4af-15f1-94c3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="16e2-4b59-8a36-351a" repeats="1"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="70.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="4224-b512-8e27-a7ae" name="Freeborn Command Squad" hidden="true" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a90a-cec1-cd13-3c17" type="equalTo"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-      </constraints>
-      <selectionEntries>
-        <selectionEntry id="8166-8ae2-85a7-d508" name="&lt; Freeborn Captain" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="74c9-0721-edb2-fe31" hidden="false" targetId="2d89-bcdb-b942-b900" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="4224-b512-8e27-a7ae" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ec55-a3a6-79d2-3d8d" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="ec55-a3a6-79d2-3d8d" name="&lt; Leader Level &gt;" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="7539-56fe-d7c4-3436" hidden="false" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="bc83-ae90-8685-ec61" name="&lt;Freeborn Captain Equipment &gt;" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="8610-880b-d363-2842" name="&lt; Armour &gt;" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="9413-43f9-5e3c-0e39" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="b05f-e970-7acf-b5c2" name="&lt; Weapons &gt;" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="dc7e-0219-458d-80af" hidden="false" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <entryLinks/>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="733f-d5cf-9ed2-cd37" name="Bodygaurds" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="433d-17af-98e2-e708" hidden="false" targetId="9fba-d6b7-c66d-99f0" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers>
-            <modifier type="increment" field="maxSelections" value="2.0">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3933-5e9f-f85c-ba75" type="equalTo"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="2a25-debf-a112-08f8" name="&lt; Armour &gt;" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="94d8-34e0-0bd0-2f8f" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="64e2-25c4-0a20-fd6f" name="&lt; Weapons &gt;" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="f2d1-fbb0-ae51-637a" hidden="false" targetId="059b-38f7-0313-5ae4" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="26.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="01c0-de81-eb4f-6520" name="&lt; Unit Options &gt;" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="2313-6b51-b6fc-4334" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="55b3-8e97-1f9f-99c1" hidden="false" targetId="502c-9855-7269-eaa2" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="6334-02c5-fe28-46b2" hidden="false" targetId="573b-88bc-97d7-d890" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="94a7-abc4-e849-288a" hidden="false" targetId="d118-8115-df5f-2402" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="points" value="2.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0">
-                  <repeats>
-                    <repeat field="selections" scope="4224-b512-8e27-a7ae" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="733f-d5cf-9ed2-cd37" repeats="1"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="70.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="0f65-b8ed-b8b2-294a" name="Freeborn Command Squad" hidden="true" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a04c-3029-b790-0cdb" type="equalTo"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-      </constraints>
-      <selectionEntries>
-        <selectionEntry id="6f3f-e7de-8b1f-9a45" name="&lt; Freeborn Captain" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="9559-7359-c187-35e7" hidden="false" targetId="2d89-bcdb-b942-b900" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="0f65-b8ed-b8b2-294a" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6ef1-5f41-d717-8432" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="3f21-c5d0-9056-3513" name="&lt; Leader Level &gt;" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="6ef1-5f41-d717-8432" hidden="false" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="eba6-42f4-e601-d9d4" name="&lt;Freeborn Captain Equipment &gt;" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="0c25-94d1-2ee1-8f97" name="&lt; Armour &gt;" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="fd6b-8d29-bb72-1f1a" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="1d89-7fac-a8ca-dea9" name="&lt; Weapons &gt;" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="bfcd-6dc1-7032-9eca" hidden="false" targetId="059b-38f7-0313-5ae4" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers>
-                        <modifier type="set" field="points" value="8.0">
-                          <repeats/>
-                          <conditions/>
-                          <conditionGroups/>
-                        </modifier>
-                      </modifiers>
-                      <constraints/>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <entryLinks/>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="f539-7c50-1fed-c0fe" name="Bodygaurds" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="c830-2ab1-3be7-3427" hidden="false" targetId="9fba-d6b7-c66d-99f0" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers>
-            <modifier type="increment" field="maxSelections" value="2.0">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3933-5e9f-f85c-ba75" type="equalTo"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="db1b-d74c-4488-f114" name="&lt; Armour &gt;" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="9dbd-a1b9-f7e2-b802" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="da8e-2b95-0031-818a" name="&lt; Weapons &gt;" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="bcc8-515f-8cbc-7a6c" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="26.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="6c4b-1586-3d8b-dbda" name="&lt; Unit Options &gt;" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="712a-24b1-dd4d-c34e" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="7484-dc39-dbc9-ced2" hidden="false" targetId="502c-9855-7269-eaa2" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="2981-4427-c93a-87d1" hidden="false" targetId="573b-88bc-97d7-d890" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="7113-0a49-238b-ccc3" hidden="false" targetId="d118-8115-df5f-2402" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="points" value="2.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0">
-                  <repeats>
-                    <repeat field="selections" scope="0f65-b8ed-b8b2-294a" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f539-7c50-1fed-c0fe" repeats="1"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="70.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="ff83-951c-1523-67b4" name="Freeborn Command Squad" hidden="true" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6559-a8ba-d266-7c27" type="equalTo"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-      </constraints>
-      <selectionEntries>
-        <selectionEntry id="0b68-b15d-4f21-400d" name="&lt; Freeborn Captain" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="865b-5fee-3347-eedb" hidden="false" targetId="2d89-bcdb-b942-b900" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="ff83-951c-1523-67b4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fab0-fb87-4db4-b758" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="4f77-859f-d36f-3f51" name="&lt; Leader Level &gt;" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="fab0-fb87-4db4-b758" hidden="false" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="534d-0cc6-dc8f-0e4a" name="&lt;Freeborn Captain Equipment &gt;" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="6168-628e-5ed2-eaa9" name="&lt; Armour &gt;" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="be23-8e40-689c-4584" hidden="false" targetId="eff8-bb0e-1b1d-bbb2" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="5ec4-d224-e3cc-e5a6" name="&lt; Weapons &gt;" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="bff1-9762-306f-171b" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers>
-                        <modifier type="set" field="points" value="8.0">
-                          <repeats/>
-                          <conditions/>
-                          <conditionGroups/>
-                        </modifier>
-                      </modifiers>
-                      <constraints/>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <entryLinks/>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="b52c-6be6-7a76-ba77" name="Bodygaurds" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="248c-567b-902f-d5d5" hidden="false" targetId="9fba-d6b7-c66d-99f0" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="48ac-19f4-04e6-2834" name="&lt; Armour &gt;" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="f1f4-b68d-48a0-6c7f" hidden="false" targetId="eff8-bb0e-1b1d-bbb2" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="1095-6dad-810d-ff4f" name="&lt; Weapons &gt;" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="dde5-232c-c035-35fa" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="26.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="4329-ec3b-739b-0050" name="&lt; Unit Options &gt;" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="9bc9-cab0-4841-6c2c" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="c86a-f1fe-6d59-873f" hidden="false" targetId="502c-9855-7269-eaa2" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="e0aa-ee5e-c24a-c338" hidden="false" targetId="573b-88bc-97d7-d890" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="0aac-c5ca-badb-4434" hidden="false" targetId="d118-8115-df5f-2402" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="points" value="2.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0">
-                  <repeats>
-                    <repeat field="selections" scope="ff83-951c-1523-67b4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b52c-6be6-7a76-ba77" repeats="1"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="70.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="d603-36ff-a2eb-312f" name="Freeborn Command Squad" hidden="true" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1ef5-d006-6a32-fddb" type="equalTo"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6c6a-8177-0350-a90c" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="3c30-80dd-c936-7ccf" name="&lt; Freeborn Captain" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
@@ -2486,15 +893,7 @@
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command , Hero, Follow, Leader 3">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="d603-36ff-a2eb-312f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7671-d1cb-8583-32f9" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
+              <modifiers/>
             </infoLink>
           </infoLinks>
           <modifiers/>
@@ -2504,88 +903,73 @@
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups>
-            <selectionEntryGroup id="6111-3b3b-a2ef-bdbc" name="&lt; Leader Level &gt;" hidden="false" collective="false">
+            <selectionEntryGroup id="459d-72f4-94b8-0dd4" name="&lt; Weapons &gt;" hidden="false" collective="false">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c86c-9bd3-665b-d289" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d8c5-0ac3-742b-9d2f" type="max"/>
               </constraints>
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="7671-d1cb-8583-32f9" hidden="false" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
+                <entryLink id="8c5d-7f33-56ba-6b88" name="New EntryLink" hidden="false" targetId="3b20-256f-60c3-aaf4" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
-                  <modifiers/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="8">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                </entryLink>
+                <entryLink id="322d-f363-b4e5-ee63" name="New EntryLink" hidden="false" targetId="1631-5857-2139-960a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="points" value="8">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
                   <constraints/>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="c091-1c08-a4c1-1e30" name="&lt;Freeborn Captain Equipment &gt;" hidden="false" collective="false">
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="ce87-f6dc-cd34-94a2" hidden="false" targetId="9cd6-dbb8-bdcb-0299" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1b3f-7f7b-3731-9aae" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f85a-037d-3911-4bd1" type="max"/>
               </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="90d1-c02b-6791-3678" name="&lt; Armour &gt;" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="ef1a-0b88-41e9-520f" hidden="false" targetId="eb94-d1e8-1084-71b3" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-                <selectionEntryGroup id="954d-9823-9e71-fdb2" name="&lt; Weapons &gt;" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="9620-1c29-bbc5-277d" hidden="false" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <entryLinks/>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
+            </entryLink>
+            <entryLink id="53d6-ce60-8633-d783" hidden="false" targetId="5a4c-2f5e-40a2-91d4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4b17-816a-7684-f21b" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="70ef-17b0-4cc6-59d6" name="Bodygaurds" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+        <selectionEntry id="70ef-17b0-4cc6-59d6" name="Bodyguard" book="BtGoA" page="190" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles/>
           <rules/>
           <infoLinks>
@@ -2598,57 +982,25 @@
           </infoLinks>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1608-fb62-6b34-821c" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4d55-efe3-8759-304f" type="max"/>
           </constraints>
           <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="b2b0-8472-6f6f-b03b" name="&lt; Armour &gt;" hidden="false" collective="false">
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="22aa-5f5a-18d0-c54c" name="New EntryLink" hidden="false" targetId="9cd6-dbb8-bdcb-0299" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="45a4-14ff-cc31-10c9" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8080-a0b5-86f9-0dec" type="max"/>
               </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="4966-a136-1d34-1648" hidden="false" targetId="eb94-d1e8-1084-71b3" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="cd16-bf68-6808-737f" name="&lt; Weapons &gt;" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="7c24-c3ed-edef-f97d" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
+            </entryLink>
+          </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="26.0"/>
+            <cost name="pts" costTypeId="points" value="21.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -2688,15 +1040,108 @@
               <rules/>
               <infoLinks/>
               <modifiers>
-                <modifier type="set" field="points" value="2.0">
+                <modifier type="increment" field="points" value="2">
                   <repeats/>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="increment" field="points" value="2.0">
+                <modifier type="increment" field="points" value="2">
                   <repeats>
-                    <repeat field="selections" scope="d603-36ff-a2eb-312f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70ef-17b0-4cc6-59d6" repeats="1"/>
+                    <repeat field="selections" scope="d603-36ff-a2eb-312f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70ef-17b0-4cc6-59d6" repeats="1" roundUp="false"/>
                   </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="6ab6-c147-7de8-09bb" name="New EntryLink" hidden="false" targetId="4b9d-a0bf-396e-384b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0083-fe0a-3ca0-52e2" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="d9df-4a9c-eaae-010d" name="New EntryLink" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="1db1-a92d-33c1-d14d" name="New EntryLink" hidden="false" targetId="1707-586b-01df-0f80" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b4fa-d4df-0ab7-334f" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="b64a-fee5-83be-5521" name="New EntryLink" hidden="false" targetId="eefe-f70d-db8e-9414" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="821b-f41b-9737-205b" name="&lt; Unit Armor &gt;" hidden="false" collective="false" defaultSelectionEntryId="aabd-17dd-cacb-2f99">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4b99-acc6-769d-36dc" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0617-ee0d-45fb-fcd4" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="aabd-17dd-cacb-2f99" name="New EntryLink" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="7aee-ac37-d44a-a202" name="New EntryLink" hidden="false" targetId="eff8-bb0e-1b1d-bbb2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70ef-17b0-4cc6-59d6" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="1">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="c4bf-1e62-3457-86b9" name="New EntryLink" hidden="false" targetId="eb94-d1e8-1084-71b3" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="70ef-17b0-4cc6-59d6" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="points" value="1">
+                  <repeats/>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
@@ -2705,10 +1150,38 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
+        <selectionEntryGroup id="996c-171a-863f-4cbf" name="&lt; Unit Weapons &gt;" hidden="false" collective="false" defaultSelectionEntryId="4126-efb1-dcbc-72b4">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bdd4-58ab-870e-c051" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="baf7-e154-f00f-cb8b" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="4126-efb1-dcbc-72b4" name="New EntryLink" hidden="false" targetId="1631-5857-2139-960a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="f9b1-725c-4ab3-1c88" name="New EntryLink" hidden="false" targetId="3b20-256f-60c3-aaf4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="70.0"/>
+        <cost name="pts" costTypeId="points" value="69.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="6a1d-c668-c7e8-ed9f" name="Freeborn Heavy Support Team" book="BtGoA" page="194" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
@@ -2756,64 +1229,19 @@
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="8b71-ca9c-1ca2-0abc" name="&lt; Unit Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="42ad-31e5-60a7-9e01">
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="1338-add1-baeb-86bb" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4bfe-8232-f088-315f" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="75fc-61ab-a8f7-f1d6" type="max"/>
               </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="42ad-31e5-60a7-9e01" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="d718-d349-ce44-fe7e" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="9dd0-b9bb-59a6-5f05" name="&lt; Unit Armor &gt;" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="7632-f6c2-622d-6f3a" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="pts" costTypeId="points" value="12.0"/>
           </costs>
@@ -2871,6 +1299,32 @@
               <infoLinks/>
               <modifiers>
                 <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="c0ce-1ac7-9c4f-3587" name="New EntryLink" hidden="false" targetId="67b6-d6f5-5ba3-e50d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="20">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="9bd8-f3c1-d715-1926" name="New EntryLink" hidden="false" targetId="2cec-e1d7-c680-7ca0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="35">
                   <repeats/>
                   <conditions/>
                   <conditionGroups/>
@@ -2937,7 +1391,43 @@
               <modifiers>
                 <modifier type="increment" field="points" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="6a1d-c668-c7e8-ed9f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d45c-a6e2-b912-4bcd" repeats="1"/>
+                    <repeat field="selections" scope="6a1d-c668-c7e8-ed9f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d45c-a6e2-b912-4bcd" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="4602-e781-818a-533b" name="&lt; Unit Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="7b3c-5db7-a1b1-5b30">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="91fa-b364-6914-c340" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fba0-8507-e0b9-d063" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="7b3c-5db7-a1b1-5b30" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="77a6-acf8-4e62-8834" hidden="false" targetId="8f47-408e-cc6e-7a19" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d45c-a6e2-b912-4bcd" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -2961,7 +1451,7 @@
         <cost name="pts" costTypeId="points" value="25.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="0223-7d39-0a7c-f8a9" name="Freeborn Skyraider Squad" book="BtGoA" page="174" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+    <selectionEntry id="0223-7d39-0a7c-f8a9" name="Skyraider Squad" book="BtGoA" page="174" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
       <profiles/>
       <rules>
         <rule id="a61b-d8b1-c4a3-6102" name="Mounted Command Unit" hidden="false">
@@ -3067,7 +1557,18 @@
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="7cc5-fbe5-ed40-bd64" hidden="false" targetId="8f47-408e-cc6e-7a19" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4624-779b-f15b-b281" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5e5e-3b70-31b1-745c" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
@@ -3089,57 +1590,25 @@
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="d042-54cc-962c-5c4e" name="&lt; Ranged Weapon &gt;" hidden="false" collective="false">
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="677f-5232-66ed-85ff" hidden="false" targetId="8f47-408e-cc6e-7a19" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b00e-8827-dcfb-bc23" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="da4d-51c0-355a-d434" type="min"/>
               </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="60da-034a-d954-5cfc" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="84fe-b5cd-ab19-23e4" name="&lt; Skyraider &gt;" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="87a0-db4c-17e6-d240" hidden="false" targetId="a1a8-ba0b-2e45-8020" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
         <selectionEntryGroup id="46d3-88f8-ecac-204c" name="&lt; Special Weapon Option &gt;" hidden="false" collective="false">
           <profiles/>
           <rules/>
@@ -3167,34 +1636,6 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="f5d5-4b78-eab5-56a2" name="&lt; Unit Armor &gt;" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="3304-35c1-b35b-5a16" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="41f4-516b-6edc-fa24" hidden="false" targetId="2e3d-bbaa-3f5c-ac53" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
         <selectionEntryGroup id="d56e-be22-258f-698c" name="&lt; Unit Options &gt; " hidden="false" collective="false">
           <profiles/>
           <rules/>
@@ -3214,7 +1655,38 @@
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks/>
+      <entryLinks>
+        <entryLink id="5d95-c183-4847-eee0" hidden="false" targetId="a1a8-ba0b-2e45-8020" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3170-a2cf-1bb4-0e87" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5fd2-b2d0-e6af-8f41" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="a382-1a4d-39a9-8594" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f856-ebdc-03ac-d1ad" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3b1-095d-bf7d-846a" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="aac1-7657-f968-f96f" hidden="false" targetId="2e3d-bbaa-3f5c-ac53" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3387-9885-3cf0-fed8" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e17-e505-d40e-7b43" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="121.0"/>
       </costs>
@@ -3264,51 +1736,29 @@
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="09ce-fa1f-63c6-0dee" name="&lt; Unit Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="e022-953c-7321-fa34">
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="6fc2-9521-bfe3-fd00" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0e22-dbc6-4a54-4c95" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="08b3-540e-fe47-f5bc" type="max"/>
               </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="e022-953c-7321-fa34" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="af1b-11cd-5a0f-d758" name="&lt; Unit Armor &gt;" hidden="false" collective="false" defaultSelectionEntryId="20cd-dacc-9c25-5545">
+            </entryLink>
+            <entryLink id="d0bd-129a-ccf8-f10c" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c657-621b-172d-0603" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a4b7-1610-c6ff-a084" type="max"/>
               </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="20cd-dacc-9c25-5545" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="pts" costTypeId="points" value="12.0"/>
           </costs>
@@ -3398,7 +1848,7 @@
               <rules/>
               <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="points" value="10.0">
+                <modifier type="increment" field="points" value="40">
                   <repeats/>
                   <conditions/>
                   <conditionGroups/>
@@ -3463,9 +1913,9 @@
               <rules/>
               <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="points" value="1.0">
+                <modifier type="increment" field="points" value="2">
                   <repeats>
-                    <repeat field="selections" scope="0f2b-5fd2-86c3-563b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3b68-a4c9-03bb-dd68" repeats="1"/>
+                    <repeat field="selections" scope="0f2b-5fd2-86c3-563b" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3b68-a4c9-03bb-dd68" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -3607,6 +2057,19 @@
               <constraints/>
             </entryLink>
             <entryLink id="ee36-d310-391a-5a23" hidden="false" targetId="fb8b-7402-c5a9-8644" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="20">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="b81e-9775-5153-f585" name="New EntryLink" hidden="false" targetId="eefe-f70d-db8e-9414" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -3762,7 +2225,18 @@
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="1978-e5b8-ed38-ffee" name="New EntryLink" hidden="false" targetId="8f47-408e-cc6e-7a19" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a43-a86e-82b6-eaa5" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1df8-981e-4ef7-18b6" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
@@ -3784,57 +2258,25 @@
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="62da-827c-1a4c-bfef" name="&lt; Ranged Weapon &gt;" hidden="false" collective="false">
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="58d8-8cc3-0266-a07d" hidden="false" targetId="8f47-408e-cc6e-7a19" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8c8a-6a84-622e-53a0" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1a5d-b892-4c6d-9c91" type="max"/>
               </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="5c2c-6873-9857-0546" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="2996-96fd-31e3-fe8c" name="&lt; Skyraider &gt;" hidden="false" collective="false" defaultSelectionEntryId="92a3-2543-174e-504b">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="92a3-2543-174e-504b" hidden="false" targetId="a1a8-ba0b-2e45-8020" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
         <selectionEntryGroup id="5f94-8423-056d-5f54" name="&lt; Special Weapon Option &gt;" hidden="false" collective="false">
           <profiles/>
           <rules/>
@@ -3862,34 +2304,6 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="2d2f-4f61-9b31-50b5" name="&lt; Unit Armor &gt;" hidden="false" collective="false" defaultSelectionEntryId="6df8-de07-b4b9-201f">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="6df8-de07-b4b9-201f" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="0eff-479f-05c9-7f65" hidden="false" targetId="2e3d-bbaa-3f5c-ac53" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
         <selectionEntryGroup id="1858-3233-777b-6a0f" name="&lt; Unit Options &gt; " hidden="false" collective="false">
           <profiles/>
           <rules/>
@@ -3909,12 +2323,43 @@
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks/>
+      <entryLinks>
+        <entryLink id="fd43-2657-bc8e-8d81" hidden="false" targetId="a1a8-ba0b-2e45-8020" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="59d9-05d8-5e13-4bae" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="857d-cadb-4258-cd9c" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="f38a-e3c4-8889-8cea" hidden="false" targetId="2e3d-bbaa-3f5c-ac53" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="326b-18ab-9d2e-c85f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9b83-0aad-38be-5496" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="c589-0160-2919-da2a" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="772c-ffb5-d0f8-c15f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="aef4-4fec-ab24-778e" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="164.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1fc7-db89-4652-3c98" name="Superior Shard" hidden="false" collective="false" categoryEntryId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" type="upgrade">
+    <selectionEntry id="1fc7-db89-4652-3c98" name="Superior Shard" hidden="false" collective="false" categoryEntryId="50ba-cf77-3941-189c" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -4062,34 +2507,6 @@
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="f5ed-8cd5-154e-1987" name="&lt; Ranged Weapon &gt;" hidden="false" collective="false" defaultSelectionEntryId="c12f-a100-2c77-940b">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="c12f-a100-2c77-940b" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="02d9-18d6-822b-c297" hidden="false" targetId="179a-c0cc-49cc-c946" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
             <entryLink id="dbcb-5feb-24da-acaf" hidden="false" targetId="8de3-1e72-72ef-e7a3" type="selectionEntry">
@@ -4098,6 +2515,29 @@
               <infoLinks/>
               <modifiers>
                 <modifier type="increment" field="points" value="5.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+            </entryLink>
+            <entryLink id="c363-26f0-3455-6832" hidden="false" targetId="1631-5857-2139-960a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0522-aab0-4577-cf53" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0a48-7316-951e-2fb5" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="a972-c3d4-27a9-06ee" hidden="false" targetId="179a-c0cc-49cc-c946" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="2">
                   <repeats/>
                   <conditions/>
                   <conditionGroups/>
@@ -4134,50 +2574,7 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="fff7-d85d-7713-194d" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="1b32-6cc9-8dc9-64b3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="1b32-6cc9-8dc9-64b3" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="8836-8c4d-3a4f-5d40" name="Armor" hidden="false" collective="false" defaultSelectionEntryId="a575-c942-e1b2-0d29">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="a575-c942-e1b2-0d29" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+      <selectionEntryGroups/>
       <entryLinks>
         <entryLink id="7876-6071-860a-2b8f" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
           <profiles/>
@@ -4193,9 +2590,56 @@
           <modifiers/>
           <constraints/>
         </entryLink>
+        <entryLink id="0628-8e7b-4e40-8cbf" hidden="false" targetId="d118-8115-df5f-2402" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="2">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="97e8-d8ef-1bec-906d" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+        </entryLink>
+        <entryLink id="4739-446a-3389-5368" hidden="false" targetId="03c2-174e-8617-cf04" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="66fe-e1a8-888e-7cdb" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="309b-3d73-ffef-fee5" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="788a-ada8-e7f0-49a5" hidden="false" targetId="1631-5857-2139-960a" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1e7a-c1a8-75da-9aaa" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5a66-565a-b196-ec97" type="min"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="ca24-1a70-6163-2c66" name="New EntryLink" hidden="false" targetId="eefe-f70d-db8e-9414" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="42.0"/>
+        <cost name="pts" costTypeId="points" value="29.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="4e0f-95bb-f4f1-6030" name="Well Prepared" hidden="false" collective="false" categoryEntryId="50ba-cf77-3941-189c" type="upgrade">
@@ -4219,15 +2663,7 @@
       </costs>
     </selectionEntry>
   </selectionEntries>
-  <entryLinks>
-    <entryLink id="5a89-9dad-479c-0ce2" name="Army Options" hidden="false" targetId="529a-3e2a-4bd5-5e5f" type="selectionEntry" categoryEntryId="50ba-cf77-3941-189c">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-    </entryLink>
-  </entryLinks>
+  <entryLinks/>
   <sharedSelectionEntries>
     <selectionEntry id="e9dd-1dc6-3c92-4305" name="AG Chute" book="BtGoA" page="120" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
@@ -4294,7 +2730,7 @@
         <cost name="pts" costTypeId="points" value="20.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8f68-d09d-6e26-c6ea" name="Batter Drone (2)" book="BtGoA" page="11" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+    <selectionEntry id="8f68-d09d-6e26-c6ea" name="Batter Drone" book="BtGoA" page="11" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -4573,35 +3009,6 @@
       </infoLinks>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="059b-38f7-0313-5ae4" name="Compression Carbine" book="BtGoA" page="72" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="e580-6389-7ec6-d445" hidden="false" targetId="7db4-2d14-3984-37d9" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="b230-6dc2-fc21-9332" hidden="false" targetId="75cb-cf9b-dd3d-9177" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
       <selectionEntries/>
@@ -5026,7 +3433,7 @@
         <cost name="pts" costTypeId="points" value="14.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4b9d-a0bf-396e-384b" name="Gun Drone (2)" book="BtGoA" page="112" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+    <selectionEntry id="4b9d-a0bf-396e-384b" name="Gun Drone" book="BtGoA" page="112" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -5225,7 +3632,7 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2e3d-bbaa-3f5c-ac53" name="HL Booster (Eq)" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+    <selectionEntry id="2e3d-bbaa-3f5c-ac53" name="HL Booster" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -5243,9 +3650,7 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="1.0"/>
-      </costs>
+      <costs/>
     </selectionEntry>
     <selectionEntry id="573b-88bc-97d7-d890" name="HL Booster Drone" book="BtGoA" page="121" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
       <profiles/>
@@ -5635,7 +4040,7 @@
       <selectionEntryGroups/>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="20.0"/>
+        <cost name="pts" costTypeId="points" value="10.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="222a-c399-636e-c285" name="Lectro Lance" book="BtGoA" page="66" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
@@ -5781,36 +4186,7 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="84ac-0f31-c388-d0bd" name="Mag Gun" book="BtGoA" page="69" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-      <profiles>
-        <profile id="d809-b3af-7007-a7b3" name="Mag Gun" book="BtGoA" page="69" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="8f47-408e-cc6e-7a19" name="Mag Gun (Eq)" book="BtGoA" page="69" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+    <selectionEntry id="8f47-408e-cc6e-7a19" name="Mag Gun" book="BtGoA" page="69" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
         <profile id="33ca-cc05-d33e-3d00" name="Mag Gun" book="BtGoA" page="69" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
           <profiles/>
@@ -5829,10 +4205,7 @@
       <rules/>
       <infoLinks/>
       <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
+      <constraints/>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
@@ -6350,7 +4723,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <repeats>
-                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1"/>
+                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -6386,7 +4759,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <repeats>
-                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1"/>
+                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -6422,7 +4795,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <repeats>
-                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1"/>
+                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -6458,7 +4831,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <repeats>
-                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1"/>
+                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -6488,7 +4861,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <repeats>
-                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1"/>
+                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -6524,7 +4897,7 @@
               <modifiers>
                 <modifier type="set" field="hidden" value="true">
                   <repeats>
-                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1"/>
+                    <repeat field="selections" scope="cf32-46fd-cdce-80dd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="057c-a217-e792-8ef7" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -6830,7 +5203,7 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1631-5857-2139-960a" name="Plasma Carbine " book="BtGoA" page="70" hidden="false" collective="true" categoryEntryId="(No Category)" type="model">
+    <selectionEntry id="1631-5857-2139-960a" name="Plasma Carbine " book="BtGoA" page="70" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -6854,44 +5227,7 @@
         </infoLink>
       </infoLinks>
       <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="b018-6101-d2e3-b4ea" name="Plasma Carbine (Eq)" book="BtGoA" page="70" hidden="false" collective="true" categoryEntryId="(No Category)" type="model">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="7c09-db8c-68d9-485b" hidden="false" targetId="ee9c-ada6-953a-b774" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="8179-73ab-e5c7-065c" hidden="false" targetId="b56d-0f1d-de00-62c4" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="f29e-ac68-7310-1db0" hidden="false" targetId="0cb1-ea91-e5bc-4f75" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
+      <constraints/>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
@@ -7120,7 +5456,7 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9cd6-dbb8-bdcb-0299" name="Plasma Pistol" book="BtGoA" page="68" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+    <selectionEntry id="9cd6-dbb8-bdcb-0299" name="Plasma Pistol" book="BtGoA" page="68" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -7132,32 +5468,7 @@
         </infoLink>
       </infoLinks>
       <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="e6db-6ed3-1a26-ea56" name="Plasma Pistol (Eq)" book="BtGoA" page="68" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="d7c4-2e9d-b85d-2cda" hidden="false" targetId="2e7c-b5f9-e3e5-9125" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
+      <constraints/>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
@@ -7187,7 +5498,7 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9cdf-f068-bbde-2d0c" name="Reflex Armor (Eq)" book="BtGoA" page="93" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+    <selectionEntry id="9cdf-f068-bbde-2d0c" name="Reflex Armor" book="BtGoA" page="93" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -7210,7 +5521,7 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="03c2-174e-8617-cf04" name="Reflex Armor/ Impact Cloak (Eq)" book="BtGoA" page="93" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+    <selectionEntry id="03c2-174e-8617-cf04" name="Reflex Armor/ Impact Cloak" book="BtGoA" page="93" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -7222,10 +5533,7 @@
         </infoLink>
       </infoLinks>
       <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
+      <constraints/>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
@@ -7381,7 +5689,7 @@
         <cost name="pts" costTypeId="points" value="10.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1707-586b-01df-0f80" name="Shield Drone (2)" book="BtGoA" page="114" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+    <selectionEntry id="1707-586b-01df-0f80" name="Shield Drone" book="BtGoA" page="114" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -7432,34 +5740,21 @@
       <rules/>
       <infoLinks/>
       <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
+      <constraints/>
       <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="d918-4412-0ae1-6f74" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="467e-1407-3119-60ef">
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="b723-2a00-921c-2fd7" hidden="false" targetId="f31c-6e5c-19c0-ada7" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="988f-cc11-a811-58e8" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7e3f-b12f-533c-a271" type="max"/>
           </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="467e-1407-3119-60ef" hidden="false" targetId="f31c-6e5c-19c0-ada7" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
@@ -7787,51 +6082,29 @@
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
       </constraints>
       <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="4e5a-4594-d2da-527c" name="Mag Repeater" hidden="false" collective="false" defaultSelectionEntryId="513b-6ec0-e655-02cd">
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="faf3-5d8c-a57e-b272" name="" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c575-11e0-d5db-5d0f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="eaa8-fdd7-6a74-ceff" type="max"/>
           </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="513b-6ec0-e655-02cd" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="273a-5de1-c9e1-5310" name="Mag Repeater" hidden="false" collective="false" defaultSelectionEntryId="6e82-7e87-0e72-610f">
+        </entryLink>
+        <entryLink id="5e81-8aa8-b388-3c8f" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e09c-92d7-c766-7875" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b2ae-21b1-042b-1947" type="min"/>
           </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="6e82-7e87-0e72-610f" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
@@ -7859,7 +6132,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="50f5-f0eb-d9cb-a569" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+            <entryLink id="50f5-f0eb-d9cb-a569" hidden="false" targetId="1631-5857-2139-960a" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -8022,7 +6295,7 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="179a-c0cc-49cc-c946" name="X-Sling (Eq)" book="BtGoA" page="68" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
+    <selectionEntry id="179a-c0cc-49cc-c946" name="X-Sling" book="BtGoA" page="68" hidden="false" collective="true" categoryEntryId="(No Category)" type="upgrade">
       <profiles>
         <profile id="8977-826a-5f65-6907" name="X-Sling" book="BtGoA" page="68" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
           <profiles/>
@@ -8049,9 +6322,34 @@
       </infoLinks>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c93a-87b4-6917-c3c5" type="max"/>
       </constraints>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3b20-256f-60c3-aaf4" name="Compression Carbine" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="9383-01f1-7c02-b7c9" name="New InfoLink" hidden="false" targetId="75cb-cf9b-dd3d-9177" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="c25e-5b21-6592-c1e4" name="New InfoLink" hidden="false" targetId="7db4-2d14-3984-37d9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>

--- a/Freeborn_Adventurers.cat
+++ b/Freeborn_Adventurers.cat
@@ -7,14 +7,12 @@
   <profileTypes/>
   <forceEntries/>
   <selectionEntries>
-    <selectionEntry id="f2dd-4a37-dae9-7560" name="Amano Harran and Bodyguards" book="Battle for Xilos" page="115" hidden="true" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
+    <selectionEntry id="f2dd-4a37-dae9-7560" name="Amano Harran and Bodyguards" book="Battle for Xilos" page="115" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
       <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
       </constraints>
       <selectionEntries>
@@ -244,7 +242,10 @@
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8023-6c64-8a78-1262" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d5f-83f6-dce8-2539" type="max"/>
+              </constraints>
             </entryLink>
           </entryLinks>
           <costs>
@@ -3650,7 +3651,9 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="573b-88bc-97d7-d890" name="HL Booster Drone" book="BtGoA" page="121" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
       <profiles/>
@@ -5203,7 +5206,7 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1631-5857-2139-960a" name="Plasma Carbine " book="BtGoA" page="70" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+    <selectionEntry id="1631-5857-2139-960a" name="Plasma Carbine " book="BtGoA" page="70" hidden="false" collective="true" categoryEntryId="(No Category)" type="model">
       <profiles/>
       <rules/>
       <infoLinks>

--- a/Isorian.cat
+++ b/Isorian.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="eaf6-3f46-6191-754c" name="Isorian" revision="6" battleScribeVersion="2.00" authorName="Lee Long" authorContact="beasturr@live.co.uk" gameSystemId="c339-677a-60db-4060" gameSystemRevision="0" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="eaf6-3f46-6191-754c" name="Isorian" revision="7" battleScribeVersion="2.00" authorName="Lee Long" authorContact="beasturr@live.co.uk" gameSystemId="c339-677a-60db-4060" gameSystemRevision="0" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -116,7 +116,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="10">
                   <repeats>
-                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -133,7 +133,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="10">
                   <repeats>
-                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -214,6 +214,13 @@
               <constraints/>
             </entryLink>
             <entryLink id="f787-39f9-566b-e5ff" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+            <entryLink id="e4de-9a06-22cb-6fd2" name="New EntryLink" hidden="false" targetId="651f-9469-74a5-505a" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -302,7 +309,7 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d626-a99a-6470-71ad" name="Isorian Nhamak NC Light Support Drone" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+    <selectionEntry id="d626-a99a-6470-71ad" name="Isorian Nhamak SC Light Support Drone" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -372,6 +379,13 @@
               <modifiers/>
               <constraints/>
             </entryLink>
+            <entryLink id="6c79-fd92-24f0-e11d" name="New EntryLink" hidden="false" targetId="651f-9469-74a5-505a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="4da3-5d4c-1262-53ab" name="&lt; Weapon Drone Options &gt;" hidden="false" collective="false">
@@ -390,7 +404,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="10">
                   <repeats>
-                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -407,7 +421,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="10">
                   <repeats>
-                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -1112,7 +1126,7 @@
       <modifiers>
         <modifier type="increment" field="maxInForce" value="1.0">
           <repeats>
-            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3e3-761c-74f3-d2f2" repeats="1"/>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3e3-761c-74f3-d2f2" repeats="1" roundUp="false"/>
           </repeats>
           <conditions>
             <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3e3-761c-74f3-d2f2" type="equalTo"/>
@@ -1182,7 +1196,13 @@
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers/>
+              <modifiers>
+                <modifier type="set" field="minSelections" value="0.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
               <constraints/>
             </entryLink>
             <entryLink id="bb6a-48bd-2cf1-f430" hidden="false" targetId="057e-2e8a-1952-9de0" type="selectionEntry">
@@ -1821,6 +1841,13 @@
               </modifiers>
               <constraints/>
             </entryLink>
+            <entryLink id="564f-776c-af3e-92fd" name="New EntryLink" hidden="false" targetId="651f-9469-74a5-505a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -1922,7 +1949,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="2">
                   <repeats>
-                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1"/>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>


### PR DESCRIPTION
Freeborn:
- LOTS: Cleaned up various places where things looked optional but weren't, some validation fixes.
- Moved Superior Shard to Army Options
- Updated Command Squad to be more usable
    - "Freeborn Command Squad" and "Freeborn Command Squad (Special)" differentiated to ensure army can only take one set of special options
- Feral Squad no longer has validation error for to many ranged weapons
- Added Synchronizer Drones to Vardanari, Command and Light GP Drone

Freeborn Adventurers
- LOTS: Small tweaks in places -- such as removing options that aren't optional, some renaming and validation fixes
- Moved Superior Shard upgrade to Army Options
- Removed "Army Options" entry in favour of individual options selection
- Updated Command squad to be more usable
    - added Synchronizer drone
- Vardanari
    - corrected base points
    - added plasma grenades
    - added X-Sling
    - aded Synchronizer drone
- Domari: Mag guns no longer optional
- Skyraider Command Squad: corrected base points, tweaking options
- Freeborn Heavy Support Team: added plasma bombard and fractal bombard options
- Light General Purpose Drone: added synchronizer drone

Isorian:
    - NuHu Senatexis no longer forced to take a spotter drone
    - Senatex Command Squad given Synchronizer Drone
    - Isorian Nhamak SC Light Support Drone given Synchronizer Drone
        - And renamed from "NC" to "SC"
    - Isorian Andhak SC2 Light Support Drone given Synchronizer Drone

Concord:
    - Added Synchronizer Drone to C3 Strike Command Squad, C3 Drop Command Squad, C3 Strike Squads, C3 Drop Squads, C3D1 Light Support Drone, C3D2 Medium Support Drone, C3D1/GP Light General Purpose Drone
    - Separated Drop Trooper (Lance) to make it clearer that there is only a single Lance in the squad to start.
    - Drop Squad Trooper count was off by 1
    
All:
    Updated Army Options limit for AUX numbers