### PR TITLE
Algoryn and Ghar Rebel updates

### DIFF
--- a/Algoryn.cat
+++ b/Algoryn.cat
@@ -3895,55 +3895,7 @@
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="9e08-6f41-23c9-b23e" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="ac29-0bf1-4bb7-fd44">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="ac29-0bf1-4bb7-fd44" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="cafb-2d79-5445-7fbd" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="a149-2c1a-0510-97e5" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
+          <selectionEntryGroups/>
           <entryLinks>
             <entryLink id="52b5-70d9-3c1a-82d2" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
               <profiles/>
@@ -4075,6 +4027,144 @@
               <constraints/>
             </entryLink>
           </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="8326-1792-3a22-a199" name="Weapons" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="61ca-ec13-260a-a8d8" value="1">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fb98-1376-32bb-e1c9" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="791f-9da9-bcc6-5603" value="1">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fb98-1376-32bb-e1c9" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="61ca-ec13-260a-a8d8" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="791f-9da9-bcc6-5603" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="5cbc-e334-a3b7-ab88" name="Mag Gun" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="4f01-4852-bb67-1ffa" name="Mag Gun" book="BtGoA" page="69" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <repeats/>
+                      <conditions>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5cbc-e334-a3b7-ab88" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <characteristics>
+                    <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                    <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                    <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
+                    <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+                    <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7cdd-6cff-ca70-b03e" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="3.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="941d-d85d-25f2-ae58" name="Mag Repeater" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="b2d8-da27-74b1-9c83" name="Mag Repeater" book="BtGoA" page="69" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <repeats/>
+                      <conditions>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="941d-d85d-25f2-ae58" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <characteristics>
+                    <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                    <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                    <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                    <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+                    <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Standard Weapon"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9fcf-be6a-1e16-19f4" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="3.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="fcac-bf1c-e137-cd62" name="Mag Pistol" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="a13b-b187-c4c3-e6f5" name="Mag Pistol" book="BtGoA" page="68" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <repeats/>
+                      <conditions>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fcac-bf1c-e137-cd62" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <characteristics>
+                    <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+                    <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+                    <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+                    <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+                    <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Hand Weapon"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7ad-61b8-ca84-f07b" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs/>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
@@ -4510,94 +4600,6 @@
       <modifiers/>
       <constraints/>
       <selectionEntries>
-        <selectionEntry id="3b68-a4c9-03bb-dd68" name="AI Trooper Crew" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-          <profiles>
-            <profile id="6c57-a89b-6cf0-a030" name="AI Trooper Crew" book="BtGoA" page="175" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
-                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
-                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (7)"/>
-                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
-                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="09ce-fa1f-63c6-0dee" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="e022-953c-7321-fa34">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="e022-953c-7321-fa34" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="c2ee-fcfd-3075-694e" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints/>
-                </entryLink>
-                <entryLink id="2552-caa3-aa9d-704b" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks>
-            <entryLink id="5647-de18-512c-9f6f" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="14.0"/>
-          </costs>
-        </selectionEntry>
         <selectionEntry id="5baf-a32e-e0b0-f74a" name="Promote one crew member to Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
           <profiles/>
           <rules/>
@@ -4634,6 +4636,46 @@
           <entryLinks/>
           <costs>
             <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4dec-8e13-7bfe-6a45" name="AI Trooper Crew" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="76ad-c861-3525-255a" name="AI Trooper Crew" book="BtGoA" page="175" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (7)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="56a5-3789-fe68-9638" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c20d-a8d3-a3ae-f8a8" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="5188-1ccf-f239-444a" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="14.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -4678,6 +4720,144 @@
               <constraints/>
             </entryLink>
           </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="0f47-5745-c3c8-279b" name="Weapons" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="a007-9012-30a0-5258" value="1">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4dec-8e13-7bfe-6a45" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="08a4-af77-5378-702a" value="1">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4dec-8e13-7bfe-6a45" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="08a4-af77-5378-702a" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a007-9012-30a0-5258" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="8308-0e37-6e54-3492" name="Mag Gun" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="352b-ad6e-2352-3dac" name="Mag Gun" book="BtGoA" page="69" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <repeats/>
+                      <conditions>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8308-0e37-6e54-3492" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <characteristics>
+                    <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                    <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                    <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
+                    <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+                    <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1b9c-c54f-6136-6da3" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="3.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7f50-7243-7f68-bec2" name="Mag Repeater" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="65bc-462e-c737-0c7e" name="Mag Repeater" book="BtGoA" page="69" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <repeats/>
+                      <conditions>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f50-7243-7f68-bec2" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <characteristics>
+                    <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                    <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                    <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                    <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+                    <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Standard Weapon"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2317-39b4-d8c7-6b73" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="3.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="00bd-7aa8-f67a-2ad2" name="Mag Pistol" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="46c9-a264-a9ae-b834" name="Mag Pistol" book="BtGoA" page="68" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="true">
+                      <repeats/>
+                      <conditions>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="00bd-7aa8-f67a-2ad2" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <characteristics>
+                    <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+                    <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+                    <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+                    <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+                    <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Hand Weapon"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5ff-970b-ad5c-fc76" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs/>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>

--- a/Ghar_Rebels.cat
+++ b/Ghar_Rebels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="2165-1159-f3ed-3ea5" name="Rebel" book="BFX" revision="4" battleScribeVersion="2.00" authorName="Maye Gelt" gameSystemId="c339-677a-60db-4060" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="2165-1159-f3ed-3ea5" name="Rebel" book="BFX" revision="5" battleScribeVersion="2.00" authorName="Maye Gelt" gameSystemId="c339-677a-60db-4060" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -2620,39 +2620,7 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
             <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="8942-dc7d-ef26-f2fa" name="Plasma Claws" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0">
-                  <repeats>
-                    <repeat field="selections" scope="a447-3e39-8eeb-e605" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8942-dc7d-ef26-f2fa" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="9c97-f250-f3ec-a793" hidden="false" targetId="0a8d-432b-4cb0-6b78" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups>
             <selectionEntryGroup id="b90e-ea97-650c-1347" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="fe8e-e203-c9b3-ab58">
               <profiles/>
@@ -2695,7 +2663,7 @@
             <cost name="pts" costTypeId="points" value="92.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="9183-d94d-d8a6-9c54" name="Ghar Trooper 1" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
+        <selectionEntry id="9183-d94d-d8a6-9c54" name="Ghar Troopers" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
           <profiles/>
           <rules/>
           <infoLinks>
@@ -2708,41 +2676,9 @@
           </infoLinks>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
-          <selectionEntries>
-            <selectionEntry id="b66e-53bb-c769-589f" name="Plasma Claws" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0">
-                  <repeats>
-                    <repeat field="selections" scope="9183-d94d-d8a6-9c54" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b66e-53bb-c769-589f" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="827a-4899-b49b-0247" hidden="false" targetId="0a8d-432b-4cb0-6b78" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks/>
           <costs>
@@ -2761,7 +2697,7 @@
             </infoLink>
           </infoLinks>
           <modifiers>
-            <modifier type="increment" field="points" value="5.0">
+            <modifier type="increment" field="points" value="5">
               <repeats>
                 <repeat field="selections" scope="6ecf-63e6-ab1c-a4fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a447-3e39-8eeb-e605" repeats="1" roundUp="false"/>
               </repeats>
@@ -2771,13 +2707,6 @@
             <modifier type="increment" field="points" value="5.0">
               <repeats>
                 <repeat field="selections" scope="6ecf-63e6-ab1c-a4fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9183-d94d-d8a6-9c54" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="5.0">
-              <repeats>
-                <repeat field="selections" scope="6ecf-63e6-ab1c-a4fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f9d0-d2bd-faea-32ca" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -2805,7 +2734,7 @@
             </infoLink>
           </infoLinks>
           <modifiers>
-            <modifier type="increment" field="points" value="10.0">
+            <modifier type="increment" field="points" value="10">
               <repeats>
                 <repeat field="selections" scope="6ecf-63e6-ab1c-a4fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a447-3e39-8eeb-e605" repeats="1" roundUp="false"/>
               </repeats>
@@ -2815,13 +2744,6 @@
             <modifier type="increment" field="points" value="10.0">
               <repeats>
                 <repeat field="selections" scope="6ecf-63e6-ab1c-a4fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9183-d94d-d8a6-9c54" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="10.0">
-              <repeats>
-                <repeat field="selections" scope="6ecf-63e6-ab1c-a4fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f9d0-d2bd-faea-32ca" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
@@ -2837,62 +2759,105 @@
             <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="f9d0-d2bd-faea-32ca" name="Ghar Trooper 2" hidden="false" collective="false" categoryEntryId="(No Category)" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="829e-a3cb-f3ed-161f" hidden="false" targetId="de07-7287-f4d3-bf98" type="profile">
+        <selectionEntry id="1218-94f3-d5cc-bbaa" name="Plasma Claw for Leader" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+          <profiles>
+            <profile id="09cf-f9d1-0fa7-49ba" name="Plasma Claw" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="-"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="-"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="D4"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Random SV, Hand to Hand Only"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1218-94f3-d5cc-bbaa" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9502-0267-4e94-2d4f" type="max"/>
+          </constraints>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2cc9-8ee7-363a-b570" name="Plasma Claws" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="2cf6-7ee5-4d65-4014" value="1">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9183-d94d-d8a6-9c54" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="79d6-e195-86a7-fc4f" type="min"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2cf6-7ee5-4d65-4014" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="3702-4189-6912-fd0e" name="Plasma Claws" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0">
-                  <repeats>
-                    <repeat field="selections" scope="f9d0-d2bd-faea-32ca" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3702-4189-6912-fd0e" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="5a1f-b7b3-f8b4-95ce" hidden="false" targetId="0a8d-432b-4cb0-6b78" type="selectionEntry">
+            <selectionEntry id="2dbe-f75a-204b-8ebe" name="Plasma Claw for Troopers" hidden="false" collective="false" categoryEntryId="(No Category)" type="upgrade">
+              <profiles>
+                <profile id="f9a5-30af-b5c2-115b" name="Plasma Claw" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
-                  <constraints/>
-                </entryLink>
-              </entryLinks>
+                  <characteristics>
+                    <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="-"/>
+                    <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="-"/>
+                    <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+                    <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="D4"/>
+                    <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Random SV, Hand to Hand Only"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2dbe-f75a-204b-8ebe" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6763-3575-1bc3-7b36" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
               <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
+                <cost name="pts" costTypeId="points" value="5.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
           <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="60.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
       <entryLinks>
         <entryLink id="de90-f44d-068a-82e4" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
           <profiles/>
@@ -3052,39 +3017,104 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="5832-c55c-655e-ae32" name="&lt; Unit Options &gt;" hidden="false" collective="false" defaultSelectionEntryId="654c-9346-bc9f-3c2d">
+        <selectionEntryGroup id="5832-c55c-655e-ae32" name="Weapons" hidden="false" collective="false" defaultSelectionEntryId="ada7-7175-ea06-932d">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="increment" field="f789-c778-be5d-3c81" value="1">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7516-1d67-a0c0-9317" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="51ca-1cee-2b4d-d8d2" value="1">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7516-1d67-a0c0-9317" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="51ca-1cee-2b4d-d8d2" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f789-c778-be5d-3c81" type="min"/>
           </constraints>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="654c-9346-bc9f-3c2d" hidden="false" targetId="6f9d-4f18-835f-deff" type="selectionEntry">
-              <profiles/>
+          <selectionEntries>
+            <selectionEntry id="2f87-efbb-7c25-bf92" name="Mag Cannon" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="b6bb-5423-15c5-e849" name="Mag Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <repeats/>
+                      <conditions>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f87-efbb-7c25-bf92" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <characteristics>
+                    <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+                    <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="50"/>
+                    <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+                    <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="5"/>
+                    <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Massive Damage"/>
+                  </characteristics>
+                </profile>
+              </profiles>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
-            </entryLink>
-            <entryLink id="baba-7bd0-e089-b791" hidden="false" targetId="306c-a91f-3fc0-e059" type="selectionEntry">
-              <profiles/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b61d-8d3d-4d43-3fc3" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs/>
+            </selectionEntry>
+            <selectionEntry id="ada7-7175-ea06-932d" name="Mag Light Support" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="151a-01b6-1d70-717d" name="Mag Light Support" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <repeats/>
+                      <conditions>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ada7-7175-ea06-932d" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <characteristics>
+                    <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+                    <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="50"/>
+                    <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+                    <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+                    <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF 3"/>
+                  </characteristics>
+                </profile>
+              </profiles>
               <rules/>
               <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="points" value="10">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-            </entryLink>
-          </entryLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7b5a-fb0f-322f-5b2c" type="max"/>
+              </constraints>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs/>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
@@ -5733,6 +5763,21 @@
         <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
         <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
         <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader, Rebel"/>
+      </characteristics>
+    </profile>
+    <profile id="c6eb-3995-3cbb-b07e" name="Outcast Rebel Unarmoured" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="6"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="3"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Rebel"/>
       </characteristics>
     </profile>
   </sharedProfiles>


### PR DESCRIPTION
Fixed an issue of Algoryn support and specialist support were forced to all take an upgrade of to their weapon if any wanted to. Rather than being able to take individual upgrades as the book says for the unit.
Also fixed issues of Rebel Ghar Command Battle Suits having issues with Plasma Claws, and the same issue as above with the Creeper making the 1-3 of them all having to take a weapon change if 1 did (again they can be upgraded individually).