### PR TITLE
Algoryn and central updates 26/01/18

### DIFF
--- a/Algoryn.cat
+++ b/Algoryn.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="4868-1e60-4bba-a4b2" name="Algoryn" revision="8" battleScribeVersion="2.01" authorName="Michael Ovsenik" authorContact="FB" gameSystemId="c339-677a-60db-4060" gameSystemRevision="0" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="4868-1e60-4bba-a4b2" name="Algoryn" revision="9" battleScribeVersion="2.01" authorName="Dom Hine" authorContact="boltactionAB@gmail.com" authorUrl="https://www.facebook.com/groups/547335118761237/?hc_location=ufi" gameSystemId="c339-677a-60db-4060" gameSystemRevision="0" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -8,23 +8,23 @@
   <categoryEntries/>
   <forceEntries/>
   <selectionEntries>
-    <selectionEntry id="b73b-6140-e2ca-f0c1" name="AI Assault Command Squad" hidden="false" collective="false" type="unit">
+    <selectionEntry id="3eb9-1d22-aac0-cf42" name="AI Assault Command Squad" book="Rulebook &amp; pdf force list v2" page="173" hidden="false" collective="false" type="unit">
       <profiles/>
-      <rules>
-        <rule id="3542-e211-b704-3388" name="Limited Choice" book="" hidden="false">
+      <rules/>
+      <infoLinks>
+        <infoLink id="b67d-94f8-52d1-1bd8" name="Limited Choice" hidden="false" targetId="8cb3-4c3e-dc5f-b952" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-        </rule>
-        <rule id="ab69-5653-55c0-16cf" name="Infantry Command Unit" book="" hidden="false">
+        </infoLink>
+        <infoLink id="d0c0-409d-63b1-4cef" name="Infantry Command" hidden="false" targetId="0a6b-dcfb-ccc3-6a0d" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-        </rule>
-      </rules>
-      <infoLinks/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
       <constraints/>
       <categoryLinks>
@@ -35,35 +35,42 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="10c2-fc83-8aef-791d" name="New CategoryLink" hidden="false" targetId="c87d-5261-face-4643" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b36d-f9f6-80eb-6f8a" name="AI Assault Commander" hidden="false" collective="false" type="model">
           <profiles>
-            <profile id="e6fb-c60a-b21f-bd96" name="AI Assault Commander" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+            <profile id="e6fb-c60a-b21f-bd96" name="AI Assault Commander" hidden="false" profileTypeId="1650-77b3-10d1-6406" profileTypeName="Model">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <characteristics>
-                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="5"/>
-                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
-                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="5"/>
-                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="6 (7)"/>
-                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="7"/>
-                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="9"/>
-                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424"/>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (7)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
               </characteristics>
             </profile>
           </profiles>
           <rules/>
           <infoLinks>
-            <infoLink id="5923-8349-07a9-9c2e" hidden="false" targetId="5c9b-1bde-ee01-04a4" type="rule">
+            <infoLink id="5923-8349-07a9-9c2e" name="Command" hidden="false" targetId="f001-a3be-81f7-f74f" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
             </infoLink>
-            <infoLink id="04eb-c412-1c75-748c" hidden="false" targetId="7bc9-5e98-2914-5abd" type="rule">
+            <infoLink id="04eb-c412-1c75-748c" name="Follow" hidden="false" targetId="4bdd-65b7-6ee8-89b2" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -78,65 +85,6 @@
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups>
-            <selectionEntryGroup id="ee93-85a8-a748-3858" name="Leader Level" hidden="false" collective="false" defaultSelectionEntryId="13a7-6cb8-6b4e-1067">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries>
-                <selectionEntry id="13a7-6cb8-6b4e-1067" name="Leader Two" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="129d-7b43-801a-0589" hidden="false" targetId="7850-89e7-bab8-86e9" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="7be4-5a80-2f33-ce29" name="Leader Three" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="8609-a47e-3460-8e88" hidden="false" targetId="05bb-4d34-70cd-25d2" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
             <selectionEntryGroup id="de4b-186e-6c61-b8c8" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="b6b5-3cea-3fa2-850b">
               <profiles/>
               <rules/>
@@ -150,7 +98,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="b6b5-3cea-3fa2-850b" hidden="false" targetId="b08e-548a-fda7-0a4e" type="selectionEntry">
+                <entryLink id="b6b5-3cea-3fa2-850b" name="X-Sling" hidden="false" targetId="e629-3c26-9e22-f80b" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -162,7 +110,7 @@
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="e315-7c8e-c397-f04f" hidden="false" targetId="8de3-1e72-72ef-e7a3" type="selectionEntry">
+            <entryLink id="e315-7c8e-c397-f04f" name="SlingNet Ammo" hidden="false" targetId="6849-c480-4332-7ffc" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -176,7 +124,7 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="1c7d-3ba7-b033-2246" hidden="false" targetId="6b54-c223-3c4a-5de7" type="selectionEntry">
+            <entryLink id="1c7d-3ba7-b033-2246" name="Overload Ammo" hidden="false" targetId="5de1-746b-be1f-93b1" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -187,6 +135,14 @@
                   <conditionGroups/>
                 </modifier>
               </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="7fea-bd77-d93c-a0ae" name="Leader Level (Up To 3)" hidden="false" targetId="6fc6-32a7-74b6-1b4b" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
               <constraints/>
               <categoryLinks/>
             </entryLink>
@@ -197,19 +153,19 @@
         </selectionEntry>
         <selectionEntry id="4581-2e23-0a04-b8cc" name="AI Assault Trooper" hidden="false" collective="false" type="model">
           <profiles>
-            <profile id="7dd7-204e-3f42-653d" name="AI Assault Trooper" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+            <profile id="7dd7-204e-3f42-653d" name="AI Assault Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406" profileTypeName="Model">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <characteristics>
-                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="5"/>
-                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
-                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="5"/>
-                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="6 (7)"/>
-                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="7"/>
-                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="8"/>
-                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424"/>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (7)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
               </characteristics>
             </profile>
           </profiles>
@@ -229,120 +185,88 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="8620-6d9e-b094-c795" name="Close Combat Weapon" hidden="false" collective="false" defaultSelectionEntryId="47f0-ec05-82ba-dabf">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="47f0-ec05-82ba-dabf" hidden="false" targetId="72ba-15e7-dbf7-816c" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="2c02-cbb9-e589-21a8" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="3366-c793-e3b7-e8d1">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="3366-c793-e3b7-e8d1" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+      <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="b6c9-b77c-8db6-960c" hidden="false" targetId="7ac3-5fd7-f7a8-3a01" type="selectionEntry">
+        <entryLink id="b6c9-b77c-8db6-960c" name="Plasma Grenades" hidden="false" targetId="76fa-75fa-aac0-aae1" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers>
-            <modifier type="increment" field="points" value="2.0">
+            <modifier type="increment" field="points" value="2">
               <repeats>
-                <repeat field="selections" scope="b73b-6140-e2ca-f0c1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4581-2e23-0a04-b8cc" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="2.0">
-              <repeats>
-                <repeat field="selections" scope="b73b-6140-e2ca-f0c1" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b36d-f9f6-80eb-6f8a" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="3eb9-1d22-aac0-cf42" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4581-2e23-0a04-b8cc" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="3eb9-1d22-aac0-cf42" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b36d-f9f6-80eb-6f8a" repeats="1" roundUp="false"/>
               </repeats>
               <conditions/>
               <conditionGroups/>
             </modifier>
           </modifiers>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e36c-73f8-4e87-db80" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="9320-7fb3-d40b-9284" hidden="false" targetId="502c-9855-7269-eaa2" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="20.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="5895-7a8e-8c94-2b8c" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="dd12-396f-dbfc-e1cf" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+        <entryLink id="9320-7fb3-d40b-9284" name="Medi-Drone" hidden="false" targetId="c3f0-2a1d-815e-b61a" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3803-9e67-7091-19c9" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="f223-6e88-8981-51d2" hidden="false" targetId="3af1-7df9-4f90-c12c" type="selectionEntry">
+        <entryLink id="5895-7a8e-8c94-2b8c" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0097-57fc-d610-f5f8" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="dd12-396f-dbfc-e1cf" name="Reflex Armor" hidden="false" targetId="1523-0845-c12b-4980" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0584-19d3-b10c-ac6e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2127-664c-7c11-903b" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="f223-6e88-8981-51d2" name="Synchronizer Drone" hidden="false" targetId="3b29-0c16-4aa3-aca3" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d80-5353-5907-bb66" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="03af-a986-9f2b-c513" name="Plasma Carbine" hidden="false" targetId="3877-96bf-06bb-ff8f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2661-6110-4b8e-feca" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d07-70bc-064d-2c88" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="abf4-93dc-aebd-8b11" name="D-Spinner" hidden="false" targetId="4e4f-41b5-07ab-ffcc" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de8f-7172-8272-b5d6" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf52-ab57-6169-d5cf" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
@@ -350,19 +274,29 @@
         <cost name="pts" costTypeId="points" value="69.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="5cda-2300-7dae-8090" name="AI Assault Squad" hidden="false" collective="false" type="unit">
+    <selectionEntry id="5cda-2300-7dae-8090" name="AI Assault Squad" book="Rulebook &amp; pdf force list v2" page="173" hidden="false" collective="false" type="unit">
       <profiles/>
-      <rules>
-        <rule id="0587-e7a6-cccd-a152" name="Infantry Unit" book="" hidden="false">
+      <rules/>
+      <infoLinks>
+        <infoLink id="6a25-2f98-62a7-f802" name="Infantry Unit" hidden="false" targetId="9a87-2673-83b1-3986" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-        </rule>
-      </rules>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
+        </infoLink>
+      </infoLinks>
+      <modifiers>
+        <modifier type="increment" field="98ab-0ab2-2967-f90e" value="1">
+          <repeats>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="true" childId="3eb9-1d22-aac0-cf42" repeats="31" roundUp="false"/>
+          </repeats>
+          <conditions/>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98ab-0ab2-2967-f90e" type="max"/>
+      </constraints>
       <categoryLinks>
         <categoryLink id="5cda-2300-7dae-8090-481abf13-c03e-0dd0-d520-9f9837253cbe" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
           <profiles/>
@@ -400,116 +334,39 @@
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="7bf3-7f8c-bb36-8056" name="Leader Level" hidden="false" collective="false" defaultSelectionEntryId="8bb2-13f1-ebb2-0d18">
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="3c80-7788-069b-a114" name="Leader Level (Up To 2)" hidden="false" targetId="14a9-9070-281d-b6d6" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="377d-9b43-a1cd-0a0a" name="Mag Repeater" book="" hidden="false" targetId="ada9-abf5-49da-db67" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3703-4c37-ed74-f539" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52d4-1052-badd-e065" type="max"/>
               </constraints>
               <categoryLinks/>
-              <selectionEntries>
-                <selectionEntry id="1fb7-4557-878e-29b0" name="Leader Two" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="7124-cd7f-e6ae-bab4" hidden="false" targetId="7850-89e7-bab8-86e9" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="8bb2-13f1-ebb2-0d18" name="Leader One" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="8222-a0b4-a917-311b" hidden="false" targetId="e441-c3a6-7d61-2c63" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="f6c4-adbe-a27d-129a" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="f607-640a-427e-f60b">
+            </entryLink>
+            <entryLink id="ff57-a2a5-7035-ff63" name="D-Spinner" book="" hidden="false" targetId="4e4f-41b5-07ab-ffcc" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a52-7961-9511-2b55" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fad-fa3c-e9c9-eeb8" type="max"/>
               </constraints>
               <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="f607-640a-427e-f60b" book="" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="e06e-a516-32a9-510b" name="Close Combat Weapon" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0f6-1033-78de-aecf" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a0a-c7f5-c53a-e93a" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="22b8-01a1-ff95-ff38" name="" hidden="false" targetId="72ba-15e7-dbf7-816c" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
@@ -548,97 +405,69 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="07d2-b644-beb6-a202" name="Close Combat Weapon" hidden="false" collective="false" defaultSelectionEntryId="8180-7329-3c28-309c">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="8180-7329-3c28-309c" hidden="false" targetId="72ba-15e7-dbf7-816c" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="ba41-be49-a2d8-0b1b" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="fa33-be90-9a74-eca3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="fa33-be90-9a74-eca3" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+      <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="85ac-b191-0b0d-b952" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="3142-6999-6b67-9a7a" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+        <entryLink id="85ac-b191-0b0d-b952" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa15-2ed4-a09e-18aa" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="764c-a373-c9f4-1395" hidden="false" targetId="1b16-412b-662a-5467" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="15.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="13aa-e20e-c8eb-40a4" hidden="false" targetId="3af1-7df9-4f90-c12c" type="selectionEntry">
+        <entryLink id="3142-6999-6b67-9a7a" name="Reflex Armor" hidden="false" targetId="1523-0845-c12b-4980" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="81b8-f516-85fc-0d45" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f543-2d87-8dba-ddc6" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="13aa-e20e-c8eb-40a4" name="Synchronizer Drone" hidden="false" targetId="3b29-0c16-4aa3-aca3" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c0d-8ad4-2d8f-b361" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="b393-ca96-e728-1193" name="D-Spinner" book="" hidden="false" targetId="4e4f-41b5-07ab-ffcc" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eddd-0c69-4a83-1827" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90c5-2553-0369-3fa4" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="ed6a-8275-f862-77ff" name="Mag Repeater" book="" hidden="false" targetId="ada9-abf5-49da-db67" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e106-b673-5e1d-2ebd" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="174d-df01-b3c5-1e27" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="a638-cdab-f52e-be12" name="Homer Drone" hidden="false" targetId="f0a7-4c49-aa22-ba0d" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7734-869b-4898-0851" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
@@ -646,211 +475,45 @@
         <cost name="pts" costTypeId="points" value="32.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="04d7-b8fa-d20d-5a98" name="Avenger Attack Skimmer" hidden="false" collective="false" type="unit">
-      <profiles/>
-      <rules>
-        <rule id="3282-4fa8-4571-f511" name="Vehicle Unit" hidden="false">
+    <selectionEntry id="8e96-907a-4420-b86b" name="Bastion Heavy Combat Skimmer" book="Rulebook &amp; pdf force list v2" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="05b7-f3b4-9c1d-0870" name="Bastion Heavy Combat Skimmer" hidden="false" profileTypeId="1650-77b3-10d1-6406" profileTypeName="Model">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-        </rule>
-      </rules>
+          <characteristics>
+            <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+            <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+            <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+            <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="15"/>
+            <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+            <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+            <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value=""/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
       <infoLinks>
-        <infoLink id="b3ea-1e90-ad90-ee02" hidden="false" targetId="5565-ce10-1c78-1ee7" type="rule">
+        <infoLink id="c33c-1c39-2527-ed08" name="MOD3" hidden="false" targetId="3297-97ec-8602-752c" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="48a7-1194-3630-6d90" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+        <infoLink id="a501-c7f3-fa66-a68e" name="Large" hidden="false" targetId="59d7-7273-b97c-0dff" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="04d7-b8fa-d20d-5a98-5c47879b-41d0-1383-5fe5-a5989615db89" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="c30a-e7b6-bb84-7bb5" name="AI Avenger Skimmer" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="bab1-4391-32c8-71c1" name="AI Avenger Skimmer" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="f214-abe8-c922-c51b" value="1">
-                  <repeats>
-                    <repeat field="selections" scope="04d7-b8fa-d20d-5a98" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d788-9457-e43f-3692" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <characteristics>
-                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
-                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
-                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="11"/>
-                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
-                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="c647-b28b-df13-6d30" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="4c83-fe4e-babc-141c">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="4c83-fe4e-babc-141c" name="Mag Light Support" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="a15c-d3b9-b787-53f8" name="Twin Mag Light Support" hidden="false" targetId="ac1e-a740-57b7-cc64" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="increment" field="points" value="25">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="0977-b38c-36c4-0e4d" name="Mag Cannon" hidden="false" targetId="6a2b-50c5-9a33-b756" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="increment" field="points" value="10">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="d788-9457-e43f-3692" name="HL Booster (adds +1 res)" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="24.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks>
-        <entryLink id="77a4-a25f-8f3d-ddd5" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="fad5-611a-6a4f-5232" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="20.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="128.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="8e96-907a-4420-b86b" name="Bastion Heavy Combat Skimmer" hidden="false" collective="false" type="unit">
-      <profiles/>
-      <rules>
-        <rule id="fd56-a7ac-05bb-f09d" name="Vehicle Unit" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-      </rules>
-      <infoLinks>
-        <infoLink id="c33c-1c39-2527-ed08" hidden="false" targetId="8151-2e24-94ee-0477" type="rule">
+        <infoLink id="fbc9-aa13-ad9a-0d47" name="Slow" hidden="false" targetId="04bc-743b-092f-8c3a" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="a501-c7f3-fa66-a68e" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="fbc9-aa13-ad9a-0d47" hidden="false" targetId="7c88-64d4-50ad-2313" type="rule">
+        <infoLink id="99fd-04d0-3bae-9ea1" name="Vehicle Unit" hidden="false" targetId="29d8-590a-bc46-d27a" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -869,62 +532,57 @@
         </categoryLink>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="632e-ffdc-3914-61fd" name="Heavy Combat Skimmer" hidden="false" collective="false" type="model">
-          <profiles>
-            <profile id="15cb-1690-7486-ff16" name="Heavy Combat Skimmer" book="BtGoA" page="177" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+        <selectionEntry id="e7bb-38cd-60f1-d00a" name="Self-repair" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="ea04-a869-16aa-e442" name="Self Repair" hidden="false" targetId="7c54-5982-a5ef-b888" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <characteristics>
-                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
-                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
-                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="15"/>
-                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
-                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="160b-1206-7540-f9e8" name="Weapon Options" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ddb2-b1e8-5438-9c34" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26b7-b55b-0434-ad5f" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
           <selectionEntryGroups>
-            <selectionEntryGroup id="838e-15d8-5642-5e1d" name="Weapon 2" hidden="false" collective="false" defaultSelectionEntryId="c5f6-8957-d653-74bc">
+            <selectionEntryGroup id="4b1a-2d65-10c8-a630" name="Weapon 1" hidden="false" collective="false" defaultSelectionEntryId="9a30-6d5d-7e3f-3f2f">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a891-e572-0618-ce11" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cfd6-d809-20f5-9c62" type="max"/>
               </constraints>
               <categoryLinks/>
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="3185-11b1-845c-6d8c" name="Plasma Light Support" hidden="false" targetId="cf3a-e6a9-bdc0-e0ae" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="increment" field="points" value="20">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="a832-43c3-1367-a986" name="Twin Mag Light Support" hidden="false" targetId="ac1e-a740-57b7-cc64" type="selectionEntry">
+                <entryLink id="557e-aaf8-d135-63fd" name="Twin Mag Light Support" hidden="false" targetId="b065-9dee-2444-0546" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -938,7 +596,7 @@
                   <constraints/>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="c5f6-8957-d653-74bc" name="Mag Light Support" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
+                <entryLink id="9a30-6d5d-7e3f-3f2f" name="Mag Light Support" hidden="false" targetId="8e77-f151-c27d-0eb0" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -946,22 +604,36 @@
                   <constraints/>
                   <categoryLinks/>
                 </entryLink>
+                <entryLink id="3c77-6ca9-e850-dee3" name="Plasma Light Support" hidden="false" targetId="eaa4-a3c1-d269-d3cb" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="20">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="904b-239e-b811-6062" name="Weapon 1" hidden="false" collective="false" defaultSelectionEntryId="6195-3bcc-f9b1-0807">
+            <selectionEntryGroup id="113b-e474-94d6-35d4" name="Weapon 2" hidden="false" collective="false" defaultSelectionEntryId="73cc-93bf-097e-80ac">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3fec-78ac-c1ad-2447" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5e3c-0fb8-f613-e89b" type="max"/>
               </constraints>
               <categoryLinks/>
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="6195-3bcc-f9b1-0807" name="Heavy Mag Cannon" hidden="false" targetId="5149-5183-64d5-feaf" type="selectionEntry">
+                <entryLink id="73cc-93bf-097e-80ac" name="Heavy Mag Cannon" hidden="false" targetId="5142-d68f-1b75-482e" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -973,147 +645,78 @@
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="e7bb-38cd-60f1-d00a" name="Self-repair" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="ea04-a869-16aa-e442" hidden="false" targetId="3377-9408-33bb-6a02" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="312b-43f9-e3f0-11f4" name="Batter Drone" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="20">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f649-ef3c-590d-b025" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="eedc-e2bb-4f36-19ca" name="Shield Drone" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0d7-5dc2-8e17-6aa9" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="6a05-cc97-fb38-b09a" name="Spotter Drone" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff7d-457c-abb0-a5e6" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="b7cf-d031-b4af-a0fb" name="Spotter Drone" hidden="false" collective="false" defaultSelectionEntryId="ed14-1b82-dde1-a5fb">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="ed14-1b82-dde1-a5fb" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks/>
+      <entryLinks>
+        <entryLink id="d9b9-d2cb-c6bf-4e40" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="points" value="0.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9a0-5191-3aec-e213" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9647-82ca-c43a-4b88" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="4e45-d214-1f87-d484" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f21-b423-c6b6-1437" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="c4e7-cca7-b16f-961d" name="Shield Drone" hidden="false" targetId="81b9-02e2-63b6-9c6e" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5267-a1e5-b86f-5fc7" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="8ff3-2601-3f96-2d32" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ca5-df97-5fce-3377" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="388.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1405-a43b-534b-ab05" name="AI Command Squad" book="BtGoA" page="172" hidden="false" collective="false" type="unit">
+    <selectionEntry id="1405-a43b-534b-ab05" name="AI Command Squad" book="Rulebook &amp; pdf force list v2" page="172" hidden="false" collective="false" type="unit">
       <profiles/>
-      <rules>
-        <rule id="b2d5-107a-301c-db27" name="Limited Choice" book="" hidden="false">
+      <rules/>
+      <infoLinks>
+        <infoLink id="31b0-6447-8642-f0bf" name="Limited Choice" hidden="false" targetId="8cb3-4c3e-dc5f-b952" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-        </rule>
-        <rule id="05ad-d2b8-2f3f-67e1" name="Infantry Command Unit" book="" hidden="false">
+        </infoLink>
+        <infoLink id="42dd-6a65-f204-d60b" name="Infantry Command" hidden="false" targetId="0a6b-dcfb-ccc3-6a0d" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-        </rule>
-      </rules>
-      <infoLinks/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
       <constraints/>
       <categoryLinks>
@@ -1124,35 +727,42 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="2290-8677-1a0c-8bb9" name="New CategoryLink" hidden="false" targetId="c87d-5261-face-4643" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="9d5a-e373-e211-b23f" name="AI Commander" hidden="false" collective="false" type="model">
           <profiles>
-            <profile id="39d5-3220-e21e-4db1" name="AI Commander" book="BtGoA" page="172" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+            <profile id="39d5-3220-e21e-4db1" name="AI Commander" book="" page="" hidden="false" profileTypeId="1650-77b3-10d1-6406" profileTypeName="Model">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <characteristics>
-                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="5"/>
-                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
-                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="5"/>
-                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="6 (7)"/>
-                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="7"/>
-                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="9"/>
-                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424"/>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (7)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
               </characteristics>
             </profile>
           </profiles>
           <rules/>
           <infoLinks>
-            <infoLink id="8602-3bc3-a97f-da4e" hidden="false" targetId="5c9b-1bde-ee01-04a4" type="rule">
+            <infoLink id="8602-3bc3-a97f-da4e" name="Command" hidden="false" targetId="f001-a3be-81f7-f74f" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
             </infoLink>
-            <infoLink id="3252-b423-64d9-9d6b" hidden="false" targetId="7bc9-5e98-2914-5abd" type="rule">
+            <infoLink id="3252-b423-64d9-9d6b" name="Follow" hidden="false" targetId="4bdd-65b7-6ee8-89b2" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -1167,83 +777,44 @@
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups>
-            <selectionEntryGroup id="630f-9d3c-aa03-5c21" name="Leader Level" hidden="false" collective="false" defaultSelectionEntryId="a337-bb3b-7f63-a07d">
+            <selectionEntryGroup id="92e0-86d6-3743-6a80" name="Specialist Ammo" hidden="false" collective="false">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries>
-                <selectionEntry id="a337-bb3b-7f63-a07d" name="Leader Two" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="6ac6-af14-69ac-df2e" hidden="false" targetId="7850-89e7-bab8-86e9" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="d566-c736-730d-469f" name="Leader Three" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="b069-cf74-6fac-ccf1" hidden="false" targetId="05bb-4d34-70cd-25d2" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="52a6-3ce8-252c-c409" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="6ed7-4c98-cab0-baca">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c206-cf1f-b457-3560" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7cf-acfa-cd56-afba" type="max"/>
               </constraints>
               <categoryLinks/>
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="6ed7-4c98-cab0-baca" hidden="false" targetId="b08e-548a-fda7-0a4e" type="selectionEntry">
+                <entryLink id="8617-bbba-0d8c-347f" name="SlingNet Ammo" hidden="false" targetId="6849-c480-4332-7ffc" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
-                  <modifiers/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="5.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="bdfd-c8a8-54c4-3269" name="Overload Ammo" hidden="false" targetId="5de1-746b-be1f-93b1" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="5.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
                   <constraints/>
                   <categoryLinks/>
                 </entryLink>
@@ -1251,32 +822,45 @@
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="cf1c-44f1-6657-cd52" hidden="false" targetId="8de3-1e72-72ef-e7a3" type="selectionEntry">
+            <entryLink id="b5d2-d265-c2c2-f71b" name="X-Sling" hidden="false" targetId="e629-3c26-9e22-f80b" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3430-b2a1-0311-76a6" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="64cf-975c-62c9-33fd" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="5144-ac9e-6960-fb80" name="Leader Level (Up To 3)" hidden="false" targetId="6fc6-32a7-74b6-1b4b" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="1fd5-10fc-1961-7c0e" hidden="false" targetId="6b54-c223-3c4a-5de7" type="selectionEntry">
+            <entryLink id="25c3-1435-44d6-d91f" name="Plasma Carbine" hidden="false" targetId="3877-96bf-06bb-ff8f" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99f1-033b-0dfd-6a6a" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="999a-3ea0-8fe5-13a9" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="f408-a2e1-4be2-5bd8" name="Reflex Armor" hidden="false" targetId="1523-0845-c12b-4980" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="59ae-18b0-9877-568d" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c754-201f-64ea-8ffc" type="max"/>
+              </constraints>
               <categoryLinks/>
             </entryLink>
           </entryLinks>
@@ -1286,19 +870,19 @@
         </selectionEntry>
         <selectionEntry id="6f86-347f-273f-84ca" name="AI Trooper" hidden="false" collective="false" type="model">
           <profiles>
-            <profile id="c89a-7590-da72-6fef" name="AI Trooper" book="BtGoA" page="172" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+            <profile id="c89a-7590-da72-6fef" name="AI Trooper" book="" page="" hidden="false" profileTypeId="1650-77b3-10d1-6406" profileTypeName="Model">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <characteristics>
-                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="5"/>
-                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
-                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="5"/>
-                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="6 (7)"/>
-                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="7"/>
-                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="8"/>
-                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424"/>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (7)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
               </characteristics>
             </profile>
           </profiles>
@@ -1312,101 +896,84 @@
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="f571-727c-7f72-c63a" name="Reflex Armor" hidden="false" targetId="1523-0845-c12b-4980" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bf8-f723-8419-fc8a" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea3b-cc72-0c6a-4b25" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="ed78-b21e-c06e-dbf7" name="Plasma Carbine" hidden="false" targetId="3877-96bf-06bb-ff8f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8f8-4ae0-efdd-d5c1" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07de-4f71-1999-8430" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="pts" costTypeId="points" value="20.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="6a2d-6157-812a-f7fb" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="65c3-8209-8f2a-270d">
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="5adb-71d8-e2d3-99fd" name="Plasma Grenades" hidden="false" targetId="76fa-75fa-aac0-aae1" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="2">
+              <repeats>
+                <repeat field="selections" scope="1405-a43b-534b-ab05" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6f86-347f-273f-84ca" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="1405-a43b-534b-ab05" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9d5a-e373-e211-b23f" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39f3-b458-faf0-465e" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="32bd-d9c2-5ebd-a3d2" name="Medi-Drone" hidden="false" targetId="c3f0-2a1d-815e-b61a" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82c0-5373-82a5-f8df" type="max"/>
           </constraints>
           <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="65c3-8209-8f2a-270d" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="5adb-71d8-e2d3-99fd" name="" hidden="false" targetId="7ac3-5fd7-f7a8-3a01" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="2.0">
-              <repeats>
-                <repeat field="selections" scope="1405-a43b-534b-ab05" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6f86-347f-273f-84ca" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="2.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints/>
-          <categoryLinks/>
         </entryLink>
-        <entryLink id="32bd-d9c2-5ebd-a3d2" hidden="false" targetId="502c-9855-7269-eaa2" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="20.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="61bb-6fc6-c633-8420" name="Spotter Drone" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="6b0e-52a5-ac46-3630" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+        <entryLink id="61bb-6fc6-c633-8420" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a79f-cb6f-1bed-3e7d" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="9ee7-2ebf-4786-f817" hidden="false" targetId="3af1-7df9-4f90-c12c" type="selectionEntry">
+        <entryLink id="9ee7-2ebf-4786-f817" name="Synchronizer Drone" hidden="false" targetId="3b29-0c16-4aa3-aca3" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0630-34f0-0c64-4c94" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
@@ -1414,27 +981,36 @@
         <cost name="pts" costTypeId="points" value="64.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2c84-d60c-787a-53bf" name="AI Command Squad - General Tar Es Janar" book="BtGoA" page="172" hidden="false" collective="false" type="unit">
+    <selectionEntry id="2c84-d60c-787a-53bf" name="AI Command Squad - General Tar Es Janar" book="Rulebook" page="172, 220-221" hidden="false" collective="false" type="unit">
       <profiles/>
-      <rules>
-        <rule id="6eaf-e8a3-9c82-8a79" name="Limited Choice" book="" hidden="false">
+      <rules/>
+      <infoLinks>
+        <infoLink id="b4b2-de34-f3e9-3e70" name="Infantry Command Unit" hidden="false" targetId="0a6b-dcfb-ccc3-6a0d" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-        </rule>
-        <rule id="e3b0-fd02-8fe9-9236" name="Infantry Command Unit" book="" hidden="false">
+        </infoLink>
+        <infoLink id="d7b2-44b5-7b57-190b" name="Limited Choice" hidden="false" targetId="8cb3-4c3e-dc5f-b952" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-        </rule>
-      </rules>
-      <infoLinks/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e2a-8af2-ecab-9e0c" type="max"/>
+      </constraints>
       <categoryLinks>
         <categoryLink id="2c84-d60c-787a-53bf-481abf13-c03e-0dd0-d520-9f9837253cbe" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="5027-70c8-60c6-fc82" name="New CategoryLink" hidden="false" targetId="c87d-5261-face-4643" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1445,24 +1021,55 @@
       <selectionEntries>
         <selectionEntry id="9ba6-ad89-b106-ccdf" name="General Tar Es Janar" hidden="false" collective="false" type="model">
           <profiles>
-            <profile id="e684-e721-4d5b-8160" name="General Tar Es Janar" book="BtGoA" page="221" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+            <profile id="e684-e721-4d5b-8160" name="General Tar Es Janar" book="" page="" hidden="false" profileTypeId="1650-77b3-10d1-6406" profileTypeName="Model">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <characteristics>
-                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="5"/>
-                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
-                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="5"/>
-                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="6 (7)"/>
-                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="8"/>
-                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="10"/>
-                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424"/>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (7)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="10"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
               </characteristics>
             </profile>
           </profiles>
           <rules/>
-          <infoLinks/>
+          <infoLinks>
+            <infoLink id="bbd8-9192-e380-2ef6" name="Command" hidden="false" targetId="f001-a3be-81f7-f74f" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="2ee1-575d-72ff-e816" name="Leader 3" hidden="false" targetId="ce3b-c908-3ded-7a49" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="a595-835d-b6c4-9fc7" name="Follow" hidden="false" targetId="4bdd-65b7-6ee8-89b2" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="02c2-b2c2-bb7f-be01" name="Strategic Genius" hidden="false" targetId="33cb-3828-44a5-e63f" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="74b1-ab32-3c54-9fb2" name="Wound" hidden="false" targetId="98a7-475a-f0ed-fa91" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
           <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
@@ -1470,33 +1077,9 @@
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="3e7b-f325-9d1c-8a70" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="d809-f3a9-13a3-d6e8">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="d809-f3a9-13a3-d6e8" hidden="false" targetId="e6db-6ed3-1a26-ea56" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
+          <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="a8b9-0454-3df1-671f" hidden="false" targetId="67fa-a913-bd09-5b13" type="selectionEntry">
+            <entryLink id="a8b9-0454-3df1-671f" name="Vertex Mace KEEP" hidden="false" targetId="67fa-a913-bd09-5b13" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -1504,12 +1087,37 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="5754-6af9-f502-5a10" hidden="false" targetId="9cab-babb-fd75-a302" type="selectionEntry">
+            <entryLink id="db7a-7058-35f9-9f63" name="Plasma Pistol" hidden="false" targetId="9851-4076-e2e9-3df8" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e17-993e-8311-aa43" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f7a-7ec5-4b21-7616" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="e54e-5e20-f138-d4ee" name="Reflex Armor" hidden="false" targetId="1523-0845-c12b-4980" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4703-97b4-c21d-2c81" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="79ec-a7f2-ac93-d022" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="b95e-4ab8-c750-97f7" name="Impact Cloak" hidden="false" targetId="811c-8623-5489-9ee0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6650-18ff-ba07-3760" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc26-6ee1-316e-adef" type="min"/>
+              </constraints>
               <categoryLinks/>
             </entryLink>
           </entryLinks>
@@ -1519,19 +1127,19 @@
         </selectionEntry>
         <selectionEntry id="f3ea-9f2c-c96a-7aa5" name="AI Trooper" hidden="false" collective="false" type="model">
           <profiles>
-            <profile id="5484-f1a2-ada9-fb48" name="AI Trooper" book="BtGoA" page="172" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+            <profile id="5484-f1a2-ada9-fb48" name="AI Trooper" book="" page="" hidden="false" profileTypeId="1650-77b3-10d1-6406" profileTypeName="Model">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <characteristics>
-                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="5"/>
-                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
-                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="5"/>
-                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="6 (7)"/>
-                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="7"/>
-                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="8"/>
-                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424"/>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (7)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
               </characteristics>
             </profile>
           </profiles>
@@ -1544,44 +1152,43 @@
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="cf6d-3d20-1ccf-560a" name="Reflex Armor" hidden="false" targetId="1523-0845-c12b-4980" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="56fe-7cb4-7003-eab8" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="944e-d741-48e1-adea" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="0bb1-1377-9516-efbb" name="Plasma Carbine" hidden="false" targetId="3877-96bf-06bb-ff8f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5701-740b-ff49-3a07" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e857-1c0b-35e2-6ec4" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="pts" costTypeId="points" value="20.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="a5ce-7f12-9d34-2772" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="8d72-d6d9-9cc7-15ef">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="8d72-d6d9-9cc7-15ef" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+      <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="e392-c338-4e8f-b800" hidden="false" targetId="7ac3-5fd7-f7a8-3a01" type="selectionEntry">
+        <entryLink id="e392-c338-4e8f-b800" name="Plasma Grenades" hidden="false" targetId="76fa-75fa-aac0-aae1" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers>
-            <modifier type="increment" field="points" value="2.0">
+            <modifier type="increment" field="points" value="2">
               <repeats>
                 <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="f3ea-9f2c-c96a-7aa5" repeats="1" roundUp="false"/>
               </repeats>
@@ -1594,29 +1201,19 @@
               <conditionGroups/>
             </modifier>
           </modifiers>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="263e-d97d-47fa-660c" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="e8cc-b606-0691-7064" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="e0a0-b333-4df7-b100" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+        <entryLink id="e8cc-b606-0691-7064" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3bc6-2074-cc1f-c4e5" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
@@ -1624,40 +1221,87 @@
         <cost name="pts" costTypeId="points" value="105.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="cdfd-7d13-efd0-6540" name="Defiant Transport Skimmer" book="BtGoA" page="176" hidden="false" collective="false" type="unit">
-      <profiles/>
-      <rules>
-        <rule id="5dd0-14ba-f6df-3805" name="Vehicle Unit" hidden="false">
+    <selectionEntry id="cdfd-7d13-efd0-6540" name="Defiant Transport Skimmer (Support)" book="Rulebook &amp; pdf force list v2" page="176" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="98f3-e29c-9850-7b76" name="AI Defiant Transport Skimmer" book="" page="" hidden="false" profileTypeId="5f97-84dc-4c56-bbe5" profileTypeName="Transport">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
-        </rule>
-      </rules>
+          <modifiers>
+            <modifier type="set" field="0b84-3b60-5c7d-efa5" value="12">
+              <repeats>
+                <repeat field="selections" scope="cdfd-7d13-efd0-6540" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e2b3-c29f-0173-df73" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="0b84-3b60-5c7d-efa5" value="13">
+              <repeats>
+                <repeat field="selections" scope="cdfd-7d13-efd0-6540" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="57b7-f709-954d-2379" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Ag" characteristicTypeId="43b0-b2e6-6e84-43b5" value="5"/>
+            <characteristic name="Acc" characteristicTypeId="4f48-ad72-be82-1bf7" value="6"/>
+            <characteristic name="Str" characteristicTypeId="e341-f364-940e-4b44" value="1"/>
+            <characteristic name="Res" characteristicTypeId="0b84-3b60-5c7d-efa5" value="11"/>
+            <characteristic name="Init" characteristicTypeId="ef5f-c702-c74a-236d" value="8"/>
+            <characteristic name="Co" characteristicTypeId="c1ac-eacd-b766-3931" value="8"/>
+            <characteristic name="Transport Capacity" characteristicTypeId="28cd-349f-14f4-0e36" value="10"/>
+            <characteristic name="Special" characteristicTypeId="68b5-aa47-fdb5-1640"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
       <infoLinks>
-        <infoLink id="4f72-dd3a-c2e4-f2f6" hidden="false" targetId="5565-ce10-1c78-1ee7" type="rule">
+        <infoLink id="4f72-dd3a-c2e4-f2f6" name="MOD2" hidden="false" targetId="88ae-fedb-5c1c-3a7b" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="da13-89f6-1936-7777" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+        <infoLink id="da13-89f6-1936-7777" name="Large" hidden="false" targetId="59d7-7273-b97c-0dff" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="7260-678e-004e-ec18" hidden="false" targetId="ab37-33d8-41f3-7532" type="rule">
+        <infoLink id="7260-678e-004e-ec18" name="Transport 10" hidden="false" targetId="8509-6fcc-0fc0-21ae" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6605-8dca-8bfc-0497" name="Vehicle Unit" hidden="false" targetId="29d8-590a-bc46-d27a" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
+      <modifiers>
+        <modifier type="increment" field="03e1-db47-7024-6b22" value="1">
+          <repeats>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="3eb9-1d22-aac0-cf42" repeats="1" roundUp="false"/>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="5cda-2300-7dae-8090" repeats="1" roundUp="false"/>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="1405-a43b-534b-ab05" repeats="1" roundUp="false"/>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="40ad-08b6-fa6a-0171" repeats="1" roundUp="false"/>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="a44f-4447-aff2-0dcd" repeats="1" roundUp="false"/>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c84-d60c-787a-53bf" repeats="1" roundUp="false"/>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5b80-c0ed-2c5c-3adc" repeats="1" roundUp="false"/>
+          </repeats>
+          <conditions/>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03e1-db47-7024-6b22" type="max"/>
+      </constraints>
       <categoryLinks>
-        <categoryLink id="cdfd-7d13-efd0-6540-a01f5f58-334c-8442-d861-15099ebdf5e5" hidden="false" targetId="a01f5f58-334c-8442-d861-15099ebdf5e5" primary="true">
+        <categoryLink id="8dd3-4b6e-4b1a-59a8" name="New CategoryLink" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1666,68 +1310,11 @@
         </categoryLink>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="ae68-51cd-72e4-7d16" name="Transport Skimmer" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="52eb-0d0b-7f7a-ceb5" name="AI Defiant Transport Skimmer" book="BtGoA" page="176" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
-                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
-                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="13"/>
-                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
-                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="15aa-6cbb-cf07-cc0d" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="9f00-29c6-1215-a78c">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="9f00-29c6-1215-a78c" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
         <selectionEntry id="2cb5-9676-7408-1e67" name="Self Repair" hidden="false" collective="false" type="upgrade">
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="828c-1127-983a-c4ea" name="Self Repair" hidden="false" targetId="3377-9408-33bb-6a02" type="rule">
+            <infoLink id="828c-1127-983a-c4ea" name="Self Repair" hidden="false" targetId="7c54-5982-a5ef-b888" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -1741,215 +1328,6 @@
               <conditionGroups/>
             </modifier>
           </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="f268-d13f-731f-5a57" name="Shield Drone" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="237c-0c18-b83b-9dfd" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks>
-        <entryLink id="646a-6f39-6651-8108" name="Spotter Drone" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ccb0-6272-6f80-4ae8" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="b8ef-dcef-9393-5153" name="Batter Drone" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="20">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dacb-2408-c62d-c561" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="174.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="c921-cfbe-51c6-44f8" name="AI Heavy Support Team" book="BtGoA" page="176" hidden="false" collective="false" type="unit">
-      <profiles>
-        <profile id="7202-783f-fe86-4d0a" name="AI Trooper Crew" book="BtGoA" page="176" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-            <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
-            <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
-            <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (7)"/>
-            <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
-            <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-            <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules>
-        <rule id="75c1-4b49-0793-db9e" name="Weapon Team Unit" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-      </rules>
-      <infoLinks>
-        <infoLink id="e2a2-f0ce-1b55-1a05" name="Large" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="c921-cfbe-51c6-44f8-a01f5f58-334c-8442-d861-15099ebdf5e5" hidden="false" targetId="a01f5f58-334c-8442-d861-15099ebdf5e5" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="eba4-0d79-41b8-1568" name="AI Trooper Crew" hidden="false" collective="false" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="4760-495f-6534-ada3" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="be3f-4e32-9b54-3fff">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="0636-a911-f505-3eb8" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="be3f-4e32-9b54-3fff" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="e68a-5d99-1837-00bf" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks>
-            <entryLink id="a84d-a071-f48f-33ab" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="14.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="9044-f681-7df2-2217" name="Promote one crew member to Leader" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="2f85-136a-da3c-3dc1" hidden="false" targetId="e441-c3a6-7d61-2c63" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
           </constraints>
@@ -1963,25 +1341,25 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="c5a0-5915-45d9-3ebc" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="a41c-198c-6e6b-9630">
+        <selectionEntryGroup id="aad4-8cbe-7635-eb22" name="Weapon" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9a65-12b9-de9c-2aa9" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9600-6b5d-8d36-dd15" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="c9f2-2169-2f1e-3e18" hidden="false" targetId="9733-7039-e306-26b5" type="selectionEntry">
+            <entryLink id="cb3c-1084-ad21-fe5c" name="Mag Light Support" hidden="false" targetId="8e77-f151-c27d-0eb0" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="points" value="10.0">
+                <modifier type="increment" field="points" value="20">
                   <repeats/>
                   <conditions/>
                   <conditionGroups/>
@@ -1990,12 +1368,12 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="cdf4-eed0-f3d7-f3ce" name="X-Howitzer" hidden="false" targetId="b9f1-a313-3e59-57ab" type="selectionEntry">
+            <entryLink id="b90c-35ee-0079-6bcd" name="Mag Cannon" hidden="false" targetId="eec6-9dbc-8db5-5a96" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers>
-                <modifier type="increment" field="points" value="10.0">
+                <modifier type="increment" field="points" value="30">
                   <repeats/>
                   <conditions/>
                   <conditionGroups/>
@@ -2004,42 +1382,60 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="a41c-198c-6e6b-9630" hidden="false" targetId="cea7-8511-2208-1b1f" type="selectionEntry">
+            <entryLink id="75d0-c56a-ea5b-692a" name="Twin Mag Light Support" hidden="false" targetId="b065-9dee-2444-0546" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="1dd0-b0d7-ca04-2982" name="Heavy Mag Cannon" hidden="false" targetId="5149-5183-64d5-feaf" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
+              <modifiers>
+                <modifier type="increment" field="points" value="45">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
               <constraints/>
               <categoryLinks/>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="46ac-8536-740b-1631" name="Spotter Drone" hidden="false" collective="false" defaultSelectionEntryId="dae2-19d0-0b13-21d4">
+        <selectionEntryGroup id="632e-d8ff-dd50-ea92" name="Armour Upgrades" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="41cd-7c49-4c7d-ca5d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="04c1-1aca-1ace-460f" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="dae2-19d0-0b13-21d4" name="Spotter Drone" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+            <entryLink id="e2b3-c29f-0173-df73" name="HL Booster" hidden="false" targetId="6c89-65f8-fa8e-7131" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers/>
+              <modifiers>
+                <modifier type="increment" field="points" value="24">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="57b7-f709-954d-2379" name="Fixed-Emission Armour Upgrade" hidden="false" targetId="2836-8f7f-68e6-1ac0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="48">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
               <constraints/>
               <categoryLinks/>
             </entryLink>
@@ -2047,44 +1443,52 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="d0c6-69c7-03f7-6e2c" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+        <entryLink id="646a-6f39-6651-8108" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5708-fe90-0f88-49f3" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="cca7-6248-d4d1-89fb" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+        <entryLink id="b8ef-dcef-9393-5153" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="20.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58ed-7f7d-ddca-cc4c" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="d907-3ae5-bdea-0542" name="Shield Drone" hidden="false" targetId="81b9-02e2-63b6-9c6e" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="449e-dc22-c5fe-a466" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="55.0"/>
+        <cost name="pts" costTypeId="points" value="106.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="40ad-08b6-fa6a-0171" name="AI Infiltration Squad" book="BtGoA" page="174" hidden="false" collective="false" type="unit">
+    <selectionEntry id="40ad-08b6-fa6a-0171" name="AI Infiltration Squad" book="Rulebook &amp; pdf force list v2" page="174" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules/>
       <infoLinks>
-        <infoLink id="478c-3cc9-275f-7eac" hidden="false" targetId="96c4-7a43-2a4c-d7d3" type="rule">
+        <infoLink id="478c-3cc9-275f-7eac" name="Infiltrator" hidden="false" targetId="1646-967d-a579-e0c9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="c955-a792-ae98-66fd" name="Infantry Unit" hidden="false" targetId="9a87-2673-83b1-3986" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2105,7 +1509,7 @@
       <selectionEntries>
         <selectionEntry id="c3fa-7787-a4d1-50f8" name="AI Infiltration Leader" hidden="false" collective="false" type="model">
           <profiles>
-            <profile id="fd6a-ddcd-7bd1-baf2" name="AI Infiltration Leader" book="BtGoA" page="174" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+            <profile id="fd6a-ddcd-7bd1-baf2" name="AI Infiltration Leader" book="" page="" hidden="false" profileTypeId="1650-77b3-10d1-6406">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -2131,68 +1535,7 @@
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups>
-            <selectionEntryGroup id="189f-239f-cc54-f496" name="Leader Level" hidden="false" collective="false" defaultSelectionEntryId="6d3e-ba32-c035-533f">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries>
-                <selectionEntry id="6d3e-ba32-c035-533f" name="Leader One" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="3c69-4c06-1da1-77d4" hidden="false" targetId="e441-c3a6-7d61-2c63" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="6cd8-052e-b9da-e94e" name="Leader Two" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="f2ac-6316-75a8-0504" hidden="false" targetId="7850-89e7-bab8-86e9" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="f5ed-8cd5-154e-1987" name="Ranged Weapon 1" hidden="false" collective="false" defaultSelectionEntryId="5c28-c516-b9ce-5802">
+            <selectionEntryGroup id="f5ed-8cd5-154e-1987" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="5c28-c516-b9ce-5802">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -2205,7 +1548,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="5c28-c516-b9ce-5802" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+                <entryLink id="5c28-c516-b9ce-5802" name="Mag Pistol" hidden="false" targetId="32dd-05fd-f75b-81ee" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -2213,7 +1556,7 @@
                   <constraints/>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="a317-28d4-96e1-cd44" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
+                <entryLink id="a317-28d4-96e1-cd44" name="Mag Repeater" hidden="false" targetId="ada9-abf5-49da-db67" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -2229,24 +1572,44 @@
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="5601-2930-b7cc-3680" name="Ranged Weapon 2" hidden="false" collective="false" defaultSelectionEntryId="a4e2-f9bc-7f43-1bec">
+            <selectionEntryGroup id="fecd-3e50-0fb8-b00b" name="Specialist Ammo" hidden="false" collective="false">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ea7-54d1-c420-8bdb" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e34-43fa-3f7d-05de" type="max"/>
               </constraints>
               <categoryLinks/>
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="a4e2-f9bc-7f43-1bec" hidden="false" targetId="b08e-548a-fda7-0a4e" type="selectionEntry">
+                <entryLink id="56b0-11eb-714c-bc5e" name="Overload Ammo" hidden="false" targetId="5de1-746b-be1f-93b1" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
-                  <modifiers/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="5.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="e21a-e169-1422-4e77" name="SlingNet Ammo" hidden="false" targetId="6849-c480-4332-7ffc" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="5.0">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
                   <constraints/>
                   <categoryLinks/>
                 </entryLink>
@@ -2254,32 +1617,23 @@
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="db1e-2f71-fc74-8619" hidden="false" targetId="6b54-c223-3c4a-5de7" type="selectionEntry">
+            <entryLink id="fa48-bbf8-eec3-3a0f" name="Leader Level (Up To 2)" hidden="false" targetId="14a9-9070-281d-b6d6" type="selectionEntryGroup">
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
+              <modifiers/>
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="dbcb-5feb-24da-acaf" hidden="false" targetId="8de3-1e72-72ef-e7a3" type="selectionEntry">
+            <entryLink id="d1c9-9247-b9d4-9822" name="X-Sling" hidden="false" targetId="e629-3c26-9e22-f80b" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07e1-cf0f-94c5-580b" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c75f-f8c0-b716-b91c" type="max"/>
+              </constraints>
               <categoryLinks/>
             </entryLink>
           </entryLinks>
@@ -2289,7 +1643,7 @@
         </selectionEntry>
         <selectionEntry id="97e8-d8ef-1bec-906d" name="AI Infiltration Trooper" hidden="false" collective="false" type="model">
           <profiles>
-            <profile id="c30e-c14d-871a-7b22" name="AI Infiltration Trooper" book="BtGoA" page="17" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+            <profile id="c30e-c14d-871a-7b22" name="AI Infiltration Trooper" book="" page="" hidden="false" profileTypeId="1650-77b3-10d1-6406">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -2321,56 +1675,9 @@
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="6250-ec69-9b1a-177f" name="Spotter Drone" hidden="false" collective="false" defaultSelectionEntryId="5e81-802d-021d-5a05">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="5e81-802d-021d-5a05" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="fff7-d85d-7713-194d" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="1b32-6cc9-8dc9-64b3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="1b32-6cc9-8dc9-64b3" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+      <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="33fc-4af1-3af0-2309" hidden="false" targetId="7ac3-5fd7-f7a8-3a01" type="selectionEntry">
+        <entryLink id="33fc-4af1-3af0-2309" name="Plasma Grenades" hidden="false" targetId="76fa-75fa-aac0-aae1" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2390,60 +1697,69 @@
               <conditionGroups/>
             </modifier>
           </modifiers>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef5b-27ec-0ab1-a196" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="6e03-f2a2-1a44-794d" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+        <entryLink id="6e03-f2a2-1a44-794d" name="Reflex Armor" hidden="false" targetId="1523-0845-c12b-4980" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="40c8-e40d-1a9c-1b8c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca82-a52a-af11-8eec" type="min"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="7876-6071-860a-2b8f" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+        <entryLink id="7876-6071-860a-2b8f" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers>
-            <modifier type="increment" field="points" value="10.0">
+            <modifier type="decrement" field="points" value="10">
               <repeats/>
-              <conditions/>
+              <conditions>
+                <condition field="selections" scope="40ad-08b6-fa6a-0171" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7876-6071-860a-2b8f" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="decrement" field="points" value="5">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="40ad-08b6-fa6a-0171" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7876-6071-860a-2b8f" type="equalTo"/>
+              </conditions>
               <conditionGroups/>
             </modifier>
           </modifiers>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57c0-699e-bab3-6d5a" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f665-ffa6-451a-d173" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="2e0c-d76f-3052-0617" hidden="false" targetId="1b16-412b-662a-5467" type="selectionEntry">
+        <entryLink id="2e0c-d76f-3052-0617" name="Homer Drone" hidden="false" targetId="f0a7-4c49-aa22-ba0d" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="15.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="125c-a422-353e-1f18" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="dc54-b931-3a06-f2b0" hidden="false" targetId="4933-25f0-2896-ac60" type="selectionEntry">
+        <entryLink id="dc54-b931-3a06-f2b0" name="Camo Drone" hidden="false" targetId="b6b4-e09d-694d-a464" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="391a-070f-5b41-7343" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="55f2-7f85-9f7a-d31c" hidden="false" targetId="db03-7794-daeb-fef6" type="selectionEntry">
+        <entryLink id="55f2-7f85-9f7a-d31c" name="Solar Charges" hidden="false" targetId="5bfe-0652-1831-84b1" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2463,1508 +1779,60 @@
               <conditionGroups/>
             </modifier>
           </modifiers>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="2f0f-7aeb-c2c2-ead0" hidden="false" targetId="3af1-7df9-4f90-c12c" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="47.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="969a-8139-9654-9cdf" name="AI Intruder Skimmer Command Squad" book="BtGoA" page="186" hidden="false" collective="false" type="unit">
-      <profiles/>
-      <rules>
-        <rule id="76be-d990-01b2-40b5" name="Mounted Command Unit" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-        <rule id="801f-37d3-aeef-35ef" name="Limited Choice" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-      </rules>
-      <infoLinks>
-        <infoLink id="8ada-48df-990a-b1c6" hidden="false" targetId="b0ca-8e7d-d03f-f027" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="0026-0fee-242b-f524" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="969a-8139-9654-9cdf-5c47879b-41d0-1383-5fe5-a5989615db89" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="d40e-0a4d-13fa-863b" name="AI Intruder Commander" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="c399-5307-6ed8-f37e" name="AI Intruder Commander" book="BtGoA" page="174" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="5"/>
-                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
-                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="5"/>
-                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="6 (8)"/>
-                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="7"/>
-                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="9"/>
-                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks>
-            <infoLink id="0b4f-18e9-64d4-1bc8" name="Command" hidden="false" targetId="5c9b-1bde-ee01-04a4" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="7780-1ba7-1b1c-b4c2" hidden="false" targetId="7bc9-5e98-2914-5abd" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="7395-c0d8-a3d6-c34b" name="Large" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="9880-b60f-30bb-5123" name="Fast" hidden="false" targetId="b0ca-8e7d-d03f-f027" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cad3-c488-060b-aeb8" type="max"/>
           </constraints>
           <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="e0b2-8c3a-7575-9736" name="Leader Level" hidden="false" collective="false" defaultSelectionEntryId="b5bf-1e38-3cd6-1854">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries>
-                <selectionEntry id="6aec-3a3c-0e12-62d2" name="Leader Three" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="1f66-c0d1-8d27-5711" hidden="false" targetId="05bb-4d34-70cd-25d2" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="b5bf-1e38-3cd6-1854" name="Leader Two" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="b6ec-8536-6683-19c2" hidden="false" targetId="7850-89e7-bab8-86e9" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="2c42-d94f-83c4-fb4f" name="AI Intruder Trooper" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="eebb-ce4e-05d2-168c" name="AI Intruder Trooper" book="BtGoA" page="174" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="5"/>
-                <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
-                <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="5"/>
-                <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="6 (8)"/>
-                <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="7"/>
-                <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="8"/>
-                <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks>
-            <infoLink id="f33e-43b7-8673-c779" name="Large" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="5481-cdf8-ea6f-3987" name="Fast" hidden="false" targetId="b0ca-8e7d-d03f-f027" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="6569-9429-8783-633d" name="Compactor Drone" hidden="false" collective="false">
+        </entryLink>
+        <entryLink id="2f0f-7aeb-c2c2-ead0" name="Synchronizer Drone" hidden="false" targetId="3b29-0c16-4aa3-aca3" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14dd-92bd-3e73-7f03" type="max"/>
           </constraints>
           <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="7dc0-df51-06b7-f55f" hidden="false" targetId="babd-f951-933b-1254" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="ec3d-370a-88c3-460a" hidden="false" targetId="2144-e450-c8f2-af26" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="15.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="9809-38d3-a32e-66a6" hidden="false" targetId="666e-aa69-6e72-f168" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="25.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="56bf-6681-ddbb-0f61" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
+        </entryLink>
+        <entryLink id="7977-cf23-ca06-d6a5" name="Mag Repeater" hidden="false" targetId="ada9-abf5-49da-db67" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="c483-cdc7-d858-3c42" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="aa2a-68f4-e973-4cd9" hidden="false" targetId="573b-88bc-97d7-d890" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="b590-78da-ab5f-0d08" hidden="false" targetId="d3a3-d3e0-1480-e349" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="42ca-1a8a-cce2-27fa" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f49-f3ca-bb76-a282" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98ed-b18f-5d14-a87b" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="186.0"/>
+        <cost name="pts" costTypeId="points" value="37.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="a370-0f8b-0d94-4a92" name="AI Intruder Skimmer Squad" book="BtGoA" page="174" hidden="false" collective="false" type="unit">
-      <profiles/>
-      <rules>
-        <rule id="d6d7-1279-f75c-631d" name="Mounted Unit" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-      </rules>
-      <infoLinks>
-        <infoLink id="c2e3-b061-d782-a118" hidden="false" targetId="b0ca-8e7d-d03f-f027" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="3995-9f22-61e1-b9b9" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="a370-0f8b-0d94-4a92-5c47879b-41d0-1383-5fe5-a5989615db89" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="878f-69c7-26a8-6ce6" name="AI Intruder Leader" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="8fa0-38f8-b4f7-0628" name="AI Intruder Leader" book="BtGoA" page="174" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
-                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
-                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (8)"/>
-                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
-                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="ae93-a927-8e78-de03" name="Leader Level" hidden="false" collective="false" defaultSelectionEntryId="2cc3-9451-546f-657e">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries>
-                <selectionEntry id="2cc3-9451-546f-657e" name="Leader One" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="89a6-bbef-965b-3f5c" hidden="false" targetId="e441-c3a6-7d61-2c63" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="84f4-c3d5-1823-40f0" name="Leader Two" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="f55f-569b-afc4-bbf0" hidden="false" targetId="7850-89e7-bab8-86e9" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="866e-82e8-762b-d9e4" name="AI Intruder Trooper" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="09b6-2b18-a5f2-e766" name="AI Intruder Trooper" book="BtGoA" page="174" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
-                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
-                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (8)"/>
-                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
-                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="0f92-fd86-3f9e-e9fe" name="Compactor Drone" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="557a-84b3-18bd-cc77" hidden="false" targetId="babd-f951-933b-1254" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="9a43-cccb-c740-8ebe" hidden="false" targetId="2144-e450-c8f2-af26" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="15.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="62bc-0d96-f9ef-d438" hidden="false" targetId="666e-aa69-6e72-f168" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="25.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="aa34-e573-72bb-e9cc" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="b225-a9df-6064-269c" hidden="false" targetId="573b-88bc-97d7-d890" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="8dbf-1e54-2cf4-54d1" hidden="false" targetId="d3a3-d3e0-1480-e349" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="8207-ff16-0131-7167" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="42b1-9365-4a16-cdee" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="106.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="0686-8100-d42b-6954" name="Liberator Combat Skimmer - X01 Hi-Mag" book="BtGoA" page="177" hidden="false" collective="false" type="unit">
-      <profiles/>
-      <rules>
-        <rule id="62b4-e4e2-6e8f-f278" name="Vehicle Unit" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-      </rules>
-      <infoLinks>
-        <infoLink id="59ef-0e7f-1772-9e70" hidden="false" targetId="5565-ce10-1c78-1ee7" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="7286-f996-cc44-fec2" name="Large" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="0686-8100-d42b-6954-a01f5f58-334c-8442-d861-15099ebdf5e5" hidden="false" targetId="a01f5f58-334c-8442-d861-15099ebdf5e5" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="7b1b-0acb-dc91-c73c" name="Combat Skimmer" hidden="false" collective="false" type="model">
-          <profiles>
-            <profile id="5e4d-1347-d97b-2c1c" name="Combat Skimmer" book="BtGoA" page="177" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
-                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
-                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="13"/>
-                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
-                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="47c3-c21c-89a3-b7aa" name="Weapon 1" hidden="false" collective="false" defaultSelectionEntryId="1986-3dd7-bc70-4c75">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="e124-c6c8-c9a6-aba5" hidden="false" targetId="6a2b-50c5-9a33-b756" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="increment" field="points" value="10">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="1986-3dd7-bc70-4c75" name="Mag Light Support" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="e38e-9547-9de7-4d25" name="Twin Mag Light Support" hidden="false" targetId="ac1e-a740-57b7-cc64" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="increment" field="points" value="25">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="8f5d-6287-181b-080e" name="Weapon 2" hidden="false" collective="false" defaultSelectionEntryId="c220-bfa1-44ba-606d">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="c220-bfa1-44ba-606d" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="minSelections" value="1.0">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="f530-4134-9321-4225" name="Self-repair" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="d0d1-b167-3160-1832" hidden="false" targetId="3377-9408-33bb-6a02" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="3259-643a-6c5c-4510" name="Spotter Drone" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bf2-ae2b-a904-c6b0" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="9767-fefd-dc1e-47aa" name="Batter Drone" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="20">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b03-bff7-c861-4d84" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="25a8-9c44-b5eb-73fa" name="Shield Drone" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="837d-06b0-9a8f-8d36" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="194.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="cf98-8e3e-b9d5-f49a" name="Liberator Combat Skimmer - X06 Plasma Destroyer" book="BtGoA" page="177" hidden="false" collective="false" type="unit">
-      <profiles/>
-      <rules>
-        <rule id="5ff2-21b6-d9eb-8179" name="Vehicle Unit" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-      </rules>
-      <infoLinks>
-        <infoLink id="cb8f-8375-aa9f-ae21" hidden="false" targetId="5565-ce10-1c78-1ee7" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="8f7c-f29c-bcb9-2ad0" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="cf98-8e3e-b9d5-f49a-a01f5f58-334c-8442-d861-15099ebdf5e5" hidden="false" targetId="a01f5f58-334c-8442-d861-15099ebdf5e5" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="56de-38d4-1aca-461a" name="Combat Skimmer" hidden="false" collective="false" type="model">
-          <profiles>
-            <profile id="a1fc-039b-f26f-d312" name="Combat Skimmer" book="BtGoA" page="177" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
-                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
-                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="13"/>
-                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
-                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="f07c-b712-2b7c-c102" name="Weapon 1" hidden="false" collective="false" defaultSelectionEntryId="c603-2a8c-dd35-9edc">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="71e8-3334-6c11-96c8" hidden="false" targetId="c2bf-0272-30c6-dd20" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="increment" field="points" value="5.0">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="c603-2a8c-dd35-9edc" hidden="false" targetId="cf3a-e6a9-bdc0-e0ae" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="7238-1278-7cd9-35b9" name="Weapon 2" hidden="false" collective="false" defaultSelectionEntryId="c713-86f2-8e3c-d472">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="c713-86f2-8e3c-d472" hidden="false" targetId="cf3a-e6a9-bdc0-e0ae" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="4b89-b0c3-6567-01ea" name="Self-repair" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="7100-9b0a-a8e8-4e34" hidden="false" targetId="3377-9408-33bb-6a02" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="1aef-95b6-0bb8-a122" name="Batter Drone" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="20">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9edd-7c7e-3d80-fcc2" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="091a-95c6-def1-c445" name="Spotter Drone" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cac4-eadc-c4f9-adab" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="5f5a-c964-97af-6606" name="Shield Drone" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28cb-bcfc-6119-49ce" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="234.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="17b0-20bb-f500-0569" name="Liberator Combat Skimmer - X10 Special" book="BtGoA" page="177" hidden="false" collective="false" type="unit">
-      <profiles/>
-      <rules>
-        <rule id="5885-c36a-df02-8929" name="Vehicle Unit" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-      </rules>
-      <infoLinks>
-        <infoLink id="a585-1593-09ca-fa4f" hidden="false" targetId="5565-ce10-1c78-1ee7" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="4440-5c30-6a45-9157" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="17b0-20bb-f500-0569-a01f5f58-334c-8442-d861-15099ebdf5e5" hidden="false" targetId="a01f5f58-334c-8442-d861-15099ebdf5e5" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="6f63-5f0c-90ec-e2b3" name="Combat Skimmer" hidden="false" collective="false" type="model">
-          <profiles>
-            <profile id="b3f1-d6e2-efa7-8d7d" name="Combat Skimmer" book="BtGoA" page="177" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
-                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
-                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="13"/>
-                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
-                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="9e35-33d9-cae6-d346" name="Weapon 2" hidden="false" collective="false" defaultSelectionEntryId="1fb7-e103-c0d9-9236">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="aa6b-9767-c637-e7fe" hidden="false" targetId="71c9-4382-01cf-c737" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="1fb7-e103-c0d9-9236" hidden="false" targetId="93db-3751-fdd4-08f9" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="c220-2f65-16f0-92b3" name="Weapon 1" hidden="false" collective="false" defaultSelectionEntryId="5702-e83d-65f6-5c48">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="5702-e83d-65f6-5c48" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="05c1-f431-5866-b555" name="Self-repair" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="f21d-ca8b-0cc0-a455" hidden="false" targetId="3377-9408-33bb-6a02" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="3faf-3692-a92e-680e" name="Batter Drone" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="20">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f0f-3c8e-a2c2-4a6e" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="04de-765c-210c-73ae" name="Shield Drone" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14de-4578-f0c4-1c40" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="313b-f390-285f-40a6" name="Spotter Drone" hidden="false" collective="false" defaultSelectionEntryId="d040-0f75-6159-a817">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="d040-0f75-6159-a817" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="d5cc-327b-cc1e-1b7c" name="Spotter Drone" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="234.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="7ad1-0ccb-ea7e-405e" name="AI Medic Team" book="BtGoA" page="178" hidden="false" collective="false" type="unit">
+    <selectionEntry id="500b-c1c5-a0da-aecc" name="AI Specialist Heavy Support Team" book="Rulebook &amp; pdf force list v2" page="176" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="7ad1-0ccb-ea7e-405e-72807c5d-e370-9ddf-c2b7-de5d2797f24d" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="bc34-41d2-bb66-d916" name="Algoryn Medic" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="a149-379a-67e9-44b9" name="Algoryn Medic" book="BtGoA" page="178" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
-                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
-                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (7)"/>
-                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
-                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks>
-            <infoLink id="51b6-9c64-6a1e-ca04" hidden="false" targetId="137e-c2b6-65b7-ecc3" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="48dd-78d2-9329-d56a" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="7d3f-fe8e-3299-77b5">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="9d2b-b5d7-170a-1dcf" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="7d3f-fe8e-3299-77b5" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="c6a1-68fd-f47c-0fe6" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="15.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="a112-61a7-be5e-8620" name="Spotter Drone" hidden="false" collective="false" defaultSelectionEntryId="ac15-6ba2-59ae-15c0">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="ac15-6ba2-59ae-15c0" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="035c-588d-4b1e-482e" hidden="false" targetId="502c-9855-7269-eaa2" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="20.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="500b-c1c5-a0da-aecc" name="AI Specialist Heavy Support Team" book="BtGoA" page="176" hidden="false" collective="false" type="unit">
-      <profiles/>
-      <rules>
-        <rule id="9f81-a903-76b1-2432" name="Weapon Team Unit" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-        <rule id="05e7-9036-3057-a796" name="Limited Choice" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-      </rules>
       <infoLinks>
-        <infoLink id="d6cc-47c5-c602-dd58" hidden="false" targetId="a221-d53c-b4bd-b52c" type="rule">
+        <infoLink id="d6cc-47c5-c602-dd58" name="Large" hidden="false" targetId="59d7-7273-b97c-0dff" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
-        <infoLink id="d7b2-c85c-0f0d-e5fb" hidden="false" targetId="7c88-64d4-50ad-2313" type="rule">
+        <infoLink id="d7b2-c85c-0f0d-e5fb" name="Slow" hidden="false" targetId="04bc-743b-092f-8c3a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3499-0d72-d227-5984" name="Limited Choice" hidden="false" targetId="8cb3-4c3e-dc5f-b952" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="9fbb-4baa-fc0e-5050" name="Weapon Team Unit" hidden="false" targetId="3f2c-9814-0c0d-e4d7" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3981,11 +1849,25 @@
           <modifiers/>
           <constraints/>
         </categoryLink>
+        <categoryLink id="0cad-03af-074d-8edc" name="New CategoryLink" hidden="false" targetId="c87d-5261-face-4643" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="66ac-a414-c033-84b3" name="New CategoryLink" hidden="false" targetId="db48-a6b8-4b98-e3ed" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="6eab-104b-f771-03c2" name="AI Trooper Crew" book="" hidden="false" collective="false" type="model">
           <profiles>
-            <profile id="3d91-fd9c-e7ea-045e" name="AI Trooper Crew" book="BtGoA" page="176" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+            <profile id="3d91-fd9c-e7ea-045e" name="AI Trooper Crew" book="" page="" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4010,61 +1892,9 @@
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="df91-f3d2-baf0-d57b" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="90f4-92b9-a73e-7a8e">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="df08-f4ae-9c52-fdfc" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="90f4-92b9-a73e-7a8e" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="0242-1032-6f80-0baa" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="increment" field="points" value="3.0">
-                      <repeats/>
-                      <conditions/>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
+          <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="d4b7-2639-1cdf-ae0e" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+            <entryLink id="d4b7-2639-1cdf-ae0e" name="Reflex Armor" hidden="false" targetId="1523-0845-c12b-4980" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4081,7 +1911,7 @@
           <profiles/>
           <rules/>
           <infoLinks>
-            <infoLink id="dea8-fdda-5e18-1abc" hidden="false" targetId="e441-c3a6-7d61-2c63" type="rule">
+            <infoLink id="dea8-fdda-5e18-1abc" name="Leader" hidden="false" targetId="4675-d30d-3451-8672" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4115,7 +1945,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="8562-8e48-301a-2b10" hidden="false" targetId="2cec-e1d7-c680-7ca0" type="selectionEntry">
+            <entryLink id="8562-8e48-301a-2b10" name="Fractal Bombard" hidden="false" targetId="e1aa-ab5e-a6bf-936f" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4129,7 +1959,7 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="271c-f9a4-c727-98ec" hidden="false" targetId="67b6-d6f5-5ba3-e50d" type="selectionEntry">
+            <entryLink id="271c-f9a4-c727-98ec" name="Plasma Bombard" hidden="false" targetId="4a45-8595-c131-0604" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4139,20 +1969,52 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="e6ec-90fe-f9df-14d6" name="Spotter Drone" hidden="false" collective="false" defaultSelectionEntryId="f7c2-a2e6-f678-9d8c">
+        <selectionEntryGroup id="15c2-8f2f-e844-893f" name="Crew Weapons" hidden="false" collective="false" defaultSelectionEntryId="28ed-7ce3-64ad-72cd">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="da2a-2b44-8fb1-62cb" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2225-d2bb-0149-eb78" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="f7c2-a2e6-f678-9d8c" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+            <entryLink id="5dd9-8284-45c0-c375" name="Mag Gun" hidden="false" targetId="0f88-ab36-c5a8-7a97" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="500b-c1c5-a0da-aecc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6eab-104b-f771-03c2" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="bb33-477e-8206-4ccd" name="Mag Repeater" hidden="false" targetId="ada9-abf5-49da-db67" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="500b-c1c5-a0da-aecc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6eab-104b-f771-03c2" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="28ed-7ce3-64ad-72cd" name="Mag Pistol" hidden="false" targetId="32dd-05fd-f75b-81ee" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4164,32 +2026,41 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="feab-a4b0-75c9-7c44" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+        <entryLink id="feab-a4b0-75c9-7c44" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9144-1a87-ab89-bc45" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="2a78-7bc5-b123-adcb" hidden="false" targetId="d571-d584-85fc-9110" type="selectionEntry">
+        <entryLink id="2a78-7bc5-b123-adcb" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d5d-a272-614f-18a1" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="726c-1b02-39d7-2d20" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers>
-            <modifier type="increment" field="points" value="20.0">
+            <modifier type="set" field="points" value="0.0">
               <repeats/>
               <conditions/>
               <conditionGroups/>
             </modifier>
           </modifiers>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0a9-9a70-031d-f42c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0cc-f32a-f397-0ed1" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
@@ -4197,363 +2068,17 @@
         <cost name="pts" costTypeId="points" value="75.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6d12-fb12-c8a4-6e92" name="AI Specialist Support Team" book="BtGoA" page="175" hidden="false" collective="false" type="unit">
-      <profiles/>
-      <rules>
-        <rule id="8c84-00e0-fedc-fd8b" name="Weapon Team Unit" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-      </rules>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="6d12-fb12-c8a4-6e92-5c47879b-41d0-1383-5fe5-a5989615db89" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="fb98-1376-32bb-e1c9" name="AI Trooper Crew" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="2ece-5823-dbf7-60fe" name="AI Trooper Crew" book="BtGoA" page="175" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
-                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
-                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (7)"/>
-                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
-                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="52b5-70d9-3c1a-82d2" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="14.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="8fb3-51ec-113a-efb3" name="Promote one crew member to Leader" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="a6ea-6c72-b495-c935" name="Leader Level" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries>
-                <selectionEntry id="53ad-d00a-2804-2864" name="Leader One" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="851e-d52c-6b45-e360" hidden="false" targetId="e441-c3a6-7d61-2c63" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="a923-9852-a132-dc1e" name="Spotter Drone" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c49-7e45-a5e3-d371" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="39c8-fdfb-8dea-b355" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="280e-bb1b-83db-559d">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="510d-3509-91ea-5410" name="Fractal Cannon" hidden="false" targetId="93db-3751-fdd4-08f9" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="3aee-e32a-a8dd-ee3c" hidden="false" targetId="c2bf-0272-30c6-dd20" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="5.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="280e-bb1b-83db-559d" hidden="false" targetId="cf3a-e6a9-bdc0-e0ae" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="19ef-aa68-146b-c160" name="Compression Cannon" hidden="false" targetId="71c9-4382-01cf-c737" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="10">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="8326-1792-3a22-a199" name="Weapons" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="61ca-ec13-260a-a8d8" value="1">
-              <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fb98-1376-32bb-e1c9" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="791f-9da9-bcc6-5603" value="1">
-              <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fb98-1376-32bb-e1c9" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="61ca-ec13-260a-a8d8" type="max"/>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="791f-9da9-bcc6-5603" type="min"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries>
-            <selectionEntry id="5cbc-e334-a3b7-ab88" name="Mag Gun" hidden="false" collective="false" type="upgrade">
-              <profiles>
-                <profile id="4f01-4852-bb67-1ffa" name="Mag Gun" book="BtGoA" page="69" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="true">
-                      <repeats/>
-                      <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5cbc-e334-a3b7-ab88" type="equalTo"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <characteristics>
-                    <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-                    <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
-                    <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
-                    <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
-                    <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7cdd-6cff-ca70-b03e" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="3.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="941d-d85d-25f2-ae58" name="Mag Repeater" hidden="false" collective="false" type="upgrade">
-              <profiles>
-                <profile id="b2d8-da27-74b1-9c83" name="Mag Repeater" book="BtGoA" page="69" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="true">
-                      <repeats/>
-                      <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="941d-d85d-25f2-ae58" type="equalTo"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <characteristics>
-                    <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-                    <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
-                    <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
-                    <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
-                    <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Standard Weapon"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9fcf-be6a-1e16-19f4" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="3.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="fcac-bf1c-e137-cd62" name="Mag Pistol" hidden="false" collective="false" type="upgrade">
-              <profiles>
-                <profile id="a13b-b187-c4c3-e6f5" name="Mag Pistol" book="BtGoA" page="68" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="true">
-                      <repeats/>
-                      <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fcac-bf1c-e137-cd62" type="equalTo"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <characteristics>
-                    <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
-                    <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
-                    <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
-                    <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
-                    <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Hand Weapon"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7ad-61b8-ca84-f07b" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="40.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="a44f-4447-aff2-0dcd" name="AI Squad" book="BtGoA" page="173" hidden="false" collective="false" type="unit">
+    <selectionEntry id="a44f-4447-aff2-0dcd" name="AI Squad" book="Rulebook &amp; pdf force list v2" page="173" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules/>
-      <infoLinks/>
+      <infoLinks>
+        <infoLink id="b9ad-5e05-238f-d3eb" name="Infantry" hidden="false" targetId="9a87-2673-83b1-3986" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
       <constraints/>
       <categoryLinks>
@@ -4594,68 +2119,7 @@
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups>
-            <selectionEntryGroup id="eeeb-14fc-3015-51fc" name="Leader Level" hidden="false" collective="false" defaultSelectionEntryId="36ec-d26c-3022-b885">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries>
-                <selectionEntry id="36ec-d26c-3022-b885" name="Leader One" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="93f8-4f41-c31d-0653" hidden="false" targetId="e441-c3a6-7d61-2c63" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="a094-8787-d876-c144" name="Leader Two" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="4cb6-9a0e-7326-22e3" hidden="false" targetId="7850-89e7-bab8-86e9" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="10.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="614f-b64a-4c29-8d4f" name="Ranged Weapon 1" hidden="false" collective="false" defaultSelectionEntryId="2bc1-4f6e-02ba-7d1c">
+            <selectionEntryGroup id="614f-b64a-4c29-8d4f" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="2bc1-4f6e-02ba-7d1c">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4668,7 +2132,7 @@
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks>
-                <entryLink id="ea0d-f127-d94d-dc3d" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+                <entryLink id="ea0d-f127-d94d-dc3d" name="Mag Gun" hidden="false" targetId="0f88-ab36-c5a8-7a97" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -4682,7 +2146,7 @@
                   <constraints/>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="2bc1-4f6e-02ba-7d1c" hidden="false" targetId="8690-3ab7-9fef-06ee" type="selectionEntry">
+                <entryLink id="2bc1-4f6e-02ba-7d1c" name="Mag Pistol" hidden="false" targetId="32dd-05fd-f75b-81ee" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -4690,7 +2154,7 @@
                   <constraints/>
                   <categoryLinks/>
                 </entryLink>
-                <entryLink id="f673-3a81-fee5-e6ee" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
+                <entryLink id="f673-3a81-fee5-e6ee" name="Mag Repeater" hidden="false" targetId="ada9-abf5-49da-db67" type="selectionEntry">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -4701,43 +2165,40 @@
                       <conditionGroups/>
                     </modifier>
                   </modifiers>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-            <selectionEntryGroup id="fb07-2f58-0224-c3c4" name="Ranged Weapon 2" hidden="false" collective="false" defaultSelectionEntryId="4f39-d122-493b-a05f">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="4f39-d122-493b-a05f" hidden="false" targetId="b08e-548a-fda7-0a4e" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
                   <constraints/>
                   <categoryLinks/>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="781b-bc6c-fc3f-1aa5" name="X-Sling" hidden="false" targetId="e629-3c26-9e22-f80b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d2c-6a4c-bdea-9414" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e77-0059-5d7d-d38f" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="c834-d2f9-4d51-aff2" name="Leader Level (Up To 2)" book="" hidden="false" targetId="14a9-9070-281d-b6d6" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="pts" costTypeId="points" value="26.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="d441-f08b-6ae0-3ce1" name="AI Trooper" hidden="false" collective="false" type="model">
           <profiles>
-            <profile id="c3fb-a74b-70a2-dc3c" name="AI Trooper" book="BtGoA" page="173" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+            <profile id="c3fb-a74b-70a2-dc3c" name="AI Trooper" book="" page="" hidden="false" profileTypeId="1650-77b3-10d1-6406">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4768,67 +2229,9 @@
             <cost name="pts" costTypeId="points" value="17.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="4ecc-3f7f-9999-5af9" name="SlingNet Ammo for X-sling / Micro-X Launchers" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="5">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c077-8ef3-73f4-f156" type="equalTo"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="10">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="7197-0bcf-a743-25bd" name="Overload Ammo for X-sling / Micro-X Launchers" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="5">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c077-8ef3-73f4-f156" type="equalTo"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="10">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="ca95-0934-b9b4-b948" name="One Special Weapon" hidden="false" collective="false">
+        <selectionEntryGroup id="ca95-0934-b9b4-b948" name="Exchange Weapon" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4840,7 +2243,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="6b69-fba3-4cfc-2523" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+            <entryLink id="21c1-860e-a5c0-590b" name="Mag Repeater" hidden="false" targetId="ada9-abf5-49da-db67" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4848,7 +2251,39 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="21c1-860e-a5c0-590b" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
+            <entryLink id="c077-8ef3-73f4-f156" name="Micro-X Launcher" hidden="false" targetId="02e7-5a6e-5888-dd34" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="a6b3-9cbc-f6e5-f6aa" value="1">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6b3-9cbc-f6e5-f6aa" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd7f-da7b-d027-2cb4" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="b598-1bdf-f0d9-376d" name="Special Weapon" hidden="false" collective="false" defaultSelectionEntryId="4633-a89f-ed54-c5a5">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9821-c2ed-8782-3412" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f650-eb66-20fa-7949" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="4633-a89f-ed54-c5a5" name="Micro-X Launcher" hidden="false" targetId="02e7-5a6e-5888-dd34" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4856,7 +2291,7 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="c077-8ef3-73f4-f156" hidden="false" targetId="1a9d-01a2-ee09-883c" type="selectionEntry">
+            <entryLink id="537b-6055-c96f-fc4b" name="Mag Gun" hidden="false" targetId="0f88-ab36-c5a8-7a97" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -4866,55 +2301,63 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="b9b6-482e-88c8-9a56" name="Ranged Weapon" hidden="false" collective="false" defaultSelectionEntryId="de3c-744f-11c6-d83f">
+        <selectionEntryGroup id="4617-c952-3eb4-cd79" name="Specialist Ammo for X-Xling &amp; Micro-X Launchers" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5fc-28a3-2b5f-b37a" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="de3c-744f-11c6-d83f" hidden="false" targetId="84ac-0f31-c388-d0bd" type="selectionEntry">
+            <entryLink id="b798-fc49-4f71-9372" name="Overload Ammo" hidden="false" targetId="5de1-746b-be1f-93b1" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers/>
-              <constraints/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5">
+                  <repeats>
+                    <repeat field="selections" scope="a44f-4447-aff2-0dcd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="4633-a89f-ed54-c5a5" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="a44f-4447-aff2-0dcd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c077-8ef3-73f4-f156" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="a44f-4447-aff2-0dcd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="781b-bc6c-fc3f-1aa5" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="164c-12b7-afc6-febd" type="max"/>
+              </constraints>
               <categoryLinks/>
             </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="b3d3-d6e4-df8d-5379" name="Micro-X Launcher" hidden="false" collective="false" defaultSelectionEntryId="7bac-8174-3f34-cc91">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="7bac-8174-3f34-cc91" hidden="false" targetId="1a9d-01a2-ee09-883c" type="selectionEntry">
+            <entryLink id="379e-1b5f-25bb-6f50" name="SlingNet Ammo" hidden="false" targetId="6849-c480-4332-7ffc" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers/>
-              <constraints/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5">
+                  <repeats>
+                    <repeat field="selections" scope="a44f-4447-aff2-0dcd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c077-8ef3-73f4-f156" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="a44f-4447-aff2-0dcd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="781b-bc6c-fc3f-1aa5" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="a44f-4447-aff2-0dcd" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="4633-a89f-ed54-c5a5" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c417-2441-b936-e09f" type="max"/>
+              </constraints>
               <categoryLinks/>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="4af6-1eac-39c6-7d91" name="Plasma Grenades" hidden="false" targetId="7ac3-5fd7-f7a8-3a01" type="selectionEntry">
+        <entryLink id="4af6-1eac-39c6-7d91" name="Plasma Grenades" hidden="false" targetId="76fa-75fa-aac0-aae1" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4926,7 +2369,7 @@
               <conditions/>
               <conditionGroups/>
             </modifier>
-            <modifier type="increment" field="points" value="2.0">
+            <modifier type="increment" field="points" value="2">
               <repeats>
                 <repeat field="selections" scope="a44f-4447-aff2-0dcd" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c61f-6de1-069d-821f" repeats="1" roundUp="false"/>
               </repeats>
@@ -4934,535 +2377,81 @@
               <conditionGroups/>
             </modifier>
           </modifiers>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73cb-f059-1373-5159" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="0c7f-6883-5b9e-f555" name="Reflex Armor" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="13d3-407b-5520-a098" name="Spotter Drone" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="8ea5-97f9-9ffd-604f" hidden="false" targetId="3af1-7df9-4f90-c12c" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="0f2b-5fd2-86c3-563b" name="AI Support Team" book="BtGoA" page="175" hidden="false" collective="false" type="unit">
-      <profiles/>
-      <rules>
-        <rule id="a6d0-fc64-ad5d-674a" name="Weapon Team Unit" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-      </rules>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="0f2b-5fd2-86c3-563b-5c47879b-41d0-1383-5fe5-a5989615db89" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="5baf-a32e-e0b0-f74a" name="Promote one crew member to Leader" hidden="false" collective="false" type="upgrade">
+        <entryLink id="0c7f-6883-5b9e-f555" name="Reflex Armor" hidden="false" targetId="1523-0845-c12b-4980" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2db-48b6-c82b-eff5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1eff-0038-ca23-24d2" type="max"/>
           </constraints>
           <categoryLinks/>
-          <selectionEntries>
-            <selectionEntry id="0160-815b-453d-fb00" name="Leader One" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="276a-5c2d-6a39-a811" hidden="false" targetId="e441-c3a6-7d61-2c63" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="4dec-8e13-7bfe-6a45" name="AI Trooper Crew" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="76ad-c861-3525-255a" name="AI Trooper Crew" book="BtGoA" page="175" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
-                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
-                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (7)"/>
-                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
-                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="56a5-3789-fe68-9638" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c20d-a8d3-a3ae-f8a8" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="5188-1ccf-f239-444a" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="14.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="85a1-9aa5-986c-0134" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="5764-6087-e7b6-4c73">
+        </entryLink>
+        <entryLink id="13d3-407b-5520-a098" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="185c-21c3-b79e-c9f8" type="max"/>
           </constraints>
           <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="7198-55af-d564-f2fd" hidden="false" targetId="6a2b-50c5-9a33-b756" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="10.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="4711-a1d0-8193-4ddf" name="X-Launcher" hidden="false" targetId="eed0-b68f-b5fb-92c7" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="5764-6087-e7b6-4c73" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="0f47-5745-c3c8-279b" name="Weapons" hidden="false" collective="false">
+        </entryLink>
+        <entryLink id="8ea5-97f9-9ffd-604f" name="Synchronizer Drone" hidden="false" targetId="3b29-0c16-4aa3-aca3" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="a007-9012-30a0-5258" value="1">
-              <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4dec-8e13-7bfe-6a45" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="08a4-af77-5378-702a" value="1">
-              <repeats>
-                <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4dec-8e13-7bfe-6a45" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
+          <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="08a4-af77-5378-702a" type="max"/>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a007-9012-30a0-5258" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87f0-d1d3-63c9-f2c2" type="max"/>
           </constraints>
           <categoryLinks/>
-          <selectionEntries>
-            <selectionEntry id="8308-0e37-6e54-3492" name="Mag Gun" hidden="false" collective="false" type="upgrade">
-              <profiles>
-                <profile id="352b-ad6e-2352-3dac" name="Mag Gun" book="BtGoA" page="69" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="true">
-                      <repeats/>
-                      <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8308-0e37-6e54-3492" type="equalTo"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <characteristics>
-                    <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-                    <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
-                    <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
-                    <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
-                    <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1b9c-c54f-6136-6da3" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="3.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="7f50-7243-7f68-bec2" name="Mag Repeater" hidden="false" collective="false" type="upgrade">
-              <profiles>
-                <profile id="65bc-462e-c737-0c7e" name="Mag Repeater" book="BtGoA" page="69" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="true">
-                      <repeats/>
-                      <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7f50-7243-7f68-bec2" type="equalTo"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <characteristics>
-                    <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-                    <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
-                    <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
-                    <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
-                    <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Standard Weapon"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2317-39b4-d8c7-6b73" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="3.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="00bd-7aa8-f67a-2ad2" name="Mag Pistol" hidden="false" collective="false" type="upgrade">
-              <profiles>
-                <profile id="46c9-a264-a9ae-b834" name="Mag Pistol" book="BtGoA" page="68" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers>
-                    <modifier type="set" field="hidden" value="true">
-                      <repeats/>
-                      <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="00bd-7aa8-f67a-2ad2" type="equalTo"/>
-                      </conditions>
-                      <conditionGroups/>
-                    </modifier>
-                  </modifiers>
-                  <characteristics>
-                    <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
-                    <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
-                    <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
-                    <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
-                    <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Hand Weapon"/>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5ff-970b-ad5c-fc76" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="216c-c44e-3347-b938" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+        </entryLink>
+        <entryLink id="b74b-a6c5-bf68-b2b3" name="Mag Gun" hidden="false" targetId="0f88-ab36-c5a8-7a97" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="10.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0145-9962-6664-ef99" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4275-9f67-462d-7297" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="10.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="5dcd-bab6-1f25-0e1c" name="Scout Probe Shard" book="BtGoA" page="178" hidden="false" collective="false" type="unit">
-      <profiles/>
-      <rules>
-        <rule id="c1cd-61c1-df04-7b1e" name="Probe Unit" book="" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-      </rules>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="5dcd-bab6-1f25-0e1c-72807c5d-e370-9ddf-c2b7-de5d2797f24d" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="d71e-dea9-a547-4ad4" name="Scout Probe" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="4d1a-750f-a521-9748" name="Scout Probe" book="BtGoA" page="178" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
-                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
-                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
-                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
-                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
-                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
-                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks>
-            <infoLink id="513a-bdeb-bad5-0c83" hidden="false" targetId="00b8-b49c-4c61-2943" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="aa6c-67b7-3d3b-2a61" name="Targeter Probe Shard" book="BtGoA" page="178" hidden="false" collective="false" type="unit">
+    <selectionEntry id="bfd9-5e29-5a73-ae18" name="Iso-Drone" book="CS &amp; pdf force list v2" page="68" hidden="false" collective="false" type="unit">
       <profiles/>
-      <rules>
-        <rule id="8104-2eac-f495-21f9" name="Probe Unit" book="" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-      </rules>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="aa6c-67b7-3d3b-2a61-72807c5d-e370-9ddf-c2b7-de5d2797f24d" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="31ff-3d6d-2a30-3b5a" name="Targeter Probe" hidden="false" collective="false" type="model">
-          <profiles>
-            <profile id="5411-31d1-ef11-d835" name="Targeter Probe" book="BtGoA" page="178" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
-                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
-                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
-                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
-                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
-                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
-                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks>
-            <infoLink id="58b0-e470-5c3a-0e30" hidden="false" targetId="00b8-b49c-4c61-2943" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="5.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="555d-6536-8efa-f2d2" name="General Tar Es Janar" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="5ee2-b40c-8e33-0639" name="General Tar Es Janar" hidden="false" profileTypeId="f9a2-eeae-3284-75fd" profileTypeName="Limited Choice">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="5"/>
-            <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
-            <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="5"/>
-            <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="6(7)"/>
-            <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="8"/>
-            <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="10"/>
-            <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424" value="Command, Follow, Leader 3, Strategic Genius, Wound, Vertex Mace"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules>
-        <rule id="60a7-25b5-5545-2e3e" name="Vertex Mace" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-        <rule id="19e3-1d34-d08b-68ca" name="Strategic Genius" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </rule>
-      </rules>
+      <rules/>
       <infoLinks>
-        <infoLink id="edc8-e9dd-78bf-b73c" name="Plasma Pistol" hidden="false" targetId="749a-029f-6b4b-c96d" type="profile">
+        <infoLink id="6445-d779-d57d-b639" name="Probe Unit" hidden="false" targetId="b8e9-1952-608c-accf" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="e809-1183-b1dd-0544" name="Iso-Shield" hidden="false" targetId="d584-98e1-53cc-4397" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="99c4-b251-cc29-d7ad" name="Slow" hidden="false" targetId="04bc-743b-092f-8c3a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="922e-6522-62bb-5736" name="Scramble Proof" hidden="false" targetId="377d-0cdc-6ba7-f1d2" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5472,7 +2461,7 @@
       <modifiers/>
       <constraints/>
       <categoryLinks>
-        <categoryLink id="4016-5a62-47ea-b1db" name="New CategoryLink" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
+        <categoryLink id="2c32-3c2a-4b03-43c3" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="true">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5481,9 +2470,182 @@
         </categoryLink>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="1899-5883-af0d-b14d" name="AI Trooper" hidden="false" collective="false" type="model">
+        <selectionEntry id="4ee4-79d6-1110-8143" name="Iso-Drone" hidden="false" collective="false" type="model">
           <profiles>
-            <profile id="3822-a5ea-7971-76dd" name="AI Trooper" book="BtGoA" page="173" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+            <profile id="9486-d35a-ec12-93ef" name="Iso-Drone **" hidden="false" profileTypeId="1650-77b3-10d1-6406" profileTypeName="Model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="7"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="0"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="10"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="727e-bb03-481e-bfd0" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eee1-6ef4-f104-ddf6" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5b80-c0ed-2c5c-3adc" name="AI Command Squad - General Ess Ma Rahq" book="CS" page="109" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="ee73-eecf-f26a-6869" name="Infantry Command Unit" hidden="false" targetId="0a6b-dcfb-ccc3-6a0d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3e96-6a37-00e2-f8f7" name="Limited Choice" hidden="false" targetId="8cb3-4c3e-dc5f-b952" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7252-913e-6d9c-cf12" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="09b0-2cd4-2fb8-40f6" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="26fc-0465-e67d-c7e3" name="New CategoryLink" hidden="false" targetId="c87d-5261-face-4643" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="3d45-5a41-206c-dd27" name="General Ess Ma Rahq" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="e3cd-20f7-36d0-7ea2" name="General Ess Ma Rahq" book="" page="" hidden="false" profileTypeId="1650-77b3-10d1-6406" profileTypeName="Model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (7)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="10"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="dd5c-9d2c-6652-795e" name="Command" hidden="false" targetId="f001-a3be-81f7-f74f" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="8fe1-25e5-1728-559f" name="Leader 3" hidden="false" targetId="ce3b-c908-3ded-7a49" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="25b3-74c4-23de-db31" name="Follow" hidden="false" targetId="4bdd-65b7-6ee8-89b2" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="34c6-3147-bcd5-1ac0" name="Nerves of Steel" hidden="false" targetId="5da4-f1f8-09d7-a67a" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="0b23-22e2-6bfb-a813" name="Wound" hidden="false" targetId="98a7-475a-f0ed-fa91" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0155-5f54-e154-dd19" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="75b6-51ca-008e-2d8c" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="3c45-25c6-13a2-920a" name="Vertex Mace KEEP" hidden="false" targetId="67fa-a913-bd09-5b13" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="6905-d371-c199-1f22" name="Plasma Pistol" hidden="false" targetId="9851-4076-e2e9-3df8" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d42f-3333-2bf5-ec01" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2c4-618b-5caa-64b6" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="710a-b34f-7ac3-205b" name="Reflex Armor" hidden="false" targetId="1523-0845-c12b-4980" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="919c-32df-508f-e367" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a95f-5a1c-d40f-dcf2" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="3b0d-f541-750c-431f" name="SD Trooper" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="988e-31d5-8242-cfc8" name="SD Trooper" book="" page="" hidden="false" profileTypeId="1650-77b3-10d1-6406" profileTypeName="Model">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -5503,13 +2665,47 @@
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cd19-9e90-d0c4-ae9e" type="min"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="888b-5d56-aff5-2f30" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9326-4511-b531-3eb0" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf62-3f52-23a2-83d5" type="min"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>
-          <entryLinks/>
+          <entryLinks>
+            <entryLink id="3c40-ff03-07ea-6aa2" name="Reflex Armor" hidden="false" targetId="1523-0845-c12b-4980" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e851-90b8-264c-dbf6" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7ce-713b-4c60-47c9" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="0bc5-d1c8-21d3-2623" name="Plasma Carbine" hidden="false" targetId="3877-96bf-06bb-ff8f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94cc-6246-6237-e624" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec9a-9298-0702-6bb7" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="bad8-7752-ac80-9894" name="Fractal Sights" hidden="false" targetId="65c0-6778-512b-de19" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6049-fab6-7f78-7ffe" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="270e-a626-0cef-52e9" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name="pts" costTypeId="points" value="20.0"/>
           </costs>
@@ -5517,59 +2713,67 @@
       </selectionEntries>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="376f-1de2-6ca6-2677" name="Spotter Drone" hidden="false" targetId="f3aa-148a-0460-c7e5" type="selectionEntry">
+        <entryLink id="8223-97bd-764c-a3d0" name="Plasma Grenades" hidden="false" targetId="76fa-75fa-aac0-aae1" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers>
-            <modifier type="increment" field="points" value="10.0">
+            <modifier type="increment" field="points" value="2">
+              <repeats>
+                <repeat field="selections" scope="5b80-c0ed-2c5c-3adc" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3b0d-f541-750c-431f" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="points" value="2">
               <repeats/>
               <conditions/>
               <conditionGroups/>
             </modifier>
           </modifiers>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="833c-de05-af64-75e4" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="c991-d6a2-9a5c-c9a1" name="Reflex Armor" hidden="false" targetId="9cdf-f068-bbde-2d0c" type="selectionEntry">
+        <entryLink id="d831-297f-1190-fa6a" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73b0-f3f2-b14d-29f8" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="2e95-4dbc-afc2-4b3c" name="Plasma Grenades" hidden="false" targetId="7ac3-5fd7-f7a8-3a01" type="selectionEntry">
+        <entryLink id="a11c-77f0-8380-7ac5" name="Synchronizer Drone" hidden="false" targetId="3b29-0c16-4aa3-aca3" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="2">
-              <repeats>
-                <repeat field="selections" scope="555d-6536-8efa-f2d2" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="unit" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="increment" field="points" value="2">
-              <repeats>
-                <repeat field="selections" scope="555d-6536-8efa-f2d2" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1899-5883-af0d-b14d" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1dc7-7928-d823-d47f" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="fb62-6097-ed9c-a328" name="Medi-Drone" hidden="false" targetId="c3f0-2a1d-815e-b61a" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="930a-30ab-a70a-756e" type="max"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="105.0"/>
+        <cost name="pts" costTypeId="points" value="106.0"/>
       </costs>
     </selectionEntry>
   </selectionEntries>
   <entryLinks>
-    <entryLink id="0714-acf5-311e-bcd9" name="Army Options" hidden="false" targetId="529a-3e2a-4bd5-5e5f" type="selectionEntry">
+    <entryLink id="0714-acf5-311e-bcd9" name="Army Options" book="BtGoA &amp; pdf force list v2" hidden="false" targetId="529a-3e2a-4bd5-5e5f" type="selectionEntry">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -5585,1208 +2789,129 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
+    <entryLink id="c80b-6ed5-15c8-6bd7" name="Hazard Command Squad" hidden="false" targetId="2205-7ba4-9eda-b3a8" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="e7cb-3121-3923-c594" name="Hazard Squad" hidden="false" targetId="28be-c479-2900-63ff" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="609b-22b5-55fc-ae6a" name="Scout Probe Shard" hidden="false" targetId="0c5c-da8a-4405-a1ce" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="3f20-1a5c-cdcc-dfce" name="Targeter Probe Shard" hidden="false" targetId="1fea-1f1e-73d8-9a98" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="e7d0-8078-d3e0-fce5" name="AI Medic Team" hidden="false" targetId="9a7a-ffee-ac9b-986f" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="e40c-75f1-995e-098a" name="Defiant Transport Skimmer (Strategic)" hidden="false" targetId="7bac-88c5-659f-8b76" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="8948-68c3-b17d-05e0" name="Avenger Attack Skimmer" hidden="false" targetId="4ee7-4a59-69c0-3fa3" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="6c2e-d453-0427-cc21" name="AI Support Team" hidden="false" targetId="0e5d-41c7-4061-6a70" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="05f3-040c-946e-9bf9" name="AI Specialist Support Team" hidden="false" targetId="0c51-2b67-3982-5c81" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="a118-d05a-1157-0fb5" name="AI Intruder Skimmer Command Squad" hidden="false" targetId="20d0-b1d4-4916-8e85" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="191a-fca7-e6a3-ab26" name="AI Intruder Skimmer Squad" hidden="false" targetId="99d2-b3d9-d1d0-fe6e" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="6960-9c82-40ee-a937" name="AI Heavy Support Team" hidden="false" targetId="2b1a-5dc0-3317-de96" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="855b-dd5a-c1a5-4bec" name="Liberator Combat Skimmer - X01 Hi-Mag" hidden="false" targetId="5e09-b21a-554e-9f8d" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="baab-e0a1-ad96-5f96" name="Liberator Combat Skimmer - X06 Plasma Destroyer" hidden="false" targetId="bd95-ec93-fc21-a6bb" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="f2ad-6cf3-072d-b58d" name="Liberator Combat Skimmer - X10 Special" hidden="false" targetId="34e3-44ad-f58c-4ed4" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
-    <selectionEntry id="e9dd-1dc6-3c92-4305" name="AG Chute" book="BtGoA" page="120" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="54c4-0df3-268c-9fe1" hidden="false" targetId="7daf-414b-c030-7626" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="828e-3aa2-3dbf-f2cb" name="Auto-Workshop" book="BtGoA" page="120" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="2aa0-3909-ff3b-5bfe" hidden="false" targetId="b7c6-fc7c-d48b-aae4" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="d571-d584-85fc-9110" name="Batter Drone" book="BtGoA" page="11" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="af35-43cb-665c-f896" name="Booster Drone" book="BtGoA" page="111" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="afb1-18d4-57fc-1fd3" name="Booster Drone" book="BtGoA" page="111" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd"/>
-            <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d"/>
-            <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145"/>
-            <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b"/>
-            <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e"/>
-            <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20"/>
-            <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="be1b-5f25-85e3-4789" hidden="false" targetId="c3e6-4e9b-858c-80d3" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="4933-25f0-2896-ac60" name="Camo Drone" book="BtGoA" page="112" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="babd-f951-933b-1254" name="Compactor Drone" book="BtGoA" page="112" hidden="false" collective="false" type="unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="666e-aa69-6e72-f168" name="Compactor Drone with Mag Cannon" book="BtGoA" page="112" hidden="false" collective="false" type="unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks>
-        <entryLink id="9c4f-f6de-c09c-eab2" hidden="false" targetId="6a2b-50c5-9a33-b756" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="2144-e450-c8f2-af26" name="Compactor Drone with Mag Light Support" book="BtGoA" page="112" hidden="false" collective="false" type="unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks>
-        <entryLink id="d525-3a93-38f1-7e4e" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="0299-39fc-32bd-8ac2" name="Compactor Drone with Plasma Cannon" book="BtGoA" page="112" hidden="false" collective="false" type="unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks>
-        <entryLink id="e506-bd0d-b513-7050" hidden="false" targetId="c2bf-0272-30c6-dd20" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="af24-45f9-4669-bf98" name="Compression Bombard" book="BtGoA" page="84" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="f3f6-794b-82b3-a39a" name="Compression Bombard" book="BtGoA" page="84" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-50"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="150"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="9/7/5"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Cycle, Heavy Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="d318-c320-5b7c-b089" hidden="false" targetId="7db4-2d14-3984-37d9" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="a2f7-528d-dd59-9d00" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="b53d-32d6-c4fc-cefc" hidden="false" targetId="cf7f-6f85-e64e-0363" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="71c9-4382-01cf-c737" name="Compression Cannon" book="BtGoA" page="78" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="b626-3a7f-ecf5-ea69" name="Compression Cannon" book="BtGoA" page="78" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="7/4/2"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Cycle,  Light Support Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="a6f9-23ce-e99d-7c15" name="Compressor" hidden="false" targetId="7db4-2d14-3984-37d9" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="3003-31fb-fb6c-3084" name="No Cover" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="70d5-a230-ba57-ead0" name="Cycle" hidden="false" targetId="cf7f-6f85-e64e-0363" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="059b-38f7-0313-5ae4" name="Compression Carbine" book="BtGoA" page="72" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="7915-046b-1179-7fab" name="Compression Carbine" book="BtGoA" page="72" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-20"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="5"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2/1/0"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Standard Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="e580-6389-7ec6-d445" hidden="false" targetId="7db4-2d14-3984-37d9" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="908d-0879-a0b5-3f4b" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="72ba-15e7-dbf7-816c" name="D-Spinner" book="BtGoA" page="66" hidden="false" collective="true" type="upgrade">
-      <profiles>
-        <profile id="bc08-23ff-215d-d442" name="D-Spinner" book="BtGoA" page="66" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="Varies"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks, Variable Res/Strike, Grenade, Hand Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="bf1e-fb77-9e71-f9fe" hidden="false" targetId="2cbd-47c9-de87-ec2a" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="363c-73f0-41ad-dfb8" hidden="false" targetId="99fd-f354-1703-5941" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="91a4-fa2b-910b-b8f8" hidden="false" targetId="b466-7990-db34-55b1" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="ff6c-f8d8-94e6-57bc" name="Disruptor Bomber" book="BtGoA" page="77" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="c100-99b7-2ff6-24a0" name="Disruptor Bomber" book="BtGoA" page="77" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D5, No Crew, Limited Ammo, No Cover, Disruptor,  Light Support Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="5bfd-e568-cff9-ff1b" hidden="false" targetId="c3bc-87fd-fa5d-5055" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="ada8-a0a5-d314-27a6" hidden="false" targetId="b050-496a-ed16-2b2a" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="c9a5-e124-997c-44ea" hidden="false" targetId="f502-611e-9704-97bb" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="b3e6-5aa3-ef1f-f7b1" hidden="false" targetId="5efa-64a9-bbc9-3dba" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="df53-3436-c62e-c73e" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="7fb2-1ffe-610d-7f33" hidden="false" targetId="6305-72fa-da02-235b" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="f771-f4b5-0047-de53" name="Disruptor Cannon" book="BtGoA" page="79" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="17db-4b84-9d1b-122d" name="Disruptor Cannon" book="BtGoA" page="79" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, No Cover, Disruptor, Light Support Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="48bb-4c87-e0f2-08b4" hidden="false" targetId="ca96-58c9-9551-d4fe" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="3b06-bc9e-4002-8aeb" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="8e03-d6b4-1fab-5cd2" hidden="false" targetId="6305-72fa-da02-235b" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="396e-b157-b3bb-a5e7" name="Disruptor Discharger" book="BtGoA" page="86" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="de01-ba7b-11ee-55ca" name="Disruptor Discharger" book="BtGoA" page="86" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="Point blank shooting only"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="Point blank shooting only"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="Point blank shooting only"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, No Cover, Disruptor, Grenade"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="e755-a7a2-1343-d27a" hidden="false" targetId="5d64-4bf5-e947-95d1" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="b2cb-0542-2c44-9f1b" hidden="false" targetId="ca96-58c9-9551-d4fe" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="049f-1e26-3f5d-a4f9" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="adad-ebe2-3953-6510" hidden="false" targetId="6305-72fa-da02-235b" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="2cec-e1d7-c680-7ca0" name="Fractal Bombard" book="BtGoA" page="83" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="279b-22b3-c3ff-1320" name="Fractal Bombard" book="BtGoA" page="83" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="50"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="200"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3 + 2 Max 10"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock, Heavy Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="fe6a-32a9-1211-b766" hidden="false" targetId="d50c-3bbe-c62d-34c3" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="93db-3751-fdd4-08f9" name="Fractal Cannon" book="BtGoA" page="76" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="cb47-aad3-9a1b-1266" name="Fractal Cannon" book="BtGoA" page="76" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2 + 1 Max 10"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock,  Light Support Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="b7b4-01fa-5f1f-ebee" hidden="false" targetId="d50c-3bbe-c62d-34c3" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="aac7-43b0-4a5c-05bb" name="Frag Borer" book="BtGoA" page="77" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="5cb2-9abf-ed28-03ff" name="Frag Borer" book="BtGoA" page="77" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3 + 1 Max 10"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock,  Light Support Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="eac9-8b04-b66c-5db6" hidden="false" targetId="d50c-3bbe-c62d-34c3" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="3975-3892-22f2-0c8e" name="Ghar Plasma Claw" book="BtGoA" page="66" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="57de-9415-94c2-a9cd" name="Ghar Plasma Claw" book="BtGoA" page="66" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="D4"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Random SV,  Hand Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="7eb4-a0e1-1e61-3d82" hidden="false" targetId="b6e3-9cf0-1a9f-a941" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="f319-5d36-f853-9d45" name="Gouger Gun" book="BtGoA" page="74" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="5caa-0eb3-a2c8-d79c" name="Gouger Gun" book="BtGoA" page="74" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-20"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Down, Inaccurate, Standard Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="6c43-9149-1b89-35e5" hidden="false" targetId="9444-e2a0-8048-5ce9" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="aa66-a1ad-73f1-8bd2" hidden="false" targetId="3b84-9d0e-a3c1-6c1f" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="b8d1-46be-c623-ad68" name="Gun Drone" book="BtGoA" page="112" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks>
-        <entryLink id="4ada-f132-9605-ef1f" hidden="false" targetId="78dd-7840-1210-fb35" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="f9cf-568d-998b-c3ca" name="Heavy Disruptor Bomber" book="BtGoA" page="80" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="a9a7-e90e-e54a-e37c" name="Heavy Disruptor Bomber" book="BtGoA" page="80" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH x2, Blast D10, Limited Ammo, No Cover, Disruptor, Heavy Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="baaa-0b37-7581-545a" hidden="false" targetId="aef6-6934-1dee-6fa0" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="ad5f-454c-b4ec-0b29" hidden="false" targetId="04d9-a48d-7b25-4dd3" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="3dc5-ce4c-aaf4-7bc4" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="1d69-8270-126c-b660" hidden="false" targetId="6305-72fa-da02-235b" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="564d-3561-f5e4-783d" name="Heavy Frag Borer" book="BtGoA" page="83" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="4001-9da2-86d1-6b80" name="Heavy Frag Borer" book="BtGoA" page="83" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6 + 1 Max 10"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock, Heavy Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="174d-fb91-0ee1-de89" hidden="false" targetId="d50c-3bbe-c62d-34c3" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="5149-5183-64d5-feaf" name="Heavy Mag Cannon" book="BtGoA" page="81" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="49f7-05c7-8536-e088" name="Heavy Mag Cannon" book="BtGoA" page="81" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="50"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="10"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="250"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Massive Damage, Heavy Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="2226-327b-9cef-5629" hidden="false" targetId="c863-510b-e239-be92" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="4fbe-feab-de05-5312" name="Heavy Tractor Maul" book="BtGoA" page="65" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="05cc-6d3b-93d8-0b0e" name="Heavy Tractor Maul" book="BtGoA" page="65" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks, Hand Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="c401-a6db-93c9-69e0" hidden="false" targetId="2cbd-47c9-de87-ec2a" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="eff8-bb0e-1b1d-bbb2" name="HL armor" book="BtGoA" page="93" hidden="false" collective="true" type="model">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="2a6f-a102-e7b6-54c7" hidden="false" targetId="b436-1f8a-5d3a-2d7d" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="573b-88bc-97d7-d890" name="HL Booster" book="BtGoA" page="121" hidden="false" collective="false" type="model">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="45e9-26e8-e029-93d0" hidden="false" targetId="56ab-52fc-9557-2586" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="1b16-412b-662a-5467" name="Homer Drone" book="BtGoA" page="112" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="f99c-daab-b3d7-9c61" name="Implosion Grenades" book="BtGoA" page="85" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="50ac-e85f-6480-9e2e" name="Implosion Grenades" book="BtGoA" page="85" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Hazardous H2H, Grenade"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="9868-0703-9743-d4b5" hidden="false" targetId="1c2c-6574-0a17-f90c" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="b357-a997-60e5-053e" name="IMTel Stave" book="BtGoA" page="67" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries>
-        <selectionEntry id="d6be-b9a8-1ea3-d1ee" name="IMTel Stave - Standard" hidden="true" collective="false" type="upgrade">
-          <profiles>
-            <profile id="9cc5-5341-3598-a655" name="IMTel Stave - Standard" book="BtGoA" page="67" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
-                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
-                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
-                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
-                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="3 Attacks, Hand Weapon"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks>
-            <infoLink id="051e-0412-fe0f-16d2" hidden="false" targetId="61e2-3707-ade3-c9ad" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="da2f-6bd2-fb0e-5e5e" name="IMTel Stave - Nano Drone Boost" hidden="true" collective="false" type="upgrade">
-          <profiles>
-            <profile id="cf0b-c836-c681-d9c0" name="IMTel Stave - Nano Drone Boost" book="BtGoA" page="67" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
-                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
-                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6"/>
-                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="3 Attacks, Blast D3, Exhausted, Hand Weapon"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks>
-            <infoLink id="8918-00b1-258e-5005" hidden="false" targetId="61e2-3707-ade3-c9ad" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="a14f-0f5e-7b8f-63f5" hidden="false" targetId="1acd-39d3-94e7-48e1" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="e461-67a4-a88e-a136" hidden="false" targetId="4232-2801-36cf-704c" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="5346-a420-8994-c5ed" name="Interceptor Bike" book="BtGoA" page="100" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="c7d2-5723-e428-dd5a" name="Ranged Weapon" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="fa7c-b456-730f-167f" hidden="false" targetId="47d9-8149-9744-9849" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="ec8f-9506-26e0-53ec" hidden="false" targetId="78dd-7840-1210-fb35" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="d3a3-d3e0-1480-e349" name="Intruder Skimmer" book="BtGoA" page="9" hidden="false" collective="true" type="upgrade">
+    <selectionEntry id="d3a3-d3e0-1480-e349" name="Intruder Skimmer" book="Rulebook" page="9" hidden="false" collective="true" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -6829,7 +2954,7 @@
           </selectionEntries>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="3aa7-ded4-1810-f136" hidden="false" targetId="f31c-6e5c-19c0-ada7" type="selectionEntry">
+            <entryLink id="3aa7-ded4-1810-f136" name="Twin Mag Repeaters" hidden="false" targetId="f6f8-67cc-ec58-fc0e" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -6845,1656 +2970,7 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="02f3-3134-ae39-afed" name="Leader 2" book="BtGoA" page="135" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="0240-940c-2896-fe6d" hidden="false" targetId="7850-89e7-bab8-86e9" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="5a4c-2f5e-40a2-91d4" name="Leader 3" book="BtGoA" page="135" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="0722-f7c8-1f58-524e" hidden="false" targetId="05bb-4d34-70cd-25d2" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="222a-c399-636e-c285" name="Lectro Lance" book="BtGoA" page="66" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="1194-e016-79d8-8f37" name="Lectro Lance" book="BtGoA" page="66" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Hand Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="10e4-842d-bb66-6204" name="Lectro Lash" book="BtGoA" page="65" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="0e1a-a803-d9c9-9f0a" name="Lectro Lash" book="BtGoA" page="65" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="3 Attacks, Hand Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="485e-5cd5-458a-5b01" hidden="false" targetId="61e2-3707-ade3-c9ad" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="3ad3-bfdd-6120-7c29" name="Lugger Gun" book="BtGoA" page="73" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="5c6f-c4ef-b4a1-32eb" name="Lugger Gun" book="BtGoA" page="73" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Limited Ammo, Standard Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="a5ed-7915-9221-076b" hidden="false" targetId="0cb1-ea91-e5bc-4f75" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="cc2c-1225-57ca-f1ed" hidden="false" targetId="5efa-64a9-bbc9-3dba" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="6a2b-50c5-9a33-b756" name="Mag Cannon" book="BtGoA" page="75" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="295a-d623-e2d2-c684" name="Mag Cannon" book="BtGoA" page="75" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="5"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="5"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Massive Damage, Light Support Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="ba14-c26b-33c6-8283" hidden="false" targetId="c863-510b-e239-be92" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="84ac-0f31-c388-d0bd" name="Mag Gun" book="BtGoA" page="69" hidden="false" collective="true" type="upgrade">
-      <profiles>
-        <profile id="d809-b3af-7007-a7b3" name="Mag Gun" book="BtGoA" page="69" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="cea7-8511-2208-1b1f" name="Mag Heavy Support" book="BtGoA" page="81" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="c318-2375-d610-2950" name="Mag Heavy Support" book="BtGoA" page="81" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="5"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF5, Heavy Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="d752-3c59-1096-f66d" hidden="false" targetId="b0cb-c022-0531-4852" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="b5e9-5297-04d2-2bf8" name="Mag Lash" book="BtGoA" page="67" hidden="false" collective="true" type="upgrade">
-      <profiles>
-        <profile id="f404-2eda-272f-57cf" name="Mag Lash" book="BtGoA" page="67" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="a97e-ddef-2a97-6023" hidden="false" targetId="2cbd-47c9-de87-ec2a" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="a00c-0542-f2a5-8124" name="Mag Light Support" book="BtGoA" page="75" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="df5b-35ce-669c-6aee" name="Mag Light Support" book="BtGoA" page="75" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="50"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3, Light Support Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="1edc-0547-c0b3-df09" hidden="false" targetId="97d4-67cb-2671-ca29" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="9733-7039-e306-26b5" name="Mag Mortar" book="BtGoA" page="81" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="d461-69b8-c506-322a" name="Mag Mortar" book="BtGoA" page="81" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH x2, Blast D10, No Cover, Heavy Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="f42c-7e9e-5b27-6658" hidden="false" targetId="aef6-6934-1dee-6fa0" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="bfd1-e214-1717-c121" hidden="false" targetId="04d9-a48d-7b25-4dd3" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="f78e-6fd2-fff5-58e2" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="515f-16b8-bc76-bce7" name="Munitions" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="77ab-48ff-9cab-2776" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries>
-            <selectionEntry id="8c7d-55d6-e1e5-cb56" name="Scrambler" book="BtGoA" page="87" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="c476-720e-e3e2-20eb" hidden="false" targetId="7a3b-74a5-3ced-dd88" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="b638-47b2-b5ea-2e59" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6494-bc1d-b5df-e211" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="5da1-c5f0-21a6-692b" name="Arc" book="BtGoA" page="87" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="cd8d-3886-23a0-8726" hidden="false" targetId="c1ba-c745-22a8-e2d7" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="18ac-e5fe-48da-edbc" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="82e7-f40e-6d30-7566" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="f7a8-81ed-30d1-1b4e" name="Blur" book="BtGoA" page="87" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="0cb7-c1e2-7a61-5cb2" hidden="false" targetId="117a-a2aa-4be7-dffe" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="80d0-ded8-3ea2-0bb6" name="" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="63d9-90c5-4551-036b" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="b724-38ff-5041-39a9" name="Scoot" book="BtGoA" page="87" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="182d-0d66-7058-f279" hidden="false" targetId="28a0-7151-a0c5-9495" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="2405-fd31-6224-3bae" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ed5c-07f7-1344-1cb5" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="973e-1e56-6981-e880" name="Net" book="BtGoA" page="87" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="eb04-ee7a-a60a-0a35" hidden="false" targetId="ac33-af99-2d76-c981" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5574-450e-4962-3b13" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e54f-b071-d13d-e536" name="Grip" book="BtGoA" page="87" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="b921-8ec2-8f15-357e" hidden="false" targetId="1045-95cb-5504-9050" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="535b-8bd3-d709-0395" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="de9d-30a6-f0b7-d375" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e0ec-966c-3971-2d18" name="All" book="BtGoA" page="87" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="cfde-9a7e-5ee3-d61f" hidden="false" targetId="c1ba-c745-22a8-e2d7" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="8951-5224-3d14-ec02" hidden="false" targetId="117a-a2aa-4be7-dffe" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="c8de-a428-d8b7-d472" hidden="false" targetId="1045-95cb-5504-9050" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="317f-3dc5-e9c2-aaa5" hidden="false" targetId="ac33-af99-2d76-c981" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="99df-e83c-17c7-845f" hidden="false" targetId="28a0-7151-a0c5-9495" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="a7ba-1f33-3492-3df2" hidden="false" targetId="7a3b-74a5-3ced-dd88" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="e103-ad44-97ad-a274" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a75e-b73b-1154-c242" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="15.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="8690-3ab7-9fef-06ee" name="Mag Pistol" book="BtGoA" page="68" hidden="false" collective="true" type="upgrade">
-      <profiles>
-        <profile id="57f9-ac99-e46c-2757" name="Mag Pistol" book="BtGoA" page="68" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Hand Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="790a-6841-6372-870b" name="Mag Repeater" book="BtGoA" page="69" hidden="false" collective="true" type="upgrade">
-      <profiles>
-        <profile id="1c20-93a8-d402-9d61" name="Mag Repeater" book="BtGoA" page="69" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Standard Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="af4a-bed9-243c-993e" hidden="false" targetId="0cb1-ea91-e5bc-4f75" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="3ecf-d559-4559-c1bb" name="Mass Compactor" book="BtGoA" page="71" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="b468-06b2-1a5d-2ec0" name="Mass Compactor" book="BtGoA" page="71" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3/2/1"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Standard Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="068c-0048-aa5f-9906" hidden="false" targetId="7db4-2d14-3984-37d9" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="af50-5808-cb3e-2ec9" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="502c-9855-7269-eaa2" name="Medi-Drone" book="BtGoA" page="113" hidden="false" collective="false" type="model">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="1a9d-01a2-ee09-883c" name="Micro-X Launcher" book="BtGoA" page="71" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries>
-        <selectionEntry id="756b-b4d4-8824-056b" name="Micro X-Launcher - Overhead" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="b067-87fe-65b4-6bd8" name="Micro X-Launcher Overhead" book="BtGoA" page="71" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-20"/>
-                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
-                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="5"/>
-                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
-                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D4, No Cover, Standard Weapon"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks>
-            <infoLink id="29b1-77a8-eac1-dcb8" hidden="false" targetId="c3bc-87fd-fa5d-5055" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="5888-4d4d-b427-d1f3" hidden="false" targetId="ca96-58c9-9551-d4fe" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="de68-1314-0e93-bc44" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="b484-5b5d-96fb-e628" name="Micro X-Launcher - Direct Fire" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="c0c1-ee5f-5c1f-77a0" name="Micro X-Launcher - Direct Fire" book="BtGoA" page="71" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
-                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
-                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
-                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="bf0f-913b-e028-8891" name="Nano Drone" book="BtGoA" page="113" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="6b54-c223-3c4a-5de7" name="Overload Ammo" book="BtGoA" page="89" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="6edf-03c1-417f-13e8" hidden="false" targetId="3559-4b87-980d-f90d" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="eb94-d1e8-1084-71b3" name="Phase Armor" book="BtGoA" page="93" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="3da3-80ac-dc11-6809" hidden="false" targetId="b28d-571e-af69-4582" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="5725-5e4d-d4f2-1dd0" name="Phase Rifle" book="BtGoA" page="72" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="d2b1-2482-5f97-a4e4" name="Phase Rifle" book="BtGoA" page="72" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="No Cover, RF D6 Fire Only, Concentrated Fire, Standard Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="0d4d-4f3f-c86d-9dbe" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="b46e-26ca-aad6-e64b" hidden="false" targetId="1863-c041-6dc4-c62d" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="6fea-ec6b-df33-2abe" hidden="false" targetId="5fb8-4f09-d496-4ea9" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="a18f-8d16-f879-e590" name="Phaseshift Shield" book="BtGoA" page="122" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="67b6-d6f5-5ba3-e50d" name="Plasma Bombard" book="BtGoA" page="82" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="a5d1-11c5-eb13-f676" name="Plasma Bombard" book="BtGoA" page="82" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="200"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="7"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Plasma Fade, Heavy Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="7388-9f57-6e2a-eadb" hidden="false" targetId="6b03-2ad4-34c1-7f73" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="c2bf-0272-30c6-dd20" name="Plasma Cannon" book="BtGoA" page="76" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="dce6-92d7-7812-820a" name="Plasma Cannon" book="BtGoA" page="76" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="4"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Plasma Fade, Light Support Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="3c39-3d6d-7a5a-f2f5" hidden="false" targetId="6b03-2ad4-34c1-7f73" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="b018-6101-d2e3-b4ea" name="Plasma Carbine" book="BtGoA" page="70" hidden="false" collective="true" type="model">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries>
-        <selectionEntry id="6eee-a6a9-5856-1e5c" name="Plasma Carbine - Single Shot" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="7257-2eab-532a-574a" name="Plasma Carbine - Single Shot" book="BtGoA" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
-                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
-                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
-                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="ee30-9dc9-222e-98ff" name="Plasma Carbine - Scatter" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="91b8-8208-7974-813c" name="Plasma Carbine - Scatter" book="BtGoA" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
-                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
-                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
-                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Standard Weapon"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks>
-            <infoLink id="b68d-f1c4-f949-d02b" hidden="false" targetId="0cb1-ea91-e5bc-4f75" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="7ac3-5fd7-f7a8-3a01" name="Plasma Grenades" book="BtGoA" page="85" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="e2c1-97d0-4ba5-2d8f" name="Plasma Grenades" book="BtGoA" page="85" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Grenade"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="47d9-8149-9744-9849" name="Plasma Lance" book="BtGoA" page="70" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries>
-        <selectionEntry id="b6e9-addd-c005-4547" name="Plasma Lance - Single Shot" book="BtGoA" page="70" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="3799-96cf-d949-da4e" name="Plasma Lance - Single Shot" book="BtGoA" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
-                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
-                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
-                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="80ed-e766-57b1-3d2a" name="Plasma Lance - Scatter" book="BtGoA" page="70" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="9ad5-3648-6628-2caa" name="Plasma Lance - Scatter" book="BtGoA" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
-                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
-                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
-                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Standard Weapon"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks>
-            <infoLink id="3f8e-ffa3-e1eb-fde7" hidden="false" targetId="0cb1-ea91-e5bc-4f75" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="4069-4420-c5b5-56af" name="Plasma Lance - Lance" book="BtGoA" page="70" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="f44f-9fdb-7e3c-bf9e" name="Plasma Lance - Lance" book="BtGoA" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
-                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
-                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="4"/>
-                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Choose Target, Inaccurate, Standard Weapon"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks>
-            <infoLink id="7213-775a-deac-dce8" hidden="false" targetId="fd72-d48c-e8af-4883" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="9752-310b-98a1-37af" hidden="false" targetId="3b84-9d0e-a3c1-6c1f" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="cf3a-e6a9-bdc0-e0ae" name="Plasma Light Support" book="BtGoA" page="76" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="d429-b8cc-aca0-aac9" name="Plasma Light Support" book="BtGoA" page="76" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="4"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3, Light Support Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="9e8b-6ee9-56f0-aedf" hidden="false" targetId="97d4-67cb-2671-ca29" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="e6db-6ed3-1a26-ea56" name="Plasma Pistol" book="BtGoA" page="68" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="6f3c-42a6-dd21-2d9d" name="Plasma Pistol" page="68" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Hand Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="9cdf-f068-bbde-2d0c" name="Reflex Armor" book="BtGoA" page="93" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="abe2-ce1e-271f-5a85" name="Scourer Cannon" book="BtGoA" page="73" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries>
-        <selectionEntry id="ccbf-d756-25d7-40f4" name="Scourer Cannon - Dispersed" book="BtGoA" page="73" hidden="true" collective="false" type="upgrade">
-          <profiles>
-            <profile id="03b8-44da-840d-df59" name="Scourer Cannon - Dispersed" book="BtGoA" page="73" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
-                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
-                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
-                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3, Standard Weapon"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks>
-            <infoLink id="6631-7298-fd9d-ce64" hidden="false" targetId="97d4-67cb-2671-ca29" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="713c-944f-32ee-fe55" name="Scourer Cannon - Concentrated" book="BtGoA" page="73" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="0f28-d6ef-0f10-6e8f" name="Scourer Cannon - Concentrated" book="BtGoA" page="73" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
-                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="40"/>
-                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="4"/>
-                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="9a2e-529c-2e81-0d99" name="Scourer Cannon - Disruptor" book="BtGoA" page="73" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="1b2e-f75a-2b45-9cde" name="Scourer Cannon - Disruptor" book="BtGoA" page="73" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
-                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
-                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
-                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, No Cover, Disruptor, Standard Weapon"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks>
-            <infoLink id="393a-a871-9061-745a" hidden="false" targetId="ca96-58c9-9551-d4fe" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="dee2-529a-c466-8b1e" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="1a7e-03a3-9055-86c1" hidden="false" targetId="6305-72fa-da02-235b" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="b145-19b3-baae-ff39" name="Shield Drone" book="BtGoA" page="114" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="8de3-1e72-72ef-e7a3" name="SlingNet Ammo" book="BtGoA" page="87" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="27d6-5dd8-337d-1005" hidden="false" targetId="5bd0-9ab2-0523-cbc8" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="db03-7794-daeb-fef6" name="Solar Charges" book="BtGoA" page="85" hidden="false" collective="true" type="upgrade">
-      <profiles>
-        <profile id="457b-abde-ffd5-bb14" name="Solar Charges" book="BtGoA" page="85" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D3, Hazardhous H2H, Grenade"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="7a23-290e-0678-0165" hidden="false" targetId="1acd-39d3-94e7-48e1" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="7cdc-f9ef-85bc-947a" hidden="false" targetId="1c2c-6574-0a17-f90c" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="3878-9363-1705-9eda" name="Soma Graft" book="BtGoA" page="121" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="3d50-6009-476b-2dd3" hidden="false" targetId="1253-ef5b-67d4-3e18" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="f3aa-148a-0460-c7e5" name="Spotter Drone" book="BtGoA" page="114" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="9cab-babb-fd75-a302" name="Strategic Genius" book="GOA" page="221" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules>
-        <rule id="d728-35a5-0ebb-1929" name="Strategic Genius" book="GOA" page="221" hidden="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <description>Strategic Genius.As a General of one of the Prosperate’s most famous armies, Tar Es Janar is expert at placing his forces where they are needed as quickly as possible. To represent this, in games where units must test their Command to deploy onto or move on to the table, they test as if they had the same stat value as Tar Es Janar – i.e. 10. Remember that rolls of a 10 will fail anyway, so even Ta Es Janar is not infallible.</description>
-        </rule>
-      </rules>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="6bfe-ff47-b61c-afd2" name="Sub-mounted X-Sling" book="BtGoA" hidden="false" collective="true" type="upgrade">
+    <selectionEntry id="6bfe-ff47-b61c-afd2" name="Sub-mounted X-Sling" book="Rulebook" hidden="false" collective="true" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -8506,7 +2982,7 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks>
-        <entryLink id="a9af-f28d-4e65-6d1b" hidden="false" targetId="b08e-548a-fda7-0a4e" type="selectionEntry">
+        <entryLink id="a9af-f28d-4e65-6d1b" name="X-Sling" hidden="false" targetId="e629-3c26-9e22-f80b" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -8519,256 +2995,7 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="fb8b-7402-c5a9-8644" name="Subverter Matrix" book="BtGoA" page="122" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="24bd-bd70-2f6b-0434" hidden="false" targetId="cd8d-624c-ed86-e310" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="02f1-fd15-ca9d-ad79" name="Tractor Maul" book="BtGoA" page="65" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="0f4d-9895-e878-29ea" name="Tractor Maul" book="BtGoA" page="65" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks, Hand Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="311e-56e1-d1bc-36a1" hidden="false" targetId="2cbd-47c9-de87-ec2a" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="ac1e-a740-57b7-cc64" name="Twin Mag Light Support" book="BtGoA" page="75" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="25d4-13e2-3977-4bd4" name="Mag Light Support" hidden="false" collective="false" defaultSelectionEntryId="d17e-2eae-cc33-8d46">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="d17e-2eae-cc33-8d46" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="c10e-6e9c-dabb-e6f1" name="Mag Light Support" hidden="false" collective="false" defaultSelectionEntryId="b385-bf67-9722-e7f9">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="b385-bf67-9722-e7f9" hidden="false" targetId="a00c-0542-f2a5-8124" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="f31c-6e5c-19c0-ada7" name="Twin Mag Repeaters" book="BtGoA" page="69" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="4e5a-4594-d2da-527c" name="Mag Repeater" hidden="false" collective="false" defaultSelectionEntryId="513b-6ec0-e655-02cd">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="513b-6ec0-e655-02cd" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="273a-5de1-c9e1-5310" name="Mag Repeater" hidden="false" collective="false" defaultSelectionEntryId="6e82-7e87-0e72-610f">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="6e82-7e87-0e72-610f" hidden="false" targetId="790a-6841-6372-870b" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="78dd-7840-1210-fb35" name="Twin Plasma Carbines" book="BtGoA" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="3053-5f5d-f959-4765" name="Plasma Carbine" hidden="false" collective="false" defaultSelectionEntryId="e69d-d58d-9506-291e">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="e69d-d58d-9506-291e" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="306b-df6b-34af-a65f" name="Plasma Carbine" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="50f5-f0eb-d9cb-a569" hidden="false" targetId="b018-6101-d2e3-b4ea" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="67fa-a913-bd09-5b13" name="Vertex Mace" book="GOA" page="221" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="67fa-a913-bd09-5b13" name="Vertex Mace" book="Rulebook" page="221" hidden="false" collective="false" type="upgrade">
       <profiles/>
       <rules>
         <rule id="0313-f279-525f-da8c" name="Vertex Mace" book="GOA" page="221" hidden="false">
@@ -8793,1210 +3020,53 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b9f1-a313-3e59-57ab" name="X-Howitzer" book="BtGoA" page="82" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="acf4-2a5f-e9a1-6d3c" name="X-Howitzer" book="BtGoA" page="82" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-50"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="250"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D10, No Cover, Heavy Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="6f40-42de-4957-1df4" hidden="false" targetId="c3bc-87fd-fa5d-5055" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="b631-2638-986b-4611" hidden="false" targetId="04d9-a48d-7b25-4dd3" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="7c8b-6880-8593-4b52" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="9c84-aa8a-fdae-0eee" name="Munitions" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1c65-4cad-f184-8ca0" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries>
-            <selectionEntry id="5e70-35f6-1241-66b5" name="Scrambler" book="BtGoA" page="87" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="921f-8605-5f61-353a" hidden="false" targetId="7a3b-74a5-3ced-dd88" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="582b-39bc-2540-df6f" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="777e-35b0-9f0f-1975" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="7f98-e7a4-5fa7-529a" name="Arc" book="BtGoA" page="87" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="335a-fd94-96c4-a6d1" hidden="false" targetId="c1ba-c745-22a8-e2d7" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="a51c-e113-d923-5b25" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6020-7091-3979-de1b" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="9fd9-4cde-846e-9b3a" name="Blur" book="BtGoA" page="87" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="bb3b-ab31-bd60-e979" hidden="false" targetId="117a-a2aa-4be7-dffe" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="a617-128b-5a82-4871" name="" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d40d-913f-a768-252a" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="3c99-94b7-7b92-b661" name="Scoot" book="BtGoA" page="87" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="9e3c-9ca7-90e4-b686" hidden="false" targetId="28a0-7151-a0c5-9495" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="0bcc-f3bd-1b1c-f89b" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f36f-8d4f-4ebd-01ec" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="15fe-38d6-b27f-fe6b" name="Net" book="BtGoA" page="87" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="c0c1-d4cb-ebce-eda1" hidden="false" targetId="ac33-af99-2d76-c981" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3e1a-c951-23f9-bbfe" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="148b-4c21-ba52-e4cd" name="Grip" book="BtGoA" page="87" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="ca8e-2899-2dec-0dc1" hidden="false" targetId="1045-95cb-5504-9050" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="8145-9cfc-9a7c-fb22" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9454-5f20-ccc0-0412" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="52a6-cafc-76a5-66da" name="All" book="BtGoA" page="87" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="de55-5375-efe7-2eaa" hidden="false" targetId="c1ba-c745-22a8-e2d7" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="e241-7517-dfab-c400" hidden="false" targetId="117a-a2aa-4be7-dffe" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="6588-020e-34af-5042" hidden="false" targetId="1045-95cb-5504-9050" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="f13a-ba1b-a665-395b" hidden="false" targetId="ac33-af99-2d76-c981" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="1692-c78c-3002-9c6c" hidden="false" targetId="28a0-7151-a0c5-9495" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="4ce6-26de-4951-a44a" hidden="false" targetId="7a3b-74a5-3ced-dd88" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="f9c9-e095-2e3b-4299" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2c67-b7a9-0fdb-6679" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="15.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="eed0-b68f-b5fb-92c7" name="X-Launcher" book="BtGoA" page="78" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="2489-100b-d116-96c6" name="X-Launcher" book="BtGoA" page="78" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D5, No Cover,  Light Support Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="cbba-ff32-112c-3173" hidden="false" targetId="c3bc-87fd-fa5d-5055" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="57ac-1f50-9d13-b33b" hidden="false" targetId="b050-496a-ed16-2b2a" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="613e-43c3-a036-e997" hidden="false" targetId="a41d-d55e-6d97-049d" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="52dd-d96e-36a2-92c3" name="Munitions" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a591-c1d3-b6de-4d3f" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries>
-            <selectionEntry id="a582-e707-8e50-7942" name="Scrambler" book="BtGoA" page="87" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="4fb0-8dbd-a444-4fff" hidden="false" targetId="7a3b-74a5-3ced-dd88" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="4ce3-0a17-ec73-68ad" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ab03-8487-b1e3-8ff4" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="97c5-6c81-103c-09e0" name="Arc" book="BtGoA" page="87" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="2bf3-1840-c201-1929" hidden="false" targetId="c1ba-c745-22a8-e2d7" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="e790-a01c-6efe-3385" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d964-f85f-7a17-6192" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="24a7-4594-3f31-bbb2" name="Blur" book="BtGoA" page="87" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="45ac-b7cc-b2b9-688b" hidden="false" targetId="117a-a2aa-4be7-dffe" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="f6d2-290c-3b69-af7b" name="" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4a02-c4c9-65c9-a624" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="9499-11a0-167a-5d95" name="Scoot" book="BtGoA" page="87" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="5479-767a-2652-af0a" hidden="false" targetId="28a0-7151-a0c5-9495" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="a8d2-5809-c054-6a59" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="48d9-fee7-77ad-8ef9" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="c1c8-d7e8-494b-d4d1" name="Net" book="BtGoA" page="87" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="ece4-43ab-abd8-60ee" hidden="false" targetId="ac33-af99-2d76-c981" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f9b6-f691-67e0-6d9a" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="98de-fab3-4b15-99a2" name="Grip" book="BtGoA" page="87" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="0c81-4950-6337-c1bf" hidden="false" targetId="1045-95cb-5504-9050" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="6d6c-ebc0-6944-cdfc" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="dae8-dc7c-6ad3-e4df" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a00d-e28d-b787-7c76" name="All" book="BtGoA" page="87" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="6f98-3bdc-3247-d742" hidden="false" targetId="c1ba-c745-22a8-e2d7" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="87d9-b0c7-9324-85b2" hidden="false" targetId="117a-a2aa-4be7-dffe" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="f6dd-242f-fde8-7dad" hidden="false" targetId="1045-95cb-5504-9050" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="f43b-9a44-ccb9-8db8" hidden="false" targetId="ac33-af99-2d76-c981" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="bdd5-34d8-2bbe-4214" hidden="false" targetId="28a0-7151-a0c5-9495" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="ffd1-a91c-652c-7491" hidden="false" targetId="7a3b-74a5-3ced-dd88" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="3a65-1001-aa3c-7d87" hidden="false" targetId="b996-131f-b84a-4724" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="01ae-b293-07f6-7248" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="15.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="b08e-548a-fda7-0a4e" name="X-Sling" book="BtGoA" page="68" hidden="false" collective="true" type="upgrade">
-      <profiles>
-        <profile id="3cec-d2e0-b0ed-7856" name="X-Sling" book="BtGoA" page="68" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D3, Hand Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks>
-        <infoLink id="ff22-4293-45d6-b483" hidden="false" targetId="1acd-39d3-94e7-48e1" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="3af1-7df9-4f90-c12c" name="Synchronizer Drone" book="BFX" page="79" hidden="false" collective="false" type="model">
+    <selectionEntry id="65c0-6778-512b-de19" name="Fractal Sights" book="CS" page="67" hidden="false" collective="true" type="upgrade">
       <profiles/>
-      <rules>
-        <rule id="8a43-b875-0c02-cece" name="Synchoniser Drone" book="BfX" page="79" hidden="false">
+      <rules/>
+      <infoLinks>
+        <infoLink id="b3d0-1ab8-3f4f-33fb" name="Fractal Sights" hidden="false" targetId="a2f2-a438-5045-8ba1" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <description>If a unit with a Synchoroniser Drone is given an order, and if it passes any order test required, then after the unit has carried out its acton the player can use the drone to try to synchonise the unit with another unit within 10&quot; of it. If sucessful draw one of his order dice from the dice bag and give this second unit an order in the usual way
-10&quot; synchonisation distance is measured AFTER the synchoronising unit resolving anything resulting from the action itself (including enemy reactions.
-If the drone dies then you may no longer sync.
-May NOT &apos;Chain&apos; syncronisers to make unit 1 sync to unit 2, who syncs to unit 3.
-May NOT be used in combination with the Command rule.
-The unit may perform any action that it normally would be able to pick.</description>
-        </rule>
-      </rules>
-      <infoLinks/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
+      <constraints/>
       <categoryLinks/>
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="20.0"/>
+        <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups/>
   <sharedRules>
-    <rule id="2cbd-47c9-de87-ec2a" name="2 Attacks" book="BtGoA" page="133" hidden="false">
+    <rule id="33cb-3828-44a5-e63f" name="Strategic Genius" book="Rulebook" page="221" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
-      <description>Two attacks in close combat.</description>
+      <description>• If units have to test to move onto table then use Janar&apos;s stats</description>
     </rule>
-    <rule id="61e2-3707-ade3-c9ad" name="3 Attacks" book="BtGoA" page="133" hidden="false">
+    <rule id="5da4-f1f8-09d7-a67a" name="Nerves of Steel" book="CS" page="109" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
-      <description>Three attacks in close combat.</description>
+      <description>• As long as Rahq is alive and the unit passes an Order test then remove an extra pin
+• On a 1 then remove three pins</description>
     </rule>
-    <rule id="7daf-414b-c030-7626" name="AG Chute" book="BtGoA" page="120" hidden="false">
+    <rule id="a2f2-a438-5045-8ba1" name="Fractal Sights" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
       <modifiers/>
-      <description>May make 2M move and shoot when given advance order. +1 Ag. Treat difficult ground as suspensored vehicle. </description>
-    </rule>
-    <rule id="c1ba-c745-22a8-e2d7" name="Arc" book="BtGoA" page="88" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Creates 3&quot; sink area. Affects any shooter attemping to draw LOS and shoot through the arc. Roll a D10 if LOS goes through - 1-5 the shot is normal, 6-10 the shot automatically misses. Make test before rolling Acc to hit. 
-
-OH shots are affected if the target is within 3&quot; of the marker. </description>
-    </rule>
-    <rule id="b7c6-fc7c-d48b-aae4" name="Auto-Workshop" book="BtGoA" page="121" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Activated from any order to the unit. Affects every vehicle, weapon drone, weapon team, and machine mounted unit within 5&quot; of the unit, and itself. Roll D10 - on 1-5, nothing happens, 6-10 each unit removes a pin.</description>
-    </rule>
-    <rule id="04d9-a48d-7b25-4dd3" name="Blast D10" book="BtGoA" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Inflicts D10 hits on a successful shooting attack.</description>
-    </rule>
-    <rule id="1acd-39d3-94e7-48e1" name="Blast D3" book="BtGoA" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Inflicts D3 hits on a successful shooting attack.</description>
-    </rule>
-    <rule id="ca96-58c9-9551-d4fe" name="Blast D4" book="BtGoA" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Inflicts D4 hits on a successful shooting attack.</description>
-    </rule>
-    <rule id="b050-496a-ed16-2b2a" name="Blast D5" book="BtGoA" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Inflicts D5 hits on a successful shooting attack.</description>
-    </rule>
-    <rule id="117a-a2aa-4be7-dffe" name="Blur" book="BtGoA" page="89" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Any unit within 3&quot; reduces Acc by D3 each time it shoots. If within two or more blur markers, roll a D3 for each and take highest.</description>
-    </rule>
-    <rule id="c3e6-4e9b-858c-80d3" name="Booster Drone" book="BtGoA" page="92" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Infantry, Weapon Team, or Command unit gains +1 armor bonus from reflex, hyperlight, and phase armor. Cannot benefit units with HL boosters.</description>
-    </rule>
-    <rule id="fd72-d48c-e8af-4883" name="Choose Target" book="BtGoA" page="70" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>May fire at a different target from the test of the unit. If more than one model has a weapon with Choose Target, all weapons with Choose Target must shoot at same target.</description>
-    </rule>
-    <rule id="5c9b-1bde-ee01-04a4" name="Command" book="BtGoA" page="133" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Friendly units within 10&quot; can use this model&apos;s Co value for any Co based test instead of their own. Pins still affect this Co value.</description>
-    </rule>
-    <rule id="7db4-2d14-3984-37d9" name="Compressor" book="BtGoA" page="71" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>SV value varies with range band.</description>
-    </rule>
-    <rule id="5fb8-4f09-d496-4ea9" name="Concentrated Fire" book="BtGoA" page="72" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Any lucky hits can be allocated to the same model, do not have to be distributed evenly.</description>
-    </rule>
-    <rule id="c34f-bbca-9bfc-6874" name="Crawler" book="BtGoA" page="133" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Crawlers are restricted when moving over certain terrain types as described in the terrain section. They cross obstacles in the same manner as a heavy weapon team. They cannot cross at a run and must test to cross at advance rate. Crossing obstacles, p22</description>
-    </rule>
-    <rule id="cf7f-6f85-e64e-0363" name="Cycle" book="BtGoA" page="78" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>On the Acc roll of a 10 shot misses and weapon team goes down.</description>
-    </rule>
-    <rule id="6305-72fa-da02-235b" name="Disruptor" book="BtGoA" page="79" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>A target hit by a disruptor weapon gets no cover bonus to its Res roll against the hit.
-
-A non-Ghar target hit by a disruptor weapon takes 2 pins rather than the usual 1 pin. If the target has Res &gt; 10, it takes these pins even if the hit is successfully resisted. Ghar do not suffer these pins. 
-
-Buddy drones can be allocated hits from this weapon by the shooter from any hits, not just lucky hits.
-
-If the target is a probe it only passes Res tests on a 1.</description>
-    </rule>
-    <rule id="9444-e2a0-8048-5ce9" name="Down" book="BtGoA" page="74" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Unit hit automatically goes down after shooting has been worked out whether casualties are caused or not. </description>
-    </rule>
-    <rule id="4232-2801-36cf-704c" name="Exhausted" book="BtGoA" page="67" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Rolls of 10 on Str or Acc to-hit rolls cannot be re-rolled and stave has become exhausted. Make a test at the turn end phase - 1-5 it is still exhausted, 6-10 it is replenished.</description>
-    </rule>
-    <rule id="b0ca-8e7d-d03f-f027" name="Fast" book="BtGoA" page="133" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Move at double pace - 10&quot; per advance, 20&quot; for run. Shots fired at fast targets with a run order must re-roll hits. 
-Fast units may break off of assault after point blank shooting has been conducted. They may move through the enemy during this move.</description>
-    </rule>
-    <rule id="7bc9-5e98-2914-5abd" name="Follow" book="BtGoA" page="13" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>When a leader with follow gives his unit an order, any other friendly units within 5&quot; may make the same action as long as they have no pins and are otherwise able to make the action.</description>
-    </rule>
-    <rule id="d50c-3bbe-c62d-34c3" name="Fractal Lock" book="BtGoA" page="83" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>If the weapon hits, it locks on. If the target does not move and the unit receives a fire order it automatically hits. Each time it auto-hits the SV value goes up by 2.</description>
-    </rule>
-    <rule id="b466-7990-db34-55b1" name="Grenade" book="BtGoA" page="85" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>In H2H counts as hand weapon +1 Str bonus. Grenade hits compound in H2H - if a model takes suffers two or more hits from grenades, add all SVs together and take one Res test.</description>
-    </rule>
-    <rule id="1045-95cb-5504-9050" name="Grip" book="BtGoA" page="87" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Unit beginning its move within 3&quot; must take and pass an Ag test. If failed it may not move, if passed it can move half rate, failed on a 10 it takes a pin and cannot move.
-
-If a unit moves within 3&quot; it must take the Ag test as above. </description>
-    </rule>
-    <rule id="1c2c-6574-0a17-f90c" name="Hazardous H2H" book="BtGoA" page="85" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Any H2H Str roll of 10 hits the user, not enemy.</description>
-    </rule>
-    <rule id="a846-6829-3398-bac1" name="Heavy" book="BtGoA" page="134" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Movement restricted across obstacles per p22. Cannot cross obstacles at a run. Agility test required to cross at advance. When rolling resistance checks only fail on a 10, roll on damage chart p37.</description>
-    </rule>
-    <rule id="3c64-6022-a5f1-9c04" name="Hero" book="BtGoA" page="134" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Friendly units within 10&quot; may use this model&apos;s Init stat. </description>
-    </rule>
-    <rule id="34e0-c5a3-3998-5d0b" name="High Commander" book="BtGoA" page="134" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>May re-roll every failed resist test once. May use command, hero, and follow special rules on any units.</description>
-    </rule>
-    <rule id="b436-1f8a-5d3a-2d7d" name="HL Armor" book="BtGoA" page="93" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Ranges of 10&quot; or less, +1 to Res. Ranges of greater than 10&quot; +2 Res. Against any Blast hits, +3 Res. </description>
-    </rule>
-    <rule id="56ab-52fc-9557-2586" name="HL Booster" book="BtGoA" page="93" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>+1 Res on top of all other bonuses.</description>
-    </rule>
-    <rule id="3b84-9d0e-a3c1-6c1f" name="Inaccurate" book="BtGoA" page="70" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Additional -1 Acc penalty.</description>
-    </rule>
-    <rule id="96c4-7a43-2a4c-d7d3" name="Infiltrator" book="BtGoA" page="134" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>May make a special pre-game run action. May sprint, test for exhaustion. May not move within 10&quot; of enemy. May lay a minefield before game starts.</description>
-    </rule>
-    <rule id="a221-d53c-b4bd-b52c" name="Large" book="BtGoA" page="134" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Cannot sprint unless also fast. Passes when testing Ag to move through dense terrain reduce movement to half. Passes on a one mean unit can move at full rate. Failure means unit cannot move, failure on a 10 gains one pin. 
-
-Units may fire over regular sized units at no penalty. Large targets never gain cover bonuses to their Res stat. May not enter buildings. </description>
-    </rule>
-    <rule id="7cfb-9874-dfe0-b136" name="Lava Spit" book="BtGoA" page="135" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Lavamites may shoot during point blank shooting at SV 2.</description>
-    </rule>
-    <rule id="e441-c3a6-7d61-2c63" name="Leader" book="BtGoA" page="135" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>May re-roll one failed res test per leader level. </description>
-    </rule>
-    <rule id="7850-89e7-bab8-86e9" name="Leader 2" book="BtGoA" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>May re-roll one failed res test per leader level.</description>
-    </rule>
-    <rule id="05bb-4d34-70cd-25d2" name="Leader 3" book="BtGoA" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>May re-roll one failed res test per leader level.</description>
-    </rule>
-    <rule id="5efa-64a9-bbc9-3dba" name="Limited Ammo" book="BtGoA" page="73,77" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Risks running out of ammunition.</description>
-    </rule>
-    <rule id="d8dc-cf25-ef95-c94b" name="Limited Choice" book="BtGoA" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>May only be taken as 1 in 4 choices of entire force.</description>
-    </rule>
-    <rule id="c863-510b-e239-be92" name="Massive Damage" book="BtGoA" page="75" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>If the mag cannon&apos;s target rolls for damage on a damage table it suffers Massive Damage - page 37.</description>
-    </rule>
-    <rule id="137e-c2b6-65b7-ecc3" name="Medic" book="BtGoA" page="135" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Units within 5&quot; of a medic unit may re-roll one failed Res test each time it is shot at. Medi-probes and drones may add their re-rolls to total number of re-rolls.
-
-Cannot be used on non-humans. </description>
-    </rule>
-    <rule id="5565-ce10-1c78-1ee7" name="MOD2" book="BtGoA" page="136" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Unit contributes two die to the dice pool and may act twice per turn. Always treated as having used the most recent action.</description>
-    </rule>
-    <rule id="8151-2e24-94ee-0477" name="MOD3" book="BtGoA" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Unit contributes three die to the dice pool and may act thrice per turn. Always treated as having used the most recent action.</description>
-    </rule>
-    <rule id="ac33-af99-2d76-c981" name="Net" book="BtGoA" page="88" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Roll to hit as normal for a blast weapon. Target does not suffer blast damage, rather suffers pins:
-
-X-Launcher: D3+1 pin
-X-Howitzer: D5+1 pin
-Mag Mortar: D10+1 pin
-
-Targets that would normally force an Acc re-roll suffer half the number of pins rounded down. Divide pins equally between two or more units as normal.</description>
-    </rule>
-    <rule id="a41d-d55e-6d97-049d" name="No Cover" book="BtGoA" page="71" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>No cover bonus to Res roll.</description>
-    </rule>
-    <rule id="f502-611e-9704-97bb" name="No Crew" book="BtGoA" page="7" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>When carried by a model in battle armor it counts as having full crew.</description>
-    </rule>
-    <rule id="c3bc-87fd-fa5d-5055" name="OH" book="BtGoA" page="34" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Fires as an Overhead weapon.</description>
-    </rule>
-    <rule id="aef6-6934-1dee-6fa0" name="OHx2" book="BtGoA" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-    </rule>
-    <rule id="7db4-6bd3-fb59-706d" name="Outcast" book="BtGoA" page="136" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Command, hero, and follow rules only work on Outcast units. Cannot benefit from command, hero, or follow from non-Outcast unless it is a High Commander.</description>
-    </rule>
-    <rule id="3559-4b87-980d-f90d" name="Overload Ammo" book="BtGoA" page="89" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Can only be used with direct fire. SV = 3, single hit. If a 10 is rolled on Acc roll, shot misses, cannot be re-rolled, and overload ammo cannot be used again.</description>
-    </rule>
-    <rule id="b28d-571e-af69-4582" name="Phase Armor" book="BtGoA" page="93" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>10&quot; or less, +1 Res. Greater than 10&quot;, +2 Res. May make a down reaction even if it already has order die - flip to down if so. </description>
-    </rule>
-    <rule id="6b03-2ad4-34c1-7f73" name="Plasma Fade" book="BtGoA" page="76" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>On the Acc roll of a 10 to hit the shot is a miss and the unit goes down.</description>
-    </rule>
-    <rule id="0f12-545e-1c86-f482" name="Plasma Reactor" book="BtGoA" page="1367" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Lucky hits are allocated by shooter and hit plasma reactor. On a Res failure of 10, roll for every other model in unit and on a 10 they are removed as well.</description>
-    </rule>
-    <rule id="5d64-4bf5-e947-95d1" name="Point Blank Shooting Only" book="BtGoA" page="86" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>May only be used for point blank shooting. Cannot be used for H2H.</description>
-    </rule>
-    <rule id="b6e3-9cf0-1a9f-a941" name="Random SV" book="BtGoA" page="66" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Roll every round for entire unit to determine SV. </description>
-    </rule>
-    <rule id="9ad5-9fc3-726e-852a" name="Rapid Sprint" book="BtGoA" page="136" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>May sprint at 4M. </description>
-    </rule>
-    <rule id="1863-c041-6dc4-c62d" name="RF D6 Fire Only" book="BtGoA" page="72" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Rapid Fire D6 when making a fire action. When shooting with advance action weapon has one shot. If issued in multiples, roll D6 for all weapons in unit.</description>
-    </rule>
-    <rule id="0cb1-ea91-e5bc-4f75" name="RF2" book="BtGoA" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>May fire two shots at rapid fire.</description>
-    </rule>
-    <rule id="97d4-67cb-2671-ca29" name="RF3" book="BtGoA" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>May fire three shots at rapid fire.</description>
-    </rule>
-    <rule id="b0cb-c022-0531-4852" name="RF5" book="BtGoA" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>May fire five shots at rapid fire.</description>
-    </rule>
-    <rule id="f7af-59ec-acde-2f75" name="Savage Strike" book="BtGoA" page="136" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Passes order check to assault on any roll except a 10, regardless of modifiers.</description>
-    </rule>
-    <rule id="28a0-7151-a0c5-9495" name="Scoot" book="BtGoA" page="88" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Only affects infantry, mounted, weapon team, beast, and humongous beast, command, and bike mounted units with living crew. Affects scramble proof units. Any affected unit within 3&quot; canno tbe given any order except run or down. Cannot make any reaction apart from go down.</description>
-    </rule>
-    <rule id="94f5-4a4c-92ad-94f9" name="Scramble Proof" book="BtGoA" page="137" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Not affected by scrambler munitions. Vehicles may be affected by scoot. Subverter matrixes cannot affect model.</description>
-    </rule>
-    <rule id="7a3b-74a5-3ced-dd88" name="Scrambler" book="BtGoA" page="88" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Enemy units within 3&quot; that are not scramble proof it loses Reflex Armor, Hyperlight Armor, and Phase Armor along with any bonuses. Units in Phase Armor cannot use their armor to go down.
-
-Weapon Drone and vehicles have Res reduced by 2 within 3&quot;. Buddy drones cease to function if the unit is within 3&quot;. Probes can do nothing at all while marker is within 3&quot;. Penalties are not cumulative.</description>
-    </rule>
-    <rule id="3377-9408-33bb-6a02" name="Self Repair" book="BtGoA" page="137" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Give unit rally order. If no pins exist after order, may attempt one repair on  immobilisation or weapon. 1-5 = success, 6-10 failure. Success = that function is working again.</description>
-    </rule>
-    <rule id="00b8-b49c-4c61-2943" name="Shard" book="BtGoA" page="137" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Every individual unit in the shard makes same action from order. Probes always run.
-
-Shard units never take pins. Always assumed to pass order tests. </description>
-    </rule>
-    <rule id="0c20-4983-db8a-0d56" name="Shared SV" book="BtGoA" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-    </rule>
-    <rule id="5bd0-9ab2-0523-cbc8" name="Slingnet Ammo" book="BtGoA" page="112" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Fired direct unless from Micro X Launcher. Targets hit suffer no damage but take +1 additional pin. Cannot affect units that cannot be pinned when hit.</description>
-    </rule>
-    <rule id="7c88-64d4-50ad-2313" name="Slow" book="BtGoA" page="137" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Move at half pace.</description>
-    </rule>
-    <rule id="6f47-5038-573a-b225" name="Sniper" book="BtGoA" page="137" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Deploy anywhere within player&apos;s half. Snipers may not be deployed within 20&quot; of other snipers, enemy may not deploy within 10&quot;. </description>
-    </rule>
-    <rule id="1253-ef5b-67d4-3e18" name="Soma Graft" book="BtGoA" page="121" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>May activate when a unit takes a Co test. Will past any Co test on any score other than 10. If a 10 is rolled, unit goes out of control and must roll the order die to generate an order. The unit does not have to comply, but if it does an order that is the only one it can do.</description>
-    </rule>
-    <rule id="b996-131f-b84a-4724" name="Special Munition" book="BtGoA" page="87" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Stays on the battlefield until it ceases to work p87. Use a marker to locate where shot lands.</description>
-    </rule>
-    <rule id="cd8d-624c-ed86-e310" name="Subverter Matrix" book="BtGoA" page="122" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-    </rule>
-    <rule id="ab37-33d8-41f3-7532" name="Transport 10" book="BtGoA" page="137" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>May transport 10 human sized models.</description>
-    </rule>
-    <rule id="99fd-f354-1703-5941" name="Variable Res/Strike" book="BtGoA" page="66" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Use to boost Res +2 or give a SV +2 each round of fighting. If used as +2 SV, counts as Grenade. </description>
+      <description>• Pass Firefight Reaction test on any roll but 10
+• Fire first in Firefight
+• If both units equipped with Fractal Sights or a unit has Duellist then roll to decide who fires first</description>
     </rule>
   </sharedRules>
   <sharedProfiles>

--- a/Algoryn_Spearhead.cat
+++ b/Algoryn_Spearhead.cat
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="fda2-ab66-dd82-bc13" name="Algoryn Spearhead" revision="1" battleScribeVersion="2.01" authorName="Dom Hine" gameSystemId="c339-677a-60db-4060" gameSystemRevision="17" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <profiles/>
+  <rules/>
+  <infoLinks/>
+  <costTypes/>
+  <profileTypes/>
+  <categoryEntries/>
+  <forceEntries/>
+  <selectionEntries/>
+  <entryLinks>
+    <entryLink id="c37b-f786-6d2b-71b6" name="Army Options" hidden="false" targetId="529a-3e2a-4bd5-5e5f" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="434a-b5d3-d66a-e467" name="Hazard Command Squad" hidden="false" targetId="2205-7ba4-9eda-b3a8" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="5f80-c8e3-f378-5759" name="AI Medic Team" hidden="false" targetId="9a7a-ffee-ac9b-986f" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="3cec-845d-515f-5506" name="Targeter Probe Shard" hidden="false" targetId="1fea-1f1e-73d8-9a98" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="2ab7-2467-6bb5-6b5e" name="Scout Probe Shard" hidden="false" targetId="0c5c-da8a-4405-a1ce" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="2a36-74ef-ba5f-2ba5" name="Defiant Transport Skimmer (Strategic)" hidden="false" targetId="7bac-88c5-659f-8b76" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="caa1-854e-9ca1-1839" name="Avenger Attack Skimmer" hidden="false" targetId="4ee7-4a59-69c0-3fa3" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="48d1-9f9e-fda0-00c8" name="AI Support Team" hidden="false" targetId="0e5d-41c7-4061-6a70" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="b913-7412-7a82-c7b5" name="AI Specialist Support Team" hidden="false" targetId="0c51-2b67-3982-5c81" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="d550-57da-b03c-2a89" name="AI Intruder Skimmer Command Squad" hidden="false" targetId="20d0-b1d4-4916-8e85" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="d8cd-4a1b-f007-1a2a" name="AI Intruder Skimmer Squad" hidden="false" targetId="99d2-b3d9-d1d0-fe6e" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="2d5b-a026-3839-d8f2" name="AI Heavy Support Team" hidden="false" targetId="2b1a-5dc0-3317-de96" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="f431-f390-af6f-3b44" name="Liberator Combat Skimmer - X01 Hi-Mag" hidden="false" targetId="5e09-b21a-554e-9f8d" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="5034-ebbd-f68c-2d32" name="Liberator Combat Skimmer - X06 Plasma Destroyer" hidden="false" targetId="bd95-ec93-fc21-a6bb" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="9682-ed29-6dfc-fae6" name="Liberator Combat Skimmer - X10 Special" hidden="false" targetId="34e3-44ad-f58c-4ed4" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="d138-9eed-bba6-e872" name="Hazard Squad" hidden="false" targetId="28be-c479-2900-63ff" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+  </entryLinks>
+  <sharedSelectionEntries/>
+  <sharedSelectionEntryGroups/>
+  <sharedRules/>
+  <sharedProfiles/>
+</catalogue>

--- a/Beyond_the_Gates_of_Antares.gst
+++ b/Beyond_the_Gates_of_Antares.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="c339-677a-60db-4060" name="Beyond the Gates of Antares" revision="14" battleScribeVersion="2.01" authorName="Muggins" authorContact="mugginns@gmail.com" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="c339-677a-60db-4060" name="Beyond the Gates of Antares" revision="18" battleScribeVersion="2.01" authorName="Dom Hine" authorContact="boltactionAB@gmail.com" authorUrl="https://www.facebook.com/groups/547335118761237/?hc_location=ufi" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -36,6 +36,18 @@
         <characteristicType id="bf58-0ad5-c7ee-3fd9" name="Extreme"/>
         <characteristicType id="897c-d3c4-3983-896a" name="Strike Value"/>
         <characteristicType id="7e87-2586-653f-d6ec" name="Special Rules"/>
+      </characteristicTypes>
+    </profileType>
+    <profileType id="5f97-84dc-4c56-bbe5" name="Transport">
+      <characteristicTypes>
+        <characteristicType id="43b0-b2e6-6e84-43b5" name="Ag"/>
+        <characteristicType id="4f48-ad72-be82-1bf7" name="Acc"/>
+        <characteristicType id="e341-f364-940e-4b44" name="Str"/>
+        <characteristicType id="0b84-3b60-5c7d-efa5" name="Res"/>
+        <characteristicType id="ef5f-c702-c74a-236d" name="Init"/>
+        <characteristicType id="c1ac-eacd-b766-3931" name="Co"/>
+        <characteristicType id="28cd-349f-14f4-0e36" name="Transport Capacity"/>
+        <characteristicType id="68b5-aa47-fdb5-1640" name="Special"/>
       </characteristicTypes>
     </profileType>
   </profileTypes>
@@ -76,6 +88,22 @@
       <constraints/>
     </categoryEntry>
     <categoryEntry id="72de-2c22-ac68-efcf" name="Army Options" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
+    <categoryEntry id="c87d-5261-face-4643" name="Limited" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="force" value="25.0" percentValue="true" shared="true" includeChildSelections="false" includeChildForces="false" id="0a3e-6bd0-f9ce-c071" type="max"/>
+      </constraints>
+    </categoryEntry>
+    <categoryEntry id="db48-a6b8-4b98-e3ed" name="Weapon Team" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -599,7 +627,9 @@
               <repeats>
                 <repeat field="limit::points" scope="roster" value="250.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="true"/>
               </repeats>
-              <conditions/>
+              <conditions>
+                <condition field="limit::points" scope="roster" value="999.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="any" type="greaterThan"/>
+              </conditions>
               <conditionGroups/>
             </modifier>
             <modifier type="set" field="d8ec-7000-299f-d24f" value="0.0">
@@ -611,7 +641,7 @@
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="-3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d8ec-7000-299f-d24f" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d8ec-7000-299f-d24f" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="e172-eb02-269f-1843-72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="false">
@@ -703,6 +733,13 @@
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cdee-09bb-189f-d6d8" type="max"/>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="baf9-ab7c-865d-2236" type="min"/>
           </constraints>
+        </categoryLink>
+        <categoryLink id="5f8b-025e-e52f-8f37" name="Limited" hidden="false" targetId="c87d-5261-face-4643" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
         </categoryLink>
       </categoryLinks>
     </forceEntry>
@@ -2062,6 +2099,190 @@
         </categoryLink>
       </categoryLinks>
     </forceEntry>
+    <forceEntry id="0845-ad59-215a-fba2" name="Algoryn Spearhead" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <forceEntries/>
+      <categoryLinks>
+        <categoryLink id="b197-07d9-af87-8452" name="Army Options" hidden="false" targetId="72de-2c22-ac68-efcf" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="ef11-6640-529f-16fb" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="ef11-6640-529f-16fb" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="c38b-d7ff-84ab-b34b" name="Tactical" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="32ec-32fe-6f2e-f839" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f077-1549-fcc1-32e4" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="aa3f-69e0-0e7c-f81f" name="Strategic" hidden="false" targetId="a01f5f58-334c-8442-d861-15099ebdf5e5" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="61c6-f921-7dfe-3148" value="2">
+              <repeats/>
+              <conditions>
+                <condition field="limit::points" scope="roster" value="999.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="greaterThan"/>
+                <condition field="limit::points" scope="roster" value="1500.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="lessThan"/>
+              </conditions>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions/>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="61c6-f921-7dfe-3148" value="3">
+              <repeats/>
+              <conditions>
+                <condition field="limit::points" scope="roster" value="1499.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="greaterThan"/>
+                <condition field="limit::points" scope="roster" value="1749.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="lessThan"/>
+              </conditions>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions/>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="61c6-f921-7dfe-3148" value="4">
+              <repeats/>
+              <conditions>
+                <condition field="limit::points" scope="roster" value="1749.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="greaterThan"/>
+                <condition field="limit::points" scope="roster" value="1999.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="lessThan"/>
+              </conditions>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions/>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="61c6-f921-7dfe-3148" value="5">
+              <repeats/>
+              <conditions>
+                <condition field="limit::points" scope="roster" value="1999.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="greaterThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="61c6-f921-7dfe-3148" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="382b-a122-840b-3659" name="Auxiliary" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="45b4-37f0-c102-be99" value="2">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="limit::points" scope="roster" value="750.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                    <condition field="limit::points" scope="roster" value="1251.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="lessThan"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="45b4-37f0-c102-be99" value="3">
+              <repeats/>
+              <conditions>
+                <condition field="limit::points" scope="roster" value="1250.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="45b4-37f0-c102-be99" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="bbf1-8b6a-4d08-0408" name="Support" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="b66c-4d9f-6069-939a" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="250.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="true"/>
+              </repeats>
+              <conditions>
+                <condition field="limit::points" scope="roster" value="1500.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="lessThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="b66c-4d9f-6069-939a" value="7">
+              <repeats/>
+              <conditions>
+                <condition field="limit::points" scope="roster" value="1499.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="greaterThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="5ec8-8ea6-4301-52e8" value="2">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="250.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="true"/>
+              </repeats>
+              <conditions>
+                <condition field="limit::points" scope="roster" value="2249.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="lessThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="5ec8-8ea6-4301-52e8" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="250.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="true"/>
+              </repeats>
+              <conditions>
+                <condition field="limit::points" scope="roster" value="2249.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="greaterThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5ec8-8ea6-4301-52e8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b66c-4d9f-6069-939a" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="91da-5ba0-de3c-d93d" name="Limited" hidden="false" targetId="c87d-5261-face-4643" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="4446-6035-f0f9-68e8" name="Weapon Team" hidden="false" targetId="db48-a6b8-4b98-e3ed" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="force" value="25.0" percentValue="true" shared="true" includeChildSelections="false" includeChildForces="false" id="dab9-4857-e9ad-7c56" type="max"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
   </forceEntries>
   <selectionEntries/>
   <entryLinks/>
@@ -2316,8 +2537,8436 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="af31-e0a9-a262-d18e" name="AG Chute" book="Rulebook" page="120" hidden="false" collective="true" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="439f-1ff9-c534-717c" name="AG Chute" hidden="false" targetId="9b49-f2a1-9917-d571" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3a6d-2025-acf1-7ba7" name="Auto-Workshop" book="Rulebook" page="120" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d588-c192-8422-07bf" name="Auto-Workshop" hidden="false" targetId="efa8-8f40-fcd9-4542" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="becb-7e47-7963-5cd9" name="Batter Drone" book="Rulebook" page="11" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="ea94-d9b0-947f-9a7a" name="Batter Drone" hidden="false" targetId="fc9f-1b48-4fc9-1044" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="63f4-ed24-5d17-1990" name="Buddy Drone" hidden="false" targetId="097c-000b-3674-ebba" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f74f-d25c-b2d4-437d" name="Booster Drone" book="Rulebook" page="111" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="2f8d-fcc4-5d43-e3b1" name="Buddy Drone" hidden="false" targetId="097c-000b-3674-ebba" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="109f-cb01-abdf-b64e" name="Booster Drone" hidden="false" targetId="2f9d-1ea5-01d2-b530" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b6b4-e09d-694d-a464" name="Camo Drone" book="Rulebook" page="112" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="20f9-6d62-52a9-9a8a" name="Camo Drone" hidden="false" targetId="3f65-c4d3-fdf3-5266" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="896f-01b8-3a91-c57b" name="Buddy Drone" hidden="false" targetId="097c-000b-3674-ebba" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="440d-ac97-e975-c6d2" name="Compactor Drone" book="Rulebook" page="112" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="c999-6614-a4ac-c40c" name="Buddy Drone" hidden="false" targetId="097c-000b-3674-ebba" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="d8d0-6206-2f87-5f68" name="Compactor Drone" hidden="false" targetId="2295-7312-b996-dc86" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3681-a2b0-5c2e-4cf2" name="Compactor Drone with Mag Cannon" book="Rulebook" page="112" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="00a0-af3d-c61c-3405" name="Buddy Drone" hidden="false" targetId="097c-000b-3674-ebba" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="996b-1aad-50e0-c378" name="Compactor Drone" hidden="false" targetId="2295-7312-b996-dc86" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="9c2b-871c-7153-c8f8" name="Mag Cannon" hidden="false" targetId="eec6-9dbc-8db5-5a96" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7b24-dfae-72c0-dd99" name="Compactor Drone with Mag Light Support" book="Rulebook" page="112" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a0fc-122b-c971-953b" name="Buddy Drone" hidden="false" targetId="097c-000b-3674-ebba" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="37d8-cb0d-2bcf-9d10" name="Compactor Drone" hidden="false" targetId="2295-7312-b996-dc86" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="3027-0ed5-5fd0-e18a" name="Mag Light Support" hidden="false" targetId="8e77-f151-c27d-0eb0" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f5a9-5ae9-121e-7657" name="Compactor Drone with Plasma Cannon" book="Rulebook" page="112" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="fedb-7928-b72b-1406" name="Compactor Drone" hidden="false" targetId="2295-7312-b996-dc86" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b7b8-714a-0164-d3b5" name="Buddy Drone" hidden="false" targetId="097c-000b-3674-ebba" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="5a67-2685-52e0-e897" name="Plasma Cannon" hidden="false" targetId="1c29-8394-0315-8140" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fd51-200c-8f6e-00a0" name="Compression Bombard" book="Rulebook" page="84" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="92c4-ca96-2b5b-4b84" name="Compression Bombard" book="Rulebook" page="84" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-50"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="150"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="9/7/5"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Cycle, Heavy Weapon, Minimum Range, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="aa8f-9a98-6667-6202" name="Cycle" hidden="false" targetId="3dda-5ab1-1343-fcf1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f64c-6b0e-59e9-0e80" name="No Cover" hidden="false" targetId="1ca0-252b-ab29-afe5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6cca-600e-ddff-6899" name="Minimum Range" hidden="false" targetId="1f14-b13a-04ed-d905" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6345-d3f0-6f49-f6cc" name="Heavy Weapon" hidden="false" targetId="5daf-557d-8a03-2a72" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="9a66-33bd-9e2b-3a8d" name="Compressor" hidden="false" targetId="d89d-cedd-bd84-ddb1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="320a-eea0-72d4-c09b" name="Compression Cannon" book="Rulebook" page="78" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="c7ff-39d6-750f-9779" name="Compression Cannon" book="Rulebook" page="78" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="7/4/2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="No Cover, Compressor, Cycle, Minimum Range, Light Support"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="7545-11a1-bfdc-43e9" name="Compressor" hidden="false" targetId="d89d-cedd-bd84-ddb1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="2246-2ba5-be60-7598" name="Light Support Weapon" hidden="false" targetId="c43d-552b-d553-8f20" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="4e96-2bae-1706-0e30" name="No Cover" hidden="false" targetId="1ca0-252b-ab29-afe5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="dbe1-d38f-34d1-fbfd" name="Minimum Range" hidden="false" targetId="1f14-b13a-04ed-d905" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="9a8d-9325-235a-a056" name="Cycle" hidden="false" targetId="3dda-5ab1-1343-fcf1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1c29-8394-0315-8140" name="Plasma Cannon" book="Rulebook" page="76" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="7393-0fbd-6f56-36ea" name="Plasma Cannon" book="Rulebook" page="76" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="4"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Plasma Fade, Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="56bc-8429-af0c-f103" name="Plasma Fade" hidden="false" targetId="72e3-4555-8f67-d0db" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7845-9c55-a7bc-0936" name="Light Support Weapon" hidden="false" targetId="c43d-552b-d553-8f20" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eec6-9dbc-8db5-5a96" name="Mag Cannon" book="Rulebook" page="75" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="60f2-7700-bdab-6698" name="Mag Cannon" book="Rulebook" page="75" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="5"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="5"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Massive Damage, Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="aae3-9a30-3c4e-1c77" name="Massive Damage" hidden="false" targetId="8622-ce63-c303-a2ed" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="0e25-875f-6a09-c912" name="Light Support Weapon" hidden="false" targetId="c43d-552b-d553-8f20" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8e77-f151-c27d-0eb0" name="Mag Light Support" book="Rulebook" page="75" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="5638-5ba4-b428-49f6" name="Mag Light Support" book="Rulebook" page="75" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="50"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3, Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="b672-dd4e-d567-b2c7" name="RF3" hidden="false" targetId="89ce-469b-2b76-90fa" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="006e-db18-9631-8ef9" name="Light Support Weapon" hidden="false" targetId="c43d-552b-d553-8f20" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="acf3-95bd-f507-dced" name="Compression Carbine" book="Rulebook" page="72" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="c933-1528-d5be-d34d" name="Compression Carbine" book="Rulebook" page="72" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="5"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2/1/0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="No Cover, Compressor, Minimum Range, Standard"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="3960-0a13-0b05-0b21" name="Compressor" hidden="false" targetId="d89d-cedd-bd84-ddb1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="4bbe-71fa-fce2-1993" name="No Cover" hidden="false" targetId="1ca0-252b-ab29-afe5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="bc44-261e-5f0f-0765" name="Standard Weapon" hidden="false" targetId="8730-6c80-7d0a-c566" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="49a8-fe6e-5ac7-cf66" name="Minimum Range" hidden="false" targetId="1f14-b13a-04ed-d905" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7184-0f74-b738-fc54" name="Compressor Torus" book="CS" page="62" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries>
+        <selectionEntry id="d861-fcea-07e5-f154" name="Ranged" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="2ddd-1104-03fe-76d5" name="Ranged" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3" profileTypeName="Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3/2/0"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Hand Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="f2a5-2cf5-10e2-ceac" name="Compressor" hidden="false" targetId="d89d-cedd-bd84-ddb1" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="1691-6f56-6b82-28c7" name="No Cover" hidden="false" targetId="1ca0-252b-ab29-afe5" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="1af4-50fd-9ba8-d59a" name="Hand Weapon" hidden="false" targetId="b159-3f51-9005-f463" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c712-aedc-bbd6-bdad" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a71e-33ad-d556-aaa9" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="827c-9a97-5a1a-1017" name="Hand to Hand" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="0cc4-2db1-3983-4f4d" name="Hand to Hand" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3" profileTypeName="Weapon">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="3 Attacks, Shock Wave, Hand Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="819d-02a4-af74-27ef" name="Hand Weapon" hidden="false" targetId="b159-3f51-9005-f463" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="c4e7-02fe-578c-e4c4" name="Shock Wave" hidden="false" targetId="8330-ddbe-10a8-d9ae" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6269-1f2e-2e18-5f8f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3149-e0e3-7ea3-b6d9" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f375-4e1e-a221-51e5" name="Cranogn Hunting Knife" book="Download" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="7edf-f763-460b-e1dc" name="Cranogn Hunting Knife" book="Download" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3" profileTypeName="Weapon">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="dff6-369c-77fc-3f62" name="Custom Mag Pistol" book="Rulebook" page="68" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="dfb0-bc5a-40d2-78f3" name="Custom Mag Pistol" book="Rulebook" page="68" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3" profileTypeName="Weapon">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Hand Weapon, Big Jobs!"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="7fb8-4f43-5f28-659d" name="Big Jobs!" hidden="false" targetId="8016-3cbd-ab0a-3b19" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="a069-8a72-c1f4-5265" name="Hand Weapon" hidden="false" targetId="b159-3f51-9005-f463" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="4035-3362-d7e8-6d63" name="Blast D3" hidden="false" targetId="177e-8b60-cc2a-557d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="324d-725c-743a-ca1e" name="Customised Mag Gun" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="7d17-3e25-0c99-bf9e" name="Customised Mag Gun" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3" profileTypeName="Weapon">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard, Customised Mag Gun"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="44db-0c89-6413-9a44" name="Standard Weapon" hidden="false" targetId="8730-6c80-7d0a-c566" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="d964-acee-3750-8489" name="Customised Mag Gun" hidden="false" targetId="1fc1-32bb-3cd2-8103" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4e4f-41b5-07ab-ffcc" name="D-Spinner" book="Rulebook" page="66" hidden="false" collective="true" type="upgrade">
+      <profiles>
+        <profile id="81a1-7aef-d548-21cc" name="D-Spinner" book="Rulebook" page="66" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="Varies"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks, Variable Strike, Grenade, Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="05eb-087e-9c60-9d45" name="2 Attacks" hidden="false" targetId="6949-9f5f-f9fa-ba1c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ef53-d6b8-2cb5-0c5f" name="Grenade" hidden="false" targetId="3ba7-d5fc-750a-c143" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7cd3-0fca-8cf2-5e45" name="Hand Weapon" hidden="false" targetId="b159-3f51-9005-f463" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="8902-a188-9128-a10a" name="Variable Res/Strike" hidden="false" targetId="8272-f4ac-feec-d11c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ce1c-4707-b943-4b9c" name="Disruptor Bomber" book="Rulebook" page="77" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="44cb-5005-66c1-657d" name="Disruptor Bomber" book="Rulebook" page="77" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D5, No Crew, Limited Ammo, No Cover, Disruptor, Minimum Range, Light Support"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="aa91-3aa4-e5de-7811" name="Disruptor" hidden="false" targetId="185f-7889-5373-782a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="0922-c838-2c09-69fd" name="Limited Ammo" hidden="false" targetId="4db2-5125-a18d-f743" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="99b0-7bb5-ff8d-fa2a" name="No Cover" hidden="false" targetId="1ca0-252b-ab29-afe5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="0caa-3c0b-4067-1e4b" name="OH" hidden="false" targetId="aa94-3f78-41b9-89cc" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="2d7a-f835-e677-48e4" name="No Crew" hidden="false" targetId="f0d7-3685-db32-141e" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f62a-3b6e-ab8d-e050" name="Minimum Range" hidden="false" targetId="1f14-b13a-04ed-d905" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7253-e670-948e-1506" name="Light Support Weapon" hidden="false" targetId="c43d-552b-d553-8f20" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ef1f-f75e-3db3-f30a" name="Blast D5" hidden="false" targetId="0ee6-cf0c-7083-dde0" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b0fc-9343-8a42-bc1a" name="Disruptor Cannon" book="Rulebook" page="79" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="5bd3-b774-9921-a077" name="Disruptor Cannon" book="Rulebook" page="79" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="No Cover, Blast D4, Disruptor, Light Support"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="9a33-a4b6-a320-008e" name="Blast D4" hidden="false" targetId="805e-60a2-1b4a-46e9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="818f-e5f7-35c6-ab2d" name="Disruptor" hidden="false" targetId="185f-7889-5373-782a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3362-92ca-8c16-1bec" name="No Cover" hidden="false" targetId="1ca0-252b-ab29-afe5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="432b-70f8-223f-6cd5" name="Light Support Weapon" hidden="false" targetId="c43d-552b-d553-8f20" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="30ad-5098-d33b-88ae" name="Disruptor Discharger" book="Rulebook" page="86" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="03e3-f652-d6f3-856e" name="Disruptor Discharger" book="Rulebook" page="86" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="Point blank shooting only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="Point blank shooting only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="Point blank shooting only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Disruptor, Blast D4, No Cover, Point Blank Shooting"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="e3ce-7244-6a0c-d58c" name="Disruptor" hidden="false" targetId="185f-7889-5373-782a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="5073-f7cc-ccfa-1f1a" name="No Cover" hidden="false" targetId="1ca0-252b-ab29-afe5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="5cea-76f3-d376-fc62" name="Point Blank Shooting Only" hidden="false" targetId="4450-f5d1-5c73-2302" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="db27-3edc-7fee-eb07" name="Blast D4" hidden="false" targetId="805e-60a2-1b4a-46e9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e1aa-ab5e-a6bf-936f" name="Fractal Bombard" book="Rulebook" page="83" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="a9cb-19bd-9c14-aa34" name="Fractal Bombard" book="Rulebook" page="83" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="50"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="200"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3 + 2 Max 10"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="66af-aaaf-784b-ef43" name="Fractal Lock" hidden="false" targetId="2af1-5c34-05ab-6369" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="39d7-7556-7252-47e8" name="Heavy Weapon" hidden="false" targetId="5daf-557d-8a03-2a72" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ace6-ea6e-a45c-fb45" name="Fractal Cannon" book="Rulebook" page="76" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="c105-b40b-617d-0fc4" name="Fractal Cannon" book="Rulebook" page="76" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2 + 1 Max 10"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock,  Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0227-c4ae-cfd9-4b76" name="Fractal Lock" hidden="false" targetId="2af1-5c34-05ab-6369" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="c289-1813-ed54-4d1a" name="Light Support Weapon" hidden="false" targetId="c43d-552b-d553-8f20" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="044a-73b8-7e3a-419e" name="Frag Borer" book="Rulebook" page="77" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="4af7-0c09-67ef-c7b6" name="Frag Borer" book="Rulebook" page="77" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3 + 1 Max 10"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock,  Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="dcea-d8b9-24db-901a" name="Fractal Lock" hidden="false" targetId="2af1-5c34-05ab-6369" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="2b62-d53b-156d-9cee" name="Light Support Weapon" hidden="false" targetId="c43d-552b-d553-8f20" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="41c4-1dbc-56fe-a91f" name="Ghar Plasma Claw" book="Rulebook" page="66" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="294f-26fb-20f5-5ee5" name="Ghar Plasma Claw" book="Rulebook" page="66" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="D4"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Random SV,  Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="1e75-842f-8f76-e6c1" name="Random SV" hidden="false" targetId="a652-6fac-03ef-4783" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6186-d04d-b12b-f3d4" name="Hand Weapon" hidden="false" targetId="b159-3f51-9005-f463" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4fc9-6bc0-766b-ad9b" name="Gouger Gun" book="Rulebook" page="74" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="a552-28ed-f4c7-5e12" name="Gouger Gun" book="Rulebook" page="74" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Down, Inaccurate, Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="cc0a-4a81-88c7-0053" name="Inaccurate" hidden="false" targetId="557e-16fd-7531-c26d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ba93-03fc-4968-78cf" name="Down" hidden="false" targetId="5464-7e74-3df1-f384" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="a75e-59d9-7e7f-720b" name="Standard Weapon" hidden="false" targetId="8730-6c80-7d0a-c566" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3608-ef7d-5cac-48ca" name="Gun Drone" book="Rulebook" page="112" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="13de-a0ac-ea3c-3cee" name="Gun Drone" hidden="false" targetId="6896-1385-66b6-d10a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f842-7b18-09f0-f668" name="Buddy Drone" hidden="false" targetId="097c-000b-3674-ebba" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="e2e3-a647-9ef9-1471" name="Twin Plasma Carbines" hidden="false" targetId="87b1-a87b-594d-257b" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="14.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1546-ac1d-c5ec-b6b8" name="Heavy Disruptor Bomber" book="Rulebook" page="80" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="831d-7c73-42ec-2b31" name="Heavy Disruptor Bomber" book="Rulebook" page="80" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH x2, Blast D10, Limited Ammo, No Cover, Disruptor, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="86b7-270f-488e-cb4d" name="Blast D10" hidden="false" targetId="d5f3-3586-02bd-c293" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="5eaf-9a9a-14d0-dfce" name="OHx2" hidden="false" targetId="8889-ca43-13d0-1afc" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="d436-37dd-a231-89fe" name="No Cover" hidden="false" targetId="1ca0-252b-ab29-afe5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="8c77-8419-7b51-161b" name="Disruptor" hidden="false" targetId="185f-7889-5373-782a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="1879-e03a-49f1-5927" name="Heavy Weapon" hidden="false" targetId="5daf-557d-8a03-2a72" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a2dc-009c-a6ec-2bdb" name="Heavy Frag Borer" book="Rulebook" page="83" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="cbae-d887-85e3-a09b" name="Heavy Frag Borer" book="Rulebook" page="83" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6 + 1 Max 10"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d5db-a277-4c67-e9a9" name="Fractal Lock" hidden="false" targetId="2af1-5c34-05ab-6369" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="db6c-055a-a9aa-f410" name="Heavy Weapon" hidden="false" targetId="5daf-557d-8a03-2a72" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5142-d68f-1b75-482e" name="Heavy Mag Cannon" book="Rulebook" page="81" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="4ac6-a39b-0fd7-14b4" name="Heavy Mag Cannon" book="Rulebook" page="81" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="50"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="10"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="250"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Massive Damage, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="b3d4-1526-5002-a0b2" name="Massive Damage" hidden="false" targetId="8622-ce63-c303-a2ed" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="8594-69e0-0a79-5778" name="Heavy Weapon" hidden="false" targetId="5daf-557d-8a03-2a72" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fc06-158f-6517-0fdc" name="Heavy Tractor Maul" book="Rulebook" page="65" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="4082-db3d-f5cb-a00e" name="Heavy Tractor Maul" book="Rulebook" page="65" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks, Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="c677-6506-3158-19be" name="2 Attacks" hidden="false" targetId="6949-9f5f-f9fa-ba1c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ad37-73c6-a045-47b0" name="Hand Weapon" hidden="false" targetId="b159-3f51-9005-f463" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f561-c73c-de8c-ae6f" name="HL Armour" book="Rulebook" page="93" hidden="false" collective="true" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="4b18-a7c2-e81c-0fe4" name="HL Armour" hidden="false" targetId="2ddf-41de-2c4e-c779" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6c89-65f8-fa8e-7131" name="HL Booster" book="Rulebook" page="121" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="5ea6-8599-1c15-9dc4" name="HL Booster" hidden="false" targetId="7ffb-4ae6-61b1-9bac" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c7c1-0444-161e-ae32" name="HL Booster Drone" book="Rulebook" page="111" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="c85d-489f-49d9-766f" name="Buddy Drone" hidden="false" targetId="097c-000b-3674-ebba" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="516e-70cd-2f71-f679" name="HL Booster Drone" hidden="false" targetId="6add-f3a8-9fbf-8031" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f0a7-4c49-aa22-ba0d" name="Homer Drone" book="Rulebook" page="112" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d6d1-bb8e-15f0-efcd" name="Buddy Drone" hidden="false" targetId="097c-000b-3674-ebba" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="84d5-60d3-2887-a1c4" name="Homer Drone" hidden="false" targetId="cad2-a1be-d4c5-48ff" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="87b1-a87b-594d-257b" name="Twin Plasma Carbines" book="Rulebook" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="52d9-6e25-66a1-73fc" name="Plasma Carbine" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3f4a-69e3-f315-b450" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="33e0-2669-9768-bba6" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="99c9-d756-1581-5d67" name="Plasma Carbine" hidden="false" targetId="3877-96bf-06bb-ff8f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e99f-7e0e-7b39-fdc6" name="Plasma Carbine" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1575-e512-73fa-d9a1" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="83a7-e4a9-e6e7-fa3d" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="a1e3-4024-d6d6-9619" name="Plasma Carbine" hidden="false" targetId="3877-96bf-06bb-ff8f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3877-96bf-06bb-ff8f" name="Plasma Carbine" book="Rulebook" page="70" hidden="false" collective="true" type="model">
+      <profiles>
+        <profile id="0b2f-b834-f4a8-13ad" name="Plasma Carbine - Scatter" book="Rulebook" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Standard Weapon"/>
+          </characteristics>
+        </profile>
+        <profile id="8ccc-4eff-2608-bfd7" name="Plasma Carbine - Single Shot" book="Rulebook" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="bca2-6487-41aa-29b1" name="Standard Weapon" hidden="false" targetId="8730-6c80-7d0a-c566" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="e557-9d28-44a9-e7ca" name="RF2" hidden="false" targetId="f0d7-e63b-bd7e-b9c8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e0cc-7e81-bd5a-f4a3" name="Implosion Grenades" book="Rulebook" page="85" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="0dc1-79ed-d81b-87a3" name="Implosion Grenades" book="Rulebook" page="85" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Hazardous H2H, Grenade"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="06b8-6003-564c-acdc" name="Grenade" hidden="false" targetId="3ba7-d5fc-750a-c143" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="87d2-d5b8-d028-e6a2" name="Hazardous H2H" hidden="false" targetId="0f95-2ca6-3bd9-35b4" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cc8b-35e4-f568-c570" name="IMTel Stave" book="Rulebook" page="67" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="95aa-66ec-323f-35dc" name="IMTel Stave - Nano Drone Boost" book="Rulebook" page="67" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="3 Attacks, Blast D3, Exhausted, Hand Weapon"/>
+          </characteristics>
+        </profile>
+        <profile id="2750-a175-eafa-8a03" name="IMTel Stave - Standard" book="Rulebook" page="67" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="3 Attacks, Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="fd80-cd04-d057-2106" name="3 Attacks" hidden="false" targetId="c286-a2b9-610b-96f2" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="503f-7cd0-1280-4299" name="Blast D3" hidden="false" targetId="177e-8b60-cc2a-557d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7649-24b5-0bf6-61e3" name="Exhausted" hidden="false" targetId="a32b-8b04-bccb-c4ea" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="334b-89ff-5d18-7d30" name="Hand Weapon" hidden="false" targetId="b159-3f51-9005-f463" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="74f0-24fa-9d47-3e0a" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6c0c-496b-7bae-0552" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="337d-13d3-81bd-c8c9" name="Interceptor Bike" book="Rulebook" page="100" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="1b43-8f77-3ea1-a204" name="Ranged Weapon" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9dcf-9b73-a331-8b08" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0e4b-db78-85e0-4f8d" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="621c-86e3-66c1-f279" name="Plasma Lance" hidden="false" targetId="3017-11d8-80c9-ba77" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="aaac-ef80-b80e-c1e0" name="Twin Plasma Carbines" hidden="false" targetId="87b1-a87b-594d-257b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4c2b-ae8c-c0cb-ae2e" name="Leader 2" book="Rulebook" page="135" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0beb-4f53-edc9-7128" name="Leader 2" hidden="false" targetId="f7db-9f56-2fd9-fd72" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6bfe-e4b6-b10e-d85d" name="Leader 3" book="Rulebook" page="135" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="9951-8393-38bc-e890" name="Leader 3" hidden="false" targetId="ce3b-c908-3ded-7a49" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6c6c-c2a4-1f79-f89e" name="Lectro Lance" book="Rulebook" page="66" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="0fac-1125-d334-d650" name="Lectro Lance" book="BtGoA" page="66" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="e915-5d67-9333-92a4" name="Hand Weapon" hidden="false" targetId="b159-3f51-9005-f463" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a396-aec1-006f-9792" name="Lectro Lash" book="Rulebook" page="65" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="2fbb-82c5-e66c-6507" name="Lectro Lash" book="Rulebook" page="65" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="3 Attacks, Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="1dc2-a7c5-7cca-2c27" name="3 Attacks" hidden="false" targetId="c286-a2b9-610b-96f2" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0418-62ae-5e81-8be1" name="Lugger Gun" book="Rulebook" page="73" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="cd91-a679-7c27-08c0" name="Lugger Gun" book="Rulebook" page="73" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Limited Ammo, Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="8bb0-0436-f8ac-690f" name="Limited Ammo" hidden="false" targetId="4db2-5125-a18d-f743" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="2b4d-73e7-9467-aa77" name="RF2" hidden="false" targetId="f0d7-e63b-bd7e-b9c8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="5320-b70e-1ea2-b24b" name="Standard Weapon" hidden="false" targetId="8730-6c80-7d0a-c566" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0f88-ab36-c5a8-7a97" name="Mag Gun" book="Rulebook" page="69" hidden="false" collective="true" type="upgrade">
+      <profiles>
+        <profile id="9282-ebe4-adc3-3c29" name="Mag Gun" book="Rulebook" page="69" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="193d-562f-c3fd-2792" name="Standard Weapon" hidden="false" targetId="8730-6c80-7d0a-c566" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="debc-cb6c-57db-3daa" name="Mag Heavy Support" book="Rulebook" page="81" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="7b0c-edef-8acc-4484" name="Mag Heavy Support" book="Rulebook" page="81" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="5"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF5, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="ca91-9987-5303-60b9" name="RF5" hidden="false" targetId="527d-a6b6-cf23-2c8d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="e337-7d0e-dceb-d40a" name="Heavy Weapon" hidden="false" targetId="5daf-557d-8a03-2a72" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3d06-c4e7-0c42-0d96" name="Mag Lash" book="Rulebook" page="67" hidden="false" collective="true" type="upgrade">
+      <profiles>
+        <profile id="8ee8-7c8f-44d3-7e88" name="Mag Lash" book="Rulebook" page="67" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d1a9-f412-750f-3e60" name="2 Attacks" hidden="false" targetId="6949-9f5f-f9fa-ba1c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="94fa-3409-fa21-c086" name="Hand Weapon" hidden="false" targetId="b159-3f51-9005-f463" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="61b9-9d2d-aa1a-1b3f" name="Mag Mortar" book="Rulebook" page="81" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="c106-7594-ca30-1e4c" name="Mag Mortar" book="Rulebook" page="81" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH x2, Blast D10, No Cover, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0099-91fb-da65-4659" name="OHx2" hidden="false" targetId="8889-ca43-13d0-1afc" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="e90e-7fa9-bfc5-9eb3" name="No Cover" hidden="false" targetId="1ca0-252b-ab29-afe5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="fb34-6759-ff3c-92e7" name="Blast D10" hidden="false" targetId="d5f3-3586-02bd-c293" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="34c9-8297-c2b0-ee63" name="Heavy Weapon" hidden="false" targetId="5daf-557d-8a03-2a72" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="32dd-05fd-f75b-81ee" name="Mag Pistol" book="Rulebook" page="68" hidden="false" collective="true" type="upgrade">
+      <profiles>
+        <profile id="e753-60cf-952c-04d2" name="Mag Pistol" book="Rulebook" page="68" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="e4a4-bc99-567c-efc4" name="Hand Weapon" hidden="false" targetId="b159-3f51-9005-f463" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ada9-abf5-49da-db67" name="Mag Repeater" book="Rulebook" page="69" hidden="false" collective="true" type="upgrade">
+      <profiles>
+        <profile id="7ae9-02b7-2d8b-afaf" name="Mag Repeater" book="Rulebook" page="69" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="aa5a-4dbe-8ceb-e0a7" name="RF2" hidden="false" targetId="f0d7-e63b-bd7e-b9c8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b49f-8096-4bda-be5d" name="Standard Weapon" hidden="false" targetId="8730-6c80-7d0a-c566" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9be5-1276-d093-3588" name="Mass Compactor" book="Rulebook" page="71" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="3617-d8d1-26bc-7224" name="Mass Compactor" book="Rulebook" page="71" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3/2/1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="5438-0775-03ed-d488" name="No Cover" hidden="false" targetId="1ca0-252b-ab29-afe5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="66e4-775f-1ae6-8218" name="Compressor" hidden="false" targetId="d89d-cedd-bd84-ddb1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6d56-d10a-9b29-5dcf" name="Standard Weapon" hidden="false" targetId="8730-6c80-7d0a-c566" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c3f0-2a1d-815e-b61a" name="Medi-Drone" book="Rulebook" page="113" hidden="false" collective="false" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="8401-fe58-ac88-eaf2" name="Medi-Probe" hidden="false" targetId="676d-baca-7681-270a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b474-f02c-691b-5118" name="Buddy Drone" hidden="false" targetId="097c-000b-3674-ebba" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="02e7-5a6e-5888-dd34" name="Micro X-Launcher" book="Rulebook" page="71" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="ae93-39aa-3146-00fd" name="Micro X-Launcher - Direct Fire" book="Rulebook" page="71" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+          </characteristics>
+        </profile>
+        <profile id="e02d-53c0-4ba5-82ac" name="Micro X-Launcher Overhead" book="Rulebook" page="71" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="5"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D4, No Cover, Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="5370-7418-157c-08a7" name="Standard Weapon" hidden="false" targetId="8730-6c80-7d0a-c566" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="dc72-66bb-5254-7d64" name="Blast D4" hidden="false" targetId="805e-60a2-1b4a-46e9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="07a2-c85a-9409-8dae" name="No Cover" hidden="false" targetId="1ca0-252b-ab29-afe5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="bf1b-9067-2399-9914" name="OH" hidden="false" targetId="aa94-3f78-41b9-89cc" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="64a6-3be3-d454-21d4" name="Standard Weapon" hidden="false" targetId="8730-6c80-7d0a-c566" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="af78-a756-8869-edf5" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5c84-8d44-fbb1-a211" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="553a-9310-02ea-dcc7" name="Nano Drone" book="Rulebook" page="113" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="9025-b581-6aa2-a1e6" name="Nano Drone Boost" hidden="false" targetId="02a5-5867-b0d9-bb0a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="377c-0e73-31b4-2eba" name="Buddy Drone" hidden="false" targetId="097c-000b-3674-ebba" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5de1-746b-be1f-93b1" name="Overload Ammo" book="Rulebook" page="89" hidden="false" collective="true" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="1a36-0f59-d8e6-b6a4" name="Overload Ammo" hidden="false" targetId="4141-4945-7178-0640" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8884-333e-43fe-b644" name="Phase Armor" book="Rulebook" page="93" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="fe55-16f8-048c-0227" name="Phase Armour" hidden="false" targetId="29e8-5172-36b9-2b93" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f6a8-ce91-f2ec-16db" name="Phase Rifle" book="Rulebook" page="72" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="73d4-cc6e-bd88-90e3" name="Phase Rifle" book="Rulebook" page="72" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="No Cover, RF D6 Fire Only, Concentrated Fire, Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="6793-e290-3993-0ab6" name="No Cover" hidden="false" targetId="1ca0-252b-ab29-afe5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="08b3-3cf0-5a15-d9b6" name="Concentrated Fire" hidden="false" targetId="0762-a86b-97dd-39f2" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="5443-403f-4abe-61db" name="RF D6 Fire Only" hidden="false" targetId="3f22-81fe-dd03-eda6" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="a506-2db0-1520-2c94" name="Standard Weapon" hidden="false" targetId="8730-6c80-7d0a-c566" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9fd4-47cc-597e-c7fe" name="Phaseshift Shield" book="Rulebook" page="122" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4a45-8595-c131-0604" name="Plasma Bombard" book="Rulebook" page="82" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="fab6-99c4-056d-11ef" name="Plasma Bombard" book="Rulebook" page="82" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="200"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="7"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Plasma Fade, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d0fb-7b68-5a9b-a5f4" name="Plasma Fade" hidden="false" targetId="72e3-4555-8f67-d0db" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="2cfe-7426-8d53-e526" name="Heavy Weapon" hidden="false" targetId="5daf-557d-8a03-2a72" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="76fa-75fa-aac0-aae1" name="Plasma Grenades" book="Rulebook" page="85" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="d6c5-2e3f-20b8-743f" name="Plasma Grenades" book="Rulebook" page="85" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Grenade"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="4614-d42b-cdc5-61c1" name="Grenade" hidden="false" targetId="3ba7-d5fc-750a-c143" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3017-11d8-80c9-ba77" name="Plasma Lance" book="Rulebook" page="70" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="d971-44c5-28b1-fd07" name="Plasma Lance - Lance" book="Rulebook" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="4"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Choose Target, Inaccurate, Standard Weapon"/>
+          </characteristics>
+        </profile>
+        <profile id="862d-9c0e-1906-b1a3" name="Plasma Lance - Scatter" book="Rulebook" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Standard Weapon"/>
+          </characteristics>
+        </profile>
+        <profile id="1d21-a32d-05a0-4f47" name="Plasma Lance - Single Shot" book="Rulebook" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="e5b0-d849-92a7-cd24" name="Choose Target" hidden="false" targetId="7b4c-a6f4-dc1f-0989" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b0fd-d8f6-9c0e-47d3" name="Inaccurate" hidden="false" targetId="557e-16fd-7531-c26d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="173c-b9f5-5d9c-1855" name="Standard Weapon" hidden="false" targetId="8730-6c80-7d0a-c566" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="1047-ed98-5f77-480b" name="RF2" hidden="false" targetId="f0d7-e63b-bd7e-b9c8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eaa4-a3c1-d269-d3cb" name="Plasma Light Support" book="Rulebook" page="76" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="110f-0740-2fbd-3c3e" name="Plasma Light Support" book="Rulebook" page="76" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="4"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3, Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="01a9-673c-28c3-03da" name="RF3" hidden="false" targetId="89ce-469b-2b76-90fa" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="86c1-b670-fd96-977f" name="Light Support Weapon" hidden="false" targetId="c43d-552b-d553-8f20" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9851-4076-e2e9-3df8" name="Plasma Pistol" book="Rulebook" page="68" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="68aa-24a6-21c6-83ae" name="Plasma Pistol" book="Rulebook" page="68" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0776-ce25-a7c1-3854" name="Hand Weapon" hidden="false" targetId="b159-3f51-9005-f463" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1523-0845-c12b-4980" name="Reflex Armor" book="Rulebook" page="93" hidden="false" collective="true" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="1f19-f897-ccf7-43aa" name="Reflex Armour" hidden="false" targetId="a71a-33af-8fc2-33d2" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8904-ceeb-024f-3535" name="Scourer Cannon" book="Rulebook" page="73" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries>
+        <selectionEntry id="3797-bdde-17dd-950e" name="Scourer Cannon - Dispersed" book="BtGoA" page="73" hidden="true" collective="false" type="upgrade">
+          <profiles>
+            <profile id="b0de-829a-16db-5b13" name="Scourer Cannon - Dispersed" book="BtGoA" page="73" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3, Standard Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="8091-1789-ecbd-ead4" name="RF3" hidden="false" targetId="89ce-469b-2b76-90fa" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="524f-da0b-7c40-bad6" name="Standard Weapon" hidden="false" targetId="8730-6c80-7d0a-c566" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a975-172b-fe07-4a35" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="94d0-f22a-7100-820a" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="aa71-ed2b-b668-142e" name="Scourer Cannon - Concentrated" book="BtGoA" page="73" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="574b-6a25-133f-72a2" name="Scourer Cannon - Concentrated" book="BtGoA" page="73" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="40"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="4"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="72d2-48d7-e7cc-1f9f" name="Standard Weapon" hidden="false" targetId="8730-6c80-7d0a-c566" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="f425-9c99-ab17-a9cb" name="Scourer Cannon - Disruptor" book="BtGoA" page="73" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="9729-41d7-b453-a3b4" name="Scourer Cannon - Disruptor" book="BtGoA" page="73" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+                <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="3"/>
+                <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+                <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, No Cover, Disruptor, Standard Weapon"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="04bf-2972-70fc-903b" name="No Cover" hidden="false" targetId="1ca0-252b-ab29-afe5" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="c199-f8ff-a518-b22d" name="Disruptor" hidden="false" targetId="185f-7889-5373-782a" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="c016-36a0-07c1-3402" name="Blast D4" hidden="false" targetId="805e-60a2-1b4a-46e9" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="4d63-642e-c487-0048" name="Standard Weapon" hidden="false" targetId="8730-6c80-7d0a-c566" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="81b9-02e2-63b6-9c6e" name="Shield Drone" book="Rulebook" page="114" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="2db5-96c0-cb31-a795" name="Buddy Drone" hidden="false" targetId="097c-000b-3674-ebba" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3cf4-b7ae-d90a-66a1" name="Shield Drone" hidden="false" targetId="0f88-1555-b001-b47e" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6849-c480-4332-7ffc" name="SlingNet Ammo" book="Rulebook" page="87" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a9e7-a3a6-7ea3-56ac" name="Slingnet Ammo" hidden="false" targetId="f562-930d-c5d5-4ca3" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="a09e-bdcd-fbc2-f682" name="Special Munition" hidden="false" targetId="8b32-dbb7-da83-4fb7" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5bfe-0652-1831-84b1" name="Solar Charges" book="Rulebook" page="85" hidden="false" collective="true" type="upgrade">
+      <profiles>
+        <profile id="a702-d909-b356-3dbc" name="Solar Charges" book="BtGoA" page="85" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D3, Hazardhous H2H, Grenade"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="3eb8-ea05-b500-c2ba" name="Blast D3" hidden="false" targetId="177e-8b60-cc2a-557d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="9feb-2087-b23b-e25d" name="Hazardous H2H" hidden="false" targetId="0f95-2ca6-3bd9-35b4" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="67e3-aaf8-ee66-9a1c" name="Grenade" hidden="false" targetId="3ba7-d5fc-750a-c143" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="12b0-e7ae-1e84-a1fb" name="Soma Graft" book="Rulebook" page="121" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="bdd0-2b1f-ca5b-f1bd" name="Soma Graft" hidden="false" targetId="cc0f-f1a5-19a0-0ed5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1da9-896b-0041-4098" name="Spotter Drone" book="Rulebook" page="114" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="de82-5076-58d8-4730" name="Spotter Drone" hidden="false" targetId="c7ec-607b-07f1-fc01" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ace3-bad0-c755-9a61" name="Buddy Drone" hidden="false" targetId="097c-000b-3674-ebba" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2b54-e8c3-b36d-8d52" name="Leader 1" book="Rulebook" page="135" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="7f5b-4a1d-d119-8139" name="Leader" hidden="false" targetId="4675-d30d-3451-8672" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4696-72ef-e971-f0b3" name="All" book="BtGoA" page="87" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="c621-86f1-015d-841c" name="Blur" hidden="false" targetId="bc98-2e6b-c063-fe98" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3b1a-8b5f-7dfc-8cef" name="Grip" hidden="false" targetId="dc90-d00c-0484-16ea" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="5b79-ffc9-d095-67ce" name="Scoot" hidden="false" targetId="c858-b4e8-5b6b-4159" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="36d9-b50d-d37e-9146" name="Special Munition" hidden="false" targetId="8b32-dbb7-da83-4fb7" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="aed6-8feb-f201-843f" name="Scrambler" hidden="false" targetId="e627-a8fe-3b4b-f1f9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6355-3c0b-2e3d-1692" name="No Cover" hidden="false" targetId="1ca0-252b-ab29-afe5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="4566-c92c-8596-6c9c" name="Arc" hidden="false" targetId="41e8-a0f3-ed44-f9d4" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6127-1d92-7372-f755" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="15.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="21b6-41b2-7add-6f1d" name="Arc" book="BtGoA" page="87" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="6a85-b7e3-112b-6137" name="Special Munition" hidden="false" targetId="8b32-dbb7-da83-4fb7" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7eb0-adb6-575f-b1d7" name="Arc" hidden="false" targetId="41e8-a0f3-ed44-f9d4" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5a50-7482-d0f3-d099" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f833-725e-65cf-ee13" name="Blur" book="BtGoA" page="87" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0e22-ae52-a296-48e8" name="Blur" hidden="false" targetId="bc98-2e6b-c063-fe98" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="4f98-532f-97d0-76dd" name="Special Munition" hidden="false" targetId="8b32-dbb7-da83-4fb7" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="91c4-da8f-8729-b0ee" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b009-d7e0-e177-e9f4" name="Grip" book="BtGoA" page="87" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="1da8-b38a-624e-3806" name="Grip" hidden="false" targetId="dc90-d00c-0484-16ea" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="647c-7a3f-6376-6b97" name="Special Munition" hidden="false" targetId="8b32-dbb7-da83-4fb7" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="de6c-2733-0d2e-02b0" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ba2f-b979-7229-0cb2" name="Net" book="BtGoA" page="87" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="c157-b424-df89-345b" name="Net" hidden="false" targetId="0ad1-fb02-de9e-6e2a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="918d-2f56-636c-7350" name="Special Munition" hidden="false" targetId="8b32-dbb7-da83-4fb7" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3911-bb00-11e5-0726" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="21a9-1a1a-7793-3301" name="Scoot" book="BtGoA" page="87" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="50cc-4317-5eb4-a4f3" name="Scoot" hidden="false" targetId="c858-b4e8-5b6b-4159" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="700e-e6df-0cb0-11e8" name="Special Munition" hidden="false" targetId="8b32-dbb7-da83-4fb7" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="152a-3201-5aa9-6571" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0d46-b571-8bcc-1a71" name="Scrambler" book="BtGoA" page="87" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="7c85-083f-7355-7241" name="Scrambler" hidden="false" targetId="e627-a8fe-3b4b-f1f9" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="235c-7559-d098-cd7b" name="Special Munition" hidden="false" targetId="8b32-dbb7-da83-4fb7" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b4f1-7ade-b05d-07b1" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fad2-eb31-e6fc-b4ec" name="Strategic Genius" book="Rulebook" page="221" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules>
+        <rule id="01e6-a2b4-ff0b-13c8" name="Strategic Genius" book="GOA" page="221" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>Strategic Genius.As a General of one of the Prosperate’s most famous armies, Tar Es Janar is expert at placing his forces where they are needed as quickly as possible. To represent this, in games where units must test their Command to deploy onto or move on to the table, they test as if they had the same stat value as Tar Es Janar – i.e. 10. Remember that rolls of a 10 will fail anyway, so even Ta Es Janar is not infallible.</description>
+        </rule>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="488a-2fb6-54b8-3dd7" name="Sub-mounted X-Sling" book="Rulebook" hidden="false" collective="true" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="9e1d-a6da-f589-42f7" name="X-Sling" hidden="false" targetId="e629-3c26-9e22-f80b" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a7f9-0a45-15f9-2f79" name="Subverter Matrix" book="Rulebook" page="122" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d475-563a-69e2-0758" name="Subverter Matrix" hidden="false" targetId="795b-3127-4b6d-91f7" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3b29-0c16-4aa3-aca3" name="Synchronizer Drone" book="BX" page="79" hidden="false" collective="false" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="2a46-4cd2-2810-99d2" name="Buddy Drone" hidden="false" targetId="097c-000b-3674-ebba" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="fdd8-53c3-7689-fea3" name="Synchroniser Drone" hidden="false" targetId="8bba-bf54-4439-2f32" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e105-87cd-5813-0e1b" name="Tractor Maul" book="Rulebook" page="65" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="dcf7-2d9a-2103-5066" name="Lectro Lash" book="Rulebook" page="65" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="2 Attacks, Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="c28b-b69d-c112-af49" name="2 Attacks" hidden="false" targetId="6949-9f5f-f9fa-ba1c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f2a1-d5af-dfe5-9a87" name="Hand Weapon" hidden="false" targetId="b159-3f51-9005-f463" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f6f8-67cc-ec58-fc0e" name="Twin Mag Repeaters" book="Rulebook" page="69" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="a090-328b-0b3d-45e4" name="Mag Repeater" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9d1e-f3b4-9a82-496e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="47d0-ffc5-0201-7822" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="d2ff-ab4d-8aff-5ac2" name="Mag Repeater" hidden="false" targetId="ada9-abf5-49da-db67" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="50a4-c4c9-9b35-c736" name="Mag Repeater" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b118-a523-5347-3411" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="62c2-7db6-87b0-adc3" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="d8b2-a3c5-1071-306c" name="Mag Repeater" hidden="false" targetId="ada9-abf5-49da-db67" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d250-8bf1-5c55-e9c6" name="Vertex Mace" book="Rulebook" page="221" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules>
+        <rule id="aca7-9355-fab0-07a3" name="Vertex Mace" book="GOA" page="221" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>The vertex mace is both a symbol of oﬃce and a tool that gives its wielder the ability to intercept and direct nano‐coms and interface directly with the combat shards of units under his command. This enables the commander to extend his Command rule to any unit on the table that has a spotter drone regardless of range.</description>
+        </rule>
+      </rules>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ab2e-edc9-b214-f7d5" name="X-Howitzer" book="Rulebook" page="82" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="c17d-42c3-b4e5-517f" name="X-Howitzer" book="Rulebook" page="82" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-50"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="250"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D10, No Cover, Heavy Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="1bb6-0670-63bf-26f4" name="Blast D10" hidden="false" targetId="d5f3-3586-02bd-c293" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ab56-5a0c-895f-e85d" name="No Cover" hidden="false" targetId="1ca0-252b-ab29-afe5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="c3d6-e7c5-0071-8ff5" name="OH" hidden="false" targetId="aa94-3f78-41b9-89cc" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f73c-9796-c5a2-27ea" name="Heavy Weapon" hidden="false" targetId="5daf-557d-8a03-2a72" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="b1dc-f7b0-87af-172d" name="Special Munitions" hidden="false" targetId="6dbe-a221-4d79-ff6a" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e2c7-1c85-2088-3005" name="X-Launcher" book="Rulebook" page="78" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="4aeb-2db5-e5e9-95dd" name="X-Launcher" book="Rulebook" page="78" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D5, No Cover,  Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="e3cd-e712-9e0b-51ca" name="OH" hidden="false" targetId="aa94-3f78-41b9-89cc" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6b16-8a6f-5b9f-924d" name="No Cover" hidden="false" targetId="1ca0-252b-ab29-afe5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="e0c0-3e8f-9fc0-0b93" name="Blast D5" hidden="false" targetId="0ee6-cf0c-7083-dde0" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="d9c1-7489-4b9d-9fab" name="Light Support Weapon" hidden="false" targetId="c43d-552b-d553-8f20" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e629-3c26-9e22-f80b" name="X-Sling" book="Rulebook" page="68" hidden="false" collective="true" type="upgrade">
+      <profiles>
+        <profile id="7799-83dd-33bc-6564" name="X-Sling" book="Rulebook" page="68" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D3, Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d51d-b640-4dd9-c93f" name="Blast D3" hidden="false" targetId="177e-8b60-cc2a-557d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="d80e-c8df-df69-961d" name="Hand Weapon" hidden="false" targetId="b159-3f51-9005-f463" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b065-9dee-2444-0546" name="Twin Mag Light Support" book="Rulebook" page="75" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e205-13a7-9e0c-4338" name="Mag Light Support" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2484-9769-f22f-54be" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fe22-6d18-8ea1-5053" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="22f9-dddf-4144-0d87" name="Mag Light Support" hidden="false" targetId="8e77-f151-c27d-0eb0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1ae9-8afe-1a36-99e7" name="Mag Light Support" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a293-e699-26a2-b27b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1b4e-bdd5-fd83-9a52" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="2201-6a59-5a35-5497" name="Mag Light Support" hidden="false" targetId="8e77-f151-c27d-0eb0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2836-8f7f-68e6-1ac0" name="Fixed-Emission Armour Upgrade" book="pdf v2" page="" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="811c-8623-5489-9ee0" name="Impact Cloak" book="Rulebook" page="93" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="ab33-e523-0901-27a6" name="Impact Cloak" hidden="false" targetId="3ab2-763e-e2eb-30f6" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="abb5-85f1-2716-bbee" name="Choose Munitions" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f93-c0a6-4cee-817b" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="91a4-6868-b8a8-4051" name="Hazard Armor" book="CS" page="67" hidden="false" collective="true" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="64c9-f725-80ec-a974" name="Hazard Armour" hidden="false" targetId="3c69-0775-51bd-bf1c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="83c2-5b86-3558-8d1b" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="36ec-17ff-51ed-b4bb" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3f4b-988a-c3c2-8819" name="Plasma Carbine (Hazard)" book="Rulebook, CS" page="70, 67 CS" hidden="false" collective="true" type="model">
+      <profiles>
+        <profile id="333f-cb72-5cef-04db" name="Plasma Carbine - Scatter" book="Rulebook" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3, Standard Weapon"/>
+          </characteristics>
+        </profile>
+        <profile id="e691-3c99-8668-ae32" name="Plasma Carbine - Single Shot" book="Rulebook" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="14d8-dfb8-b9af-536e" name="Plasma Carbine - Scatter" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="1b91-c074-1099-dde6" name="RF3" hidden="false" targetId="89ce-469b-2b76-90fa" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="caab-7131-c3b2-59d8" name="Standard Weapon" hidden="false" targetId="8730-6c80-7d0a-c566" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="451a-0e4a-4831-4c59" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d31a-9eb4-ccc8-59d6" name="Intruder Skimmer" book="Rulebook" page="9" hidden="false" collective="true" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9270-3f68-a4eb-5c93" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4cdd-bee0-021c-a455" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="51c1-aae4-3a68-7e77" name="Ranged Weapon" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b838-b323-27d7-1efe" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1e90-4b8a-58ed-d29e" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="642f-1a50-8d58-f04f" name="Twin Mag Repeaters" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a063-6e5b-2c5d-a670" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6f82-d6ce-4923-3658" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="f9e3-cc4a-2bf9-4682" name="Twin Mag Repeaters" hidden="false" targetId="f6f8-67cc-ec58-fc0e" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2205-7ba4-9eda-b3a8" name="Hazard Command Squad" book="CS &amp; pdf force list v2" page="" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="4912-d86c-957c-55f5" name="Infantry Command Unit" hidden="false" targetId="0a6b-dcfb-ccc3-6a0d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="04c5-7967-b42f-5a37" name="Limited Choice" hidden="false" targetId="8cb3-4c3e-dc5f-b952" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="d3a2-ca11-3048-48e8" name="New CategoryLink" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="676f-7f92-9182-218f" name="New CategoryLink" hidden="false" targetId="c87d-5261-face-4643" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="b46c-0d29-9580-5107" name="Hazard Commander" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="9209-61bb-bd26-c498" name="Hazard Commander" book="BtGoA" page="" hidden="false" profileTypeId="1650-77b3-10d1-6406" profileTypeName="Model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="3"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (10)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="5"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="d29e-00bc-4e24-6e8b" name="Command" hidden="false" targetId="f001-a3be-81f7-f74f" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="d697-f3cf-dc0e-12d1" name="Follow" hidden="false" targetId="4bdd-65b7-6ee8-89b2" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7e3b-d713-9ef6-86af" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7836-c7f7-7011-8f40" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="42bf-e043-d18a-6470" name="D-Spinner" hidden="false" targetId="4e4f-41b5-07ab-ffcc" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d61-3457-ebc3-52c4" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="caec-c7da-89ea-9a9d" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="b987-4df9-606b-290d" name="Leader Level (Up To 3)" hidden="false" targetId="6fc6-32a7-74b6-1b4b" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="0326-bd92-f371-1a44" name="Plasma Carbine (Hazard)" hidden="false" targetId="3f4b-988a-c3c2-8819" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e67-2576-58d8-b0e0" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fdd-d42f-81b3-f5a6" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="41e4-d911-4a0f-0184" name="Hazard Armor" hidden="false" targetId="91a4-6868-b8a8-4051" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8de5-5d07-fca5-d53a" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0945-ff62-611a-f864" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7acd-a9c1-915e-196e" name="Hazard Trooper" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="d70d-84cf-5b83-db4f" name="HazardTrooperHQ" book="" page="" hidden="false" profileTypeId="1650-77b3-10d1-6406" profileTypeName="Model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="3"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (10)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="5"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9376-694e-ab0b-8123" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2ce9-556d-8626-6ce1" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="32.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="8f99-c836-6a0a-7225" name="Medi-Drone" hidden="false" targetId="c3f0-2a1d-815e-b61a" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af50-13f8-f474-ea04" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="a0f4-97ad-a941-ae0f" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ece6-ae06-8057-a888" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="a539-0211-a415-535a" name="Hazard Armor" hidden="false" targetId="91a4-6868-b8a8-4051" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="57b8-d4b5-2948-3845" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a1b-bec7-79a9-8790" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="a2cf-4059-f74a-f954" name="Synchronizer Drone" hidden="false" targetId="3b29-0c16-4aa3-aca3" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0afb-4a92-fc3e-0cdf" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="d2ce-2cf9-9cdc-1334" name="D-Spinner" hidden="false" targetId="4e4f-41b5-07ab-ffcc" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="900c-64d9-75db-5284" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b48c-acad-b111-9a08" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="5f0d-f585-4da1-44c4" name="Plasma Carbine (Hazard)" hidden="false" targetId="3f4b-988a-c3c2-8819" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18d1-4413-8165-7834" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7dd0-8a5e-c36c-3e7b" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="74.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="28be-c479-2900-63ff" name="Hazard Squad" book="CS &amp; pdf force list v2" page="" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="9f43-ce0b-499b-0365" name="Infantry Unit" hidden="false" targetId="9a87-2673-83b1-3986" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="6279-7e7b-d172-c20e" name="New CategoryLink" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="33a6-b633-5f2e-97b2" name="Hazard Leader" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="5223-b722-bf27-d6d3" name="Hazard Leader" book="" page="" hidden="false" profileTypeId="1650-77b3-10d1-6406" profileTypeName="Model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="3"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (10)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="5"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="3d25-a94f-2e91-1e8c" name="Command" hidden="false" targetId="f001-a3be-81f7-f74f" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="e73e-c0ce-1217-1255" name="Follow" hidden="false" targetId="4bdd-65b7-6ee8-89b2" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5a0e-882a-9fc0-a699" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5afc-3876-f16d-92d1" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="8e3f-5a34-fe9a-f0a4" name="Plasma Carbine (Hazard)" hidden="false" targetId="3f4b-988a-c3c2-8819" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f821-af02-2f35-3430" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35a0-570e-d091-c9f6" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="b978-75d8-4f47-a34b" name="D-Spinner" hidden="false" targetId="4e4f-41b5-07ab-ffcc" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31b4-2afb-f710-8907" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9ff8-5cce-42ef-f570" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="d49d-9f23-c63f-9899" name="Leader Level (Up To 2)" hidden="false" targetId="14a9-9070-281d-b6d6" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d625-ef23-1923-35b5" name="Hazard Trooper" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="4419-41d1-4a03-c25a" name="HazardTrooperUnit" book="" page="" hidden="false" profileTypeId="1650-77b3-10d1-6406" profileTypeName="Model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="3"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (10)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="5"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3242-243e-5939-32f7" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0f51-4611-8d5c-17a4" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="30.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="6d62-8839-bc68-9a9d" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a91-955f-5a8b-ebfe" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="7179-978a-8094-157a" name="Hazard Armor" hidden="false" targetId="91a4-6868-b8a8-4051" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="942a-f94b-9495-5265" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="74da-6850-9d23-ad6f" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="7e2b-5643-fd0d-f395" name="Synchronizer Drone" hidden="false" targetId="3b29-0c16-4aa3-aca3" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35ef-c311-b8e8-3b94" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="789f-2be4-f345-e0c7" name="D-Spinner" hidden="false" targetId="4e4f-41b5-07ab-ffcc" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8dfb-7bec-de54-001a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="208b-f283-7c4f-3ba1" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="be2d-3493-9184-ce2b" name="Plasma Carbine (Hazard)" hidden="false" targetId="3f4b-988a-c3c2-8819" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07d5-78d9-ad5f-2956" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e77-ae90-19de-6776" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1fea-1f1e-73d8-9a98" name="Targeter Probe Shard" book="Rulebook &amp; pdf force list v2" page="178" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="efc5-0a60-b00d-e172" name="Probe Unit" hidden="false" targetId="b8e9-1952-608c-accf" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="f6c2-6202-df38-2ecd" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="2a31-63b6-5ae6-6531" name="Targeter Probe" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="81ff-2848-9f2e-e5eb" name="Targeter Probe" book="" page="" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="c3c5-6389-3284-7f74" name="Shard" hidden="false" targetId="e1b9-e087-1984-fde7" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8402-2bda-15c4-c6b7" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="90d9-cf9b-9219-a0a8" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0c5c-da8a-4405-a1ce" name="Scout Probe Shard" book="Rulebook &amp; pdf force list v2" page="178" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="96b9-53fe-89c7-29a2" name="Probe Unit" hidden="false" targetId="b8e9-1952-608c-accf" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="7e9c-f01d-2d87-f1de" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="7824-1d43-138a-327b" name="Scout Probe" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="9516-2acf-989f-9426" name="Scout Probe" book="" page="" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="63bf-1aa0-fea0-6121" name="Shard" hidden="false" targetId="e1b9-e087-1984-fde7" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="39a1-5237-0379-b961" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cb86-56cf-6bd4-d751" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9a7a-ffee-ac9b-986f" name="AI Medic Team" book="Rulebook &amp; pdf force list v2" page="178" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="3c9b-4182-df4d-bcf2" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="b5b7-787b-1b9a-7d54" name="Algoryn Medic" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="86f3-5691-1ec0-d112" name="Algoryn Medic" book="" page="" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (7)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="b20a-6a49-acf1-c870" name="Medic" hidden="false" targetId="0a73-a3fc-2183-7548" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="04c0-4b62-4d2d-b8fe" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bfb6-97bc-425b-5300" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="39a7-ce1a-f785-7a23" name="Reflex Armor" hidden="false" targetId="1523-0845-c12b-4980" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e8f7-48a5-5f0f-7745" name="Weapons" hidden="false" collective="false" defaultSelectionEntryId="8c73-db67-8e87-da80">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3212-ed95-0fd7-a8c2" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2d46-dea0-a5b7-abf3" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="032e-7445-26ef-5aae" name="Mag Gun" hidden="false" targetId="0f88-ab36-c5a8-7a97" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="9a7a-ffee-ac9b-986f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b5b7-787b-1b9a-7d54" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="7f27-0f32-e420-3bb5" name="Mag Repeater" hidden="false" targetId="ada9-abf5-49da-db67" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="9a7a-ffee-ac9b-986f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b5b7-787b-1b9a-7d54" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="8c73-db67-8e87-da80" name="Mag Pistol" hidden="false" targetId="32dd-05fd-f75b-81ee" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="c084-15a0-96e0-22e7" name="Medi-Drone" hidden="false" targetId="c3f0-2a1d-815e-b61a" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23b1-ff2f-7061-6d0c" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="a5b5-a5d0-1573-86e4" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2511-67ea-50fc-380c" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7bac-88c5-659f-8b76" name="Defiant Transport Skimmer (Strategic)" book="Rulebook &amp; pdf force list v2" page="176" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="7884-cf21-e6bf-7e32" name="AI Defiant Transport Skimmer" book="" page="" hidden="false" profileTypeId="5f97-84dc-4c56-bbe5" profileTypeName="Transport">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="0b84-3b60-5c7d-efa5" value="12">
+              <repeats>
+                <repeat field="selections" scope="7bac-88c5-659f-8b76" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="db56-c2b7-cd5f-48ca" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="0b84-3b60-5c7d-efa5" value="13">
+              <repeats>
+                <repeat field="selections" scope="7bac-88c5-659f-8b76" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="397b-fd02-599d-eb8b" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Ag" characteristicTypeId="43b0-b2e6-6e84-43b5" value="5"/>
+            <characteristic name="Acc" characteristicTypeId="4f48-ad72-be82-1bf7" value="6"/>
+            <characteristic name="Str" characteristicTypeId="e341-f364-940e-4b44" value="1"/>
+            <characteristic name="Res" characteristicTypeId="0b84-3b60-5c7d-efa5" value="11"/>
+            <characteristic name="Init" characteristicTypeId="ef5f-c702-c74a-236d" value="8"/>
+            <characteristic name="Co" characteristicTypeId="c1ac-eacd-b766-3931" value="8"/>
+            <characteristic name="Transport Capacity" characteristicTypeId="28cd-349f-14f4-0e36" value="10"/>
+            <characteristic name="Special" characteristicTypeId="68b5-aa47-fdb5-1640"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="2a00-9277-0b09-8453" name="MOD2" hidden="false" targetId="88ae-fedb-5c1c-3a7b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="fe7a-8343-a8b5-f22c" name="Large" hidden="false" targetId="59d7-7273-b97c-0dff" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6dbe-1012-0654-a1ac" name="Transport 10" hidden="false" targetId="8509-6fcc-0fc0-21ae" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7dfe-6f73-fa46-d742" name="Vehicle Unit" hidden="false" targetId="29d8-590a-bc46-d27a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="3635-e4e8-9d41-403c" name="New CategoryLink" hidden="false" targetId="a01f5f58-334c-8442-d861-15099ebdf5e5" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="1e70-d862-6390-0390" name="Self Repair" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="4133-4ba4-7390-f665" name="Self Repair" hidden="false" targetId="7c54-5982-a5ef-b888" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="points" value="10">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="af8e-5265-d835-9d23" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="9061-987f-f2af-5137" name="Weapon" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0284-1031-a8d0-9854" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="15b0-6887-fc65-f581" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="5f1d-6ce1-5d67-9339" name="Mag Light Support" hidden="false" targetId="8e77-f151-c27d-0eb0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="20">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="010a-6145-6b15-823b" name="Mag Cannon" hidden="false" targetId="eec6-9dbc-8db5-5a96" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="30">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="b075-7f38-6186-a71c" name="Twin Mag Light Support" hidden="false" targetId="b065-9dee-2444-0546" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="45">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6dbc-033f-f046-22f0" name="Armour Upgrades" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5ca7-9740-1cd4-2e26" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ca43-1933-787b-39f3" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="db56-c2b7-cd5f-48ca" name="HL Booster" hidden="false" targetId="6c89-65f8-fa8e-7131" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="24">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="397b-fd02-599d-eb8b" name="Fixed-Emission Armour Upgrade" hidden="false" targetId="2836-8f7f-68e6-1ac0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="48">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="0726-d7f5-3ae6-23a4" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="584e-42a6-3775-9c61" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="d66e-122d-24d4-9bbc" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="476f-58ac-b7fb-a6ca" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="9fb8-fd38-1ec6-e476" name="Shield Drone" hidden="false" targetId="81b9-02e2-63b6-9c6e" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="94bb-550c-d780-a3db" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="106.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4ee7-4a59-69c0-3fa3" name="Avenger Attack Skimmer" book="Rulebook &amp; pdf force list v2" page="175" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="a43d-745f-eaeb-a643" name="AI Avenger Skimmer" book="Rulebook &amp; pdf force list v2" page="175" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="f214-abe8-c922-c51b" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="4ee7-4a59-69c0-3fa3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b56b-f2ce-02d0-a15a" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <characteristics>
+            <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+            <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+            <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+            <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="11"/>
+            <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+            <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+            <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="f80b-2a99-3a79-ad67" name="MOD2" hidden="false" targetId="88ae-fedb-5c1c-3a7b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="850e-c8c0-2491-ae5b" name="Large" hidden="false" targetId="59d7-7273-b97c-0dff" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="053d-f6ae-c756-b6f6" name="Vehicle" hidden="false" targetId="29d8-590a-bc46-d27a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="b271-34df-be6f-7005" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="d50f-3f93-6af6-1c61" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="034b-f79c-ca1e-80c7">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1dec-171b-c2bb-3c1f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ff6c-de3b-2283-3ae9" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="034b-f79c-ca1e-80c7" name="Mag Light Support" hidden="false" targetId="8e77-f151-c27d-0eb0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="9ee9-3c0a-b10c-7697" name="Twin Mag Light Support" hidden="false" targetId="b065-9dee-2444-0546" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="25">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="73c2-23c1-ed05-dca1" name="Mag Cannon" hidden="false" targetId="eec6-9dbc-8db5-5a96" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="eced-d902-bbaa-cf08" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3991-6073-93e4-32e5" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="372e-07c2-4439-0cc0" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1fc-c413-c857-86e3" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="b56b-f2ce-02d0-a15a" name="HL Booster" hidden="false" targetId="6c89-65f8-fa8e-7131" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="points" value="24">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f5f-5823-276b-a73b" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="128.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0e5d-41c7-4061-6a70" name="AI Support Team" book="Rulebook &amp; pdf force list v2" page="175" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="81b9-59e2-9b99-da0c" name="Weapon Team" hidden="false" targetId="3f2c-9814-0c0d-e4d7" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="6b45-2071-ff1b-041f" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="5800-d074-9324-ccc4" name="New CategoryLink" hidden="false" targetId="db48-a6b8-4b98-e3ed" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="d19f-fcca-6f6a-3d73" name="Promote one crew member to Leader" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c904-b651-7dec-035b" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="1ace-0c7d-eac9-8e20" name="Leader One" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="d6ca-2314-fbf2-e420" name="Leader" hidden="false" targetId="4675-d30d-3451-8672" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="49d1-8d76-efb7-2253" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="eb92-b9ea-4c08-466f" name="AI Trooper Crew" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="2f57-c070-e47a-2e91" name="AI Trooper Crew" book="" page="" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (7)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="83fe-2029-3880-1be1" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="44c5-cfb0-b88f-c2d9" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="f603-66ea-f5c5-64e1" name="Reflex Armor" hidden="false" targetId="1523-0845-c12b-4980" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="14.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="66f5-2f52-d6ea-418a" name="Support Weapon" hidden="false" collective="false" defaultSelectionEntryId="7a8c-b7e2-21d4-cc44">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="78a8-2193-2536-22b0" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a1d4-87d4-3d64-f3bc" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="5ca8-5abc-74bd-6235" name="Mag Cannon" hidden="false" targetId="eec6-9dbc-8db5-5a96" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="8e15-e6c9-f806-f215" name="X-Launcher" hidden="false" targetId="e2c7-1c85-2088-3005" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="7a8c-b7e2-21d4-cc44" name="Mag Light Support" hidden="false" targetId="8e77-f151-c27d-0eb0" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="daac-c4e1-b0fc-be4b" name="Crew Weapon" hidden="false" collective="false" defaultSelectionEntryId="1f87-27e1-3995-96fa">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="36ce-e3b2-fd1d-6118" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7bc7-6ba2-806d-76ca" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="210e-c609-69ac-2634" name="Mag Gun" hidden="false" targetId="0f88-ab36-c5a8-7a97" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="0e5d-41c7-4061-6a70" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb92-b9ea-4c08-466f" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="a166-6899-a981-833f" name="Mag Repeater" hidden="false" targetId="ada9-abf5-49da-db67" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="0e5d-41c7-4061-6a70" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb92-b9ea-4c08-466f" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="1f87-27e1-3995-96fa" name="Mag Pistol" hidden="false" targetId="32dd-05fd-f75b-81ee" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="07df-06c9-7c4c-f603" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c23-20b9-3789-9991" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="6cdf-3a9b-2673-a395" name="Reflex Armor" hidden="false" targetId="1523-0845-c12b-4980" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2502-1247-a369-92f9" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3c5-07b9-d6aa-1ea9" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="7643-0678-e631-f662" name="Special Munitions" hidden="true" targetId="6dbe-a221-4d79-ff6a" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="0e5d-41c7-4061-6a70" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8e15-e6c9-f806-f215" type="atLeast"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0c51-2b67-3982-5c81" name="AI Specialist Support Team" book="Rulebook &amp; pdf force list v2" page="175" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="6f5c-fb0f-47a8-5521" name="Weapon Team Unit" hidden="false" targetId="3f2c-9814-0c0d-e4d7" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ff1a-c163-000a-c289" name="Limited Choice" hidden="false" targetId="8cb3-4c3e-dc5f-b952" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="aa62-0566-7e95-85e6" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="9b38-ac5d-d346-c372" name="New CategoryLink" hidden="false" targetId="c87d-5261-face-4643" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="87fb-401b-8a8e-f2fb" name="New CategoryLink" hidden="false" targetId="db48-a6b8-4b98-e3ed" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="a119-c680-d17d-ff47" name="AI Trooper Crew" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="26eb-23be-6496-80b6" name="AI Trooper Crew" book="BtGoA" page="175" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (7)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6e74-41af-74df-0f30" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6a6a-42b7-ba01-c675" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="14.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1fbe-2a61-8d0f-c2e4" name="Promote one crew member to Leader" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f6bf-6002-137f-85b3" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="d3b2-b348-c779-9b05" name="Leader Level" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c7bf-7f80-8031-6420" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fdaf-cb2b-1ca0-b8d2" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="093b-dde2-1b19-eecb" name="Leader One" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="bc18-81a0-5ab3-5101" name="Leader" hidden="false" targetId="4675-d30d-3451-8672" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="257a-b58a-8767-d5bb" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="f7eb-ea8c-f01d-eca1" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="bb2e-955f-54ee-31b6">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="923d-54d4-ce61-2094" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ab39-8390-0ae8-6851" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="c0f5-51ac-dfec-d619" name="Fractal Cannon" hidden="false" targetId="ace6-ea6e-a45c-fb45" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="0c3f-99e0-1c18-af3f" name="Plasma Cannon" hidden="false" targetId="1c29-8394-0315-8140" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="bb2e-955f-54ee-31b6" name="Plasma Light Support" hidden="false" targetId="eaa4-a3c1-d269-d3cb" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="8344-d20e-d060-a4a7" name="Compression Cannon" hidden="false" targetId="320a-eea0-72d4-c09b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="604c-9309-f91c-0b54" name="Crew Weapons" hidden="false" collective="false" defaultSelectionEntryId="79d4-1dc9-3e99-7c5b">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4179-bed2-99cf-8bce" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee19-3a1b-0fea-872d" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="0780-66e5-f862-83b8" name="Mag Repeater" hidden="false" targetId="ada9-abf5-49da-db67" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="0c51-2b67-3982-5c81" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a119-c680-d17d-ff47" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="79d4-1dc9-3e99-7c5b" name="Mag Pistol" hidden="false" targetId="32dd-05fd-f75b-81ee" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="2a64-b564-c98d-5907" name="Mag Gun" hidden="false" targetId="0f88-ab36-c5a8-7a97" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="0c51-2b67-3982-5c81" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a119-c680-d17d-ff47" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="43b5-d969-83be-425e" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e0a-135d-092d-05cd" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="5b0c-f10a-aaa2-bed0" name="Reflex Armor" hidden="false" targetId="1523-0845-c12b-4980" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c88-d476-9876-b43a" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd82-4cd7-375c-9e01" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="40.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="99d2-b3d9-d1d0-fe6e" name="AI Intruder Skimmer Squad" book="Rulebook &amp; pdf force list v2" page="174" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="3818-f4ff-de91-9a3a" name="Fast" hidden="false" targetId="166d-5d48-1fc6-4a4b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="53ab-59c0-eab2-72dd" name="Large" hidden="false" targetId="59d7-7273-b97c-0dff" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="34e5-e33e-3a2a-96da" name="Mounted Unit" hidden="false" targetId="878e-3922-3d01-8f26" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers>
+        <modifier type="increment" field="d5e0-c569-66ec-1a12" value="1">
+          <repeats>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="20d0-b1d4-4916-8e85" repeats="100" roundUp="false"/>
+          </repeats>
+          <conditions/>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d5e0-c569-66ec-1a12" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="4cc0-9646-9279-1d8d" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="7b19-8237-2afe-d7ae" name="AI Intruder Leader" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="a846-9293-4196-7d4e" name="AI Intruder Leader" book="" page="" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (8)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2ae0-c24d-0d56-05f9" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="77f0-2378-6ced-6403" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="55aa-d3f2-20a4-986d" name="Leader Level (Up To 2)" hidden="false" targetId="14a9-9070-281d-b6d6" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="cf32-7e6b-8f4b-4cc6" name="AI Intruder Trooper" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="27eb-ea73-539c-6702" name="AI Intruder Trooper" book="" page="" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (8)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fabf-e1df-93e3-864d" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fd97-de79-6ccf-0126" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5e85-6831-110d-e5e8" name="Compactor Drone" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3798-5cde-db74-8ca9" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="43f5-0e70-87c8-7515" name="Compactor Drone" hidden="false" targetId="440d-ac97-e975-c6d2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="750a-f690-504e-c212" name="Compactor Drone with Mag Light Support" hidden="false" targetId="7b24-dfae-72c0-dd99" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="a597-de16-6b36-88a3" name="Compactor Drone with Mag Cannon" hidden="false" targetId="3681-a2b0-5c2e-4cf2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="da54-a70b-9408-0d0e" name="Reflex Armor" hidden="false" targetId="1523-0845-c12b-4980" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f11e-3fec-19a6-b9d5" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8071-b270-9aaf-350a" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="ed66-3db0-ded6-2b10" name="HL Booster" hidden="false" targetId="6c89-65f8-fa8e-7131" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ef5-2f47-662a-b712" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e17-df3e-8d83-5aff" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="03a0-2b76-e3ca-2790" name="Intruder Skimmer" hidden="false" targetId="d31a-9eb4-ccc8-59d6" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="42d0-df4d-3c7e-8a2a" name="Mag Repeater" hidden="false" targetId="ada9-abf5-49da-db67" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="329c-1ef7-936a-878a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc25-ab05-39cf-6081" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="1aa8-4a4b-70a5-766b" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="74c5-fefb-54a3-1151" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="115.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="20d0-b1d4-4916-8e85" name="AI Intruder Skimmer Command Squad" book="Rulebook &amp; pdf force list v2" page="186" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="2991-7b5b-3507-b594" name="Fast" hidden="false" targetId="166d-5d48-1fc6-4a4b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="677d-a272-64c3-07d3" name="Large" hidden="false" targetId="59d7-7273-b97c-0dff" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="4f88-3848-96b4-f5ab" name="Limited Choice" hidden="false" targetId="8cb3-4c3e-dc5f-b952" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="1cea-0f1e-2810-f1a4" name="Mounted Command" hidden="false" targetId="4294-13e8-90a8-2e17" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="82c1-bac8-e271-64e3" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="4d5f-a25d-20d8-f13a" name="New CategoryLink" hidden="false" targetId="c87d-5261-face-4643" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="5de8-a9af-cfc5-2256" name="AI Intruder Commander" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="6db5-11c3-c29b-788a" name="AI Intruder Commander" book="" page="" hidden="false" profileTypeId="1650-77b3-10d1-6406" profileTypeName="Model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (8)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="85de-496e-6f04-6c09" name="Command" hidden="false" targetId="f001-a3be-81f7-f74f" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="12ff-1ce7-efd8-d5a1" name="Follow" hidden="false" targetId="4bdd-65b7-6ee8-89b2" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="b98a-14bc-39ec-d267" name="Large" hidden="false" targetId="59d7-7273-b97c-0dff" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="5461-a475-50fa-505d" name="Fast" hidden="false" targetId="166d-5d48-1fc6-4a4b" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e1f5-bf68-8f6a-a35c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2472-7149-6375-c984" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="b32e-8fe6-4d32-f5c9" name="Leader Level (Up To 2)" hidden="false" targetId="14a9-9070-281d-b6d6" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="87b0-96b8-1dff-f35d" name="AI Intruder Trooper" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="4aa5-4358-1035-7710" name="AI Intruder Trooper" book="" page="" hidden="false" profileTypeId="1650-77b3-10d1-6406" profileTypeName="Model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (8)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="ede2-d67e-00fb-495b" name="Large" hidden="false" targetId="59d7-7273-b97c-0dff" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="5bf8-9f1d-033c-bde6" name="Fast" hidden="false" targetId="166d-5d48-1fc6-4a4b" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1c6e-0fe5-6c7d-6189" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e94b-6a34-0925-6eb2" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0804-8f26-1f8f-0fac" name="Compactor Drone" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="38c3-c804-7e83-ef2a" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="b424-051e-d692-1763" name="Compactor Drone" hidden="false" targetId="440d-ac97-e975-c6d2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="b4b2-d53b-c4a3-bfee" name="Compactor Drone with Mag Light Support" hidden="false" targetId="7b24-dfae-72c0-dd99" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="af55-0acd-18d7-d7b4" name="Compactor Drone with Mag Cannon" hidden="false" targetId="3681-a2b0-5c2e-4cf2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="a876-f6ec-4640-d455" name="Plasma Carbine" hidden="false" targetId="3877-96bf-06bb-ff8f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b1d-5738-67e7-6fc0" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5849-8324-ac58-69b0" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="bf14-39b2-2d01-59a3" name="Reflex Armor" hidden="false" targetId="1523-0845-c12b-4980" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c655-497b-87f6-f0a8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e9c-7d97-f3c7-5dab" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="93df-0983-cbe6-9497" name="HL Booster" hidden="false" targetId="6c89-65f8-fa8e-7131" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a90b-97ff-bb30-0d6b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d163-1403-0f9c-cddf" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="646a-e300-681f-ab61" name="Intruder Skimmer" hidden="false" targetId="d31a-9eb4-ccc8-59d6" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="3ce0-2b5d-bacb-35bb" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="230e-b573-af4f-8125" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="147.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2b1a-5dc0-3317-de96" name="AI Heavy Support Team" book="Rulebook &amp; pdf force list v2" page="176" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="0773-cb85-0512-e957" name="AI Trooper Crew" book="BtGoA" page="176" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+            <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+            <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+            <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (7)"/>
+            <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+            <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+            <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a37e-b2ab-aa64-cb9d" name="Weapon Team Unit" hidden="false" targetId="3f2c-9814-0c0d-e4d7" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="fcfb-38cc-0efe-771e" name="Large" hidden="false" targetId="59d7-7273-b97c-0dff" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="7d2e-a795-68a0-d8f1" hidden="false" targetId="a01f5f58-334c-8442-d861-15099ebdf5e5" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="614b-4a39-39ab-96bc" name="New CategoryLink" hidden="false" targetId="db48-a6b8-4b98-e3ed" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="cc80-213b-9865-f264" name="AI Trooper Crew" hidden="false" collective="false" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5ba7-31d3-3077-a1bc" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9bae-9236-2521-2e41" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="6963-6bc4-8505-70ff" name="Reflex Armor" hidden="false" targetId="1523-0845-c12b-4980" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="14.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c797-0f87-63d5-b945" name="Promote one crew member to Leader" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="e7ef-ab95-8b7f-b73a" name="Leader" hidden="false" targetId="4675-d30d-3451-8672" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0750-e7d2-9562-06c9" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e8ed-99e5-c589-3151" name="Support Weapon" hidden="false" collective="false" defaultSelectionEntryId="11da-647a-2747-ec28">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7efc-39cb-4539-bdb0" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="05d7-dde0-08cb-d4b4" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="1aa0-4da2-5d69-93fe" name="Mag Mortar" hidden="false" targetId="61b9-9d2d-aa1a-1b3f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="4919-68c5-8831-3151" name="X-Howitzer" hidden="false" targetId="ab2e-edc9-b214-f7d5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="11da-647a-2747-ec28" name="Mag Heavy Support" hidden="false" targetId="debc-cb6c-57db-3daa" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="6a96-9d39-e948-b1bc" name="Heavy Mag Cannon" hidden="false" targetId="5142-d68f-1b75-482e" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="61b7-4831-5647-907d" name="Crew Weapons" hidden="false" collective="false" defaultSelectionEntryId="3c9d-dcf7-87ae-8d04">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8e0c-b74c-9950-419f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="be1b-2504-a8a7-5a41" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="69ca-cd4f-a7f0-2796" name="Mag Gun" hidden="false" targetId="0f88-ab36-c5a8-7a97" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="2b1a-5dc0-3317-de96" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cc80-213b-9865-f264" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="7862-1dda-a011-eb54" name="Mag Repeater" hidden="false" targetId="ada9-abf5-49da-db67" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="3">
+                  <repeats>
+                    <repeat field="selections" scope="2b1a-5dc0-3317-de96" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cc80-213b-9865-f264" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="3c9d-dcf7-87ae-8d04" name="Mag Pistol" hidden="false" targetId="32dd-05fd-f75b-81ee" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="1d3c-9b44-5259-e27a" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41fd-9b66-367c-438a" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="17e0-8c70-58f1-1ba6" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63d2-2a14-7b18-d52c" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="7d26-b0aa-73bf-9edf" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="points" value="0.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c15d-65b3-1604-d14b" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d18-8724-8a69-d997" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="431f-3f80-ff4c-95fb" name="Special Munitions" hidden="true" targetId="6dbe-a221-4d79-ff6a" type="selectionEntryGroup">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="2b1a-5dc0-3317-de96" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4919-68c5-8831-3151" type="equalTo"/>
+                <condition field="selections" scope="2b1a-5dc0-3317-de96" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1aa0-4da2-5d69-93fe" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="55.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5e09-b21a-554e-9f8d" name="Liberator Combat Skimmer - X01 Hi-Mag" book="Rulebook &amp; pdf force list v2" page="177" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="dbc5-74af-0c78-8a6e" name="Liberator Combat Skimmer - X01 Hi-Mag" hidden="false" profileTypeId="1650-77b3-10d1-6406" profileTypeName="Model">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+            <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+            <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+            <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="13"/>
+            <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+            <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+            <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="9055-719a-1db0-399a" name="MOD2" hidden="false" targetId="88ae-fedb-5c1c-3a7b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="4674-02cf-a445-dc69" name="Large" hidden="false" targetId="59d7-7273-b97c-0dff" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="5e3a-5979-b2da-79fd" name="Vehicle Unit" hidden="false" targetId="29d8-590a-bc46-d27a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="0b05-eb5c-780b-57fc" hidden="false" targetId="a01f5f58-334c-8442-d861-15099ebdf5e5" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="778b-8d38-e834-6705" name="Self-repair" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="5101-33ea-94f7-de00" name="Self Repair" hidden="false" targetId="7c54-5982-a5ef-b888" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1d19-9bf3-ae94-8e2d" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="926f-937e-8174-530e" name="Weapon Options" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c1b-8d9a-2147-7b06" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8fc8-e925-8564-9de6" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="ddf6-d1f4-ad9c-1e94" name="Weapon 1" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fea4-6ac7-ae19-718a" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ed1c-8950-d1e6-2ce0" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="4ced-76c6-9919-2c7d" name="Mag Cannon" hidden="false" targetId="eec6-9dbc-8db5-5a96" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="10">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="f3fe-0dd2-cf45-97f4" name="Mag Light Support" hidden="false" targetId="8e77-f151-c27d-0eb0" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="7aaf-15fa-9324-0be7" name="Twin Mag Light Support" hidden="false" targetId="b065-9dee-2444-0546" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="25">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="e72b-bbbc-0fad-5886" name="Weapon 2" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7cd1-86ff-2312-4e95" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="402b-b62f-eff4-a5f9" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="d357-9eff-aa6f-a90d" name="Mag Light Support" hidden="false" targetId="8e77-f151-c27d-0eb0" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="2ab6-cd31-13e8-9885" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fde8-675e-5ffb-9936" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="4a38-b90b-68a8-f1ab" name="Shield Drone" hidden="false" targetId="81b9-02e2-63b6-9c6e" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41c1-22f0-8a60-bd47" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="69dd-963d-7fce-7040" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c459-d0b0-8bdb-4efc" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="194.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bd95-ec93-fc21-a6bb" name="Liberator Combat Skimmer - X06 Plasma Destroyer" book="Rulebook &amp; pdf force list v2" page="177" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="564c-5510-01a0-4949" name="Liberator Combat Skimmer - X06 Plasma Destroyer" hidden="false" profileTypeId="1650-77b3-10d1-6406" profileTypeName="Model">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+            <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+            <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+            <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="13"/>
+            <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+            <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+            <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="f6be-9331-5eda-c389" name="MOD2" hidden="false" targetId="88ae-fedb-5c1c-3a7b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6a61-ae59-f424-8c04" name="Large" hidden="false" targetId="59d7-7273-b97c-0dff" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="5367-7294-a2b3-1c9e" name="Vehicle Unit" hidden="false" targetId="29d8-590a-bc46-d27a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="9cb9-fbc1-d7bd-8647" hidden="false" targetId="a01f5f58-334c-8442-d861-15099ebdf5e5" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="fb5f-7cd2-b84e-9880" name="Self-repair" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="de7a-aa1e-e71f-8d74" name="Self Repair" hidden="false" targetId="7c54-5982-a5ef-b888" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7286-33b1-25b2-407c" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="d290-cc68-33ae-0c29" name="Weapon Options" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a407-bb47-c0d6-60d3" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2845-8167-a1c3-218e" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="0e7e-c747-bb8d-9cf9" name="Weapon 1" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c8d3-4b48-e937-1ec5" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e526-a834-fd4d-474c" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="7d38-68ef-9cef-8d61" name="Plasma Cannon" hidden="false" targetId="1c29-8394-0315-8140" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="5">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="8e9a-5d05-1587-1cca" name="Plasma Light Support" hidden="false" targetId="eaa4-a3c1-d269-d3cb" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="49e5-944a-2e34-0f3b" name="Weapon 2" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c5c2-d510-e7ae-3eb4" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1e11-03ee-db08-7503" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="c5f1-7d36-9012-e524" name="Plasma Light Support" hidden="false" targetId="eaa4-a3c1-d269-d3cb" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="9cc9-31c6-78cd-de5c" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="575e-caa8-e723-cf06" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="b60e-b3b1-16f5-936b" name="Shield Drone" hidden="false" targetId="81b9-02e2-63b6-9c6e" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="456e-b4c3-76d6-e4fa" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="7e91-6632-8782-8d28" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c473-f6db-ac35-de02" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="234.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="34e3-44ad-f58c-4ed4" name="Liberator Combat Skimmer - X10 Special" book="Rulebook &amp; pdf force list v2" page="177" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="90ec-81ea-8d52-f617" name="Liberator Combat Skimmer - X10 Special" hidden="false" profileTypeId="1650-77b3-10d1-6406" profileTypeName="Model">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+            <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+            <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+            <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="13"/>
+            <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+            <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+            <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="ab22-8dce-d428-c862" name="MOD2" hidden="false" targetId="88ae-fedb-5c1c-3a7b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="1e5e-bd89-4228-f001" name="Large" hidden="false" targetId="59d7-7273-b97c-0dff" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="5c80-3e02-9a53-76bc" name="Vehicle Unit" hidden="false" targetId="29d8-590a-bc46-d27a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="0048-16a2-4d2a-ad01" hidden="false" targetId="a01f5f58-334c-8442-d861-15099ebdf5e5" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="4e31-7d40-f2c0-dc31" name="Self-repair" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="d3e0-e1b4-6679-9e33" name="Self Repair" hidden="false" targetId="7c54-5982-a5ef-b888" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7b8d-586f-40b2-b870" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5581-c5b7-8b14-34ba" name="Weapon Options" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f586-0229-9d3a-1cdf" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f917-bbd6-f776-3f1c" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="0db2-e1bf-ba83-9735" name="Weapon 1" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="50d4-2fa1-7368-d34f" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="dd8a-eaa4-6d12-31a4" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="ca04-f26d-8b0c-fe75" name="Fractal Cannon" hidden="false" targetId="ace6-ea6e-a45c-fb45" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="3aa5-11ab-f507-f4fb" name="Compression Cannon" hidden="false" targetId="320a-eea0-72d4-c09b" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="cbdf-83ff-0f5a-f43c" name="Weapon 2" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b10e-38c5-83de-ee88" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="108c-a9b7-7ea6-e15a" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="6cf4-9529-e53d-78ac" name="Mag Light Support" hidden="false" targetId="8e77-f151-c27d-0eb0" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="24cd-6cd7-c3cf-d5a8" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="155e-6705-a3b6-aa5a" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="5704-5fa7-1140-73ca" name="Shield Drone" hidden="false" targetId="81b9-02e2-63b6-9c6e" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="799b-d537-7ca4-5f09" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="027e-787e-7ae1-356e" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b97-e2a1-7882-3db9" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="103e-e908-5895-1c81" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="points" value="0.0">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1158-be13-8757-8322" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bab6-173b-68fa-9aff" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="234.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d05d-1ad4-425f-7e1c" name="Hazard Strike Capsule" book="pdf" hidden="false" collective="true" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
+    <selectionEntry id="89ff-bd2a-e85a-e682" name="Homer Beacon" book="CS" page="90" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs/>
+    </selectionEntry>
   </sharedSelectionEntries>
-  <sharedSelectionEntryGroups/>
-  <sharedRules/>
-  <sharedProfiles/>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup id="6dbe-a221-4d79-ff6a" name="Special Munitions" hidden="false" collective="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1f8-6328-5467-cf07" type="max"/>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b03-cfe8-10b2-7bc7" type="min"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="a91d-1e4c-90ba-4912" name="Munitions" hidden="true" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="abb5-85f1-2716-bbee" type="equalTo"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="bb5a-c4dc-4409-6699" name="Arc" hidden="false" targetId="21b6-41b2-7add-6f1d" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="9d7f-b118-f958-e645" name="Blur" hidden="false" targetId="f833-725e-65cf-ee13" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="74e1-413f-c6e6-2a9e" name="Scrambler" hidden="false" targetId="0d46-b571-8bcc-1a71" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="0b5a-a910-55b1-bd67" name="Scoot" hidden="false" targetId="21a9-1a1a-7793-3301" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="c2bb-4dc4-74ef-588c" name="Net" hidden="false" targetId="ba2f-b979-7229-0cb2" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="4ea2-3f8e-c68f-68b7" name="Grip" hidden="false" targetId="b009-d7e0-e177-e9f4" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="9c67-ff4a-386e-a00d" name="All" hidden="false" targetId="4696-72ef-e971-f0b3" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="7750-fd5c-6102-9fc3" name="Choose Munitions" hidden="false" targetId="abb5-85f1-2716-bbee" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="14a9-9070-281d-b6d6" name="Leader Level (Up To 2)" hidden="false" collective="false" defaultSelectionEntryId="2814-e6ec-2d95-7752">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0fd8-a34c-6032-4d3e" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6ec6-c7d6-5cc3-90ee" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries>
+        <selectionEntry id="2814-e6ec-2d95-7752" name="Leader One" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="b23e-ba0e-09de-a2ed" name="Leader" hidden="false" targetId="4675-d30d-3451-8672" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6128-7706-c461-9af4" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="c034-703e-69c1-e080" name="Leader Two" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="7c4e-7581-2d71-86d5" name="Leader 2" hidden="false" targetId="f7db-9f56-2fd9-fd72" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="488d-a0a2-617c-fe0a" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="6fc6-32a7-74b6-1b4b" name="Leader Level (Up To 3)" hidden="false" collective="false" defaultSelectionEntryId="30bc-6487-4adb-157a">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="90d1-eadc-3f17-b422" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5976-67b9-b669-7ad7" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries>
+        <selectionEntry id="30bc-6487-4adb-157a" name="Leader Two" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="5320-23a7-057a-8f9b" name="Leader 2" hidden="false" targetId="f7db-9f56-2fd9-fd72" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4e06-cf58-465b-7462" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6264-b771-f790-c423" name="Leader Three" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="ac63-dc83-d13c-0955" name="Leader 3" hidden="false" targetId="ce3b-c908-3ded-7a49" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
+  <sharedRules>
+    <rule id="6949-9f5f-f9fa-ba1c" name="2 Attacks" book="Rulebook" page="133" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Two attacks in close combat.</description>
+    </rule>
+    <rule id="c286-a2b9-610b-96f2" name="3 Attacks" book="Rulebook" page="133" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Three attacks in close combat.</description>
+    </rule>
+    <rule id="9b49-f2a1-9917-d571" name="AG Chute" book="Rulebook" page="120" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Can make 2M move and shoot when given Advance order
+• +1 Ag, +1&quot; to sprint
+• Can move through/over difficult terrain</description>
+    </rule>
+    <rule id="41e8-a0f3-ed44-f9d4" name="Arc" book="Rulebook" page="88" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Any weapon that draw LoS within 3&quot; of the Arc roll a dice
+• On a 6+ the shot is drawn away and does nothing.
+• Does not affect OH unless Aiming Point is within 3&quot;</description>
+    </rule>
+    <rule id="efa8-8f40-fcd9-4542" name="Auto-Workshop" book="Rulebook" page="121" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Activated when unit given any order
+• Affects every friendly vehicle, weapon drone, weapon team and machine mounted unit within 5&quot;
+• Roll D10 for each affected unit, on 6+ remove one pin</description>
+    </rule>
+    <rule id="fc9f-1b48-4fc9-1044" name="Batter Drone" book="Rulebook" page="110" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Shield does not affect LoS
+• No part of shield template should be more than 5&quot; from drone
+• Adds additional -2 to enemy Acc (this is not accumulative to other Synker or Batter shields)
+• Unit must be behind shield</description>
+    </rule>
+    <rule id="8016-3cbd-ab0a-3b19" name="Big Jobs!" book="Rulebook" page="236" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Blast D3, Sv 3</description>
+    </rule>
+    <rule id="d5f3-3586-02bd-c293" name="Blast D10" book="Rulebook" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Roll dice to generate number of hits
+• Allocate this number of hits against models in the target unit</description>
+    </rule>
+    <rule id="177e-8b60-cc2a-557d" name="Blast D3" book="Rulebook" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Roll dice to generate number of hits
+• Allocate this number of hits against models in the target unit</description>
+    </rule>
+    <rule id="805e-60a2-1b4a-46e9" name="Blast D4" book="Rulebook" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Roll dice to generate number of hits
+• Allocate this number of hits against models in the target unit</description>
+    </rule>
+    <rule id="0ee6-cf0c-7083-dde0" name="Blast D5" book="Rulebook" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Roll dice to generate number of hits
+• Allocate this number of hits against models in the target unit</description>
+    </rule>
+    <rule id="bc98-2e6b-c063-fe98" name="Blur" book="Rulebook" page="89" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• If lands within 3&quot; of any model in a unit the whole unit has a -D3 Acc penalty.
+• Roll each time the unit shoots.
+• If affected by several Blur shots then roll for each one and apply the highest result</description>
+    </rule>
+    <rule id="2f9d-1ea5-01d2-b530" name="Booster Drone" book="Rulebook" page="92, 111" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Boosts Reflex, Hyperlight or Phase armour by +1 Res
+• Does not combine with Hyperlight Booster</description>
+    </rule>
+    <rule id="33f1-5484-34f6-c1f1" name="Borer Drone" book="Rulebook" page="111" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• If unit has one or more Borer Drones then gains +1 Str for all tests
+• Declare throw up cover as long as unit does not move, unit gains +2 Res</description>
+    </rule>
+    <rule id="097c-000b-3674-ebba" name="Buddy Drone" book="Rulebook" page="110" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Not counted for Break tests
+• When moving unit then move all non-drones then move drone up to unit
+• Can pass through own models and terrain freely
+• Ignored for shooting LoS
+• Cannot be targetted, can be hit by lucky shots
+• Destroyed if hit
+• If unit is destroyed then buddy drone is removed</description>
+    </rule>
+    <rule id="3f65-c4d3-fdf3-5266" name="Camo Drone" book="Rulebook" page="111" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• If unit Down then cannot be targeted over 10&quot; range
+• If shot at over 10&quot; and unit goes Down then all shots automatically miss including OH
+• Scout probe can neutralise Camo Drone if within 10&quot;</description>
+    </rule>
+    <rule id="7b4c-a6f4-dc1f-0989" name="Choose Target" book="Rulebook" page="70" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• May shoot at different target to rest of unit
+• If more than one weapon of this type then must engage same target</description>
+    </rule>
+    <rule id="f001-a3be-81f7-f74f" name="Command" book="Rulebook" page="133" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• If the commander is in 10&quot; of another friendly unit they can use the commander&apos;s command stat
+• If more than one commander then use the highest value
+• Value still modified by pins</description>
+    </rule>
+    <rule id="2295-7312-b996-dc86" name="Compactor Drone" book="Rulebook" page="111-112" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Can carry one of: bike, support weapon, weapon drone, probe shard
+• Load/unload when unit makes an action at the end
+• If the drone is destroyed then anything it is carrying is also destroyed</description>
+    </rule>
+    <rule id="d89d-cedd-bd84-ddb1" name="Compressor" book="Rulebook" page="71" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• SV varies according to range</description>
+    </rule>
+    <rule id="0762-a86b-97dd-39f2" name="Concentrated Fire" book="Rulebook" page="72" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Any Lucky Hits can be allocated to same target</description>
+    </rule>
+    <rule id="6bfe-9900-4c0c-afbc" name="Crawler" book="Rulebook" page="22, 133" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Restricted when moving over terrain
+• Cannot cross obstacles at a Run, must test to Advance</description>
+    </rule>
+    <rule id="1fc1-32bb-3cd2-8103" name="Customised Mag Gun" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• +1 Acc when using customised Mag Gun
+• If no Lucky Hits scored then may treat one hit as a Lucky Hit</description>
+    </rule>
+    <rule id="3dda-5ab1-1343-fcf1" name="Cycle" book="Rulebook" page="78" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• On Acc roll of 10 the shot misses and change firing unit order dice to Down</description>
+    </rule>
+    <rule id="3613-a342-c247-d4c6" name="Dead Eye" book="Rulebook" page="237" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Gains +2 for Aimed Fire</description>
+    </rule>
+    <rule id="185f-7889-5373-782a" name="Disruptor" book="Rulebook" page="79" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Target gets no Res bonus for cover
+• A non-Ghar target hit gets 2 pins, takes pins even if Heavily Armoured and resists damage
+• If target unit includes Buddy Drones then hits can be allocated to them by the shooter
+• If target is a probe can only make Res test on a 1</description>
+    </rule>
+    <rule id="5464-7e74-3df1-f384" name="Down" book="Rulebook" page="74" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Target automatically goes down after being hit</description>
+    </rule>
+    <rule id="a32b-8b04-bccb-c4ea" name="Exhausted" book="Rulebook" page="67" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• If roll 10 on Str or Acc then may not be rerolled
+• Stave is temporarily exhausted
+• At end of turn roll D10, 6+ stave can be used next turn</description>
+    </rule>
+    <rule id="166d-5d48-1fc6-4a4b" name="Fast" book="Rulebook" page="133" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Move at double pace
+• When running and shot at then hits must be rerolled
+• With a Run order may break off from assault after point blank shooting
+• When consolidating allowed to move through enemy unit</description>
+    </rule>
+    <rule id="4bdd-65b7-6ee8-89b2" name="Follow" book="Rulebook" page="13" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Any friendly unit in 5&quot; of the commander without an Order may make the same action as long as they have no pins</description>
+    </rule>
+    <rule id="2af1-5c34-05ab-6369" name="Fractal Lock" book="Rulebook" page="83" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Once hits target and as long as firing unit has a Fire order and target does not move then hits automatically
+• Each time it auto-hits the SV value goes up by 2.</description>
+    </rule>
+    <rule id="3ba7-d5fc-750a-c143" name="Grenade" book="Rulebook" page="85, p86" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Used at short range in Shooting or H2H
+• If used in H2H then confer +1 Str
+• When used in H2H then accumulate SV for hits from grenades and take one Res test
+• Can be set as Mines (p86)</description>
+    </rule>
+    <rule id="dc90-d00c-0484-16ea" name="Grip" book="Rulebook" page="87" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Unit beginning its move within 3&quot; must take and pass an Ag test. If failed it may not move, if passed it can move half rate, failed on a 10 it takes a pin and cannot move.
+• If a unit moves within 3&quot; it must take the Ag test as above. </description>
+    </rule>
+    <rule id="6896-1385-66b6-d10a" name="Gun Drone" book="Rulebook" page="112" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Shoots same as unit&apos;s Acc
+• Draw LoS as for other models (exception to usual Buddy Drone rules)</description>
+    </rule>
+    <rule id="b159-3f51-9005-f463" name="Hand Weapon" book="Rulebook" page="64" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Can Point Blank shoot
+• Confer +1 Str in H2H</description>
+    </rule>
+    <rule id="3c69-0775-51bd-bf1c" name="Hazard Armour" book="CS" page="67" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Affected by Scrambler
+• Cannot Sprint
+• If hit by SV5+ unit takes extra pin
+• If equipped with Plasma Carbines can RF3</description>
+    </rule>
+    <rule id="0f95-2ca6-3bd9-35b4" name="Hazardous H2H" book="Rulebook" page="85" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Any Strength rolls to hit that roll a 10 inflict hits on shooting unit instead</description>
+    </rule>
+    <rule id="de2e-c0dc-f7de-fe80" name="Heavy" book="Rulebook" page="134" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Can only cross obstacles at M rate, Agility test required
+• Unit classed as Large target
+• When taking Res test always passes on anything but a 10, if fails then roll on damage chart (p37)</description>
+    </rule>
+    <rule id="5daf-557d-8a03-2a72" name="Heavy Weapon" book="Rulebook" page="80" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Can only shoot using Fire order, gains no Acc bonus for Aimed Fire
+• If shooter turns more than 90 degrees to face a target then suffers Acc -2
+• -1 Acc for each crewman lost
+• -1 Ag for each crewman lost
+• Can only cross obstacles at M rate
+• Unit classed as Large target
+• When taking Res test always passes on anything but a 10, if fails then unit is destroyed</description>
+    </rule>
+    <rule id="e70c-a7b7-b782-acad" name="Hero" book="Rulebook" page="134" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• If the commander is in 10&quot; of another friendly unit they can use the commander&apos;s initiative stat</description>
+    </rule>
+    <rule id="4228-a627-db84-7427" name="High Commander" book="Rulebook" page="134, rules update Jun 16" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Reroll every failed Res test once
+• For models that roll on the Damage chart then do not reroll Res test. 
+• Instead roll an extra dice for the result and discard the highest value
+• Uses Command, Hero and Follow</description>
+    </rule>
+    <rule id="2ddf-41de-2c4e-c779" name="HL Armour" book="Rulebook" page="93" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• +1 Res up to 10&quot;
+• +2 Res over 10&quot;
+• +3 Res against Blast at any range</description>
+    </rule>
+    <rule id="7ffb-4ae6-61b1-9bac" name="HL Booster" book="Rulebook" page="93, 111, 121" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• +1 Res to exisitng boosts</description>
+    </rule>
+    <rule id="6096-a77e-b179-d6e2" name="HL Booster Armour Upgrade" book="v2 pdf" page="" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• +1 Res</description>
+    </rule>
+    <rule id="6add-f3a8-9fbf-8031" name="HL Booster Drone" book="Rulebook" page="111" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Boosts Reflex, Hyperlight or Phase armour by +1 Res
+• Does not combine with Hyperlight Booster</description>
+    </rule>
+    <rule id="557e-16fd-7531-c26d" name="Inaccurate" book="Rulebook" page="70" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Additional -1 Acc</description>
+    </rule>
+    <rule id="1646-967d-a579-e0c9" name="Infiltrator" book="Rulebook" page="134" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• May make run move after set-up and before first turn, may not move within 10&quot; of enemy
+• If equipped may lay minefield before game starts
+• If both sides have infiltrators then place unit dice in bag and draw one</description>
+    </rule>
+    <rule id="59d7-7273-b97c-0dff" name="Large" book="Rulebook" page="134" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Cannot Sprint unless are Fast
+• Test Agility to move through difficult terrain
+• Ignore regular size units intervening when tracing LoS to Large unit
+• No cover bonus to Res</description>
+    </rule>
+    <rule id="312f-bb03-ad1f-c984" name="Lava Spit" book="Rulebook" page="135" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Strike value 2
+• Can only shoot point blank</description>
+    </rule>
+    <rule id="4675-d30d-3451-8672" name="Leader" book="Rulebook" page="135, rules update Jun 16" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Re-roll one failed Res roll
+• For models that roll on the Damage chart then do not reroll Res test. 
+• Instead roll an extra dice for the result and discard the highest value</description>
+    </rule>
+    <rule id="f7db-9f56-2fd9-fd72" name="Leader 2" book="Rulebook" page="135, rules update Jun 16" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Re-roll two failed Res roll
+• For models that roll on the Damage chart then do not reroll Res test. 
+• Instead roll an extra dice for the result and discard the highest value</description>
+    </rule>
+    <rule id="ce3b-c908-3ded-7a49" name="Leader 3" book="Rulebook" page="135, rules update Jun 16" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Re-roll three failed Res roll
+• For models that roll on the Damage chart then do not reroll Res test. 
+• Instead roll an extra dice for the result and discard the highest value</description>
+    </rule>
+    <rule id="c43d-552b-d553-8f20" name="Light Support Weapon" book="Rulebook" page="75" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• -1 Acc for each crewman lost
+• -1 Ag for each crewman lost
+• When taking Res test always passes on anything but a 10, if fails then unit is destroyed</description>
+    </rule>
+    <rule id="4db2-5125-a18d-f743" name="Limited Ammo" book="Rulebook" page="73,77, 135" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• After firing roll D10, on 10 the unit may not Rapid Fire
+• If already low on ammunition then cannot shoot for rest of game</description>
+    </rule>
+    <rule id="8cb3-4c3e-dc5f-b952" name="Limited Choice" book="Rulebook" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>May only be taken as 1 in 4 choices of entire force.</description>
+    </rule>
+    <rule id="5e14-02ad-7216-29b2" name="Man of Destiny! (1)" book="BX" page="53" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Only used once per game
+• Gives unit an extra Order die (i.e. becomes MOD2 or MOD3)</description>
+    </rule>
+    <rule id="1033-9d2c-bbad-b22b" name="Man of Destiny! (2)" book="BX" page="53" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Only used once per game
+• Gives unit an extra Order die (i.e. becomes MOD3 or MOD4)</description>
+    </rule>
+    <rule id="9184-7b76-3961-e6cf" name="Man of Destiny! (3)" book="BX" page="53" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Only used once per game
+• Gives unit an extra Order die (i.e. becomes MOD4 or MOD5)</description>
+    </rule>
+    <rule id="8622-ce63-c303-a2ed" name="Massive Damage" book="Rulebook" page="75" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Target rolls for Damage on Massive Damage table (p37)</description>
+    </rule>
+    <rule id="0951-997c-361a-9f84" name="Mastermind" book="BX" page="108" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• If given successful Rally order then in addition to removing D6 pins then every Ghar unit in 10&quot; removes 1 pin
+• If there are enemy within 10&quot; then Karg can only Run but not to assault</description>
+    </rule>
+    <rule id="676d-baca-7681-270a" name="Medi-Probe" book="Rulebook" page="133" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Unit within 5&quot; can re-roll one failed Res test each time it suffers damage
+• One re-roll for each Medi-Drone within 5&quot;
+• A re-roll cannot be re-rolled.</description>
+    </rule>
+    <rule id="0a73-a3fc-2183-7548" name="Medic" book="Rulebook" page="135" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Can only attend human casualties
+• Any friendly unit within 6&quot;may reroll one failed Res test
+• Can reroll Res test for each medic within 6&quot;</description>
+    </rule>
+    <rule id="4dab-b82f-36d2-b53b" name="Meld" book="Rulebook" page="128" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Unit has single Res value, takes damage as for vehicle</description>
+    </rule>
+    <rule id="4fb1-2032-237d-ef1b" name="Meld Damage" book="Rulebook" page="128" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Roll D10:
+1 - No effect
+2-3 - Extra pin, go Down
+4-5 - Extra pin, go Down, loses 1 MOD
+6-8 - D3 extra pins, go Down, loses 1 MOD
+9 - One Nuhu removed as casualty, loses Meld, surviving NuHu takes extra D3 pins, go Down
+10 - destroyed</description>
+    </rule>
+    <rule id="f448-19ca-8a60-1dbc" name="Microgrenades" book="Rulebook" page="" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Blur, Grip or Net
+• Innacurate</description>
+    </rule>
+    <rule id="9c0c-b010-309c-d8bc" name="Micromite Probe" book="Rulebook" page="119-120" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Only move 15&quot;
+• Any unit targetting Micromites suffers -2 Acc
+• Any cover bonus for Micromite increased by +2
+• Follow rules for Targeter Probe</description>
+    </rule>
+    <rule id="1f14-b13a-04ed-d905" name="Minimum Range" book="Rulebook" page="71" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Cannot fire at targets under 10&quot;</description>
+    </rule>
+    <rule id="fb68-03a2-0b44-2a9a" name="Misgenic Abilities" book="Rulebook" page="196" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• 1: +1 attack in H2H
+• 2: +1 Res
+• 3: +1 Str
+• 4: +1 Init
+• 5: Shooting attack Ef: 10&quot;, SV: 0
+• 6: SV +1 H2H
+• 7: H2H opponent reroll hits
+• 8: Enemy in 5&quot; must take Co test for an Order and suffers extra -1 Co
+• 9: If unit has leader then gains Co 8 Init 8.  If no leader then gains leader with base values
+• 10: Choose one of above</description>
+    </rule>
+    <rule id="88ae-fedb-5c1c-3a7b" name="MOD2" book="Rulebook" page="136" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Has two Order die
+• Unit assumed to have making the last action on the most recent order dice</description>
+    </rule>
+    <rule id="3297-97ec-8602-752c" name="MOD3" book="Rulebook" page="136" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Has three Order die
+• Unit assumed to have making the last action on the most recent order dice</description>
+    </rule>
+    <rule id="02a5-5867-b0d9-bb0a" name="Nano Drone Boost" book="Rulebook" page="67" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• May use enhanced stats if unit has Nano Drone</description>
+    </rule>
+    <rule id="1b2f-b87d-729f-2ea4" name="Nano Probe Net" book="BX, CS" page="117 BX, p73 CS" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Must maintain formation within 5&quot;
+• Must have at least two functioning Probes to maintain the Net
+• If the Net is functioning then command range is extended 10&quot; from any probe in the Net</description>
+    </rule>
+    <rule id="0ad1-fb02-de9e-6e2a" name="Net" book="Rulebook" page="88-89, rules update June 16" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Uses standard blast template
+• If target hit does not take damage, takes following number of pins: X-Launcher: D3+1, X-Howitzer: D5+1, Mag Mortar: D6+1.
+• Down units halve the value rolled.
+• If hits multiple units then divide pins equally bewteen them.
+• Pins on the unit are increased to the number rolled, if the unit already has pins and the number rolled is less then no pins are inflicted</description>
+    </rule>
+    <rule id="1ca0-252b-ab29-afe5" name="No Cover" book="Rulebook" page="32, 71" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• No Res modifiers apply for occupied cover</description>
+    </rule>
+    <rule id="f0d7-3685-db32-141e" name="No Crew" book="Rulebook" page="7" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• When carried on armour counts as having full crew</description>
+    </rule>
+    <rule id="aa94-3f78-41b9-89cc" name="OH" book="Rulebook" page="33-35" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Cannot fire from inside buildings
+• Unit must use Advance or Fire
+• Weapon team/drone with heavy weapon must use Fire
+• If unit has mixed weapons then OH must fire first
+• Position template with centre over one model in target
+• Make Acc roll with -2 penalty (no +1 for Aimed)
+• On a 10 the shot has no effect
+• If the shot misses move the template in a random direction D5 (if Fire) or D10 (if Advance/Speculative) plus 1&quot; for each pin marker
+• If firing Speculative roll a 1 then another 1 to score a hit</description>
+    </rule>
+    <rule id="8889-ca43-13d0-1afc" name="OHx2" book="Rulebook" page="33-35" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Cannot fire from inside buildings
+• Unit must use Advance or Fire
+• Weapon team/drone with heavy weapon must use Fire
+• If unit has mixed weapons then OH must fire first
+• Position template with centre over one model in target
+• Make Acc roll with -2 penalty (no +1 for Aimed)
+• On a 10 the shot has no effect
+• If the shot misses move the template in a random direction D5 (if Fire) or D10 (if Advance/Speculative) plus 1&quot; for each pin marker
+• If firing Speculative roll a 1 then another 1 to score a hit
+• Use double template</description>
+    </rule>
+    <rule id="06ea-58e5-bf79-9eb7" name="One For All" book="Rulebook" page="230" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Lucky Hits allocated as normal
+• Next hit must be allocated to Kai Lek
+• Subsequent hits can also be allocated to Kai Lek</description>
+    </rule>
+    <rule id="d944-e221-e3e9-d0f3" name="Outcast" book="Rulebook" page="136" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• If Command unit has Outcasts then only applies bonuses to other Outcasts
+• If a unit has Outcasts then cannot use bonuses from non-Outcast command units except a High Commander</description>
+    </rule>
+    <rule id="f142-d027-0670-df57" name="Outcast Champion" book="Rulebook" page="243" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• As long as on battlefield then any Outcast unit can use Fartok&apos;s Co regardless of distance</description>
+    </rule>
+    <rule id="4141-4945-7178-0640" name="Overload Ammo" book="Rulebook" page="89" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Can only be fired direct.  
+• SV3.
+• If roll 10 Acc then shot misses and cannot use Overload Ammo again</description>
+    </rule>
+    <rule id="29e8-5172-36b9-2b93" name="Phase Armour" book="Rulebook" page="93" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• +1 Res up to 10&quot;
+• +2 Res over 10&quot;
+• Can make a Down reaction even if other order completed</description>
+    </rule>
+    <rule id="72e3-4555-8f67-d0db" name="Plasma Fade" book="Rulebook" page="76" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• On the Acc roll of 10 the shot misses and change the firing unit&apos;s order dice to Down</description>
+    </rule>
+    <rule id="b0d2-5a7c-5e8b-93fd" name="Plasma Reactor" book="Rulebook" page="136" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Any lucky hits are allocated by shooter and also automatically hit reactor
+• If Res test fails then reactor is destroyed
+• Roll a dice for each surviving model equipped with a reactor, on a 10 remove model or vehicle suffers damage</description>
+    </rule>
+    <rule id="1fb6-e750-d005-6216" name="Plasma Amplifier" book="Rulebook" page="125" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• May choose to activate unit before any die drawn (place extra dice into bag for each unit activated)
+• Each activated unit gains extra order dice
+• If an amplified unit uses its extra dice and fails required test on a 10 then the amplifier is destroyed
+• Roll D10 at end of turn, 6+ Amplifier continues</description>
+    </rule>
+    <rule id="4997-cdd2-6ad5-9ab7" name="Plasma Dump" book="Rulebook" page="124 - 125" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• When given Down order then declare using Plasma Dump
+• Whilst unit remains Down any shooting against it suffers -2 Acc
+• Plasma hits any unit within 5&quot; with D6 hits at SV2</description>
+    </rule>
+    <rule id="878e-3922-3d01-8f26" name="Mounted Unit" book="Rulebook" page="95" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="377d-0cdc-6ba7-f1d2" name="Scramble Proof" book="Rulebook" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Not affected by scrambler munitions or subvertor matrix
+• Vehicles are affected by scoot munitions</description>
+    </rule>
+    <rule id="c563-b14a-9fa7-19cd" name="Attack Skimmer" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="bbcb-f5f9-c8a6-257a" name="Beast" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="7ee9-6045-2159-7a8b" name="Close Support Drone" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="2000-9286-733b-587f" name="Combat Skimmer" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="8ef6-5d8c-5185-ea17" name="Crawler Transport" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="fcaf-36c5-7d43-ba10" name="Creature" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="5e33-145d-4b7f-abff" name="Drone" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="fd0b-53f8-bc6f-a3bb" name="Drone Command Unit" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="e0ba-3299-cc14-28ba" name="Heavy Combat Skimmer" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="966f-4315-4b9b-5f01" name="Humungous Beast" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="9a87-2673-83b1-3986" name="Infantry Unit" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="0a6b-dcfb-ccc3-6a0d" name="Infantry Command Unit" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="9ff4-49b8-d77a-24d0" name="Infantry/Beast Unit" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="4294-13e8-90a8-2e17" name="Mounted Command Unit" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="b8e9-1952-608c-accf" name="Probe Unit" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="fe34-ee73-af08-487e" name="Sharded Infantry" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="dfc9-ba4c-727e-451a" name="Solo Transport Bike" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="44c9-90c6-b07e-6f75" name="Transport Skimmer" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="29d8-590a-bc46-d27a" name="Vehicle Unit" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="fb9b-1bfd-24cc-6539" name="Vehicle Command Unit" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="7fc6-0ec5-7957-b530" name="Weapon Drone" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="d6f2-8874-5225-1b13" name="Weapon Drone Command" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="ef58-4d70-33b9-042d" name="Weapon Drone Team" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="4513-5976-042c-d38c" name="Weapon Drone Unit" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="3f2c-9814-0c0d-e4d7" name="Weapon Team Unit" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="4450-f5d1-5c73-2302" name="Point Blank Shooting Only" book="Rulebook" page="86" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Have no range, cannot be used in H2H, cannot be set as mines</description>
+    </rule>
+    <rule id="a652-6fac-03ef-4783" name="Random SV" book="Rulebook" page="66" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Random SV in H2H
+• Roll D4 each round of H2H</description>
+    </rule>
+    <rule id="537e-7615-a0a1-4f5f" name="Rapid Sprint" book="Rulebook" page="136" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Sprint at 4M</description>
+    </rule>
+    <rule id="5f8a-3172-909d-a27e" name="Rebels" book="BX" page="84" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• If a friendly unit in 5&quot; has Rebel then may ignore one pin for all purposes
+• Effect is not accumulative</description>
+    </rule>
+    <rule id="a71a-33af-8fc2-33d2" name="Reflex Armour" book="Rulebook" page="93" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• +1 Res</description>
+    </rule>
+    <rule id="3f22-81fe-dd03-eda6" name="RF D6 Fire Only" book="Rulebook" page="72" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Can either fire single shot or D6 shots
+• -1 Acc if Rapid Fire
+• When shooting with advance action weapon has one shot. If issued in multiples, roll D6 for all weapons in unit.</description>
+    </rule>
+    <rule id="f0d7-e63b-bd7e-b9c8" name="RF2" book="Rulebook" page="18, 35" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Can either fire single shot or 2 shots
+• -1 Acc if Rapid Fire</description>
+    </rule>
+    <rule id="89ce-469b-2b76-90fa" name="RF3" book="Rulebook" page="18, 35" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Can either fire single shot or 3 shots
+• -1 Acc if Rapid Fire</description>
+    </rule>
+    <rule id="527d-a6b6-cf23-2c8d" name="RF5" book="Rulebook" page="18, 35" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Can either fire single shot or 5 shots
+• -1 Acc if Rapid Fire</description>
+    </rule>
+    <rule id="09f7-1ca4-b8c3-30a5" name="Ruthless" book="BX" page="108" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• If use Command rule to boost Ghar unit then add additional +1</description>
+    </rule>
+    <rule id="8844-c265-3bcf-2959" name="Savage Strike" book="Rulebook" page="136, 137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Will pass any order test to assault on anything but a 10 regardless of modifiers</description>
+    </rule>
+    <rule id="c858-b4e8-5b6b-4159" name="Scoot" book="Rulebook" page="88" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Any unit with model within 3&quot; can only be given a Run or Down order.
+• Only affects infantry, mounted, weapon team, beast, and humongous beast, command, and bike mounted units with living crew.  Can only go Down as a reaction</description>
+    </rule>
+    <rule id="f20c-e1a6-5e25-b1a2" name="Scout Probe" book="Rulebook" page="120" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• OH: If unit firing OH does not have LoS then own spotter drone can patch to Scout Probe with LoS to target within 20&quot;
+• If within 20&quot; of enemy with Camo Drone then can patch sight to friendly unit with Spotter Drone within 20&quot;</description>
+    </rule>
+    <rule id="e627-a8fe-3b4b-f1f9" name="Scrambler" book="Rulebook" page="88" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Any unit within 3&quot; with Reflex, Hyperlight or Phase armour loses bonuses.
+• If weapon drone or vehicle then loses -2 Res.  If unit includes buddy drones then loses effects.  If unit is a probe then it cannot do anything.
+• Effects are not cummulative from mutliple shots.</description>
+    </rule>
+    <rule id="7c54-5982-a5ef-b888" name="Self Repair" book="Rulebook" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Declare self repair and give unit Rally order
+• Unit must make Rally action and have no pins afterwards
+• May attempt repair immobilisation or one malfunctioning weapon
+• Roll D10, successful on 6+</description>
+    </rule>
+    <rule id="a39d-a506-6033-a3df" name="Sensor Module" book="v2 pdf" page="" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Ef: 30&quot;, Lo: 50&quot;, Ex: 100&quot;, SV: -, -, Light Support
+• Can act as spotter drone for the equipped unit and for friendly units in 10&quot;
+• Hits from Sensor Module do not give pins
+• Once a target has been hit by the Module then shots from all other units gain +1 Acc
+• The bonus is not accumulative and cannot be combined with bonuses from targeter drones etc</description>
+    </rule>
+    <rule id="e1b9-e087-1984-fde7" name="Shard" book="Rulebook" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• When shard receives order all units carry out the same order
+• Sharded units never take pins, all deploy at same time</description>
+    </rule>
+    <rule id="4d11-0423-9b5b-8d3a" name="Shared SV" book="Rulebook" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+    </rule>
+    <rule id="8330-ddbe-10a8-d9ae" name="Shock Wave" book="CS" page="62" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• SV and attacks depend on range</description>
+    </rule>
+    <rule id="90a9-5b29-2686-846e" name="Shooting Mode" book="Rulebook" page="70, 71, 73" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• The whole unit must fire the same mode</description>
+    </rule>
+    <rule id="f562-930d-c5d5-4ca3" name="Slingnet Ammo" book="Rulebook" page="87, 112" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Usually fired direct, Micro-X launcher can fire OH.
+• If target hit suffers no damage but takes +1 additional pin</description>
+    </rule>
+    <rule id="04bc-743b-092f-8c3a" name="Slow" book="Rulebook" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Move at half pace</description>
+    </rule>
+    <rule id="015c-92a1-6555-6e59" name="Sniper" book="Rulebook" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Deploy anywhere in player&apos;s side of table
+• May deploy in scenarios where units do not start game deployed
+• No enemy sniper can deploy within 20&quot; of sniper</description>
+    </rule>
+    <rule id="cc0f-f1a5-19a0-0ed5" name="Soma Graft" book="Rulebook" page="121" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Inactive until take Co test, must be declared
+• Once activated unit passes any Co test on anything but a 10 regardless of modifiers
+• If fails Co then roll order dice, unit must carry out this order, continue to roll for rest of game</description>
+    </rule>
+    <rule id="8b32-dbb7-da83-4fb7" name="Special Munition" book="Rulebook" page="68, 87-89" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Test at end of turn to see if remain in play on a D10, on 6+ continues to work
+• Declare type of munition before firing</description>
+    </rule>
+    <rule id="c7ec-607b-07f1-fc01" name="Spotter Drone" book="Rulebook" page="114" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• If unit has one or more spotter drones and a spotter drone can draw LoS then unit can reroll one miss
+• If firing OH then unit counts as having LoS if the spotter drone has LoS to target
+• If firing OH the spotter drone can patch sight to any friendly spotter drone within 20&quot; that has LoS to the target
+• The unit can either patch sight or reroll a missed shot not both
+• When firing OH and the target is marked bya spotter drone the off target roll is reducd by 1&quot;</description>
+    </rule>
+    <rule id="8730-6c80-7d0a-c566" name="Standard Weapon" book="Rulebook" page="69" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Can Point Blank shoot</description>
+    </rule>
+    <rule id="795b-3127-4b6d-91f7" name="Subverter Matrix" book="Rulebook" page="122" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Targets every enemy vehicle, mounted, weapon drone, probe and buddy drones within 15&quot;, no LoS needed, cannot target Scramble Proof
+• Targets enemy whenever unit makes an action/reaction
+• Targeted units must take Co test
+• If passed then no effect, if passed on a 1 the Subverter has no further effect
+• If failed then take one order dice and set aside, if failed by 10 then take two die
+• If a probe is targeted it is destroyed
+• At the end of the turn both players roll D10 for the removed die, highest score wins.  If owning player wins then return dice to bag, if loses then dice remains contested for the next turn</description>
+    </rule>
+    <rule id="8bba-bf54-4439-2f32" name="Synchroniser Drone" book="BX" page="79" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Used if unit given an order (and passes order test if required) and has a friendly unit in 10&quot;
+• If unit passes a Command test then place an order dice and allocate it to second unit 
+• Second unit still requires an Order test if neccessary
+• If command unit has Follow and Synchroniser Drone then can only use one or other</description>
+    </rule>
+    <rule id="b64a-ee50-a007-e56c" name="Targeter Probe" book="Rulebook" page="120" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Move into touch and remain in contact with enemy unit to mark it
+• Units shooting at marked enemy add +1 Acc per Targeter Probe marking them
+• When firing OH reduce scatter by 1&quot; for each Targeter Probe marking
+• Cannot be hit by direct shooting
+• When marking a unit Targeter Probes can be shot at by marked unit or other units tracing LoS</description>
+    </rule>
+    <rule id="8509-6fcc-0fc0-21ae" name="Transport 10" book="Rulebook" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• May transport 10 human sized models.</description>
+    </rule>
+    <rule id="8272-f4ac-feec-d11c" name="Variable Res/Strike" book="Rulebook" page="66" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Declare which option is used at start of each round of fighting
+• +2 Res or +2 SV</description>
+    </rule>
+    <rule id="cad2-a1be-d4c5-48ff" name="Homer Drone" book="Rulebook" page="112-113" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Can transport off table by unit making a Run order (does not apply to anything the unit is carrying)
+• If order test is failed on a 10 then order fails and Drone is destroyed
+• Unit cannot return once removed from table</description>
+    </rule>
+    <rule id="0f88-1555-b001-b47e" name="Shield Drone" book="Rulebook" page="114" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Can intercept one hit per shield drone
+• Roll D10 for each intecepted hit (1: drone survives, 2-9: drone destroyed, 10 - hit not intercepted)
+• Can intercept lucky hits
+• If shield drone hit by lucky shot then cannot be intercepted and drone is destroyed</description>
+    </rule>
+    <rule id="3ab2-763e-e2eb-30f6" name="Impact Cloak" book="Rulebook" page="93" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• +2 Res in H2H</description>
+    </rule>
+    <rule id="98a7-475a-f0ed-fa91" name="Wound" book="Rulebook" page="221" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• When fails first Res test becomes wounded, if fails further Res test then removed as casualty</description>
+    </rule>
+    <rule id="536e-548a-6948-96cb" name="Wound 2" book="Rulebook" page="243" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• When fails first Res test becomes wounded, this can happen twice, if fails further Res test then removed as casualty</description>
+    </rule>
+    <rule id="6ea4-40e6-718c-0d2f" name="Wound 3" book="Rulebook" page="237" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• When fails first Res test becomes wounded, this can happen thrice, if fails further Res test then removed as casualty</description>
+    </rule>
+    <rule id="d584-98e1-53cc-4397" name="Iso-Shield" book="CS" page="68" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Shield protects Drone and units within 5&quot; from Scramble and Hazardous Environments</description>
+    </rule>
+    <rule id="64fc-4815-0b06-8b5a" name="Hazard Armour" book="CS" page="67" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Affected by Scrambler
+• Cannot Sprint
+• If hit by SV5+ unit takes extra pin
+• If equipped with Plasma Carbines can RF3</description>
+    </rule>
+  </sharedRules>
+  <sharedProfiles>
+    <profile id="af66-926c-667f-6fb2" name="Plasma Pistol" page="68" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Hand Weapon"/>
+      </characteristics>
+    </profile>
+  </sharedProfiles>
 </gameSystem>


### PR DESCRIPTION
Algoryn:
1. Updated to v2 pdf costs and tweaks
2. Fixed Strategic error flagging up for less than 1000 points
3. Fixed being able to add more than one Assault unit without assault command
4. Fixed being able to add more than one skimmer squad without skimmer command
5. Fixed adding crew weapons for all support teams
6. Added Hazard units, General Ess, Iso-Drone
7. Updated Defiant changes
8. Major file rebuild
9. Added in Spearhead list
10. Moved lot of shared entries and shared rules to central file so standard across all files (in prep for other race updates)

General:
1. Updated book references
2. Made rule descriptions common across systems
3. Added in missing rules info