### PR TITLE
Updated to V2

### DIFF
--- a/Ghar_Outcast_Rebel.cat
+++ b/Ghar_Outcast_Rebel.cat
@@ -1,0 +1,6445 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="2165-1159-f3ed-3ea5" name="Ghar Outcast Rebel" book="BFX" revision="8" battleScribeVersion="2.01" authorName="Maye Gelt" gameSystemId="c339-677a-60db-4060" gameSystemRevision="4" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <profiles/>
+  <rules/>
+  <infoLinks/>
+  <costTypes/>
+  <profileTypes/>
+  <categoryEntries/>
+  <forceEntries/>
+  <selectionEntries>
+    <selectionEntry id="3d57-162c-00ab-4c84" name="Fartok, Leader Of The Outcast Revolt" book="BFX" page="107" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="cc41-d1a4-756b-8db5" name="Infantry Command Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="0457-88a3-946a-21eb" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="910d-0a3a-9847-e4e5" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="3d57-162c-00ab-4c84-481abf13-c03e-0dd0-d520-9f9837253cbe" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="0392-cdb8-e66c-08f6" name="Fartok" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="2503-767b-452a-9f0d" name="Fartok" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="3"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="10"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(12)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="9"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Follow, High Command, Wound, Large, Hybrid Plasma Reactor"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="68f3-6a1c-7ab2-188e" hidden="false" targetId="1d76-267d-696a-2e8a" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="ec4f-5ee3-cc36-a034" hidden="false" targetId="ae1d-2212-b0ef-48b6" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="b5de-d4c1-099f-d22f" hidden="false" targetId="48e7-7b6b-328c-29fe" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="5f62-26e1-d3c2-aeb0" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="a9a4-fa90-7757-39b9" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="ca4e-8c82-0775-2425" hidden="false" targetId="57d1-980d-ee47-f717" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="dd24-7c10-4a67-30df" hidden="false" targetId="f2a0-778f-5fa4-20af" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="036d-d495-7f37-864f" name="Ghar Trooper 1" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="456f-9eeb-4ec2-0879" name="Ghar Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="3"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="10"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(12)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="9"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Large, Scramble Proof, Hybrid Plasma Reactor"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="5149-8785-472f-ec8c" name="Plasma Claws" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats>
+                    <repeat field="selections" scope="3d57-162c-00ab-4c84" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="036d-d495-7f37-864f" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="38db-0f51-f87c-f8e4" hidden="false" targetId="0a8d-432b-4cb0-6b78" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="85.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1c5f-6e05-0634-9598" name="Plasma Dumps" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="aba5-9159-ad1f-9d95" hidden="false" targetId="4280-96f3-aa68-8d6e" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="3d57-162c-00ab-4c84" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0392-cdb8-e66c-08f6" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="3d57-162c-00ab-4c84" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="036d-d495-7f37-864f" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="3d57-162c-00ab-4c84" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5c66-1eb0-17c5-71e7" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5c66-1eb0-17c5-71e7" name="Ghar Trooper 2" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="0fe7-c74b-d600-df56" name="Ghar Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="3"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="10"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(12)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="9"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value=""/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Large, Scramble Proof, Hybrid Plasma Reactor"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="e4c4-e2f4-1333-2473" name="Plasma Claws" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats>
+                    <repeat field="selections" scope="3d57-162c-00ab-4c84" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5c66-1eb0-17c5-71e7" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="3dd6-23d6-b8d6-db5d" hidden="false" targetId="0a8d-432b-4cb0-6b78" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="85.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="a496-4a76-0557-8ff1" hidden="false" targetId="8592-5404-f9d1-f93b" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="179.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ba8c-4fea-3a3d-51af" name="Flitter Bombs" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="ba8c-4fea-3a3d-51af-72807c5d-e370-9ddf-c2b7-de5d2797f24d" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="5de7-d08d-e15d-7ce9" name="Flitter Bombs" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="cd10-ac71-475b-4f57" name="Flitter Bomb" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="3"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Shard, Scramble Proof"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="c2ec-750c-4e06-7cc2" name="Probe Unit" hidden="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="f145-4aa1-65bd-dca3" hidden="false" targetId="485f-1f8e-7808-4a17" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="c480-5649-1e89-904a" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="785e-2c45-97b6-5467" hidden="false" targetId="6d5c-d6f2-3426-e11c" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="b103-2dc9-6fe1-6a00" hidden="false" targetId="2bb1-783e-8a6e-5970" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a0d2-a464-576a-d53f" name="Flitters" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="a0d2-a464-576a-d53f-72807c5d-e370-9ddf-c2b7-de5d2797f24d" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="0d74-51f5-cdef-1da6" name="Flitter" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="e0b7-4216-5e20-71c4" name="Flitter" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="3"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Shard, Scramble Proof"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="88cb-8269-0777-b47e" name="Probe Unit" hidden="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="2ab9-ffed-3ff2-6498" hidden="false" targetId="485f-1f8e-7808-4a17" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="0a47-9677-96a8-9f0a" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="5000-2d94-0c7a-5ec5" hidden="false" targetId="2dca-9d1f-0a96-e2d2" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="7987-7ea4-3ee6-2b31" hidden="false" targetId="2bb1-783e-8a6e-5970" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8b5a-d5f0-e539-a0ee" name="Rebel Bomber Squad" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="ca5c-7445-3e1f-4676" name="Infantry Unit/Mixed Infantry+Mount" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="2b2a-cf47-51fe-1daf" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="016f-eaf3-dbd7-ac1e" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7729-636d-e51e-d6f7" hidden="false" targetId="f5cb-d1fc-6b00-39f5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="8b5a-d5f0-e539-a0ee-5c47879b-41d0-1383-5fe5-a5989615db89" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="4a98-4c68-15aa-a072" name="Ghar Leader" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="c216-69a9-3e8a-0f02" name="Ghar Leader" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="3"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="10"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="4(12)"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="8"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="8"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424" value="Leader, Large, Scramble Proof, Plasma Reactor"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="85b9-2e1c-9874-a211" hidden="false" targetId="f2a0-778f-5fa4-20af" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="1801-be82-bad9-46b6" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="1133-61fa-0a8e-be9c">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="e148-d3dc-c579-ecba" name="Leader 2" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="206a-a126-a295-7465" hidden="false" targetId="9d03-08db-93a6-4f05" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="5d73-1f5e-0487-13e2" name="Leader 3" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="f30e-8b02-26ec-f5a4" hidden="false" targetId="e048-25d9-af17-bdf0" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="20.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="1133-61fa-0a8e-be9c" name="Leader" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="fbc6-19e6-ecb2-afe8" hidden="false" targetId="24a5-60f8-93fc-7dff" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="9f8b-ab48-0d2d-e501" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="70.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a18c-40ae-d918-8109" name="Ghar Trooper" hidden="false" collective="false" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="4ba9-443d-2f8c-e499" hidden="false" targetId="de07-7287-f4d3-bf98" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="0e80-ade2-0809-2392" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="57.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3a43-be53-21c6-bb37" name="Plasma Dumps" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0d6e-d1da-4558-5a99" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4a98-4c68-15aa-a072" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="90ee-0a6f-9336-975d" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a18c-40ae-d918-8109" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="28a7-4a00-8b9f-618b" name="Plasma Amplifiers" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a18c-40ae-d918-8109" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4a98-4c68-15aa-a072" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0d6e-d1da-4558-5a99" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="8b5a-d5f0-e539-a0ee" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="90ee-0a6f-9336-975d" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0d6e-d1da-4558-5a99" name="Ghar Bomb Trooper" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="952f-9f4c-cbc4-2ebc" name="Ghar Bomb Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="3"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="10"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(12)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Large, Scramble Proof, Plasma Reactor"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="39b2-7138-f2dd-425b" hidden="false" targetId="e376-d612-25ff-b855" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="57.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="90ee-0a6f-9336-975d" name="Ghar Scutter" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="a63a-862a-a167-f040" hidden="false" targetId="13e9-5eeb-7392-f018" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="6790-53e2-2efa-2be5" hidden="false" targetId="562c-13be-8455-d77b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="e66e-6adf-a0cd-5f9c" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="26.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9030-9dea-f00b-e2ed" name="Rebel Assault Squad" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="fef7-39df-2b98-1c66" name="Infantry Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="85ac-ff6e-0649-05db" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="9666-60fb-6002-9667" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="2c0c-fe84-bfff-3841" hidden="false" targetId="f5cb-d1fc-6b00-39f5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="9222-95de-7dcd-a02d" hidden="false" targetId="f2a0-778f-5fa4-20af" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="9030-9dea-f00b-e2ed-5c47879b-41d0-1383-5fe5-a5989615db89" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="c8dc-aa17-3f85-1a20" name="Ghar Leader" hidden="false" collective="false" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="0af9-d07a-2fca-4caf" hidden="false" targetId="562d-6cd9-4b4a-7019" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="da1d-e454-1800-044b" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="0d25-cce8-cf4b-478d">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="bb13-ff27-bf60-82ef" hidden="false" targetId="0e9b-9aae-bd16-d30f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="a28d-5daa-1acf-caa1" hidden="false" targetId="da65-5109-5f5f-0f9a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="0d25-cce8-cf4b-478d" hidden="false" targetId="05af-fc97-7a19-cf8d" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="70.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="4850-1a32-f160-03dc" name="Ghar Trooper" hidden="false" collective="false" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="d0f1-7c67-3951-8631" hidden="false" targetId="de07-7287-f4d3-bf98" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="57.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7db0-3bc8-ba66-2437" name="Plasma Dumps" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="8608-c223-4acd-7e72" hidden="false" targetId="4280-96f3-aa68-8d6e" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="9030-9dea-f00b-e2ed" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c8dc-aa17-3f85-1a20" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="9030-9dea-f00b-e2ed" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4850-1a32-f160-03dc" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3b0a-3a3a-9ba0-4a01" name="Plasma Amplifiers" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="18c8-9dff-9749-1130" hidden="false" targetId="0448-a629-3df9-73c0" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="9030-9dea-f00b-e2ed" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4850-1a32-f160-03dc" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="9030-9dea-f00b-e2ed" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c8dc-aa17-3f85-1a20" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="cadd-7f5d-ed2e-aba9" hidden="false" targetId="3cfd-07d8-f685-fa34" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="0b52-400d-e2fa-6607" hidden="false" targetId="36a7-e564-c80c-2a7e" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="46f3-8791-7cb4-e161" hidden="false" targetId="ff6d-c9e5-a6c4-f336" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c632-a7b6-ae64-6a40" name="Rebel Attack Crawler" page="204" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="eed6-747d-2cbd-1d32" name="Vehicle Unit" book="" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="6771-8b8b-1adc-e06b" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="741b-2188-da40-de57" hidden="false" targetId="23c8-9405-75ca-7f03" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b7de-95a5-d07f-99ea" hidden="false" targetId="09d0-48ed-82d2-38b5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3dbd-a4eb-1340-ae81" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="999a-f887-fa62-07e6" hidden="false" targetId="f5cb-d1fc-6b00-39f5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="0193-5420-e0da-fd25" hidden="false" targetId="f2a0-778f-5fa4-20af" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="c632-a7b6-ae64-6a40-a01f5f58-334c-8442-d861-15099ebdf5e5" hidden="false" targetId="a01f5f58-334c-8442-d861-15099ebdf5e5" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="9578-b417-1394-8a76" name="Ghar Attack Crawler" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="e6b3-72aa-3e3d-7418" name="Ghar Attack Crawler" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="3"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="10"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="13"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="8"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="9"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424" value="MOD2, Large, Crawler, Scramble Proof, Plasma Reactor"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="abdf-c858-3e87-a1a9" name="Weapons" hidden="false" collective="false" defaultSelectionEntryId="da58-951a-1a3e-26c7">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="541e-fa64-18a7-1484" name="Quad Mag Repeater" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="e306-23c6-ee8f-9ca7" name="Quad Mag Repeater" book="BFX" page="75" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+                        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+                        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF D8, Jams"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="fb0a-1773-e399-cbd9" hidden="false" targetId="1702-a526-6e91-f2cd" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7834-7c40-c70d-d015" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="daa9-121d-f8eb-40ce" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs/>
+                </selectionEntry>
+                <selectionEntry id="c865-9036-e890-4bbc" name="Mag Cannon" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="7316-5b1f-258d-e567" name="Mag Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+                        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="50"/>
+                        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+                        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="5"/>
+                        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Massive Damage"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d4ee-3b9a-71d6-7693" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="23de-c3a6-ecda-c45c" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="da58-951a-1a3e-26c7" name="Mag Light Support" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="8b79-653d-49ca-149e" name="Mag Light Support" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+                        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="50"/>
+                        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+                        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+                        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF 3"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9ce5-69ef-ea20-ac0c" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5e63-0111-120a-01c9" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="208.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6cf2-4af4-75a3-8f07" name="Plasma Amplifiers" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0b27-b8e0-7533-1d10" name="Plasma Dumps" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c27a-aa4f-97c0-ebef" name="Rebel Attack Scutters" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="0702-c8f1-8d5b-8900" name="Mounted Unit" book="Beyond the Gates of Antares" page="95" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="10fb-a495-0f52-b962" hidden="false" targetId="f5cb-d1fc-6b00-39f5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="a984-6534-8962-0067" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="4ae7-9649-084d-3397" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="055a-0fdc-4575-9e60" hidden="false" targetId="23c8-9405-75ca-7f03" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="fcf9-45a8-690a-8da6" hidden="false" targetId="f2a0-778f-5fa4-20af" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="c27a-aa4f-97c0-ebef-5c47879b-41d0-1383-5fe5-a5989615db89" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="8974-5164-823a-fe6c" name="Ghar Attack Scutter Leader" book="Beyond the Gates of Antares" page="170" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="98cb-1e8a-385f-e77e" name="Ghar Attack Scutter Leader" book="Beyond the Gates of Antares" page="170" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="1"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="4(10)"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="8"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="8"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424" value="Leader, Large, Crawler, Scramble Proof, Plasma Reactor"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="30b2-e94a-83d5-0cdd" hidden="false" targetId="f2a0-778f-5fa4-20af" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="e731-c0ab-0ba9-c676" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="c559-421a-a988-dbfc">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="c559-421a-a988-dbfc" name="Leader" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="5b39-2a49-3a77-c370" hidden="false" targetId="24a5-60f8-93fc-7dff" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="39.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7fdb-3754-be08-c953" name="Ghar Attack Scutter" book="Beyond the Gates of Antares" page="170" hidden="false" collective="false" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="8a00-c21f-6020-a669" hidden="false" targetId="13e9-5eeb-7392-f018" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="26.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1e0c-2244-a076-556e" name="Plasma Amplifiers" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="c27a-aa4f-97c0-ebef" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8974-5164-823a-fe6c" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="c27a-aa4f-97c0-ebef" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7fdb-3754-be08-c953" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="af71-451e-6e05-d0c7" name="Plasma Dumps" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="c27a-aa4f-97c0-ebef" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7fdb-3754-be08-c953" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="c27a-aa4f-97c0-ebef" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8974-5164-823a-fe6c" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="8f8a-26e1-0356-939e" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5670-d9f9-4779-7a23" name="Rebel Battle Squad" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="54a7-9a44-ddc3-e465" name="Infantry Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="5337-8aa7-11e4-24e8" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="96af-24be-477b-617d" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="4e88-7e17-35a9-efdb" hidden="false" targetId="f5cb-d1fc-6b00-39f5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="5670-d9f9-4779-7a23-5c47879b-41d0-1383-5fe5-a5989615db89" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="c899-96c3-90ae-a7a9" name="Ghar Leader" hidden="false" collective="false" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="6dfb-a1b6-be58-5fc1" hidden="false" targetId="562d-6cd9-4b4a-7019" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="d729-76b6-d41d-caca" hidden="false" targetId="f2a0-778f-5fa4-20af" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="ed36-f6c6-fac2-472f" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="413a-de59-87e5-7423">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="7e9e-abc2-6eda-189c" hidden="false" targetId="0e9b-9aae-bd16-d30f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="8dd1-7f91-54f6-3404" hidden="false" targetId="da65-5109-5f5f-0f9a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="413a-de59-87e5-7423" hidden="false" targetId="05af-fc97-7a19-cf8d" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="70.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d842-422d-f043-b735" name="Ghar Trooper" hidden="false" collective="false" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="307d-b360-e3d6-b2ea" hidden="false" targetId="de07-7287-f4d3-bf98" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="57.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b8b4-04a9-1ee9-228b" name="Plasma Dumps" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="4065-1ed9-2939-5b44" hidden="false" targetId="4280-96f3-aa68-8d6e" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="5670-d9f9-4779-7a23" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c899-96c3-90ae-a7a9" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="5670-d9f9-4779-7a23" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d842-422d-f043-b735" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ef06-9064-c307-e665" name="Plasma Amplifiers" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="b8e3-5e41-cdf0-30e5" hidden="false" targetId="0448-a629-3df9-73c0" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="5670-d9f9-4779-7a23" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d842-422d-f043-b735" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="5670-d9f9-4779-7a23" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c899-96c3-90ae-a7a9" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="cf73-74f7-d7bd-e099" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6cfb-8ee0-4610-646d" name="Rebel Black Guard" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="e266-7204-4b62-9954" name="Infantry Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="34f9-8663-d60b-8086" hidden="false" targetId="7a50-8a69-75b6-3cca" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="6cfb-8ee0-4610-646d-481abf13-c03e-0dd0-d520-9f9837253cbe" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="0c5f-a39d-f318-124e" name="Outcast Rebel Leader" hidden="false" collective="false" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="7e56-6dae-2924-222d" hidden="false" targetId="9770-5f42-fa8c-247c" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="f3c1-a4fd-77c7-1ad3" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="fb25-afca-e693-0a27">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="246c-fea3-dfb5-693c" hidden="false" targetId="0e9b-9aae-bd16-d30f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="fb25-afca-e693-0a27" hidden="false" targetId="05af-fc97-7a19-cf8d" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="f103-3d30-5144-f158" hidden="false" targetId="ed1e-82da-96a2-9c3e" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="minSelections" value="0.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="maxSelections" value="1.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="minSelections" value="0.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="maxSelections" value="1.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="21.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f22f-86cd-4a95-b370" name="Outcast Rebel" hidden="false" collective="false" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="9936-37ff-d15e-7936" hidden="false" targetId="b56d-892d-c25e-7379" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="11.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="8.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="38f6-2e46-7911-f96c" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="bd2f-24e3-1aeb-1758" hidden="false" targetId="a0c9-26de-c4d9-59cd" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="minSelections" value="0.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="maxSelections" value="1.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="cde7-d404-1b45-716c" hidden="false" targetId="6fc0-fbd7-b4c3-f78b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="minSelections" value="0.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="maxSelections" value="1.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="438c-b342-0622-0896" hidden="false" targetId="c429-23e1-056e-cfd3" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="6cfb-8ee0-4610-646d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0c5f-a39d-f318-124e" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="6cfb-8ee0-4610-646d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f22f-86cd-4a95-b370" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="1ef9-102f-441e-cb1c" hidden="false" targetId="4003-9479-f9e0-a340" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="0ef8-b292-6e83-2f20" hidden="false" targetId="7f23-4831-7f76-fd6f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="08ad-0896-7414-9670" name="Maglash" hidden="false" targetId="dc72-b0e2-b8cb-2d5c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="4">
+              <repeats>
+                <repeat field="selections" scope="6cfb-8ee0-4610-646d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0c5f-a39d-f318-124e" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="4">
+              <repeats>
+                <repeat field="selections" scope="6cfb-8ee0-4610-646d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f22f-86cd-4a95-b370" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f21b-beb2-224e-5e3f" name="Rebel Bombardment Crawler" page="170" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="d6a3-4bb5-e5d9-3659" name="Vehicle Unit / Mixed Vehicle + Mounts" book="" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="82e8-1e97-c543-e349" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="a66d-463b-3e43-e86e" hidden="false" targetId="f5cb-d1fc-6b00-39f5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="2645-00c7-46ac-40eb" hidden="false" targetId="23c8-9405-75ca-7f03" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f118-b292-ee30-0032" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="f21b-beb2-224e-5e3f-a01f5f58-334c-8442-d861-15099ebdf5e5" hidden="false" targetId="a01f5f58-334c-8442-d861-15099ebdf5e5" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="1a33-1125-41be-a84c" name="Ghar Bombardment Crawler" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="9eb2-f76c-73b5-402f" name="Ghar Bombardment Crawler" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="3"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="10"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="13"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="8"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="9"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424" value="MOD2, Large, Crawler, Scramble Proof, Plasma Reactor"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="0e62-9dd3-f8d6-58e5" name="MOD2" hidden="false" targetId="09d0-48ed-82d2-38b5" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="dabb-bc37-63b2-f834" name="Limited" hidden="false" targetId="f2a0-778f-5fa4-20af" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="13e6-878c-c923-5a97" name="Heavy Disruptor Bomber" hidden="false" targetId="5a09-7c98-31f2-0b1b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="e938-8434-70f7-d9c7" name="Scourer Cannon" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="0019-d8b6-f4b8-fe36" name="Scourer Cannon" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="258.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a8a2-a078-6edf-978b" name="Plasma Amplifiers" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="8580-c966-a7b2-e3b0" hidden="false" targetId="0448-a629-3df9-73c0" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="points" value="10">
+              <repeats>
+                <repeat field="selections" scope="f21b-beb2-224e-5e3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1a33-1125-41be-a84c" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="10">
+              <repeats>
+                <repeat field="selections" scope="f21b-beb2-224e-5e3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ef3d-dcd6-70ae-c6c6" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6a4c-fdb7-ebdb-0a84" name="Plasma Dumps" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="bb80-60c6-c83a-a75d" hidden="false" targetId="4280-96f3-aa68-8d6e" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="points" value="5">
+              <repeats>
+                <repeat field="selections" scope="f21b-beb2-224e-5e3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1a33-1125-41be-a84c" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5">
+              <repeats>
+                <repeat field="selections" scope="f21b-beb2-224e-5e3f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ef3d-dcd6-70ae-c6c6" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ef3d-dcd6-70ae-c6c6" name="Ghar Scutter" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="d99a-7cf4-44e7-db6a" hidden="false" targetId="13e9-5eeb-7392-f018" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="0b1b-0a86-07ce-c5ec" name="Bomb Feeder" hidden="false" targetId="562c-13be-8455-d77b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="5805-0b73-8f17-f572" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="26.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8a8c-71c0-d041-09a6" name="Rebel Command Crawler" page="170" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="0436-9fe8-9e6b-50a5" name="Vehicle Command Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="6467-0c52-2d03-3bf8" hidden="false" targetId="1d76-267d-696a-2e8a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="8915-9dfa-3860-1897" hidden="false" targetId="ae1d-2212-b0ef-48b6" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="340c-1a14-abeb-546e" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="c4ce-ab60-efd6-a256" hidden="false" targetId="23c8-9405-75ca-7f03" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6212-fa71-4521-332a" hidden="false" targetId="09d0-48ed-82d2-38b5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="d54c-a9c9-6971-285c" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6ac4-7768-08a8-a64f" hidden="false" targetId="f5cb-d1fc-6b00-39f5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="8a8c-71c0-d041-09a6-a01f5f58-334c-8442-d861-15099ebdf5e5" hidden="false" targetId="a01f5f58-334c-8442-d861-15099ebdf5e5" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="cc54-51ee-9a73-2c3f" name="Ghar Commander" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="e177-ef68-f56f-fd00" name="Ghar Commander" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="10"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="13"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="8"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="9"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424" value="Command, Follow, Leader 2, Large Crawler, MOD2, Scramble Proof, Plasma Reactor"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="98af-ca21-6720-2126" hidden="false" targetId="f2a0-778f-5fa4-20af" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="a1eb-a7e9-0ba1-9166" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="4f80-8e2f-3425-932a">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="4f80-8e2f-3425-932a" name="Leader 2" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="6243-126a-8498-6540" hidden="false" targetId="9d03-08db-93a6-4f05" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="bbd9-af80-b959-dbe0" name="Leader 3" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="585f-d49e-dc61-d4ba" hidden="false" targetId="e048-25d9-af17-bdf0" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="4351-2a97-c5fa-68de" name="High Commander" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="6df5-d261-e1a6-cc51" hidden="false" targetId="48e7-7b6b-328c-29fe" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="20.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="bb84-7c0e-852e-ef11" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="66d8-4c57-7b8f-aa81" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="a403-8e75-3775-b0a9" name="Plasma Amplifiers" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6675-7341-53d3-7e85" name="Plasma Dumps" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="242.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8bf3-341f-b125-6334" name="Rebel Command Squad" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="dcc1-0cf8-5b64-89eb" name="Infantry Command Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="7abc-fe6e-6313-8353" hidden="false" targetId="7a50-8a69-75b6-3cca" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="8bf3-341f-b125-6334-481abf13-c03e-0dd0-d520-9f9837253cbe" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="b7fa-60d2-b829-a7be" name="Ghar Outcast Rebel Commander" hidden="false" collective="false" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="71f3-5c76-98db-4716" hidden="false" targetId="4a94-ffc8-8d46-6869" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="2eb4-601c-fb91-f555" hidden="false" targetId="1d76-267d-696a-2e8a" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="051d-ccd9-1c23-6d4a" hidden="false" targetId="ae1d-2212-b0ef-48b6" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="909a-62ac-0351-8778" hidden="false" targetId="167d-cdd2-aafa-0394" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="d3b2-1969-407b-c61f" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="86da-277a-ba37-4410">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="d2d6-30be-8bdb-e811" hidden="false" targetId="0e9b-9aae-bd16-d30f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="8dae-6f58-6727-960d" hidden="false" targetId="da65-5109-5f5f-0f9a" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="86da-277a-ba37-4410" hidden="false" targetId="05af-fc97-7a19-cf8d" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="51.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5bd1-2159-c56d-73c1" name="Outcast Rebel" hidden="false" collective="false" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="74a8-cda0-82fe-223d" hidden="false" targetId="b56d-892d-c25e-7379" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="11.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="2c06-feb9-7429-4b91" name="Maglash" hidden="false" targetId="dc72-b0e2-b8cb-2d5c" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="4">
+              <repeats>
+                <repeat field="selections" scope="8bf3-341f-b125-6334" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b7fa-60d2-b829-a7be" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="4">
+              <repeats>
+                <repeat field="selections" scope="8bf3-341f-b125-6334" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5bd1-2159-c56d-73c1" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="3f95-7f8e-30d1-d868" hidden="false" targetId="4003-9479-f9e0-a340" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="c8ce-474c-2a29-aa16" hidden="false" targetId="7f23-4831-7f76-fd6f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="be6d-09d2-5ae1-9a01" hidden="false" targetId="c429-23e1-056e-cfd3" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="8bf3-341f-b125-6334" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b7fa-60d2-b829-a7be" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="8bf3-341f-b125-6334" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5bd1-2159-c56d-73c1" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6ecf-63e6-ab1c-a4fe" name="Rebel Commander In Battle Armour" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="10a9-3714-7f79-92b2" name="Infantry Command Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="3cc2-48f1-8cf7-ae8b" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="69d7-2b98-817b-7619" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="36f2-9e18-633a-22fd" hidden="false" targetId="f5cb-d1fc-6b00-39f5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="6ecf-63e6-ab1c-a4fe-481abf13-c03e-0dd0-d520-9f9837253cbe" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="a447-3e39-8eeb-e605" name="Ghar Commander" hidden="false" collective="false" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="2e9b-982f-2742-8a77" hidden="false" targetId="68fa-5d5f-eae2-3f66" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="b90e-ea97-650c-1347" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="6a66-dacf-0734-700b">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="16aa-2449-9e76-0d2f" name="High Commander" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="8bb2-9c5d-ade7-cce3" hidden="false" targetId="48e7-7b6b-328c-29fe" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="02a1-d7c8-4fdc-e2fe" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="20.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="6a66-dacf-0734-700b" name="Leader 2" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="68a4-950a-e596-a4d0" hidden="false" targetId="9d03-08db-93a6-4f05" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e974-d5a4-5bff-cad1" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="08ac-2820-f509-5868" name="Leader 3" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="ba3e-b029-6aaf-c749" hidden="false" targetId="e048-25d9-af17-bdf0" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3b7f-10c3-b2d6-177d" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="102.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="9183-d94d-d8a6-9c54" name="Ghar Troopers" hidden="false" collective="false" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="f1eb-d4d7-aa0d-f6b0" hidden="false" targetId="de07-7287-f4d3-bf98" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="57.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6d2d-8d49-60eb-391e" name="Plasma Dumps" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="0966-6dc7-5acb-a359" hidden="false" targetId="4280-96f3-aa68-8d6e" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="points" value="5">
+              <repeats>
+                <repeat field="selections" scope="6ecf-63e6-ab1c-a4fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a447-3e39-8eeb-e605" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5.0">
+              <repeats>
+                <repeat field="selections" scope="6ecf-63e6-ab1c-a4fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9183-d94d-d8a6-9c54" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="5223-0081-7e79-67e2" name="Plasma Amplifiers" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="736e-63ca-9785-c8df" hidden="false" targetId="0448-a629-3df9-73c0" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="points" value="10">
+              <repeats>
+                <repeat field="selections" scope="6ecf-63e6-ab1c-a4fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a447-3e39-8eeb-e605" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="6ecf-63e6-ab1c-a4fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9183-d94d-d8a6-9c54" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1218-94f3-d5cc-bbaa" name="Plasma Claw for Leader" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="09cf-f9d1-0fa7-49ba" name="Plasma Claw" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="-"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="-"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="D4"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Random SV, Hand to Hand Only"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1218-94f3-d5cc-bbaa" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9502-0267-4e94-2d4f" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2cc9-8ee7-363a-b570" name="Plasma Claws" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ad74-68ab-1e20-7d33" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f513-7761-874a-7a24" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="2dbe-f75a-204b-8ebe" name="Plasma Claw for Troopers" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="f9a5-30af-b5c2-115b" name="Plasma Claw" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="-"/>
+                    <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="-"/>
+                    <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+                    <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="D4"/>
+                    <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Random SV, Hand to Hand Only"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="a0e1-e822-0ffd-f0f7" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="9183-d94d-d8a6-9c54" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a0e1-e822-0ffd-f0f7" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="de90-f44d-068a-82e4" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7c3d-26af-84e5-51c4" name="Rebel Creeper" book="BFX" page="90" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="0d6d-b9c2-cc1c-b94b" name="Vehicle Unit" book="" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="7da9-0492-5161-8a32" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="92f7-bd0d-57b9-f64b" hidden="false" targetId="f5cb-d1fc-6b00-39f5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="038f-cc5e-7495-8600" hidden="false" targetId="23c8-9405-75ca-7f03" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7be4-bccd-4e18-53b6" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="d177-dff5-4845-3b29" hidden="false" targetId="09d0-48ed-82d2-38b5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="7c3d-26af-84e5-51c4-5c47879b-41d0-1383-5fe5-a5989615db89" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="7516-1d67-a0c0-9317" name="Outcast Rebel Creeper" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="4ae2-28b0-6ec5-53ea" name="Outcast Rebel Creeper" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="1"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="10"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="8"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="8"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424" value="Large, Crawler, MOD2, Scramble Proof, Plasma Reactor"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="39df-66a6-97bc-21c7" name="Limited" hidden="false" targetId="f2a0-778f-5fa4-20af" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="98.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="47b6-1595-864a-c002" name="Plasma Amplifiers" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="dc57-da16-fee7-11d8" name="Plasma Amplifier" hidden="false" targetId="0448-a629-3df9-73c0" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="points" value="10">
+              <repeats>
+                <repeat field="selections" scope="7c3d-26af-84e5-51c4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7516-1d67-a0c0-9317" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="e5e7-9b9e-2d25-6bde" name="Plasma Dumps" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="94e5-fff5-123b-0533" name="Plasma Dump" hidden="false" targetId="4280-96f3-aa68-8d6e" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="points" value="5">
+              <repeats>
+                <repeat field="selections" scope="7c3d-26af-84e5-51c4" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7516-1d67-a0c0-9317" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5832-c55c-655e-ae32" name="Weapons" hidden="false" collective="false" defaultSelectionEntryId="ada7-7175-ea06-932d">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="6bd9-620d-4591-dbbe" value="1">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7516-1d67-a0c0-9317" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="4ff0-9a07-181c-fd26" value="1">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7516-1d67-a0c0-9317" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6bd9-620d-4591-dbbe" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ff0-9a07-181c-fd26" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="2f87-efbb-7c25-bf92" name="Mag Cannon" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="b6bb-5423-15c5-e849" name="Mag Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+                    <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="50"/>
+                    <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+                    <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="5"/>
+                    <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Massive Damage"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="increment" field="b61d-8d3d-4d43-3fc3" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="7516-1d67-a0c0-9317" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b61d-8d3d-4d43-3fc3" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ada7-7175-ea06-932d" name="Mag Light Support" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="151a-01b6-1d70-717d" name="Mag Light Support" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+                    <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="50"/>
+                    <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+                    <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+                    <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF 3"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="7b5a-fb0f-322f-5b2c" value="1">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="7516-1d67-a0c0-9317" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7b5a-fb0f-322f-5b2c" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7cf7-a4ad-ce2d-eba8" name="Rebel Weapon Team" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="45cb-83a8-6ea1-a8b5" name="Weapon Team Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="034c-4fe0-a1a5-eb21" hidden="false" targetId="7a50-8a69-75b6-3cca" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="7cf7-a4ad-ce2d-eba8-481abf13-c03e-0dd0-d520-9f9837253cbe" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="de51-23ed-0173-ba47" name="Outcast Crew" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="e34a-8f95-1075-fa6b" hidden="false" targetId="b56d-892d-c25e-7379" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="cc71-0ba4-2876-cc38" name="Outcast Leader" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="0875-519b-be7b-8626" name="Outcast Rebel Leader" hidden="false" targetId="9770-5f42-fa8c-247c" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="d3c3-c5ff-1552-7d0b" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="d813-a45b-705e-5144">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="99a0-ce67-06df-5518" name="Leader 2" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="cb31-6745-fde4-599b" hidden="false" targetId="9d03-08db-93a6-4f05" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="d813-a45b-705e-5144" name="Leader" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="aa5f-bdb7-15d1-83ac" hidden="false" targetId="24a5-60f8-93fc-7dff" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="36b3-a53f-c559-a4f0" name="Maglash" hidden="false" targetId="dc72-b0e2-b8cb-2d5c" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="4">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="583c-f509-bb93-5e2b" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b5f6-5a2d-5b0b-a7b5" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="13.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2941-c257-f06b-96e2" name="Weapons" hidden="false" collective="false" defaultSelectionEntryId="c9f0-82ef-6df0-b18a">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7fc9-f081-7a54-6df6" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e358-e6b8-f1e2-58b3" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="c9f0-82ef-6df0-b18a" name="Disruptor Cannon (Weapon Team)" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="39d4-96f6-7969-6aad" name="Disruptor Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                    <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                    <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+                    <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+                    <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, No Cover, Disruptor"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks>
+                <infoLink id="7ff2-6225-87ca-ccce" name="Disruptor" hidden="false" targetId="e140-2d88-ec8d-28a8" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9916-6b48-3813-992b" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fc44-5f74-9c09-83a2" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="14db-3cf1-21fe-960d" name="Mag Cannon (Weapon Team)" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="29fe-4554-49f6-899c" name="Mag Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+                    <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="50"/>
+                    <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+                    <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="5"/>
+                    <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Massive Damage"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6454-5311-1e84-3f25" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9aa0-afac-c1e5-e594" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d000-2a44-fe29-9253" name="Mag Light Support (Weapon Team)" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="1728-ad13-78e0-f6f9" name="Mag Light Support" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+                    <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="50"/>
+                    <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+                    <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+                    <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF 3"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8bf9-098b-50e7-61f7" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ab80-e8b1-bd04-81d5" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d910-65e7-0505-23b1" name="Quad Mag Repeater (Weapon Team)" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="e10d-a057-829e-d2cf" name="Quad Mag Repeater" book="BFX" page="75" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                    <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                    <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+                    <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+                    <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF D8, Jams"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks>
+                <infoLink id="c642-b04c-6c26-4fff" hidden="false" targetId="1702-a526-6e91-f2cd" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d0a4-bcb9-0743-08f6" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="535f-2003-9d67-498b" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="81c8-bbb9-9f59-c452" name="Reflex Armour" hidden="false" targetId="c70a-e0a0-0192-f2dc" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="2">
+              <repeats>
+                <repeat field="selections" scope="7cf7-a4ad-ce2d-eba8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cc71-0ba4-2876-cc38" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2">
+              <repeats>
+                <repeat field="selections" scope="7cf7-a4ad-ce2d-eba8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="de51-23ed-0173-ba47" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ac0c-ffe3-ca36-d4c0" name="Rebel Squad" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="512f-b5be-36a9-2459" name="Infantry Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="7613-d6c7-6d24-93b2" name="Rebel" hidden="false" targetId="7a50-8a69-75b6-3cca" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="ac0c-ffe3-ca36-d4c0-481abf13-c03e-0dd0-d520-9f9837253cbe" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="ebff-8528-f0d6-8bfd" name="Ghar Outcast Leader" hidden="false" collective="false" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="5e04-41c0-3380-53a5" name="Outcast Rebel Leader" hidden="false" targetId="9770-5f42-fa8c-247c" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="cd4c-2b67-0b74-96dd" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="d35e-b864-9304-3e84">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="7445-be0b-2a47-a71f" name="Leader 2" hidden="false" targetId="0e9b-9aae-bd16-d30f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="d35e-b864-9304-3e84" name="Leader" hidden="false" targetId="05af-fc97-7a19-cf8d" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="18.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f634-df4a-d8c4-fd3b" name="Ghar Outcast" hidden="false" collective="false" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="94f8-e945-a728-46b2" name="Outcast Rebel" hidden="false" targetId="b56d-892d-c25e-7379" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="11.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="7.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="b402-5948-a9cb-bda7" name="Outcast Weapon Team of Two" hidden="false" collective="false" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="22d4-54cd-a9e1-f46a" name="Disruptor Cannon" hidden="false" targetId="a975-754b-83c3-802b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="25.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="bee5-e186-0e85-a6f4" name="Plasma Grenades" hidden="false" targetId="c429-23e1-056e-cfd3" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="ac0c-ffe3-ca36-d4c0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ebff-8528-f0d6-8bfd" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2.0">
+              <repeats>
+                <repeat field="selections" scope="ac0c-ffe3-ca36-d4c0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f634-df4a-d8c4-fd3b" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="3aa2-cf1e-ccf6-5ff9" name="Lugger Gun" hidden="false" targetId="4d36-a47c-487c-f893" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fd3a-9dc3-6585-6d3e" name="Tectorist Scouts" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="0361-c2bf-5185-8a0b" name="Special: Sharded Infantry Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="ab38-b3bf-48f2-832d" hidden="false" targetId="7a50-8a69-75b6-3cca" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="fd3a-9dc3-6585-6d3e-72807c5d-e370-9ddf-c2b7-de5d2797f24d" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="b572-c2ed-763c-a0a4" name="Tectorist Scout" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="d0e9-50a7-5823-cc89" name="Tectorist Scouts" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader, Rebel, Shard"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="f6a8-13c6-b9ac-c035" hidden="false" targetId="24a5-60f8-93fc-7dff" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="8061-c0ee-f0f9-6958" hidden="false" targetId="485f-1f8e-7808-4a17" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="bee5-b458-d288-7e29" hidden="false" targetId="3b86-3198-ef3c-030e" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="105a-88d6-b03c-e681" name="Wrecking Squad" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="f18d-d08c-1481-0f21" name="Infantry Unit" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="9565-8fa7-b579-d0b6" hidden="false" targetId="7a50-8a69-75b6-3cca" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="105a-88d6-b03c-e681-72807c5d-e370-9ddf-c2b7-de5d2797f24d" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="2009-2564-ed64-e5d9" name="Outcast Rebel Leader" hidden="false" collective="false" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="08ed-2551-b524-dd0f" name="Outcast Rebel Leader" hidden="false" targetId="9770-5f42-fa8c-247c" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="f260-f310-aaac-0ffc" name="Leader Rank" hidden="false" collective="false" defaultSelectionEntryId="07a6-d6ee-7c54-e8fe">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="07a6-d6ee-7c54-e8fe" hidden="false" targetId="05af-fc97-7a19-cf8d" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="25.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8a76-6031-2e6b-1431" name="Outcast Rebel" hidden="false" collective="false" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="e629-e97c-c4a7-68a9" hidden="false" targetId="b56d-892d-c25e-7379" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="b056-62d0-b5ec-ca48" hidden="false" targetId="4003-9479-f9e0-a340" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="3ae4-7f9d-0069-74d8" hidden="false" targetId="7f23-4831-7f76-fd6f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="a27d-e086-220b-cb6c" hidden="false" targetId="ac9f-9690-ac50-3e99" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c1d8-3084-a5b8-1d2d" name="Transport Dropper" page="" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="a7e1-2be4-2035-97b8" name="Vehicle Unit / Drop Capsule" book="" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="d2e5-f1f2-6f73-26b6" name="Scramble Proof" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="bd14-2180-ce80-1d2d" name="Plasma Reactor" hidden="false" targetId="f5cb-d1fc-6b00-39f5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ac5c-cf4b-ea11-d8d5" name="Large" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="67d9-2b33-6ba3-2b78" hidden="false" targetId="a01f5f58-334c-8442-d861-15099ebdf5e5" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="bda4-4880-05de-5fd8" name="Transport Dropper" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="728e-ac3d-3c72-9ec8" name="Transport Dropper" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="3"/>
+                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="10"/>
+                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="13"/>
+                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="8"/>
+                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="8"/>
+                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424" value="MOD2, Transport 10/5, Large, Crawler, Scramble Proof, Plasma Reactor"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="24f3-8dc2-8eff-d064" name="Dropper" hidden="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <description>Teh ghar Transport Dropper is designed to fuction as a regular ground transporter and support vehicle, but can be dropped from low orbit and steered down to a ground target. As such a Dropper conbined the abilities of a drop capsule and a vehicle. See the Drop Forces rules for more about using such vehicles.</description>
+            </rule>
+            <rule id="ef13-d1e5-1eff-eed0" name="Transport 8/4" hidden="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" childId="8b70-e290-bffc-ecbc" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <description>The dropper is primarily built to carry 4 battlesuits and has a normal carrying capacity of 8, each suit counted as two ordinary models. A Dropper therefore has a transport value of 8 when carrying Outcast troopers. With an Outcast Disruptor Cannon team count each crew and the weapon as one each in the usual way for transported weapon teams. The Dropper can also carry Scutters, each Scutter counting as 2 ordinary models in the same way as battlesuits. During a drop deployment a Dropper can alternatively carry any other vehicle using its magnetic couplings, taking up all ten of its transport slots; however, once deployed a Dropper cannot carry other vehicles.</description>
+            </rule>
+            <rule id="4ed6-779d-d7e9-94ea" name="Transort 10/5" hidden="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" childId="8b70-e290-bffc-ecbc" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <description>The dropper is primarily built to carry 5 battlesuits and has a normal carrying capacity of 10, each suit counted as two ordinary models. A Dropper therefore has a transport value of 10 when carrying Outcast troopers. With an Outcast Disruptor Cannon team count each crew and the weapon as one each in the usual way for transported weapon teams. The Dropper can also carry Scutters, each Scutter counting as 2 ordinary models in the same way as battlesuits. During a drop deployment a Dropper can alternatively carry any other vehicle using its magnetic couplings, taking up all ten of its transport slots; however, once deployed a Dropper cannot carry other vehicles.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="2bcf-7ab9-1b27-08de" name="MOD2" hidden="false" targetId="09d0-48ed-82d2-38b5" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="80aa-e01a-b824-7a61" name="Limited" hidden="false" targetId="f2a0-778f-5fa4-20af" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="91ce-6884-a034-213f" name="Crawler" hidden="false" targetId="23c8-9405-75ca-7f03" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a9c7-dab4-14c0-d3b3" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fea9-e413-3deb-488b" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="434c-7fa9-b13c-e9b9" name="Weapons" hidden="false" collective="false" defaultSelectionEntryId="6e7d-8800-0b34-72be">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="535b-88de-9b0f-165a" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="361c-61fc-ff8a-6303" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="6e7d-8800-0b34-72be" name="Scourer Cannon" book="" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="cb25-7250-3035-7732" name="Scourer Cannon - Dispersed" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+                        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+                        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3"/>
+                      </characteristics>
+                    </profile>
+                    <profile id="1036-14ca-fa92-2095" name="Scourer Cannon - Concentrated" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="40"/>
+                        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="4"/>
+                        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec"/>
+                      </characteristics>
+                    </profile>
+                    <profile id="4d6e-e16c-07c3-2202" name="Scourer Cannon - Disruptor" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+                        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+                        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, No Cover, Disruptor"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="d22c-38dd-fdd2-5125" hidden="false" targetId="e140-2d88-ec8d-28a8" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9fdc-6d91-6ef1-68a2" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="97dd-ba57-ace1-dc81" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="7755-9f09-1208-167c" name="Twin Scourer Cannons" book="" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="450f-2979-989f-1652" name="Scourer Cannon - Dispersed" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+                        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+                        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3"/>
+                      </characteristics>
+                    </profile>
+                    <profile id="bef4-0a0a-1ff6-4583" name="Scourer Cannon - Concentrated" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="40"/>
+                        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="4"/>
+                        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value=""/>
+                      </characteristics>
+                    </profile>
+                    <profile id="6603-b142-fe43-d5ab" name="Scourer Cannon - Disruptor" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+                        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+                        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, No Cover, Disruptor"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules>
+                    <rule id="835a-77fc-c776-0a60" name="Twin Scourer Cannons" hidden="false">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <description>Counts as 2 Scourer Cannons</description>
+                    </rule>
+                  </rules>
+                  <infoLinks>
+                    <infoLink id="5ebb-4562-f0e0-aa0e" name="Disruptor" hidden="false" targetId="e140-2d88-ec8d-28a8" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="89f2-ae1b-eaf6-921b" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bbe7-f62d-bf9f-2942" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="15.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="8b70-e290-bffc-ecbc" name="Disruptor Bomber Turret" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0d57-2463-617e-83e6" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4740-c9a0-d892-61b6" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="534c-b9e0-e811-5e06" name="Disruptor Bomber Turret" hidden="false" collective="false" type="upgrade">
+                  <profiles>
+                    <profile id="3062-96bd-c92c-659a" name="Disruptor Bomber" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+                        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
+                        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
+                        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+                        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D5, No Crew, Limited Ammo, No Cover, Disruptor"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="33de-35ce-1c3d-b109" name="Disruptor" hidden="false" targetId="e140-2d88-ec8d-28a8" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                    <infoLink id="f25d-06b0-46cc-92e9" name="Limited Ammo (Bomber)" hidden="false" targetId="0b3f-b043-b08c-ad14" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="34b3-2f1e-75da-90b3" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9d9f-0d8e-5add-b511" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="15.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="179.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7b0a-1978-f1bb-5d2d" name="Ghar Scutter" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="f352-5e84-55d0-9948" name="Ghar Attack Scutter" hidden="false" targetId="13e9-5eeb-7392-f018" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9d5b-8f60-8b09-51ab" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="eb96-310a-98d8-c956" name="Bomb Feeder" hidden="false" targetId="562c-13be-8455-d77b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="39f1-973c-286c-1d76" name="Scourer Cannon" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="26.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="246c-a7ac-b1db-dc88" name="Plasma Dumps" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="c1f5-daac-2e69-117f" hidden="false" targetId="4280-96f3-aa68-8d6e" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="points" value="5">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="7b0a-1978-f1bb-5d2d" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="5">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="bda4-4880-05de-5fd8" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a38e-1648-6b37-f6e0" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3367-1143-0a0d-33bf" name="Plasma Amplifiers" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="ac29-94da-5642-c3b3" hidden="false" targetId="0448-a629-3df9-73c0" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="points" value="10.0">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="bda4-4880-05de-5fd8" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="10">
+              <repeats>
+                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="7b0a-1978-f1bb-5d2d" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0872-3407-a588-daaf" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5c86-bf40-f499-df82" name="Munition Scutter" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules>
+        <rule id="d1b0-e9c2-d87d-dab0" name="Mounted Unit" book="Beyond the Gates of Antares" page="95" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="213d-8e0c-123c-7dcf" name="Plasma Reactor" hidden="false" targetId="f5cb-d1fc-6b00-39f5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="bfd8-299e-f4f9-d5ae" hidden="false" targetId="a985-d1e1-a15f-c261" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="2a43-541d-1a74-9e6f" hidden="false" targetId="931b-a54d-a846-cb74" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="2be6-c807-6d40-975a" hidden="false" targetId="23c8-9405-75ca-7f03" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="6a62-46a5-a269-e81c" name="New CategoryLink" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="95c5-8db7-dab9-d8ec" name="Ghar Attack Scutter" book="Beyond the Gates of Antares" page="170" hidden="false" collective="false" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="bd80-53a9-96a2-8f54" name="Ghar Attack Scutter" hidden="false" targetId="13e9-5eeb-7392-f018" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ecdf-a71b-d7f0-9bfb" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="10c7-58fb-4be8-4102" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="26.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ab2e-db06-a7ef-434c" name="Plasma Amplifiers" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1b7b-bec6-baa9-d43e" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7e33-8287-4bfa-9e58" name="Lugger Ammo" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules>
+            <rule id="5eeb-83be-1f41-d278" name="Lugger Ammo" hidden="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <description>A Munitions Scutter can also carry a supply of Lugger Ammo. This works in the same way as the bomb feeder, except that it allows the Scutter to replenish Lugger equipped units that are either low on ammunition or which have run out all together. Not all Ghar Commanders believe such measure necessary or even desirable.</description>
+            </rule>
+          </rules>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c8b6-2e44-d4db-49b2" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="ed75-f243-ab5e-692f" name="Scourer Cannon" hidden="false" targetId="3fde-b133-beb3-43d7" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="bfae-2c44-f210-65c6" name="Bomb Feeder" hidden="false" targetId="562c-13be-8455-d77b" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <entryLinks>
+    <entryLink id="399d-d4c1-3e11-e7e1" name="Army Options" hidden="false" targetId="529a-3e2a-4bd5-5e5f" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="399d-d4c1-3e11-e7e1-50ba-cf77-3941-189c" hidden="false" targetId="50ba-cf77-3941-189c" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+    </entryLink>
+  </entryLinks>
+  <sharedSelectionEntries>
+    <selectionEntry id="562c-13be-8455-d77b" name="Bomb Feeder" book="Main Rulebook" page="124" hidden="false" collective="true" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="9b7b-ff28-ec49-0942" hidden="false" targetId="db27-0095-600e-23c4" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e376-d612-25ff-b855" name="Disruptor Bomber" hidden="false" collective="true" type="upgrade">
+      <profiles>
+        <profile id="1acb-9789-cb8b-8ef9" name="Disruptor Bomber" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D5, No Crew, Limited Ammo, No Cover, Disruptor"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d8cc-c090-9c63-5998" name="Disruptor" hidden="false" targetId="e140-2d88-ec8d-28a8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3666-098d-f1f2-ec43" hidden="false" targetId="0b3f-b043-b08c-ad14" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a975-754b-83c3-802b" name="Disruptor Cannon" hidden="false" collective="true" type="upgrade">
+      <profiles>
+        <profile id="3fc4-77d8-d391-3905" name="Disruptor Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, No Cover, Disruptor"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="899b-680e-d59e-a442" hidden="false" targetId="e140-2d88-ec8d-28a8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ff6d-c9e5-a6c4-f336" name="Disruptor Discharger" hidden="false" collective="true" type="upgrade">
+      <profiles>
+        <profile id="72a8-99cd-7759-5303" name="Disruptor Discharger" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="-"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="-"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Point Blank Shooting Only, Grenade, Blast D4, Disruptor"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="84fd-8f52-305f-f304" hidden="false" targetId="0bb9-6368-6b0e-0c1c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="76d1-263c-00e2-7e8d" hidden="false" targetId="5344-3037-5451-66d9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7452-3046-3f4b-7e77" hidden="false" targetId="e650-ca8a-00be-3fd1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="5f8c-16cb-14c1-dbd1" hidden="false" targetId="e140-2d88-ec8d-28a8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7b4d-32f1-18fb-a924" hidden="false" targetId="e140-2d88-ec8d-28a8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3cfd-07d8-f685-fa34" name="Gouger" hidden="false" collective="true" type="upgrade">
+      <profiles>
+        <profile id="9983-0148-efd4-e87b" name="Gouger" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Down, Inaccurate"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="dc53-88cf-67b6-f50c" hidden="false" targetId="4cb3-1c82-5192-1a7a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f96a-f7aa-7dff-a92d" hidden="false" targetId="c524-47f2-d062-eed0" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ac9f-9690-ac50-3e99" name="Grabber" book="Main Rulebook" page="124" hidden="false" collective="true" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="9123-7414-4eda-0134" hidden="false" targetId="43d7-b8cd-2dbc-d79b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5a09-7c98-31f2-0b1b" name="Heavy Disruptor Bomber" hidden="false" collective="true" type="upgrade">
+      <profiles>
+        <profile id="6829-9a72-421b-cfd5" name="Heavy Disruptor Bomber" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OHx2, Blast D10, No Crew, Limited Ammo, No Cover, Disruptor"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="e118-3351-73ab-3039" hidden="false" targetId="e140-2d88-ec8d-28a8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ec41-5675-21d2-b9bc" hidden="false" targetId="0b3f-b043-b08c-ad14" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0435-82ed-58ff-4ea7" name="High Commander" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="e142-2dd7-1d70-0f2d" hidden="false" targetId="48e7-7b6b-328c-29fe" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="30.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ac57-b0c4-464e-9774" name="Hybrid Plasma Light Support" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8592-5404-f9d1-f93b" name="Hybrid Reactor" book="BFX" page="107" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="05af-fc97-7a19-cf8d" name="Leader" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="6ed0-d806-e77d-98d7" hidden="false" targetId="24a5-60f8-93fc-7dff" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0e9b-9aae-bd16-d30f" name="Leader 2" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="94ea-cf78-4b71-6d44" hidden="false" targetId="9d03-08db-93a6-4f05" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="da65-5109-5f5f-0f9a" name="Leader 3" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="35f6-4a4a-f299-e85f" hidden="false" targetId="e048-25d9-af17-bdf0" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4d36-a47c-487c-f893" name="Lugger Gun" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="98d1-3d6d-debb-e8f0" name="Lugger Gun" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Limited Ammo"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="7b96-6226-be5a-13d9" hidden="false" targetId="0dab-4247-3f70-96e7" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="8fbb-fa4e-9d17-e664" hidden="false" targetId="a9b4-063d-b7f2-c577" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7870-c71a-3038-1e22" name="Lugger Guns" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="a7ee-5d84-004e-b2c7" name="Lugger Gun" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Limited Ammo"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="2723-b72b-2d1a-95ee" hidden="false" targetId="0dab-4247-3f70-96e7" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="2a6d-38c7-e168-9943" hidden="false" targetId="a9b4-063d-b7f2-c577" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="306c-a91f-3fc0-e059" name="Mag Cannon" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="7074-7af7-cb33-9842" name="Mag Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="50"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="5"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Massive Damage"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="afcd-8743-da8f-a190" name="Mag Gun" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="5ac4-a65c-7ca5-f6a5" name="Mag Gun" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7f23-4831-7f76-fd6f" name="Mag Guns" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="fc9f-0877-25cf-3e17" name="Mag Gun" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6f9d-4f18-835f-deff" name="Mag Light Support" hidden="false" collective="true" type="upgrade">
+      <profiles>
+        <profile id="118c-ea89-1867-bb09" name="Mag Light Support" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="50"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF 3"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1b8c-cb95-f75e-7790" name="Mag Multilash" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="dc72-b0e2-b8cb-2d5c" name="Maglash" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="66ab-8aa6-0aad-7137" name="Maglash" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="-"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a742-ea4f-8be3-471b" hidden="false" targetId="3d3d-094e-e819-bbc6" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ab08-23fc-b6b5-a20f" name="Maglashs" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="1194-ad4d-b79b-4557" name="Maglash" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="-"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="e2d1-f268-a03a-d807" hidden="false" targetId="3d3d-094e-e819-bbc6" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a0c9-26de-c4d9-59cd" name="Micro-X Launcher" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="29d5-220a-164f-9cce" name="Micro-X Launcher - Overhead" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D4, No Cover"/>
+          </characteristics>
+        </profile>
+        <profile id="0961-cdd8-e81f-6250" name="Micro-X Launcher - Direct Fire" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value=""/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0924-6883-4fd0-7896" name="Plasma Amplifier" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="cc93-b3fb-ea4e-672f" hidden="false" targetId="0448-a629-3df9-73c0" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ed1e-82da-96a2-9c3e" name="Plasma Carbine" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="2b75-1d5a-781f-c81f" name="Plasma Carbine - Single Shot" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec"/>
+          </characteristics>
+        </profile>
+        <profile id="cc69-fddf-25dd-df04" name="Plasma Carbine - Scatter" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="3.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="36a7-e564-c80c-2a7e" name="Plasma Claw" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="7b7f-6710-a8ca-13a0" name="Plasma Claw" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="-"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="-"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="D4"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Random SV, Hand to Hand Only"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="552b-e451-f468-5bc2" hidden="false" targetId="30d6-c6b7-e415-04b6" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="4e02-a4cc-a3ca-5602" hidden="false" targetId="34b7-4d0d-35b3-8ebe" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0a8d-432b-4cb0-6b78" name="Plasma Claw (Command)" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="f2fe-66ff-fe52-5e87" name="Plasma Claw" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="-"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="-"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="D4"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Random SV, Hand to Hand Only"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="cae6-4609-37e1-2bc4" hidden="false" targetId="30d6-c6b7-e415-04b6" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="1777-c8cc-9229-4715" hidden="false" targetId="34b7-4d0d-35b3-8ebe" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6e7f-8fb9-1596-4ab8" name="Plasma Dump" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="5609-876e-7521-4f9e" hidden="false" targetId="4280-96f3-aa68-8d6e" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c429-23e1-056e-cfd3" name="Plasma Grenades" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6fc0-fbd7-b4c3-f78b" name="Plasma Lance" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="648c-d115-3e1d-4507" name="Plasma Lance - Single Shot" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value=""/>
+          </characteristics>
+        </profile>
+        <profile id="bc6c-565f-4912-7a0c" name="Plasma Lance - Scatter" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2"/>
+          </characteristics>
+        </profile>
+        <profile id="9de4-b82d-6fd8-13b7" name="Plasma Lance - Lance" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="4"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Choose Target, Inaccurate"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="6.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3018-7ca0-b24e-e8c7" name="Quad Mag Repeater" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="e9b6-dc42-b707-9a5f" name="Quad Mag Repeater" book="BFX" page="75" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF D8, Jams"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="163c-ea47-af86-0967" hidden="false" targetId="1702-a526-6e91-f2cd" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c70a-e0a0-0192-f2dc" name="Reflex Armour" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="b2ed-6632-7d1f-b858" hidden="false" targetId="2094-a31c-bfab-8618" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4003-9479-f9e0-a340" name="Reflex Armoured" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="ab97-1529-eaae-e56a" hidden="false" targetId="2094-a31c-bfab-8618" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3fde-b133-beb3-43d7" name="Scourer Cannon" book="" hidden="false" collective="true" type="model">
+      <profiles>
+        <profile id="3a17-075b-0005-da30" name="Scourer Cannon - Dispersed" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3"/>
+          </characteristics>
+        </profile>
+        <profile id="f1bd-dc3c-6c69-200a" name="Scourer Cannon - Concentrated" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="40"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="4"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec"/>
+          </characteristics>
+        </profile>
+        <profile id="386e-981d-4010-4c7c" name="Scourer Cannon - Disruptor" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, No Cover, Disruptor"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="6248-6207-2542-bcf4" hidden="false" targetId="e140-2d88-ec8d-28a8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3b86-3198-ef3c-030e" name="Tector Rods" book="Main Rulebook" page="124" hidden="false" collective="true" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="31ac-5d3a-694c-2d0f" hidden="false" targetId="fd0c-1117-1405-8394" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="dc78-d3f5-a9c9-69eb" name="Twin Scourer Cannons" book="" hidden="false" collective="true" type="model">
+      <profiles>
+        <profile id="0c0a-e36d-e634-1899" name="Scourer Cannon - Dispersed" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3"/>
+          </characteristics>
+        </profile>
+        <profile id="d7b1-c47b-f0d1-2fbb" name="Scourer Cannon - Concentrated" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="40"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="4"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value=""/>
+          </characteristics>
+        </profile>
+        <profile id="cc20-1804-0975-cb28" name="Scourer Cannon - Disruptor" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, No Cover, Disruptor"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="5863-bf82-77f4-ce1a" name="Twin Scourer Cannons" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>Counts as 2 Scourer Cannons</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="ddde-e4c5-e259-91cd" hidden="false" targetId="e140-2d88-ec8d-28a8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="45da-6922-ca81-a23c" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e4a1-7b6f-5c36-b45c" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7eec-fb6a-ac6f-ae37" name="Disruptor Bomber Turret" hidden="false" collective="true" type="upgrade">
+      <profiles>
+        <profile id="e6a0-9be9-65e3-6e87" name="Disruptor Bomber" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D5, No Crew, Limited Ammo, No Cover, Disruptor"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="cf22-4f3e-1256-1b44" hidden="false" targetId="e140-2d88-ec8d-28a8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="9c69-adc4-0bbe-b270" hidden="false" targetId="0b3f-b043-b08c-ad14" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6a19-7dc7-68f5-d999" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0b3f-3b51-6677-c306" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups/>
+  <sharedRules>
+    <rule id="0bb9-6368-6b0e-0c1c" name="Blast" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="db27-0095-600e-23c4" name="Bomb Feeder" book="Core" page="124" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Prevents Bombers running out of ammo. Also allows a Bomber unit to shot twice once per game as 1 action.</description>
+    </rule>
+    <rule id="1d76-267d-696a-2e8a" name="Command" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="23c8-9405-75ca-7f03" name="Crawler" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="e140-2d88-ec8d-28a8" name="Disruptor" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Target gets no cover bonus to its Res rolls. Non-Ghar take 2 Pins. Can choose to hit Buddy Drones. Probes hit can only make successful Res tests on 1 regardless of Res Value</description>
+    </rule>
+    <rule id="4cb3-1c82-5192-1a7a" name="Down" book="Core" page="74" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>A unit hit by a Gouger gun automatically goes down after shooting has ben worked out.</description>
+    </rule>
+    <rule id="2bb1-783e-8a6e-5970" name="Flitter" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Flitters only move 15&quot;</description>
+    </rule>
+    <rule id="6d5c-d6f2-3426-e11c" name="Flitter Bomb" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Flitters must move into contact with enemy units to have any effect. When you want them to explode roll a D10 on a 6-10 (rolling seperately if multiple Flitters are in contact) they explode cuasing D3 hits allocated to the model touching the bomb first, then any the play whose unit has been attacked chooses. The SV is D3, but only rolled once for all the Flitters exploding on the same target, and counts as having been inflicted in hand to hand. Counts as a Disruptor weapon for the purpose of putting additional pins on targets and damaging Buddy Drones.</description>
+    </rule>
+    <rule id="ae1d-2212-b0ef-48b6" name="Follow" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="2dca-9d1f-0a96-e2d2" name="Ghar Flitter" book="Core" page="119" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>If an enemy unit has one of more flitters within 5&quot; of it any Ghar shooting at it adds +! Axx if at least one flitter can be activated. Ghar Flitters give no bonus to OH shots. Flitters activate on a D10 roll of 6-10. Roll seperately for each Flitter</description>
+    </rule>
+    <rule id="43d7-b8cd-2dbc-d79b" name="Ghar Grabber" book="Core" page="124" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Can assist units in 5&quot; in Ghar in battle armouir and Scutters and any Ghar Vehicles. Assisted units reroll Ag tests, reroll damage chart, reroll attempts to recover from being down on the End Phase, and grants the unit Self-Repair</description>
+    </rule>
+    <rule id="e650-ca8a-00be-3fd1" name="Grenade" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="34b7-4d0d-35b3-8ebe" name="Hand to Hand Only" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="4a94-ffc8-8d46-6869" name="Hero" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="48e7-7b6b-328c-29fe" name="High Commander" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="fa58-3ec1-0b4e-b2f2" name="Hybrid Reactor" book="BFX" page="107" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Hybrid reactors work the same as Plasma Ractors, but only burn out on a 10</description>
+    </rule>
+    <rule id="c524-47f2-d062-eed0" name="Inaccurate" book="Core" page="74" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>-1 Acc</description>
+    </rule>
+    <rule id="1702-a526-6e91-f2cd" name="Jams" book="BFX" page="75" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>On any Acc roll of a 10 the weapon has jammed. This means it can not fire on it&apos;s next turn.</description>
+    </rule>
+    <rule id="931b-a54d-a846-cb74" name="Large" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="24a5-60f8-93fc-7dff" name="Leader" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="9d03-08db-93a6-4f05" name="Leader 2" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="e048-25d9-af17-bdf0" name="Leader 3" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="f2a0-778f-5fa4-20af" name="Limited" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Only 25% of your army may be limited choices</description>
+    </rule>
+    <rule id="0dab-4247-3f70-96e7" name="Limited Ammo" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>After shooting roll once for the unit. On a 10 the weapons low on ammo, so may not rapid fire anymore. If this test is failed again the gun runs out of ammo.</description>
+    </rule>
+    <rule id="0b3f-b043-b08c-ad14" name="Limited Ammo (Bomber)" book="Core" page="77" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Unless it has a Bomb Feeder Scutter. if a disruptor bomber rolls a 10 to hit, the shot is not only a dud shot but also the weapon runs out of ammo.</description>
+    </rule>
+    <rule id="09d0-48ed-82d2-38b5" name="MOD2" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="3d3d-094e-e819-bbc6" name="Multiple Attacks" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="5344-3037-5451-66d9" name="No Cover" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="2ed7-3d50-bea9-5f27" name="Outcast Champion" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="0448-a629-3df9-73c0" name="Plasma Amplifier" book="Main Rulebook" page="125" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Increases the models MOD by 1. At the end of the turn on a 1-5 Amplifier runs out. If the unit fails a required order test on a 10 using the extra dice then the amplifer is destroyed and the unit suffers D5 Pins</description>
+    </rule>
+    <rule id="4280-96f3-aa68-8d6e" name="Plasma Dump" book="Main Rulebook" page="124" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>A player who declares a Down order may Plasma Dump. Shots against that unit are at -2 Acc. In addition all units in 5&quot; of the Dump take D6 SV2 hits and recieves 1 pin. If the unit elects to remain down this will happen again at the start of each turn.</description>
+    </rule>
+    <rule id="f5cb-d1fc-6b00-39f5" name="Plasma Reactor" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="30d6-c6b7-e415-04b6" name="Random SV" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="a9b4-063d-b7f2-c577" name="Rapid Fire (RF)" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="7a50-8a69-75b6-3cca" name="Rebel" book="BFX" page="84" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>Units in 5&quot; of another friendly unit with this rule ignore 1 pin</description>
+    </rule>
+    <rule id="2094-a31c-bfab-8618" name="Reflex Armour" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>+1 Resistance</description>
+    </rule>
+    <rule id="a985-d1e1-a15f-c261" name="Scramble Proof" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="485f-1f8e-7808-4a17" name="Shard" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="fd0c-1117-1405-8394" name="Tector Rods" book="Core Book" page="124" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>When a Ghar shoots at a unit in 15&quot; of 1 or more Tector Rods in may reroll 1 Accuracy Test.</description>
+    </rule>
+    <rule id="57d1-980d-ee47-f717" name="Wound" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>May fail 1 Res test without being removed as a casualty. A 2nd fail will remove the model as normal.</description>
+    </rule>
+  </sharedRules>
+  <sharedProfiles>
+    <profile id="13e9-5eeb-7392-f018" name="Ghar Attack Scutter" book="Beyond the Gates of Antares" page="170" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="3"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(10)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Large, Crawler, Scramble Proof, Plasma Reactor"/>
+      </characteristics>
+    </profile>
+    <profile id="68fa-5d5f-eae2-3f66" name="Ghar Commander in Battle Armour" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="3"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="10"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(12)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Follow, Leader 2, Large, Scrumble Proof, Plasma Reactor"/>
+      </characteristics>
+    </profile>
+    <profile id="562d-6cd9-4b4a-7019" name="Ghar Leader" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="3"/>
+        <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="10"/>
+        <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="4(12)"/>
+        <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="8"/>
+        <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="8"/>
+        <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424" value="Leader, Large, Scramble Proof, Plasma Reactor"/>
+      </characteristics>
+    </profile>
+    <profile id="de07-7287-f4d3-bf98" name="Ghar Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="3"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="10"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(12)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Large, Scramble Proof, Plasma Reactor"/>
+      </characteristics>
+    </profile>
+    <profile id="b56d-892d-c25e-7379" name="Outcast Rebel" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="6"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="3"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(5)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="6"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="6"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Rebel"/>
+      </characteristics>
+    </profile>
+    <profile id="167d-cdd2-aafa-0394" name="Outcast Rebel Commander" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="6"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="3"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(5)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader, Hero, Command, Follow, Rebel"/>
+      </characteristics>
+    </profile>
+    <profile id="9770-5f42-fa8c-247c" name="Outcast Rebel Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="6"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="3"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(5)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader, Rebel"/>
+      </characteristics>
+    </profile>
+    <profile id="c6eb-3995-3cbb-b07e" name="Outcast Rebel Unarmoured" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="6"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="3"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Rebel"/>
+      </characteristics>
+    </profile>
+  </sharedProfiles>
+</catalogue>


### PR DESCRIPTION
Rebel Command Squad Maglash increase to 4pts each.
Rebel Command in Battle Armour Troopers now 57pts each
Blackguard Maglashes increased to 4pts each
Outcast Rebel Squad increase to 7pts per model, base cost of unit also increased to 53pts, removed option to take reflex armour and mag guns. Also reduced cost of Disruptor cannon to 25pts.
Remade Weapon team entry. Increased cost of leader to 17pts including Maglash, reduced base cost of team to 25pts. Given weapon options to match update so that they are free upgrades, apart from Mag Cannon at +10pts.
Rebel Battle & Assault Squads. Lowered cost of standard troopers to 57, increased cost of leader to 70
Rebel Bomber Squad. Lowered cost of standard troopers and bomber to 57, increased cost of leader to 70
Rebel Scutter Leader increased cost by 3pts to match new points values.
Bombardment Crawler cost increased to 258pts
Attack Crawler points increased, Also options to exchange Light Supports for Mag Cannons or Quad Mag changed as they now both may be upgraded to the same weapon, rather than 1 upgrade to cannon and other to quad.
Added Transport Dropper & Munitions Scutter