### PR TITLE
Various Ghar / Rebel Ghar fixs

### DIFF
--- a/Ghar.cat
+++ b/Ghar.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="0f2e-f338-5620-a215" name="Ghar" revision="13" battleScribeVersion="2.00" gameSystemId="c339-677a-60db-4060" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="0f2e-f338-5620-a215" name="Ghar" revision="14" battleScribeVersion="2.00" gameSystemId="c339-677a-60db-4060" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -305,14 +305,14 @@
           <modifiers>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="9030-9dea-f00b-e2ed" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c8dc-aa17-3f85-1a20" repeats="1"/>
+                <repeat field="selections" scope="9030-9dea-f00b-e2ed" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c8dc-aa17-3f85-1a20" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="9030-9dea-f00b-e2ed" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4850-1a32-f160-03dc" repeats="1"/>
+                <repeat field="selections" scope="9030-9dea-f00b-e2ed" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4850-1a32-f160-03dc" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -342,14 +342,14 @@
           <modifiers>
             <modifier type="increment" field="points" value="10.0">
               <repeats>
-                <repeat field="selections" scope="9030-9dea-f00b-e2ed" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4850-1a32-f160-03dc" repeats="1"/>
+                <repeat field="selections" scope="9030-9dea-f00b-e2ed" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4850-1a32-f160-03dc" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="10.0">
               <repeats>
-                <repeat field="selections" scope="9030-9dea-f00b-e2ed" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c8dc-aa17-3f85-1a20" repeats="1"/>
+                <repeat field="selections" scope="9030-9dea-f00b-e2ed" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c8dc-aa17-3f85-1a20" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -452,95 +452,21 @@
             </profile>
           </profiles>
           <rules/>
-          <infoLinks/>
+          <infoLinks>
+            <infoLink id="b93f-3c71-d6fa-a436" hidden="false" targetId="24a5-60f8-93fc-7dff" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="e731-c0ab-0ba9-c676" name="Leader Rank" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="0133-88f6-fa5e-13f5" name="Leader 2" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="6564-66f8-98cb-f112" hidden="false" targetId="9d03-08db-93a6-4f05" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="f0a7-09f6-37c9-02f2" name="Leader 3" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="ffe5-44c2-bced-defa" hidden="false" targetId="e048-25d9-af17-bdf0" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="20.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="c559-421a-a988-dbfc" name="Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="5b39-2a49-3a77-c370" hidden="false" targetId="24a5-60f8-93fc-7dff" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
+          <selectionEntryGroups/>
           <entryLinks/>
           <costs>
             <cost name="pts" costTypeId="points" value="36.0"/>
@@ -585,14 +511,14 @@
           <modifiers>
             <modifier type="increment" field="points" value="10.0">
               <repeats>
-                <repeat field="selections" scope="c27a-aa4f-97c0-ebef" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8974-5164-823a-fe6c" repeats="1"/>
+                <repeat field="selections" scope="c27a-aa4f-97c0-ebef" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8974-5164-823a-fe6c" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="10.0">
               <repeats>
-                <repeat field="selections" scope="c27a-aa4f-97c0-ebef" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7fdb-3754-be08-c953" repeats="1"/>
+                <repeat field="selections" scope="c27a-aa4f-97c0-ebef" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7fdb-3754-be08-c953" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -615,14 +541,14 @@
           <modifiers>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="c27a-aa4f-97c0-ebef" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7fdb-3754-be08-c953" repeats="1"/>
+                <repeat field="selections" scope="c27a-aa4f-97c0-ebef" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7fdb-3754-be08-c953" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="c27a-aa4f-97c0-ebef" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8974-5164-823a-fe6c" repeats="1"/>
+                <repeat field="selections" scope="c27a-aa4f-97c0-ebef" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8974-5164-823a-fe6c" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -776,14 +702,14 @@
           <modifiers>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="5670-d9f9-4779-7a23" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c899-96c3-90ae-a7a9" repeats="1"/>
+                <repeat field="selections" scope="5670-d9f9-4779-7a23" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c899-96c3-90ae-a7a9" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="5670-d9f9-4779-7a23" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d842-422d-f043-b735" repeats="1"/>
+                <repeat field="selections" scope="5670-d9f9-4779-7a23" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d842-422d-f043-b735" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -813,14 +739,14 @@
           <modifiers>
             <modifier type="increment" field="points" value="10.0">
               <repeats>
-                <repeat field="selections" scope="5670-d9f9-4779-7a23" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d842-422d-f043-b735" repeats="1"/>
+                <repeat field="selections" scope="5670-d9f9-4779-7a23" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d842-422d-f043-b735" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="10.0">
               <repeats>
-                <repeat field="selections" scope="5670-d9f9-4779-7a23" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c899-96c3-90ae-a7a9" repeats="1"/>
+                <repeat field="selections" scope="5670-d9f9-4779-7a23" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c899-96c3-90ae-a7a9" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -851,7 +777,7 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="f21b-beb2-224e-5e3f" name="Ghar Bombardment Crawler" page="170" hidden="false" collective="false" categoryEntryId="5c47879b-41d0-1383-5fe5-a5989615db89" type="unit">
+    <selectionEntry id="f21b-beb2-224e-5e3f" name="Ghar Bombardment Crawler" page="170" hidden="false" collective="false" categoryEntryId="a01f5f58-334c-8442-d861-15099ebdf5e5" type="unit">
       <profiles/>
       <rules>
         <rule id="d6a3-4bb5-e5d9-3659" name="Vehicle Unit / Mixed Vehicle + Mounts" book="" hidden="false">
@@ -965,14 +891,14 @@
           <modifiers>
             <modifier type="increment" field="points" value="10.0">
               <repeats>
-                <repeat field="selections" scope="f21b-beb2-224e-5e3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1a33-1125-41be-a84c" repeats="1"/>
+                <repeat field="selections" scope="f21b-beb2-224e-5e3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1a33-1125-41be-a84c" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="10.0">
               <repeats>
-                <repeat field="selections" scope="f21b-beb2-224e-5e3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ef3d-dcd6-70ae-c6c6" repeats="1"/>
+                <repeat field="selections" scope="f21b-beb2-224e-5e3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ef3d-dcd6-70ae-c6c6" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -1002,14 +928,14 @@
           <modifiers>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="f21b-beb2-224e-5e3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1a33-1125-41be-a84c" repeats="1"/>
+                <repeat field="selections" scope="f21b-beb2-224e-5e3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1a33-1125-41be-a84c" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="f21b-beb2-224e-5e3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ef3d-dcd6-70ae-c6c6" repeats="1"/>
+                <repeat field="selections" scope="f21b-beb2-224e-5e3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ef3d-dcd6-70ae-c6c6" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -1278,28 +1204,28 @@
           <modifiers>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0d6e-d1da-4558-5a99" repeats="1"/>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0d6e-d1da-4558-5a99" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4a98-4c68-15aa-a072" repeats="1"/>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4a98-4c68-15aa-a072" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="90ee-0a6f-9336-975d" repeats="1"/>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="90ee-0a6f-9336-975d" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a18c-40ae-d918-8109" repeats="1"/>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a18c-40ae-d918-8109" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -1322,28 +1248,28 @@
           <modifiers>
             <modifier type="increment" field="points" value="10.0">
               <repeats>
-                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a18c-40ae-d918-8109" repeats="1"/>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a18c-40ae-d918-8109" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="10.0">
               <repeats>
-                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4a98-4c68-15aa-a072" repeats="1"/>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4a98-4c68-15aa-a072" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="10.0">
               <repeats>
-                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0d6e-d1da-4558-5a99" repeats="1"/>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0d6e-d1da-4558-5a99" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="10.0">
               <repeats>
-                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="90ee-0a6f-9336-975d" repeats="1"/>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="90ee-0a6f-9336-975d" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -1628,7 +1554,7 @@
           <modifiers>
             <modifier type="increment" field="points" value="10.0">
               <repeats>
-                <repeat field="selections" scope="8a8c-71c0-d041-09a6" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cc54-51ee-9a73-2c3f" repeats="1"/>
+                <repeat field="selections" scope="8a8c-71c0-d041-09a6" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cc54-51ee-9a73-2c3f" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -1651,7 +1577,7 @@
           <modifiers>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="8a8c-71c0-d041-09a6" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6675-7341-53d3-7e85" repeats="1"/>
+                <repeat field="selections" scope="8a8c-71c0-d041-09a6" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6675-7341-53d3-7e85" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -1695,7 +1621,7 @@
       <modifiers>
         <modifier type="increment" field="maxInForce" value="1.0">
           <repeats>
-            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6cfb-8ee0-4610-646d" repeats="1"/>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6cfb-8ee0-4610-646d" repeats="1" roundUp="false"/>
           </repeats>
           <conditions/>
           <conditionGroups/>
@@ -1741,7 +1667,7 @@
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups>
-            <selectionEntryGroup id="d3b2-1969-407b-c61f" name="Leader Rank" hidden="false" collective="false">
+            <selectionEntryGroup id="d3b2-1969-407b-c61f" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="86da-277a-ba37-4410">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -1834,7 +1760,7 @@
       <modifiers>
         <modifier type="set" field="maxInForce" value="99.0">
           <repeats>
-            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="52ba-dd45-2ef8-eb63" repeats="1"/>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="52ba-dd45-2ef8-eb63" repeats="1" roundUp="false"/>
           </repeats>
           <conditions/>
           <conditionGroups/>
@@ -2010,7 +1936,7 @@
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups>
-            <selectionEntryGroup id="f3c1-a4fd-77c7-1ad3" name="Leader Rank" hidden="false" collective="false">
+            <selectionEntryGroup id="f3c1-a4fd-77c7-1ad3" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="fb25-afca-e693-0a27">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -2023,13 +1949,6 @@
               <selectionEntryGroups/>
               <entryLinks>
                 <entryLink id="246c-fea3-dfb5-693c" hidden="false" targetId="0e9b-9aae-bd16-d30f" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="15bd-449b-fa72-2c5f" hidden="false" targetId="da65-5109-5f5f-0f9a" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -2130,21 +2049,21 @@
           <modifiers>
             <modifier type="increment" field="points" value="2.0">
               <repeats>
-                <repeat field="selections" scope="6cfb-8ee0-4610-646d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0c5f-a39d-f318-124e" repeats="1"/>
+                <repeat field="selections" scope="6cfb-8ee0-4610-646d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0c5f-a39d-f318-124e" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="2.0">
               <repeats>
-                <repeat field="selections" scope="6cfb-8ee0-4610-646d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f22f-86cd-4a95-b370" repeats="1"/>
+                <repeat field="selections" scope="6cfb-8ee0-4610-646d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f22f-86cd-4a95-b370" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="4.0">
               <repeats>
-                <repeat field="selections" scope="6cfb-8ee0-4610-646d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="770f-0ac0-8238-7bfc" repeats="1"/>
+                <repeat field="selections" scope="6cfb-8ee0-4610-646d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="770f-0ac0-8238-7bfc" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>

--- a/Ghar_Rebels.cat
+++ b/Ghar_Rebels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="2165-1159-f3ed-3ea5" name="Rebel" book="BFX" revision="3" battleScribeVersion="2.00" authorName="Maye Gelt" gameSystemId="c339-677a-60db-4060" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="2165-1159-f3ed-3ea5" name="Rebel" book="BFX" revision="4" battleScribeVersion="2.00" authorName="Maye Gelt" gameSystemId="c339-677a-60db-4060" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -7,111 +7,6 @@
   <profileTypes/>
   <forceEntries/>
   <selectionEntries>
-    <selectionEntry id="4ddf-247a-fd1d-2264" name="Army Options" book="brb" page="159" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <selectionEntries>
-        <selectionEntry id="f7ce-75c3-2997-6921" name="Block!" book="brb" page="159" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="5.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="915e-f2eb-da32-24f6" name="Get Up!" book="brb" page="159" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="3534-7fce-4a95-7c1e" name="Extra Shot" book="brb" page="159" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="1f63-b2ca-1245-db01" name="Pull Yourself Together" book="brb" page="159" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="15.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="c18c-a602-3036-dd57" name="Superior Shard" book="brb" page="159" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="15.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="9d50-659a-cb95-a5f3" name="Marksman" book="brb" page="159" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="15.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="63bf-d255-762d-7445" name="Well Prepared" book="brb" page="159" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="5.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="3d57-162c-00ab-4c84" name="Fartok, Leader Of The Outcast Revolt" book="BFX" page="107" hidden="false" collective="false" categoryEntryId="481abf13-c03e-0dd0-d520-9f9837253cbe" type="unit">
       <profiles/>
       <rules>
@@ -248,7 +143,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="3d57-162c-00ab-4c84" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="036d-d495-7f37-864f" repeats="1"/>
+                    <repeat field="selections" scope="3d57-162c-00ab-4c84" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="036d-d495-7f37-864f" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -293,21 +188,21 @@
           <modifiers>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="3d57-162c-00ab-4c84" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0392-cdb8-e66c-08f6" repeats="1"/>
+                <repeat field="selections" scope="3d57-162c-00ab-4c84" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0392-cdb8-e66c-08f6" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="3d57-162c-00ab-4c84" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="036d-d495-7f37-864f" repeats="1"/>
+                <repeat field="selections" scope="3d57-162c-00ab-4c84" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="036d-d495-7f37-864f" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="3d57-162c-00ab-4c84" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5c66-1eb0-17c5-71e7" repeats="1"/>
+                <repeat field="selections" scope="3d57-162c-00ab-4c84" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5c66-1eb0-17c5-71e7" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -355,7 +250,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="3d57-162c-00ab-4c84" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5c66-1eb0-17c5-71e7" repeats="1"/>
+                    <repeat field="selections" scope="3d57-162c-00ab-4c84" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5c66-1eb0-17c5-71e7" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -755,28 +650,28 @@
           <modifiers>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0d6e-d1da-4558-5a99" repeats="1"/>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0d6e-d1da-4558-5a99" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4a98-4c68-15aa-a072" repeats="1"/>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4a98-4c68-15aa-a072" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="90ee-0a6f-9336-975d" repeats="1"/>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="90ee-0a6f-9336-975d" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a18c-40ae-d918-8109" repeats="1"/>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a18c-40ae-d918-8109" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -799,28 +694,28 @@
           <modifiers>
             <modifier type="increment" field="points" value="10.0">
               <repeats>
-                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a18c-40ae-d918-8109" repeats="1"/>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a18c-40ae-d918-8109" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="10.0">
               <repeats>
-                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4a98-4c68-15aa-a072" repeats="1"/>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4a98-4c68-15aa-a072" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="10.0">
               <repeats>
-                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0d6e-d1da-4558-5a99" repeats="1"/>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0d6e-d1da-4558-5a99" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="10.0">
               <repeats>
-                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="90ee-0a6f-9336-975d" repeats="1"/>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="90ee-0a6f-9336-975d" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -1055,14 +950,14 @@
           <modifiers>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="9030-9dea-f00b-e2ed" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c8dc-aa17-3f85-1a20" repeats="1"/>
+                <repeat field="selections" scope="9030-9dea-f00b-e2ed" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c8dc-aa17-3f85-1a20" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="9030-9dea-f00b-e2ed" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4850-1a32-f160-03dc" repeats="1"/>
+                <repeat field="selections" scope="9030-9dea-f00b-e2ed" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4850-1a32-f160-03dc" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -1092,14 +987,14 @@
           <modifiers>
             <modifier type="increment" field="points" value="10.0">
               <repeats>
-                <repeat field="selections" scope="9030-9dea-f00b-e2ed" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4850-1a32-f160-03dc" repeats="1"/>
+                <repeat field="selections" scope="9030-9dea-f00b-e2ed" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4850-1a32-f160-03dc" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="10.0">
               <repeats>
-                <repeat field="selections" scope="9030-9dea-f00b-e2ed" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c8dc-aa17-3f85-1a20" repeats="1"/>
+                <repeat field="selections" scope="9030-9dea-f00b-e2ed" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c8dc-aa17-3f85-1a20" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -1303,7 +1198,7 @@
           <modifiers>
             <modifier type="increment" field="points" value="10.0">
               <repeats>
-                <repeat field="selections" scope="c632-a7b6-ae64-6a40" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9578-b417-1394-8a76" repeats="1"/>
+                <repeat field="selections" scope="c632-a7b6-ae64-6a40" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9578-b417-1394-8a76" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -1326,7 +1221,7 @@
           <modifiers>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="c632-a7b6-ae64-6a40" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9578-b417-1394-8a76" repeats="1"/>
+                <repeat field="selections" scope="c632-a7b6-ae64-6a40" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9578-b417-1394-8a76" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -1500,14 +1395,14 @@
           <modifiers>
             <modifier type="increment" field="points" value="10.0">
               <repeats>
-                <repeat field="selections" scope="c27a-aa4f-97c0-ebef" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8974-5164-823a-fe6c" repeats="1"/>
+                <repeat field="selections" scope="c27a-aa4f-97c0-ebef" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8974-5164-823a-fe6c" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="10.0">
               <repeats>
-                <repeat field="selections" scope="c27a-aa4f-97c0-ebef" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7fdb-3754-be08-c953" repeats="1"/>
+                <repeat field="selections" scope="c27a-aa4f-97c0-ebef" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7fdb-3754-be08-c953" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -1530,14 +1425,14 @@
           <modifiers>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="c27a-aa4f-97c0-ebef" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7fdb-3754-be08-c953" repeats="1"/>
+                <repeat field="selections" scope="c27a-aa4f-97c0-ebef" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7fdb-3754-be08-c953" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="c27a-aa4f-97c0-ebef" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8974-5164-823a-fe6c" repeats="1"/>
+                <repeat field="selections" scope="c27a-aa4f-97c0-ebef" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8974-5164-823a-fe6c" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -1703,14 +1598,14 @@
           <modifiers>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="5670-d9f9-4779-7a23" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c899-96c3-90ae-a7a9" repeats="1"/>
+                <repeat field="selections" scope="5670-d9f9-4779-7a23" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c899-96c3-90ae-a7a9" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="5670-d9f9-4779-7a23" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d842-422d-f043-b735" repeats="1"/>
+                <repeat field="selections" scope="5670-d9f9-4779-7a23" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d842-422d-f043-b735" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -1740,14 +1635,14 @@
           <modifiers>
             <modifier type="increment" field="points" value="10.0">
               <repeats>
-                <repeat field="selections" scope="5670-d9f9-4779-7a23" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d842-422d-f043-b735" repeats="1"/>
+                <repeat field="selections" scope="5670-d9f9-4779-7a23" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d842-422d-f043-b735" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="10.0">
               <repeats>
-                <repeat field="selections" scope="5670-d9f9-4779-7a23" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c899-96c3-90ae-a7a9" repeats="1"/>
+                <repeat field="selections" scope="5670-d9f9-4779-7a23" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c899-96c3-90ae-a7a9" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -1961,14 +1856,14 @@
           <modifiers>
             <modifier type="increment" field="points" value="2.0">
               <repeats>
-                <repeat field="selections" scope="6cfb-8ee0-4610-646d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0c5f-a39d-f318-124e" repeats="1"/>
+                <repeat field="selections" scope="6cfb-8ee0-4610-646d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0c5f-a39d-f318-124e" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="2.0">
               <repeats>
-                <repeat field="selections" scope="6cfb-8ee0-4610-646d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f22f-86cd-4a95-b370" repeats="1"/>
+                <repeat field="selections" scope="6cfb-8ee0-4610-646d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f22f-86cd-4a95-b370" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -1997,14 +1892,14 @@
           <modifiers>
             <modifier type="increment" field="points" value="2.0">
               <repeats>
-                <repeat field="selections" scope="6cfb-8ee0-4610-646d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0c5f-a39d-f318-124e" repeats="1"/>
+                <repeat field="selections" scope="6cfb-8ee0-4610-646d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0c5f-a39d-f318-124e" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="2.0">
               <repeats>
-                <repeat field="selections" scope="6cfb-8ee0-4610-646d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f22f-86cd-4a95-b370" repeats="1"/>
+                <repeat field="selections" scope="6cfb-8ee0-4610-646d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f22f-86cd-4a95-b370" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -2137,14 +2032,14 @@
           <modifiers>
             <modifier type="increment" field="points" value="10.0">
               <repeats>
-                <repeat field="selections" scope="f21b-beb2-224e-5e3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1a33-1125-41be-a84c" repeats="1"/>
+                <repeat field="selections" scope="f21b-beb2-224e-5e3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1a33-1125-41be-a84c" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="10.0">
               <repeats>
-                <repeat field="selections" scope="f21b-beb2-224e-5e3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ef3d-dcd6-70ae-c6c6" repeats="1"/>
+                <repeat field="selections" scope="f21b-beb2-224e-5e3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ef3d-dcd6-70ae-c6c6" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -2174,14 +2069,14 @@
           <modifiers>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="f21b-beb2-224e-5e3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1a33-1125-41be-a84c" repeats="1"/>
+                <repeat field="selections" scope="f21b-beb2-224e-5e3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1a33-1125-41be-a84c" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="f21b-beb2-224e-5e3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ef3d-dcd6-70ae-c6c6" repeats="1"/>
+                <repeat field="selections" scope="f21b-beb2-224e-5e3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ef3d-dcd6-70ae-c6c6" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -2440,7 +2335,7 @@
           <modifiers>
             <modifier type="increment" field="points" value="10.0">
               <repeats>
-                <repeat field="selections" scope="8a8c-71c0-d041-09a6" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cc54-51ee-9a73-2c3f" repeats="1"/>
+                <repeat field="selections" scope="8a8c-71c0-d041-09a6" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cc54-51ee-9a73-2c3f" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -2463,7 +2358,7 @@
           <modifiers>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="8a8c-71c0-d041-09a6" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6675-7341-53d3-7e85" repeats="1"/>
+                <repeat field="selections" scope="8a8c-71c0-d041-09a6" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6675-7341-53d3-7e85" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -2617,14 +2512,14 @@
           <modifiers>
             <modifier type="increment" field="points" value="2.0">
               <repeats>
-                <repeat field="selections" scope="8bf3-341f-b125-6334" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b7fa-60d2-b829-a7be" repeats="1"/>
+                <repeat field="selections" scope="8bf3-341f-b125-6334" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b7fa-60d2-b829-a7be" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="2.0">
               <repeats>
-                <repeat field="selections" scope="8bf3-341f-b125-6334" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5bd1-2159-c56d-73c1" repeats="1"/>
+                <repeat field="selections" scope="8bf3-341f-b125-6334" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5bd1-2159-c56d-73c1" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -2653,14 +2548,14 @@
           <modifiers>
             <modifier type="increment" field="points" value="2.0">
               <repeats>
-                <repeat field="selections" scope="8bf3-341f-b125-6334" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b7fa-60d2-b829-a7be" repeats="1"/>
+                <repeat field="selections" scope="8bf3-341f-b125-6334" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b7fa-60d2-b829-a7be" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="2.0">
               <repeats>
-                <repeat field="selections" scope="8bf3-341f-b125-6334" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5bd1-2159-c56d-73c1" repeats="1"/>
+                <repeat field="selections" scope="8bf3-341f-b125-6334" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5bd1-2159-c56d-73c1" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -2733,7 +2628,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="a447-3e39-8eeb-e605" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8942-dc7d-ef26-f2fa" repeats="1"/>
+                    <repeat field="selections" scope="a447-3e39-8eeb-e605" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8942-dc7d-ef26-f2fa" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -2823,7 +2718,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="9183-d94d-d8a6-9c54" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b66e-53bb-c769-589f" repeats="1"/>
+                    <repeat field="selections" scope="9183-d94d-d8a6-9c54" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b66e-53bb-c769-589f" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -2868,21 +2763,21 @@
           <modifiers>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="6ecf-63e6-ab1c-a4fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a447-3e39-8eeb-e605" repeats="1"/>
+                <repeat field="selections" scope="6ecf-63e6-ab1c-a4fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a447-3e39-8eeb-e605" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="6ecf-63e6-ab1c-a4fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9183-d94d-d8a6-9c54" repeats="1"/>
+                <repeat field="selections" scope="6ecf-63e6-ab1c-a4fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9183-d94d-d8a6-9c54" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="5.0">
               <repeats>
-                <repeat field="selections" scope="6ecf-63e6-ab1c-a4fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f9d0-d2bd-faea-32ca" repeats="1"/>
+                <repeat field="selections" scope="6ecf-63e6-ab1c-a4fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f9d0-d2bd-faea-32ca" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -2912,21 +2807,21 @@
           <modifiers>
             <modifier type="increment" field="points" value="10.0">
               <repeats>
-                <repeat field="selections" scope="6ecf-63e6-ab1c-a4fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a447-3e39-8eeb-e605" repeats="1"/>
+                <repeat field="selections" scope="6ecf-63e6-ab1c-a4fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a447-3e39-8eeb-e605" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="10.0">
               <repeats>
-                <repeat field="selections" scope="6ecf-63e6-ab1c-a4fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9183-d94d-d8a6-9c54" repeats="1"/>
+                <repeat field="selections" scope="6ecf-63e6-ab1c-a4fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9183-d94d-d8a6-9c54" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="10.0">
               <repeats>
-                <repeat field="selections" scope="6ecf-63e6-ab1c-a4fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f9d0-d2bd-faea-32ca" repeats="1"/>
+                <repeat field="selections" scope="6ecf-63e6-ab1c-a4fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f9d0-d2bd-faea-32ca" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -2965,7 +2860,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="5.0">
                   <repeats>
-                    <repeat field="selections" scope="f9d0-d2bd-faea-32ca" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3702-4189-6912-fd0e" repeats="1"/>
+                    <repeat field="selections" scope="f9d0-d2bd-faea-32ca" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3702-4189-6912-fd0e" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -3107,9 +3002,9 @@
             </infoLink>
           </infoLinks>
           <modifiers>
-            <modifier type="increment" field="points" value="10.0">
+            <modifier type="increment" field="points" value="10">
               <repeats>
-                <repeat field="selections" scope="7c3d-26af-84e5-51c4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7516-1d67-a0c0-9317" repeats="1"/>
+                <repeat field="selections" scope="7c3d-26af-84e5-51c4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7516-1d67-a0c0-9317" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -3137,9 +3032,9 @@
             </infoLink>
           </infoLinks>
           <modifiers>
-            <modifier type="increment" field="points" value="5.0">
+            <modifier type="increment" field="points" value="5">
               <repeats>
-                <repeat field="selections" scope="7c3d-26af-84e5-51c4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7516-1d67-a0c0-9317" repeats="1"/>
+                <repeat field="selections" scope="7c3d-26af-84e5-51c4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7516-1d67-a0c0-9317" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -3164,7 +3059,7 @@
           <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <selectionEntries/>
           <selectionEntryGroups/>
@@ -3181,10 +3076,8 @@
               <rules/>
               <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="points" value="10.0">
-                  <repeats>
-                    <repeat field="selections" scope="7c3d-26af-84e5-51c4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7516-1d67-a0c0-9317" repeats="1"/>
-                  </repeats>
+                <modifier type="set" field="points" value="10">
+                  <repeats/>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
@@ -3334,14 +3227,14 @@
           <modifiers>
             <modifier type="increment" field="points" value="2.0">
               <repeats>
-                <repeat field="selections" scope="7cf7-a4ad-ce2d-eba8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cc71-0ba4-2876-cc38" repeats="1"/>
+                <repeat field="selections" scope="7cf7-a4ad-ce2d-eba8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cc71-0ba4-2876-cc38" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="2.0">
               <repeats>
-                <repeat field="selections" scope="7cf7-a4ad-ce2d-eba8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="de51-23ed-0173-ba47" repeats="1"/>
+                <repeat field="selections" scope="7cf7-a4ad-ce2d-eba8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="de51-23ed-0173-ba47" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -3496,14 +3389,14 @@
           <modifiers>
             <modifier type="increment" field="points" value="2.0">
               <repeats>
-                <repeat field="selections" scope="fa5d-9038-2bc4-b630" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c2e8-9d7e-6286-8c57" repeats="1"/>
+                <repeat field="selections" scope="fa5d-9038-2bc4-b630" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c2e8-9d7e-6286-8c57" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="2.0">
               <repeats>
-                <repeat field="selections" scope="fa5d-9038-2bc4-b630" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eeae-becc-d65d-5322" repeats="1"/>
+                <repeat field="selections" scope="fa5d-9038-2bc4-b630" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eeae-becc-d65d-5322" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -3658,14 +3551,14 @@
           <modifiers>
             <modifier type="increment" field="points" value="2.0">
               <repeats>
-                <repeat field="selections" scope="e95f-bd48-575a-02f3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d306-97f4-a254-bf50" repeats="1"/>
+                <repeat field="selections" scope="e95f-bd48-575a-02f3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d306-97f4-a254-bf50" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="2.0">
               <repeats>
-                <repeat field="selections" scope="e95f-bd48-575a-02f3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5453-2c0b-0bab-f7d8" repeats="1"/>
+                <repeat field="selections" scope="e95f-bd48-575a-02f3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5453-2c0b-0bab-f7d8" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -3820,14 +3713,14 @@
           <modifiers>
             <modifier type="increment" field="points" value="2.0">
               <repeats>
-                <repeat field="selections" scope="8903-dc57-d9d7-6392" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7d5e-02b8-d090-58de" repeats="1"/>
+                <repeat field="selections" scope="8903-dc57-d9d7-6392" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7d5e-02b8-d090-58de" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="2.0">
               <repeats>
-                <repeat field="selections" scope="8903-dc57-d9d7-6392" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e149-4b0d-69d9-2a39" repeats="1"/>
+                <repeat field="selections" scope="8903-dc57-d9d7-6392" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e149-4b0d-69d9-2a39" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -3994,21 +3887,21 @@
               <modifiers>
                 <modifier type="increment" field="points" value="2.0">
                   <repeats>
-                    <repeat field="selections" scope="ac0c-ffe3-ca36-d4c0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b402-5948-a9cb-bda7" repeats="1"/>
+                    <repeat field="selections" scope="ac0c-ffe3-ca36-d4c0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b402-5948-a9cb-bda7" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="increment" field="points" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="ac0c-ffe3-ca36-d4c0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ebff-8528-f0d6-8bfd" repeats="1"/>
+                    <repeat field="selections" scope="ac0c-ffe3-ca36-d4c0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ebff-8528-f0d6-8bfd" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
                 <modifier type="increment" field="points" value="1.0">
                   <repeats>
-                    <repeat field="selections" scope="ac0c-ffe3-ca36-d4c0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f634-df4a-d8c4-fd3b" repeats="1"/>
+                    <repeat field="selections" scope="ac0c-ffe3-ca36-d4c0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f634-df4a-d8c4-fd3b" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -4027,14 +3920,14 @@
           <modifiers>
             <modifier type="increment" field="points" value="2.0">
               <repeats>
-                <repeat field="selections" scope="ac0c-ffe3-ca36-d4c0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ebff-8528-f0d6-8bfd" repeats="1"/>
+                <repeat field="selections" scope="ac0c-ffe3-ca36-d4c0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ebff-8528-f0d6-8bfd" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="2.0">
               <repeats>
-                <repeat field="selections" scope="ac0c-ffe3-ca36-d4c0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f634-df4a-d8c4-fd3b" repeats="1"/>
+                <repeat field="selections" scope="ac0c-ffe3-ca36-d4c0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f634-df4a-d8c4-fd3b" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -4049,21 +3942,21 @@
           <modifiers>
             <modifier type="increment" field="points" value="4.0">
               <repeats>
-                <repeat field="selections" scope="ac0c-ffe3-ca36-d4c0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b402-5948-a9cb-bda7" repeats="1"/>
+                <repeat field="selections" scope="ac0c-ffe3-ca36-d4c0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b402-5948-a9cb-bda7" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="2.0">
               <repeats>
-                <repeat field="selections" scope="ac0c-ffe3-ca36-d4c0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f634-df4a-d8c4-fd3b" repeats="1"/>
+                <repeat field="selections" scope="ac0c-ffe3-ca36-d4c0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f634-df4a-d8c4-fd3b" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
             <modifier type="increment" field="points" value="2.0">
               <repeats>
-                <repeat field="selections" scope="ac0c-ffe3-ca36-d4c0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ebff-8528-f0d6-8bfd" repeats="1"/>
+                <repeat field="selections" scope="ac0c-ffe3-ca36-d4c0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ebff-8528-f0d6-8bfd" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>


### PR DESCRIPTION
Ghar Empire
Changed Bombard Crawler to Strategic
Changed Scutters squad leader now has Leader 1 (as no other ranks are available for the squad and it is mandatory)
Changed Ghar Outcast Slave Driver has Leader 1 by default.
Changed Ghar Outcast Leader has Leader 1 by default. Also removed option for leader 3

Rebel Ghar
Removed duplication of Army Options
Changed Scutters squad leader now has Leader 1 (as no other ranks are available for the squad and it is mandatory)