### PR TITLE
v1.20 update - fixes, tweaks and rewrite on Concord and Boromites

### DIFF
--- a/Beyond_the_Gates_of_Antares.gst
+++ b/Beyond_the_Gates_of_Antares.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="c339-677a-60db-4060" name="Beyond the Gates of Antares" revision="18" battleScribeVersion="2.01" authorName="Dom Hine" authorContact="boltactionAB@gmail.com" authorUrl="https://www.facebook.com/groups/547335118761237/?hc_location=ufi" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="c339-677a-60db-4060" name="Beyond the Gates of Antares" revision="19" battleScribeVersion="2.01" authorName="Dom Hine" authorContact="boltactionAB@gmail.com" authorUrl="https://www.facebook.com/groups/547335118761237/?hc_location=ufi" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -87,13 +87,6 @@
       <modifiers/>
       <constraints/>
     </categoryEntry>
-    <categoryEntry id="72de-2c22-ac68-efcf" name="Army Options" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-    </categoryEntry>
     <categoryEntry id="c87d-5261-face-4643" name="Limited" hidden="false">
       <profiles/>
       <rules/>
@@ -110,9 +103,16 @@
       <modifiers/>
       <constraints/>
     </categoryEntry>
+    <categoryEntry id="dadf-9bf7-c922-e3f3" name="Infantry/Mounted" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+    </categoryEntry>
   </categoryEntries>
   <forceEntries>
-    <forceEntry id="b846-13d5-be2f-fc90" name="Concord" hidden="false">
+    <forceEntry id="b846-13d5-be2f-fc90" name="Concord" book="Rulebook &amp; pdf v2" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -189,17 +189,9 @@
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="855c-39b4-0631-34aa" value="1">
-              <repeats>
-                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="true"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
+          <modifiers/>
           <constraints>
-            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="855c-39b4-0631-34aa" type="max"/>
+            <constraint field="points" scope="roster" value="10.0" percentValue="true" shared="false" includeChildSelections="true" includeChildForces="false" id="855c-39b4-0631-34aa" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="b846-13d5-be2f-fc90-72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="false">
@@ -241,7 +233,16 @@
               <repeats>
                 <repeat field="limit::points" scope="roster" value="250.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="true"/>
               </repeats>
-              <conditions/>
+              <conditions>
+                <condition field="limit::points" scope="roster" value="999.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="any" type="greaterThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="a1a5-040c-8797-e22b" value="0.0">
+              <repeats/>
+              <conditions>
+                <condition field="limit::points" scope="roster" value="1000.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="lessThan"/>
+              </conditions>
               <conditionGroups/>
             </modifier>
           </modifiers>
@@ -316,9 +317,16 @@
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2cfd-ad2e-eb7e-70f4" type="min"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="1d83-a1cd-f37c-6c2b" name="Limited" hidden="false" targetId="c87d-5261-face-4643" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
-    <forceEntry id="3521-97ef-212b-0bc5" name="Isorian" hidden="false">
+    <forceEntry id="3521-97ef-212b-0bc5" name="Isorian" book="Rulebook &amp; pdf v2" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -404,17 +412,9 @@
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="d574-3297-5a75-da27" value="1">
-              <repeats>
-                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
+          <modifiers/>
           <constraints>
-            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="d574-3297-5a75-da27" type="max"/>
+            <constraint field="points" scope="roster" value="10.0" percentValue="true" shared="false" includeChildSelections="true" includeChildForces="false" id="d574-3297-5a75-da27" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="3521-97ef-212b-0bc5-72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="false">
@@ -540,7 +540,7 @@
         </categoryLink>
       </categoryLinks>
     </forceEntry>
-    <forceEntry id="e172-eb02-269f-1843" name="Algoryn" hidden="false">
+    <forceEntry id="e172-eb02-269f-1843" name="Algoryn" book="Rulebook &amp; pdf v2" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -548,21 +548,13 @@
       <constraints/>
       <forceEntries/>
       <categoryLinks>
-        <categoryLink id="e172-eb02-269f-1843-72de-2c22-ac68-efcf" name="Army Options" hidden="false" targetId="72de-2c22-ac68-efcf" primary="false">
+        <categoryLink id="e172-eb02-269f-1843-72de-2c22-ac68-efcf" name="Army Options" hidden="false" targetId="50ba-cf77-3941-189c" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="1900-5354-3f55-bdff" value="1">
-              <repeats>
-                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
+          <modifiers/>
           <constraints>
-            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="1900-5354-3f55-bdff" type="max"/>
+            <constraint field="points" scope="roster" value="10.0" percentValue="true" shared="false" includeChildSelections="true" includeChildForces="false" id="1900-5354-3f55-bdff" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="e172-eb02-269f-1843-481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="false">
@@ -576,7 +568,7 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="limit::points" scope="roster" value="751.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="lessThan"/>
+                    <condition field="limit::points" scope="roster" value="1249.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="lessThan"/>
                     <condition field="limit::points" scope="roster" value="500.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
                   </conditions>
                   <conditionGroups/>
@@ -596,8 +588,8 @@
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="limit::points" scope="roster" value="1251.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="lessThan"/>
-                    <condition field="limit::points" scope="roster" value="750.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                    <condition field="limit::points" scope="roster" value="1499.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="lessThan"/>
+                    <condition field="limit::points" scope="roster" value="1249.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
@@ -743,7 +735,7 @@
         </categoryLink>
       </categoryLinks>
     </forceEntry>
-    <forceEntry id="d495-4280-c789-74c3" name="Freeborn" hidden="false">
+    <forceEntry id="d495-4280-c789-74c3" name="Freeborn" book="Rulebook &amp; pdf v2" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -755,17 +747,9 @@
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="180e-cf12-64c0-ac4f" value="1">
-              <repeats>
-                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
+          <modifiers/>
           <constraints>
-            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="180e-cf12-64c0-ac4f" type="max"/>
+            <constraint field="points" scope="roster" value="10.0" percentValue="true" shared="false" includeChildSelections="true" includeChildForces="false" id="180e-cf12-64c0-ac4f" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="d495-4280-c789-74c3-72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="false">
@@ -968,7 +952,7 @@
         </categoryLink>
       </categoryLinks>
     </forceEntry>
-    <forceEntry id="caf9-a6ca-8320-553f" name="Boromites" hidden="false">
+    <forceEntry id="caf9-a6ca-8320-553f" name="Boromites" book="Rulebook &amp; pdf v2" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -980,17 +964,9 @@
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="cd29-12ef-c14f-5408" value="1">
-              <repeats>
-                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
+          <modifiers/>
           <constraints>
-            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="cd29-12ef-c14f-5408" type="max"/>
+            <constraint field="points" scope="roster" value="10.0" percentValue="true" shared="false" includeChildSelections="true" includeChildForces="false" id="cd29-12ef-c14f-5408" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="caf9-a6ca-8320-553f-72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="false">
@@ -1032,19 +1008,15 @@
               <repeats>
                 <repeat field="limit::points" scope="roster" value="250.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="true"/>
               </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="set" field="052d-636c-f27d-a674" value="0.0">
-              <repeats/>
               <conditions>
-                <condition field="limit::points" scope="roster" value="1000.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="lessThan"/>
+                <condition field="limit::points" scope="roster" value="1000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast"/>
               </conditions>
               <conditionGroups/>
             </modifier>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="-3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="052d-636c-f27d-a674" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="052d-636c-f27d-a674" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50e3-4ef2-f60f-62c0" type="min"/>
           </constraints>
         </categoryLink>
         <categoryLink id="caf9-a6ca-8320-553f-481abf13-c03e-0dd0-d520-9f9837253cbe" name="Tactical" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="false">
@@ -1224,9 +1196,16 @@
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a92c-8520-9da1-f955" type="min"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="fbdd-0524-7915-fb56" name="Limited" hidden="false" targetId="c87d-5261-face-4643" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
-    <forceEntry id="c0f0-d99e-a5f5-4220" name="Freeborn Adventurers" hidden="false">
+    <forceEntry id="c0f0-d99e-a5f5-4220" name="Freeborn Adventurers" book="Rulebook &amp; pdf v2" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -1238,17 +1217,9 @@
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="3adb-8ccd-7d79-7091" value="1">
-              <repeats>
-                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
+          <modifiers/>
           <constraints>
-            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="3adb-8ccd-7d79-7091" type="max"/>
+            <constraint field="points" scope="roster" value="10.0" percentValue="true" shared="false" includeChildSelections="true" includeChildForces="false" id="3adb-8ccd-7d79-7091" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="c0f0-d99e-a5f5-4220-72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="false">
@@ -1395,7 +1366,7 @@
         </categoryLink>
       </categoryLinks>
     </forceEntry>
-    <forceEntry id="1987-7c87-be93-59d7" name="Boromite Clan" hidden="false">
+    <forceEntry id="1987-7c87-be93-59d7" name="Boromite Clan" book="BX" page="96" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -1407,17 +1378,9 @@
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="44cc-036b-8f85-815a" value="1">
-              <repeats>
-                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
+          <modifiers/>
           <constraints>
-            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="44cc-036b-8f85-815a" type="max"/>
+            <constraint field="points" scope="roster" value="10.0" percentValue="true" shared="false" includeChildSelections="true" includeChildForces="false" id="44cc-036b-8f85-815a" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="1987-7c87-be93-59d7-72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="false">
@@ -1432,11 +1395,18 @@
                 <conditionGroup type="and">
                   <conditions>
                     <condition field="limit::points" scope="roster" value="750.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
-                    <condition field="limit::points" scope="roster" value="1251.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="lessThan"/>
+                    <condition field="limit::points" scope="roster" value="1001.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="lessThan"/>
                   </conditions>
                   <conditionGroups/>
                 </conditionGroup>
               </conditionGroups>
+            </modifier>
+            <modifier type="set" field="10e1-ef25-5f87-053b" value="0.0">
+              <repeats/>
+              <conditions>
+                <condition field="limit::points" scope="roster" value="1000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="greaterThan"/>
+              </conditions>
+              <conditionGroups/>
             </modifier>
           </modifiers>
           <constraints>
@@ -1452,6 +1422,13 @@
               <repeats/>
               <conditions>
                 <condition field="limit::points" scope="roster" value="750.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="6ee3-faf1-f49d-f2f9" value="0.0">
+              <repeats/>
+              <conditions>
+                <condition field="limit::points" scope="roster" value="1000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="greaterThan"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -1494,6 +1471,20 @@
               <repeats/>
               <conditions>
                 <condition field="limit::points" scope="roster" value="750.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="e764-9049-aea6-8a83" value="0.0">
+              <repeats/>
+              <conditions>
+                <condition field="limit::points" scope="roster" value="1000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="greaterThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="b813-5841-2d11-a40d" value="0.0">
+              <repeats/>
+              <conditions>
+                <condition field="limit::points" scope="roster" value="1000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="greaterThan"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -1548,6 +1539,20 @@
               </conditions>
               <conditionGroups/>
             </modifier>
+            <modifier type="set" field="bee2-4e3c-1642-7afc" value="0.0">
+              <repeats/>
+              <conditions>
+                <condition field="limit::points" scope="roster" value="1000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="greaterThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="885c-0c8f-6ec8-083b" value="0.0">
+              <repeats/>
+              <conditions>
+                <condition field="limit::points" scope="roster" value="1000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="greaterThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="885c-0c8f-6ec8-083b" type="max"/>
@@ -1556,7 +1561,7 @@
         </categoryLink>
       </categoryLinks>
     </forceEntry>
-    <forceEntry id="1ac1-5fee-53d1-dd46" name="Ghar Empire" hidden="false">
+    <forceEntry id="1ac1-5fee-53d1-dd46" name="Ghar Empire" book="Rulebook &amp; pdf v2" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -1568,17 +1573,9 @@
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="994a-84d5-76ba-fe12" value="1">
-              <repeats>
-                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
+          <modifiers/>
           <constraints>
-            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="994a-84d5-76ba-fe12" type="max"/>
+            <constraint field="points" scope="roster" value="10.0" percentValue="true" shared="false" includeChildSelections="true" includeChildForces="false" id="994a-84d5-76ba-fe12" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="1ac1-5fee-53d1-dd46-72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="false">
@@ -1700,7 +1697,7 @@
         </categoryLink>
       </categoryLinks>
     </forceEntry>
-    <forceEntry id="77bd-d06a-8711-eb03" name="Ghar Rebel" hidden="false">
+    <forceEntry id="77bd-d06a-8711-eb03" name="Ghar Rebel" book="Rulebook &amp; pdf v2" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -1712,17 +1709,9 @@
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="96e2-1dfa-15de-5b3c" value="1">
-              <repeats>
-                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
+          <modifiers/>
           <constraints>
-            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="96e2-1dfa-15de-5b3c" type="max"/>
+            <constraint field="points" scope="roster" value="10.0" percentValue="true" shared="false" includeChildSelections="true" includeChildForces="false" id="96e2-1dfa-15de-5b3c" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="77bd-d06a-8711-eb03-72807c5d-e370-9ddf-c2b7-de5d2797f24d" name="Auxiliary" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="false">
@@ -1912,7 +1901,7 @@
         </categoryLink>
       </categoryLinks>
     </forceEntry>
-    <forceEntry id="e34a-df89-3a6a-46e9" name="Boromite Survey Expedition" hidden="false">
+    <forceEntry id="e34a-df89-3a6a-46e9" name="Boromite Survey Expedition" book="Rulebook &amp; pdf v2" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -2097,9 +2086,32 @@
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ed2-b2ba-ec08-feba" type="min"/>
           </constraints>
         </categoryLink>
+        <categoryLink id="7c1d-575d-b406-b3bd" name="Limited" hidden="false" targetId="c87d-5261-face-4643" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="c502-25c4-bd8d-db47" name="Weapon Team" hidden="false" targetId="db48-a6b8-4b98-e3ed" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="9445-621e-bb56-cfca" name="Army Options" hidden="false" targetId="50ba-cf77-3941-189c" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="points" scope="roster" value="10.0" percentValue="true" shared="false" includeChildSelections="true" includeChildForces="false" id="256c-7d6d-1516-948c" type="max"/>
+          </constraints>
+        </categoryLink>
       </categoryLinks>
     </forceEntry>
-    <forceEntry id="0845-ad59-215a-fba2" name="Algoryn Spearhead" hidden="false">
+    <forceEntry id="0845-ad59-215a-fba2" name="Algoryn Spearhead" book="Rulebook &amp; pdf v2" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -2107,21 +2119,13 @@
       <constraints/>
       <forceEntries/>
       <categoryLinks>
-        <categoryLink id="b197-07d9-af87-8452" name="Army Options" hidden="false" targetId="72de-2c22-ac68-efcf" primary="false">
+        <categoryLink id="b197-07d9-af87-8452" name="Army Options" hidden="false" targetId="50ba-cf77-3941-189c" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="ef11-6640-529f-16fb" value="1">
-              <repeats>
-                <repeat field="limit::points" scope="roster" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-              </repeats>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
+          <modifiers/>
           <constraints>
-            <constraint field="points" scope="roster" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="ef11-6640-529f-16fb" type="max"/>
+            <constraint field="points" scope="roster" value="10.0" percentValue="true" shared="false" includeChildSelections="true" includeChildForces="false" id="ef11-6640-529f-16fb" type="max"/>
           </constraints>
         </categoryLink>
         <categoryLink id="c38b-d7ff-84ab-b34b" name="Tactical" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="false">
@@ -2280,6 +2284,352 @@
           <constraints>
             <constraint field="selections" scope="force" value="25.0" percentValue="true" shared="true" includeChildSelections="false" includeChildForces="false" id="dab9-4857-e9ad-7c56" type="max"/>
           </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+    <forceEntry id="9e13-68ee-3f1c-cf20" name="Concord Drone Force" book="CS &amp; pdf v2" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <forceEntries/>
+      <categoryLinks>
+        <categoryLink id="189c-0bc1-b3c8-bf4b" name="Tactical" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="b2f6-5ac6-1c6e-3fc4" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="points" scope="roster" value="749.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="greaterThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="b2f6-5ac6-1c6e-3fc4" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="points" scope="roster" value="1249.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="any" type="greaterThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="b2f6-5ac6-1c6e-3fc4" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="points" scope="roster" value="1749.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="greaterThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="b2f6-5ac6-1c6e-3fc4" value="1">
+              <repeats>
+                <repeat field="points" scope="roster" value="250.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions>
+                <condition field="points" scope="roster" value="2249.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="greaterThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b2f6-5ac6-1c6e-3fc4" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d9ff-a83f-6519-c5b7" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="40b2-c733-9691-893a" name="Army Options" hidden="false" targetId="50ba-cf77-3941-189c" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="points" scope="roster" value="10.0" percentValue="true" shared="false" includeChildSelections="true" includeChildForces="false" id="8b18-d126-e7a6-882f" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="cb5d-d4c1-058f-7f1b" name="Auxiliary" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="244f-06a7-f21c-194b" value="2">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="points" scope="roster" value="750.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                    <condition field="points" scope="roster" value="1251.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="lessThan"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="244f-06a7-f21c-194b" value="3">
+              <repeats/>
+              <conditions>
+                <condition field="points" scope="roster" value="1250.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="244f-06a7-f21c-194b" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="94df-d301-7363-45e8" name="Strategic" hidden="false" targetId="a01f5f58-334c-8442-d861-15099ebdf5e5" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="e9a0-a26b-c866-fc44" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="points" scope="roster" value="1000.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="lessThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="e9a0-a26b-c866-fc44" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="250.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="true"/>
+              </repeats>
+              <conditions>
+                <condition field="points" scope="roster" value="1000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="-2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e9a0-a26b-c866-fc44" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="1fbb-fee4-ae9d-6ef7" name="Support" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="b926-f0b3-6838-b949" value="1">
+              <repeats>
+                <repeat field="points" scope="roster" value="250.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="ef97-46cb-6fe3-05ac" value="1">
+              <repeats>
+                <repeat field="points" scope="roster" value="250.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions>
+                <condition field="points" scope="roster" value="1250.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="lessThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="ef97-46cb-6fe3-05ac" value="5">
+              <repeats/>
+              <conditions>
+                <condition field="points" scope="roster" value="1250.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b926-f0b3-6838-b949" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ef97-46cb-6fe3-05ac" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="91d8-25b4-420a-adb3" name="Infantry/Mounted" hidden="false" targetId="dadf-9bf7-c922-e3f3" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="force" value="25.0" percentValue="true" shared="true" includeChildSelections="false" includeChildForces="false" id="9816-a22d-5961-7bda" type="max"/>
+          </constraints>
+        </categoryLink>
+      </categoryLinks>
+    </forceEntry>
+    <forceEntry id="42d3-ae8f-58d4-55f0" name="Concord Rapid Reaction Force" book="pdf v2" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <forceEntries/>
+      <categoryLinks>
+        <categoryLink id="33f2-4a3b-5b52-4ae9" name="Tactical" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="a95a-b25f-3ed0-880f" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="points" scope="roster" value="749.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="greaterThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="a95a-b25f-3ed0-880f" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="points" scope="roster" value="1249.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="any" type="greaterThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="a95a-b25f-3ed0-880f" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="points" scope="roster" value="1749.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="greaterThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="a95a-b25f-3ed0-880f" value="1">
+              <repeats>
+                <repeat field="points" scope="roster" value="250.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions>
+                <condition field="points" scope="roster" value="2249.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="greaterThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a95a-b25f-3ed0-880f" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="37ef-0741-0134-11b4" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="56f1-3b61-4891-589e" name="Army Options" hidden="false" targetId="50ba-cf77-3941-189c" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="points" scope="roster" value="10.0" percentValue="true" shared="false" includeChildSelections="true" includeChildForces="false" id="0454-8739-78bd-33fd" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="305f-4fba-116a-8376" name="Auxiliary" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="e184-f0b3-0676-e5dc" value="2">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="points" scope="roster" value="750.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                    <condition field="points" scope="roster" value="1251.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="lessThan"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="e184-f0b3-0676-e5dc" value="3">
+              <repeats/>
+              <conditions>
+                <condition field="points" scope="roster" value="1250.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e184-f0b3-0676-e5dc" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="66be-016c-bfa1-c129" name="Strategic" hidden="false" targetId="a01f5f58-334c-8442-d861-15099ebdf5e5" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="set" field="8593-1133-b77d-7e20" value="1">
+              <repeats/>
+              <conditions>
+                <condition field="points" scope="roster" value="1000.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="lessThan"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="increment" field="8593-1133-b77d-7e20" value="1">
+              <repeats>
+                <repeat field="limit::points" scope="roster" value="250.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" repeats="1" roundUp="true"/>
+              </repeats>
+              <conditions>
+                <condition field="points" scope="roster" value="1000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="8593-1133-b77d-7e20" value="2">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="points" scope="roster" value="1000.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="greaterThan"/>
+                    <condition field="points" scope="roster" value="1500.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="lessThan"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="-2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8593-1133-b77d-7e20" type="max"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="1106-e382-c642-5027" name="Support" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers>
+            <modifier type="increment" field="ceee-0429-f350-8645" value="1">
+              <repeats>
+                <repeat field="points" scope="roster" value="250.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+              </repeats>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="a164-4b86-d34b-3741" value="5">
+              <repeats/>
+              <conditions>
+                <condition field="points" scope="roster" value="1250.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+            <modifier type="set" field="a164-4b86-d34b-3741" value="3">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="points" scope="roster" value="1000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="lessThan"/>
+                    <condition field="points" scope="roster" value="750.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="set" field="a164-4b86-d34b-3741" value="4">
+              <repeats/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="points" scope="roster" value="1250.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="lessThan"/>
+                    <condition field="points" scope="roster" value="1000.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ceee-0429-f350-8645" type="max"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a164-4b86-d34b-3741" type="min"/>
+          </constraints>
+        </categoryLink>
+        <categoryLink id="9029-ddcc-c886-9624" name="Limited" hidden="false" targetId="c87d-5261-face-4643" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
         </categoryLink>
       </categoryLinks>
     </forceEntry>
@@ -2542,27 +2892,6 @@
       <rules/>
       <infoLinks>
         <infoLink id="439f-1ff9-c534-717c" name="AG Chute" hidden="false" targetId="9b49-f2a1-9917-d571" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="3a6d-2025-acf1-7ba7" name="Auto-Workshop" book="Rulebook" page="120" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="d588-c192-8422-07bf" name="Auto-Workshop" hidden="false" targetId="efa8-8f40-fcd9-4542" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3761,7 +4090,7 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3608-ef7d-5cac-48ca" name="Gun Drone" book="Rulebook" page="112" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="3608-ef7d-5cac-48ca" name="Gun Drone (Twin Plasma Carbine)" book="Rulebook" page="112" hidden="false" collective="false" type="upgrade">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -4076,61 +4405,54 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="87b1-a87b-594d-257b" name="Twin Plasma Carbines" book="Rulebook" hidden="false" collective="false" type="upgrade">
-      <profiles/>
+      <profiles>
+        <profile id="ed34-6e36-a7c5-5822" name="Plasma Carbine - Scatter" book="Rulebook" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF4, Standard Weapon"/>
+          </characteristics>
+        </profile>
+        <profile id="8be8-c282-5e10-9ee6" name="Plasma Carbine - Single Shot" book="Rulebook" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
       <rules/>
-      <infoLinks/>
+      <infoLinks>
+        <infoLink id="f3bd-2c99-548d-11c5" name="RF4" hidden="false" targetId="721b-f3e7-087c-177e" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="9a16-c2b2-b7b1-19f7" name="Standard Weapon" hidden="false" targetId="8730-6c80-7d0a-c566" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
       <constraints/>
       <categoryLinks/>
       <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="52d9-6e25-66a1-73fc" name="Plasma Carbine" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3f4a-69e3-f315-b450" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="33e0-2669-9768-bba6" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="99c9-d756-1581-5d67" name="Plasma Carbine" hidden="false" targetId="3877-96bf-06bb-ff8f" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="e99f-7e0e-7b39-fdc6" name="Plasma Carbine" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1575-e512-73fa-d9a1" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="83a7-e4a9-e6e7-fa3d" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="a1e3-4024-d6d6-9619" name="Plasma Carbine" hidden="false" targetId="3877-96bf-06bb-ff8f" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+      <selectionEntryGroups/>
       <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="0.0"/>
@@ -4390,7 +4712,7 @@
     </selectionEntry>
     <selectionEntry id="6c6c-c2a4-1f79-f89e" name="Lectro Lance" book="Rulebook" page="66" hidden="false" collective="false" type="upgrade">
       <profiles>
-        <profile id="0fac-1125-d334-d650" name="Lectro Lance" book="BtGoA" page="66" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+        <profile id="0fac-1125-d334-d650" name="Lectro Lance" book="Rulebook" page="66" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -4888,10 +5210,7 @@
         </infoLink>
       </infoLinks>
       <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="af78-a756-8869-edf5" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5c84-8d44-fbb1-a211" type="max"/>
-      </constraints>
+      <constraints/>
       <categoryLinks/>
       <selectionEntries/>
       <selectionEntryGroups/>
@@ -5113,47 +5432,7 @@
       </costs>
     </selectionEntry>
     <selectionEntry id="3017-11d8-80c9-ba77" name="Plasma Lance" book="Rulebook" page="70" hidden="false" collective="false" type="upgrade">
-      <profiles>
-        <profile id="d971-44c5-28b1-fd07" name="Plasma Lance - Lance" book="Rulebook" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="4"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Choose Target, Inaccurate, Standard Weapon"/>
-          </characteristics>
-        </profile>
-        <profile id="862d-9c0e-1906-b1a3" name="Plasma Lance - Scatter" book="Rulebook" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Standard Weapon"/>
-          </characteristics>
-        </profile>
-        <profile id="1d21-a32d-05a0-4f47" name="Plasma Lance - Single Shot" book="Rulebook" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
-            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
-            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
-            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
-          </characteristics>
-        </profile>
-      </profiles>
+      <profiles/>
       <rules/>
       <infoLinks>
         <infoLink id="e5b0-d849-92a7-cd24" name="Choose Target" hidden="false" targetId="7b4c-a6f4-dc1f-0989" type="rule">
@@ -5175,6 +5454,24 @@
           <modifiers/>
         </infoLink>
         <infoLink id="1047-ed98-5f77-480b" name="RF2" hidden="false" targetId="f0d7-e63b-bd7e-b9c8" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7a77-3e1d-7ee3-f2c2" name="Plasma Lance - Lance" hidden="false" targetId="0657-a21b-613f-3ae8" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="4b11-2be4-5265-b82f" name="Plasma Lance - Single Shot" hidden="false" targetId="2033-5713-8944-6781" type="profile">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="9a4f-7165-908f-4e9c" name="Plasma Lance - Scatter" hidden="false" targetId="8df9-0599-41c9-bda6" type="profile">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -5232,7 +5529,7 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9851-4076-e2e9-3df8" name="Plasma Pistol" book="Rulebook" page="68" hidden="false" collective="false" type="upgrade">
+    <selectionEntry id="9851-4076-e2e9-3df8" name="Plasma Pistol" book="Rulebook" page="68" hidden="false" collective="true" type="upgrade">
       <profiles>
         <profile id="68aa-24a6-21c6-83ae" name="Plasma Pistol" book="Rulebook" page="68" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
           <profiles/>
@@ -6420,50 +6717,26 @@
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4cdd-bee0-021c-a455" type="max"/>
       </constraints>
       <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="51c1-aae4-3a68-7e77" name="Ranged Weapon" hidden="false" collective="false">
+      <selectionEntries>
+        <selectionEntry id="e3ba-b811-e354-e84d" name="Twin Mag Repeaters" hidden="false" collective="false" type="upgrade">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b838-b323-27d7-1efe" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1e90-4b8a-58ed-d29e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6013-d169-358a-a2ae" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c003-7f24-b971-6165" type="max"/>
           </constraints>
           <categoryLinks/>
-          <selectionEntries>
-            <selectionEntry id="642f-1a50-8d58-f04f" name="Twin Mag Repeaters" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a063-6e5b-2c5d-a670" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6f82-d6ce-4923-3658" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
+          <selectionEntries/>
           <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="f9e3-cc4a-2bf9-4682" name="Twin Mag Repeaters" hidden="false" targetId="f6f8-67cc-ec58-fc0e" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
       <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="0.0"/>
@@ -7153,29 +7426,40 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
+        <selectionEntryGroup id="9797-1b10-5b37-17b9" name="Drones" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="e59d-c606-0d87-a3c3" name="Medi-Drone" hidden="false" targetId="c3f0-2a1d-815e-b61a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4da2-ac84-6aba-1890" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="4462-d1d0-8a5b-62d6" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4a7-f885-5e2f-fd99" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="c084-15a0-96e0-22e7" name="Medi-Drone" hidden="false" targetId="c3f0-2a1d-815e-b61a" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="23b1-ff2f-7061-6d0c" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="a5b5-a5d0-1573-86e4" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2511-67ea-50fc-380c" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-      </entryLinks>
+      <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
@@ -7252,37 +7536,7 @@
           <constraints/>
         </categoryLink>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="1e70-d862-6390-0390" name="Self Repair" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="4133-4ba4-7390-f665" name="Self Repair" hidden="false" targetId="7c54-5982-a5ef-b888" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers>
-            <modifier type="increment" field="points" value="10">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="af8e-5265-d835-9d23" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="9061-987f-f2af-5137" name="Weapon" hidden="false" collective="false">
           <profiles/>
@@ -7384,39 +7638,91 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
+        <selectionEntryGroup id="a9d5-620b-d2e6-55dd" name="Drones" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="e5d6-775f-13a4-ef4c" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aec1-f4fb-be09-9621" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="875a-4c9b-afb0-50c8" name="Shield Drone" hidden="false" targetId="81b9-02e2-63b6-9c6e" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="33ad-2b1b-c977-8479" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="7ec3-263b-d0ed-f96d" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d849-dfbb-573d-bf4c" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="60a4-9d73-26ca-b58c" name="Upgrade" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="360b-69a8-40a1-b5fb" name="Self Repair" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="5d1c-d621-0f85-f020" name="Self Repair" hidden="false" targetId="7c54-5982-a5ef-b888" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers>
+                <modifier type="increment" field="points" value="10">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fa5c-8db0-2140-8b96" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="0726-d7f5-3ae6-23a4" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="584e-42a6-3775-9c61" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="d66e-122d-24d4-9bbc" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="476f-58ac-b7fb-a6ca" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="9fb8-fd38-1ec6-e476" name="Shield Drone" hidden="false" targetId="81b9-02e2-63b6-9c6e" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="94bb-550c-d780-a3db" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-      </entryLinks>
+      <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="106.0"/>
       </costs>
@@ -7431,7 +7737,7 @@
             <modifier type="increment" field="f214-abe8-c922-c51b" value="1">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="4ee7-4a59-69c0-3fa3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b56b-f2ce-02d0-a15a" type="equalTo"/>
+                <condition field="selections" scope="4ee7-4a59-69c0-3fa3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6e74-a76c-f866-9814" type="equalTo"/>
               </conditions>
               <conditionGroups/>
             </modifier>
@@ -7532,45 +7838,68 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
+        <selectionEntryGroup id="dc00-e323-00c9-685b" name="Drones" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="7f24-c09b-9c47-d845" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="327b-89ef-767b-b1e3" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="2f8b-6281-9051-45ab" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0b4-aa2e-6cda-7086" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="5211-d990-d57b-e4b5" name="Upgrade" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="6e74-a76c-f866-9814" name="HL Booster" hidden="false" targetId="6c89-65f8-fa8e-7131" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="24">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8d4-9888-1c8d-3af2" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="eced-d902-bbaa-cf08" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3991-6073-93e4-32e5" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="372e-07c2-4439-0cc0" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1fc-c413-c857-86e3" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="b56b-f2ce-02d0-a15a" name="HL Booster" hidden="false" targetId="6c89-65f8-fa8e-7131" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="increment" field="points" value="24">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f5f-5823-276b-a73b" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-      </entryLinks>
+      <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="128.0"/>
       </costs>
@@ -7604,90 +7933,7 @@
           <constraints/>
         </categoryLink>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="d19f-fcca-6f6a-3d73" name="Promote one crew member to Leader" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c904-b651-7dec-035b" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries>
-            <selectionEntry id="1ace-0c7d-eac9-8e20" name="Leader One" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="d6ca-2314-fbf2-e420" name="Leader" hidden="false" targetId="4675-d30d-3451-8672" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="49d1-8d76-efb7-2253" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="eb92-b9ea-4c08-466f" name="AI Trooper Crew" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="2f57-c070-e47a-2e91" name="AI Trooper Crew" book="" page="" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
-                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
-                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (7)"/>
-                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
-                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="83fe-2029-3880-1be1" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="44c5-cfb0-b88f-c2d9" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="f603-66ea-f5c5-64e1" name="Reflex Armor" hidden="false" targetId="1523-0845-c12b-4980" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="14.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="66f5-2f52-d6ea-418a" name="Support Weapon" hidden="false" collective="false" defaultSelectionEntryId="7a8c-b7e2-21d4-cc44">
           <profiles/>
@@ -7754,7 +8000,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="3">
                   <repeats>
-                    <repeat field="selections" scope="0e5d-41c7-4061-6a70" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb92-b9ea-4c08-466f" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="0e5d-41c7-4061-6a70" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a11c-9ff3-02c3-16b0" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -7770,7 +8016,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="3">
                   <repeats>
-                    <repeat field="selections" scope="0e5d-41c7-4061-6a70" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb92-b9ea-4c08-466f" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="0e5d-41c7-4061-6a70" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a11c-9ff3-02c3-16b0" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -7789,18 +8035,84 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="07df-06c9-7c4c-f603" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+        <selectionEntryGroup id="b4ab-615e-4ce5-ff5d" name="Drones" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c23-20b9-3789-9991" type="max"/>
-          </constraints>
+          <constraints/>
           <categoryLinks/>
-        </entryLink>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="ebea-c8e3-aee1-fa56" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9355-bc66-f90c-6d6d" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="4ffc-8d02-06cb-6d11" name="Upgrade" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="a11c-9ff3-02c3-16b0" name="AI Trooper Crew" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="d50a-1274-5ad0-2894" name="AI Trooper Crew" hidden="false" targetId="5d9e-89a4-4f24-f8ae" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e857-9fa4-eb0a-5cda" type="min"/>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9363-25d1-d634-1ea5" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="8524-d122-9cc5-7516" name="Reflex Armor" hidden="false" targetId="1523-0845-c12b-4980" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="14.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="b364-dd79-8490-af32" name="Promote one crew member to Leader" hidden="false" targetId="f668-c137-4629-1b78" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
         <entryLink id="6cdf-3a9b-2673-a395" name="Reflex Armor" hidden="false" targetId="1523-0845-c12b-4980" type="selectionEntry">
           <profiles/>
           <rules/>
@@ -7875,96 +8187,7 @@
           <constraints/>
         </categoryLink>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="a119-c680-d17d-ff47" name="AI Trooper Crew" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="26eb-23be-6496-80b6" name="AI Trooper Crew" book="BtGoA" page="175" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
-                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
-                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (7)"/>
-                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
-                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6e74-41af-74df-0f30" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6a6a-42b7-ba01-c675" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="14.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="1fbe-2a61-8d0f-c2e4" name="Promote one crew member to Leader" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f6bf-6002-137f-85b3" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="d3b2-b348-c779-9b05" name="Leader Level" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c7bf-7f80-8031-6420" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fdaf-cb2b-1ca0-b8d2" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries>
-                <selectionEntry id="093b-dde2-1b19-eecb" name="Leader One" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks>
-                    <infoLink id="bc18-81a0-5ab3-5101" name="Leader" hidden="false" targetId="4675-d30d-3451-8672" type="rule">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                    </infoLink>
-                  </infoLinks>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="257a-b58a-8767-d5bb" type="max"/>
-                  </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks/>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="f7eb-ea8c-f01d-eca1" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="bb2e-955f-54ee-31b6">
           <profiles/>
@@ -8051,7 +8274,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="3">
                   <repeats>
-                    <repeat field="selections" scope="0c51-2b67-3982-5c81" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a119-c680-d17d-ff47" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="0c51-2b67-3982-5c81" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="31b9-1019-66db-c85e" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -8075,7 +8298,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="3">
                   <repeats>
-                    <repeat field="selections" scope="0c51-2b67-3982-5c81" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a119-c680-d17d-ff47" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="0c51-2b67-3982-5c81" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="31b9-1019-66db-c85e" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -8086,18 +8309,75 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="43b5-d969-83be-425e" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+        <selectionEntryGroup id="cb9b-b32d-d21f-696b" name="Drones" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e0a-135d-092d-05cd" type="max"/>
-          </constraints>
+          <constraints/>
           <categoryLinks/>
-        </entryLink>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="ce3e-aa5a-4bc1-4c16" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="326c-461b-2e6d-75a6" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="ae0e-8725-8c82-f1d6" name="Upgrade" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="31b9-1019-66db-c85e" name="AI Trooper Crew" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="47ad-cebf-8b09-d1cd" name="AI Trooper Crew" hidden="false" targetId="5d9e-89a4-4f24-f8ae" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2bcb-c9fc-d7a0-9d7d" type="min"/>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6b9c-9360-8db7-f806" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="14.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="983d-25cf-e816-d0d8" name="Promote one crew member to Leader" hidden="false" targetId="f668-c137-4629-1b78" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
         <entryLink id="5b0c-f10a-aaa2-bed0" name="Reflex Armor" hidden="false" targetId="1523-0845-c12b-4980" type="selectionEntry">
           <profiles/>
           <rules/>
@@ -8138,7 +8418,7 @@
         </infoLink>
       </infoLinks>
       <modifiers>
-        <modifier type="increment" field="d5e0-c569-66ec-1a12" value="1">
+        <modifier type="set" field="d5e0-c569-66ec-1a12" value="-1">
           <repeats>
             <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="20d0-b1d4-4916-8e85" repeats="100" roundUp="false"/>
           </repeats>
@@ -8236,40 +8516,63 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="5e85-6831-110d-e5e8" name="Compactor Drone" hidden="false" collective="false">
+        <selectionEntryGroup id="b078-afb8-55b3-d658" name="Drones" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3798-5cde-db74-8ca9" type="max"/>
-          </constraints>
+          <constraints/>
           <categoryLinks/>
           <selectionEntries/>
-          <selectionEntryGroups/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="b467-c51b-4840-32e1" name="Compactor Drone" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="90af-c2b6-e01e-fce4" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="a34e-333b-cd32-f89a" name="Compactor Drone" hidden="false" targetId="440d-ac97-e975-c6d2" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="9a45-dced-9ebb-cac9" name="Compactor Drone with Mag Light Support" hidden="false" targetId="7b24-dfae-72c0-dd99" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="992f-fc92-fb6c-aee0" name="Compactor Drone with Mag Cannon" hidden="false" targetId="3681-a2b0-5c2e-4cf2" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="43f5-0e70-87c8-7515" name="Compactor Drone" hidden="false" targetId="440d-ac97-e975-c6d2" type="selectionEntry">
+            <entryLink id="56fa-eaa2-2e30-678a" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="750a-f690-504e-c212" name="Compactor Drone with Mag Light Support" hidden="false" targetId="7b24-dfae-72c0-dd99" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="a597-de16-6b36-88a3" name="Compactor Drone with Mag Cannon" hidden="false" targetId="3681-a2b0-5c2e-4cf2" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6875-ddba-895e-b7bc" type="max"/>
+              </constraints>
               <categoryLinks/>
             </entryLink>
           </entryLinks>
@@ -8317,22 +8620,12 @@
           </constraints>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="1aa8-4a4b-70a5-766b" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="74c5-fefb-54a3-1151" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="115.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="20d0-b1d4-4916-8e85" name="AI Intruder Skimmer Command Squad" book="Rulebook &amp; pdf force list v2" page="186" hidden="false" collective="false" type="unit">
+    <selectionEntry id="20d0-b1d4-4916-8e85" name="AI Intruder Skimmer Command Squad" book="Rulebook &amp; pdf force list v2" page="174" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules/>
       <infoLinks>
@@ -8382,7 +8675,7 @@
       <selectionEntries>
         <selectionEntry id="5de8-a9af-cfc5-2256" name="AI Intruder Commander" hidden="false" collective="false" type="upgrade">
           <profiles>
-            <profile id="6db5-11c3-c29b-788a" name="AI Intruder Commander" book="" page="" hidden="false" profileTypeId="1650-77b3-10d1-6406" profileTypeName="Model">
+            <profile id="6db5-11c3-c29b-788a" name="AI Intruder Commander" book="Rulebook &amp; pdf force list v2" page="174" hidden="false" profileTypeId="1650-77b3-10d1-6406" profileTypeName="Model">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -8449,7 +8742,7 @@
         </selectionEntry>
         <selectionEntry id="87b0-96b8-1dff-f35d" name="AI Intruder Trooper" hidden="false" collective="false" type="upgrade">
           <profiles>
-            <profile id="4aa5-4358-1035-7710" name="AI Intruder Trooper" book="" page="" hidden="false" profileTypeId="1650-77b3-10d1-6406" profileTypeName="Model">
+            <profile id="4aa5-4358-1035-7710" name="AI Intruder Trooper" book="Rulebook &amp; pdf force list v2" page="174" hidden="false" profileTypeId="1650-77b3-10d1-6406" profileTypeName="Model">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -8495,40 +8788,63 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="0804-8f26-1f8f-0fac" name="Compactor Drone" hidden="false" collective="false">
+        <selectionEntryGroup id="8673-20ce-baaa-92be" name="Drones" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="38c3-c804-7e83-ef2a" type="max"/>
-          </constraints>
+          <constraints/>
           <categoryLinks/>
           <selectionEntries/>
-          <selectionEntryGroups/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="be46-612c-41a0-fd2f" name="Compactor Drone" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6de0-b2c2-2b4d-c1e7" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="50b9-eb83-3417-5103" name="Compactor Drone" hidden="false" targetId="440d-ac97-e975-c6d2" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="4dde-065f-462c-66f6" name="Compactor Drone with Mag Light Support" hidden="false" targetId="7b24-dfae-72c0-dd99" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="7771-53c3-8659-53f5" name="Compactor Drone with Mag Cannon" hidden="false" targetId="3681-a2b0-5c2e-4cf2" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="b424-051e-d692-1763" name="Compactor Drone" hidden="false" targetId="440d-ac97-e975-c6d2" type="selectionEntry">
+            <entryLink id="db2e-df52-9ad8-a42c" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="b4b2-d53b-c4a3-bfee" name="Compactor Drone with Mag Light Support" hidden="false" targetId="7b24-dfae-72c0-dd99" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="af55-0acd-18d7-d7b4" name="Compactor Drone with Mag Cannon" hidden="false" targetId="3681-a2b0-5c2e-4cf2" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9763-6605-8618-5148" type="max"/>
+              </constraints>
               <categoryLinks/>
             </entryLink>
           </entryLinks>
@@ -8576,39 +8892,13 @@
           <constraints/>
           <categoryLinks/>
         </entryLink>
-        <entryLink id="3ce0-2b5d-bacb-35bb" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="230e-b573-af4f-8125" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" costTypeId="points" value="147.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="2b1a-5dc0-3317-de96" name="AI Heavy Support Team" book="Rulebook &amp; pdf force list v2" page="176" hidden="false" collective="false" type="unit">
-      <profiles>
-        <profile id="0773-cb85-0512-e957" name="AI Trooper Crew" book="BtGoA" page="176" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <characteristics>
-            <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-            <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
-            <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
-            <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6 (7)"/>
-            <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
-            <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-            <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
-          </characteristics>
-        </profile>
-      </profiles>
+      <profiles/>
       <rules/>
       <infoLinks>
         <infoLink id="a37e-b2ab-aa64-cb9d" name="Weapon Team Unit" hidden="false" targetId="3f2c-9814-0c0d-e4d7" type="rule">
@@ -8642,57 +8932,7 @@
           <constraints/>
         </categoryLink>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="cc80-213b-9865-f264" name="AI Trooper Crew" hidden="false" collective="false" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5ba7-31d3-3077-a1bc" type="min"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9bae-9236-2521-2e41" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="6963-6bc4-8505-70ff" name="Reflex Armor" hidden="false" targetId="1523-0845-c12b-4980" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="14.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="c797-0f87-63d5-b945" name="Promote one crew member to Leader" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="e7ef-ab95-8b7f-b73a" name="Leader" hidden="false" targetId="4675-d30d-3451-8672" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0750-e7d2-9562-06c9" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="e8ed-99e5-c589-3151" name="Support Weapon" hidden="false" collective="false" defaultSelectionEntryId="11da-647a-2747-ec28">
           <profiles/>
@@ -8779,7 +9019,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="3">
                   <repeats>
-                    <repeat field="selections" scope="2b1a-5dc0-3317-de96" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cc80-213b-9865-f264" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="2b1a-5dc0-3317-de96" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c17-ac9b-bc30-05b0" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -8795,7 +9035,7 @@
               <modifiers>
                 <modifier type="increment" field="points" value="3">
                   <repeats>
-                    <repeat field="selections" scope="2b1a-5dc0-3317-de96" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cc80-213b-9865-f264" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="2b1a-5dc0-3317-de96" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c17-ac9b-bc30-05b0" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
@@ -8814,45 +9054,95 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
+        <selectionEntryGroup id="925c-b3a0-9163-e2cd" name="Drones" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="6304-d474-5876-b4e0" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="26f1-9dfa-5903-d551" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="f219-f45b-2f30-62cf" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e02b-f8f5-8a1c-99fa" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a31-90e2-4c27-c198" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1201-eafa-1a27-ca91" name="Upgrade" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="2c17-ac9b-bc30-05b0" name="AI Trooper Crew" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="ff7a-be0b-8335-5431" name="AI Trooper Crew" hidden="false" targetId="5d9e-89a4-4f24-f8ae" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3f4f-27b6-d7eb-303f" type="min"/>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d9ae-67ae-f1c8-302a" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="8a8b-3b29-c582-6e88" name="Reflex Armor" hidden="false" targetId="1523-0845-c12b-4980" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="14.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="54f1-b108-be88-296c" name="Promote one crew member to Leader" hidden="false" targetId="f668-c137-4629-1b78" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="1d3c-9b44-5259-e27a" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41fd-9b66-367c-438a" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="17e0-8c70-58f1-1ba6" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="63d2-2a14-7b18-d52c" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="7d26-b0aa-73bf-9edf" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="points" value="0.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c15d-65b3-1604-d14b" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d18-8724-8a69-d997" type="min"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
         <entryLink id="431f-3f80-ff4c-95fb" name="Special Munitions" hidden="true" targetId="6dbe-a221-4d79-ff6a" type="selectionEntryGroup">
           <profiles/>
           <rules/>
@@ -8860,11 +9150,16 @@
           <modifiers>
             <modifier type="set" field="hidden" value="false">
               <repeats/>
-              <conditions>
-                <condition field="selections" scope="2b1a-5dc0-3317-de96" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4919-68c5-8831-3151" type="equalTo"/>
-                <condition field="selections" scope="2b1a-5dc0-3317-de96" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1aa0-4da2-5d69-93fe" type="equalTo"/>
-              </conditions>
-              <conditionGroups/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="2b1a-5dc0-3317-de96" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1aa0-4da2-5d69-93fe" type="equalTo"/>
+                    <condition field="selections" scope="2b1a-5dc0-3317-de96" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4919-68c5-8831-3151" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
             </modifier>
           </modifiers>
           <constraints/>
@@ -8872,7 +9167,7 @@
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="55.0"/>
+        <cost name="pts" costTypeId="points" value="45.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="5e09-b21a-554e-9f8d" name="Liberator Combat Skimmer - X01 Hi-Mag" book="Rulebook &amp; pdf force list v2" page="177" hidden="false" collective="false" type="unit">
@@ -8925,31 +9220,7 @@
           <constraints/>
         </categoryLink>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="778b-8d38-e834-6705" name="Self-repair" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="5101-33ea-94f7-de00" name="Self Repair" hidden="false" targetId="7c54-5982-a5ef-b888" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1d19-9bf3-ae94-8e2d" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="926f-937e-8174-530e" name="Weapon Options" hidden="false" collective="false">
           <profiles/>
@@ -8963,7 +9234,7 @@
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups>
-            <selectionEntryGroup id="ddf6-d1f4-ad9c-1e94" name="Weapon 1" hidden="false" collective="false">
+            <selectionEntryGroup id="ddf6-d1f4-ad9c-1e94" name="Weapon 1" hidden="false" collective="false" defaultSelectionEntryId="f3fe-0dd2-cf45-97f4">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -9014,7 +9285,7 @@
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="e72b-bbbc-0fad-5886" name="Weapon 2" hidden="false" collective="false">
+            <selectionEntryGroup id="e72b-bbbc-0fad-5886" name="Weapon 2" hidden="false" collective="false" defaultSelectionEntryId="d357-9eff-aa6f-a90d">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -9040,39 +9311,85 @@
           </selectionEntryGroups>
           <entryLinks/>
         </selectionEntryGroup>
+        <selectionEntryGroup id="7aec-3515-bce8-893b" name="Drone" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="f168-53ea-ef81-802b" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32f9-5a91-dcef-e7af" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="ffe2-813d-12c2-5300" name="Shield Drone" hidden="false" targetId="81b9-02e2-63b6-9c6e" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c517-78b1-6246-4b5e" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="c949-64ef-18dc-4852" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1254-af7d-cdde-e1f9" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="276e-2036-05c8-7d5c" name="Upgrade" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="6424-b2ed-8816-e3fd" name="Self-repair" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="a752-8c1a-f996-fdd0" name="Self Repair" hidden="false" targetId="7c54-5982-a5ef-b888" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4b19-a121-6d27-0c4a" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="2ab6-cd31-13e8-9885" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fde8-675e-5ffb-9936" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="4a38-b90b-68a8-f1ab" name="Shield Drone" hidden="false" targetId="81b9-02e2-63b6-9c6e" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41c1-22f0-8a60-bd47" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="69dd-963d-7fce-7040" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c459-d0b0-8bdb-4efc" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-      </entryLinks>
+      <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="194.0"/>
       </costs>
@@ -9127,31 +9444,7 @@
           <constraints/>
         </categoryLink>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="fb5f-7cd2-b84e-9880" name="Self-repair" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="de7a-aa1e-e71f-8d74" name="Self Repair" hidden="false" targetId="7c54-5982-a5ef-b888" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7286-33b1-25b2-407c" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="d290-cc68-33ae-0c29" name="Weapon Options" hidden="false" collective="false">
           <profiles/>
@@ -9165,7 +9458,7 @@
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups>
-            <selectionEntryGroup id="0e7e-c747-bb8d-9cf9" name="Weapon 1" hidden="false" collective="false">
+            <selectionEntryGroup id="0e7e-c747-bb8d-9cf9" name="Weapon 1" hidden="false" collective="false" defaultSelectionEntryId="8e9a-5d05-1587-1cca">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -9202,7 +9495,7 @@
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="49e5-944a-2e34-0f3b" name="Weapon 2" hidden="false" collective="false">
+            <selectionEntryGroup id="49e5-944a-2e34-0f3b" name="Weapon 2" hidden="false" collective="false" defaultSelectionEntryId="c5f1-7d36-9012-e524">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -9228,39 +9521,85 @@
           </selectionEntryGroups>
           <entryLinks/>
         </selectionEntryGroup>
+        <selectionEntryGroup id="f695-6818-91f3-9df1" name="Drone" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="ab15-9986-adde-109a" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c11-8a55-fdfb-f506" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="1e1f-57bd-8aca-5db2" name="Shield Drone" hidden="false" targetId="81b9-02e2-63b6-9c6e" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd67-6065-340e-f3db" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="1241-cf65-3d69-3e26" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2278-2dd9-1adb-7b73" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6a1c-8837-9807-bee5" name="Upgrade" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="ff2e-1c26-bff4-0832" name="Self-repair" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="f31f-4409-8245-1909" name="Self Repair" hidden="false" targetId="7c54-5982-a5ef-b888" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6b0c-5da2-e77a-fe1f" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="9cc9-31c6-78cd-de5c" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="575e-caa8-e723-cf06" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="b60e-b3b1-16f5-936b" name="Shield Drone" hidden="false" targetId="81b9-02e2-63b6-9c6e" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="456e-b4c3-76d6-e4fa" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="7e91-6632-8782-8d28" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c473-f6db-ac35-de02" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-      </entryLinks>
+      <entryLinks/>
       <costs>
         <cost name="pts" costTypeId="points" value="234.0"/>
       </costs>
@@ -9315,31 +9654,7 @@
           <constraints/>
         </categoryLink>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="4e31-7d40-f2c0-dc31" name="Self-repair" hidden="false" collective="false" type="upgrade">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="d3e0-e1b4-6679-9e33" name="Self Repair" hidden="false" targetId="7c54-5982-a5ef-b888" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7b8d-586f-40b2-b870" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <selectionEntries/>
       <selectionEntryGroups>
         <selectionEntryGroup id="5581-c5b7-8b14-34ba" name="Weapon Options" hidden="false" collective="false">
           <profiles/>
@@ -9353,7 +9668,7 @@
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups>
-            <selectionEntryGroup id="0db2-e1bf-ba83-9735" name="Weapon 1" hidden="false" collective="false">
+            <selectionEntryGroup id="0db2-e1bf-ba83-9735" name="Weapon 1" hidden="false" collective="false" defaultSelectionEntryId="ca04-f26d-8b0c-fe75">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -9384,7 +9699,7 @@
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
-            <selectionEntryGroup id="cbdf-83ff-0f5a-f43c" name="Weapon 2" hidden="false" collective="false">
+            <selectionEntryGroup id="cbdf-83ff-0f5a-f43c" name="Weapon 2" hidden="false" collective="false" defaultSelectionEntryId="6cf4-9529-e53d-78ac">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -9410,58 +9725,88 @@
           </selectionEntryGroups>
           <entryLinks/>
         </selectionEntryGroup>
+        <selectionEntryGroup id="b787-4a9d-7d8e-2498" name="Drones" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="a17f-1ec0-73a4-8fbf" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b72-b906-f936-a7c2" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="51ce-33ee-22be-3854" name="Shield Drone" hidden="false" targetId="81b9-02e2-63b6-9c6e" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1163-ad6f-cd0f-d453" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="e3ea-babd-8c36-eb26" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7ff-e1ce-2506-69d6" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="517c-7a34-6543-7502" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d554-5b8e-59cf-62f7" name="Upgrade" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="0d8b-9162-c9e1-5c1f" name="Self-repair" hidden="false" collective="false" type="upgrade">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="d3ce-2586-5556-db48" name="Self Repair" hidden="false" targetId="7c54-5982-a5ef-b888" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4874-d789-98c2-456c" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="24cd-6cd7-c3cf-d5a8" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="155e-6705-a3b6-aa5a" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="5704-5fa7-1140-73ca" name="Shield Drone" hidden="false" targetId="81b9-02e2-63b6-9c6e" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="799b-d537-7ca4-5f09" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="027e-787e-7ae1-356e" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b97-e2a1-7882-3db9" type="max"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="103e-e908-5895-1c81" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="points" value="0.0">
-              <repeats/>
-              <conditions/>
-              <conditionGroups/>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1158-be13-8757-8322" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bab6-173b-68fa-9aff" type="min"/>
-          </constraints>
-          <categoryLinks/>
-        </entryLink>
-      </entryLinks>
+      <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="234.0"/>
+        <cost name="pts" costTypeId="points" value="224.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="d05d-1ad4-425f-7e1c" name="Hazard Strike Capsule" book="pdf" hidden="false" collective="true" type="upgrade">
@@ -9474,7 +9819,9 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
     </selectionEntry>
     <selectionEntry id="89ff-bd2a-e85a-e682" name="Homer Beacon" book="CS" page="90" hidden="false" collective="false" type="upgrade">
       <profiles/>
@@ -9486,7 +9833,4211 @@
       <selectionEntries/>
       <selectionEntryGroups/>
       <entryLinks/>
-      <costs/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="02f6-0574-3263-0658" name="Lectro Lash" book="Rulebook" page="65" hidden="false" collective="true" type="upgrade">
+      <profiles>
+        <profile id="7e6a-5426-b699-f7ef" name="Lectro Lash" book="Rulebook" page="65" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="H2H Only"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="H2H Only"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="H2H Only"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="3 Attacks, Hand Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="c7bf-3578-170a-5e13" name="3 Attacks" hidden="false" targetId="c286-a2b9-610b-96f2" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1751-3fb6-cc2e-be8f" name="Self-Repair" book="Rulebook" page="137" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="ac87-91db-c1c7-c8de" name="Self-Repair" hidden="false" targetId="7c54-5982-a5ef-b888" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4387-b382-b19f-be83" name="Gun Drone (Plasma Carbine)" book="Rulebook" page="112" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="c5c6-d68d-0fab-1e0a" name="Gun Drone" hidden="false" targetId="6896-1385-66b6-d10a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="4037-c6c1-c66d-43d8" name="Buddy Drone" hidden="false" targetId="097c-000b-3674-ebba" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="0f53-8d48-8bf1-c58b" name="Plasma Carbine" hidden="false" targetId="3877-96bf-06bb-ff8f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="14.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f914-5d9a-c63a-74e3" name="Mag Gun" book="Rulebook" page="69" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="06ab-db15-4890-ef45" name="Mag Gun" book="Rulebook" page="69" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="60"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0257-212b-8bcd-3253" name="Standard Weapon" hidden="false" targetId="8730-6c80-7d0a-c566" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1fbd-a84e-fec0-c3d9" name="Gun Drone ( Plasma Carbine )" book="Rulebook" page="112" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="e99b-9223-dd82-9204" name="Gun Drone" hidden="false" targetId="6896-1385-66b6-d10a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b213-5e79-2be8-22ad" name="Buddy Drone" hidden="false" targetId="097c-000b-3674-ebba" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks>
+        <entryLink id="3090-b0ff-4ffe-4ab4" name="Plasma Carbine" hidden="false" targetId="3877-96bf-06bb-ff8f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="14.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0bd2-3f45-4815-e1d0" name="Mass Compactor" book="Rulebook" page="71" hidden="false" collective="true" type="upgrade">
+      <profiles>
+        <profile id="bcff-c84d-6b24-08f9" name="Mass Compactor" book="Rulebook" page="71" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3/2/1"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Standard Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="a0dd-e6ff-694a-2713" name="No Cover" hidden="false" targetId="1ca0-252b-ab29-afe5" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="fa54-c989-5b65-b97b" name="Compressor" hidden="false" targetId="d89d-cedd-bd84-ddb1" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f5f9-8654-bd86-33c8" name="Standard Weapon" hidden="false" targetId="8730-6c80-7d0a-c566" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f668-c137-4629-1b78" name="Promote one crew member to Leader" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="fb2b-1b21-5084-5a06" name="Leader" hidden="false" targetId="4675-d30d-3451-8672" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8911-afe5-0c2e-e39d" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9f4d-f4f4-46ba-0b70" name="Mag Light Support" book="Rulebook" page="75" hidden="false" collective="true" type="upgrade">
+      <profiles>
+        <profile id="cefa-1214-3fe0-8b28" name="Mag Light Support" book="Rulebook" page="75" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="50"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3, Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="3636-22a2-6d23-e589" name="RF3" hidden="false" targetId="89ce-469b-2b76-90fa" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="9893-c68d-c7b2-ef92" name="Light Support Weapon" hidden="false" targetId="c43d-552b-d553-8f20" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a5bb-0a8a-361a-a052" name="Concord Pattern Iso-Drone" book="CS &amp; pdf force list v2" page="68" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="4b2d-2799-654d-96f2" name="Probe Unit" hidden="false" targetId="b8e9-1952-608c-accf" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="0081-3dc9-325d-4163" name="Iso-Shield" hidden="false" targetId="d584-98e1-53cc-4397" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="4491-dfbb-ecc4-bd4d" name="Slow" hidden="false" targetId="04bc-743b-092f-8c3a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="7d96-1530-87f6-0133" name="Scramble Proof" hidden="false" targetId="377d-0cdc-6ba7-f1d2" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="dcfd-a7fa-029b-d08e" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="a237-1825-75c0-0c11" name="Iso-Drone" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="4bee-3ead-75bc-1683" name="Iso-Drone **" hidden="false" profileTypeId="1650-77b3-10d1-6406" profileTypeName="Model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="7"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="0"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="10"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b575-3939-747f-e82a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cce-c216-611b-8d78" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e9fc-504e-c563-d233" name="Kinetic Armour Upgrade" book="pdf v2" page="" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f001-a39e-816a-a7d9" name="Enhanced Machine Intelligence" book="pdf v2" page="" hidden="false" collective="false" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="223b-0bbd-74d0-3322" name="Sensor Module" book="v2 pdf rules amendment" page="" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="9348-65ef-7f30-50b3" name="Sensor Module" book="v2 pdf rules amendment" page="" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
+            <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="50"/>
+            <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="100"/>
+            <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="-"/>
+            <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Light Support Weapon"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="6abb-36b3-08f9-4a51" name="Sensor Module" hidden="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <description>• Can act as spotter drone for the equipped unit and for friendly units in 10&quot;
+• Hits from Sensor Module do not give pins
+• Once a target has been hit by the Module then shots from all other units gain +1 Acc
+• The bonus is not accumulative and cannot be combined with bonuses from targeter drones etc</description>
+        </rule>
+      </rules>
+      <infoLinks>
+        <infoLink id="e5ec-a791-5255-94b5" name="Light Support Weapon" hidden="false" targetId="c43d-552b-d553-8f20" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e36b-5fdf-7eed-4bd1" name="Medi-Probe Shard" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="9d83-790e-1c36-ae9c" name="Probe Unit" hidden="false" targetId="b8e9-1952-608c-accf" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="9770-af0b-3d44-b281" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="c628-f3b8-74e2-8893" name="Medi-Probe Probe" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="8502-95c3-a33f-01d7" name="Medi-Probe" book="" page="" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="2453-4d77-8cdb-8f86" name="Shard" hidden="false" targetId="e1b9-e087-1984-fde7" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="477c-fe70-ee86-8cbb" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5f12-ff5d-e29b-ea1c" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0ef5-0ee9-1d9c-5f7a" name="Concord C3D1 Light Support Drone" book="Rulebook &amp; pdf v2" page="163" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="2610-8cda-ae56-581f" name="C3D1 Light Support Drone" book="Rulebook &amp; pdf v2" page="163" hidden="false" profileTypeId="1650-77b3-10d1-6406" profileTypeName="Model">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="7"/>
+            <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+            <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+            <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="8"/>
+            <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+            <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+            <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value=""/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="5568-ea16-2e0d-c58d" name="Weapon Drone Unit" hidden="false" targetId="4513-5976-042c-d38c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="6f93-a731-61e6-ddc6" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="d89f-c83c-3aa4-3c1c" name="Upgrade" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="981f-669c-03ee-48f3" name="Self-Repair" hidden="false" targetId="1751-3fb6-cc2e-be8f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2765-0f59-5a1c-4c22" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="0827-eae0-a64a-8dd1" name="Drones" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="2e3a-f1c5-f648-4084" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6769-9d65-ac5a-cb19" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="bf32-75d7-842c-b9bf" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7078-3516-de32-202e" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="5f92-a3f4-4994-848a" name="Shield Drone" hidden="false" targetId="81b9-02e2-63b6-9c6e" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e2c-788e-99c8-bb9c" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="4c6a-bbfb-a776-12d9" name="Synchronizer Drone" hidden="false" targetId="3b29-0c16-4aa3-aca3" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3970-fde1-0f89-fcd5" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="59.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e7ca-3a4b-4345-a0c6" name="Concord C3M407 (CS) Combat Drone" book="pdf v2" page="" hidden="false" collective="false" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="3e76-d3e3-1a1c-988c" name="Vehicle Unit" hidden="false" targetId="29d8-590a-bc46-d27a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="4c2e-6c6b-fd8b-832c" name="MOD2" hidden="false" targetId="88ae-fedb-5c1c-3a7b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="4b9a-0577-3a36-3163" name="Large" hidden="false" targetId="59d7-7273-b97c-0dff" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="0508-ebc0-74eb-18cc" hidden="false" targetId="a01f5f58-334c-8442-d861-15099ebdf5e5" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="6c83-a508-5a0a-5e85" name="Concord C3M407 (CS) Combat Drone" book="pdf v2" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="937b-3096-39ce-68e1" name="Concord C3M407 (CS) Combat Drone" book="pdf v2" page="" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="13"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value=""/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0488-5e97-f505-87da" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2150-77a0-dabb-f67c" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="eddd-6835-60c5-af33" name="Upgrade" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="2c12-3cdb-ca43-bc9f" name="Self-Repair" hidden="false" targetId="1751-3fb6-cc2e-be8f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="10">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9a2-4e22-9f42-2dcb" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e543-e990-4afa-1a47" name="Weapon Options" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="00e0-3087-b9df-0e8f" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="78bf-f972-8922-4db6" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="bf41-a602-5dcb-f8bd" name="Plasma Light Support" hidden="false" targetId="eaa4-a3c1-d269-d3cb" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="22">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="b3a2-8b4e-94fb-e8b4" name="Twin Plasma Carbines" hidden="false" targetId="87b1-a87b-594d-257b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="cd77-ea68-712a-cc95" name="Drones" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="b751-c9b6-a3d5-7996" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="767a-bd7f-ffcf-ca1f" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d83-d89b-d95e-7f35" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="103b-5993-2da1-5852" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f359-fcd3-ddcb-a03b" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="1560-3626-d3e3-490b" name="Shield Drone" hidden="false" targetId="81b9-02e2-63b6-9c6e" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ae7-82e8-b0c4-085e" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="fb1b-df20-0df8-c4a6" name="Plasma Light Support" hidden="false" targetId="eaa4-a3c1-d269-d3cb" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73c8-82ba-7c4b-c076" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7357-0537-415d-de37" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="230.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a496-fdcd-a5f6-d085" name="Concord C3M4 Combat Drone" book="Rulebook &amp; pdf v2" page="164" hidden="false" collective="false" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d89b-1088-1bf1-2f9d" name="Vehicle Unit" hidden="false" targetId="29d8-590a-bc46-d27a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="005b-fe51-0033-fd1c" name="MOD2" hidden="false" targetId="88ae-fedb-5c1c-3a7b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f684-ea89-9ad3-c301" name="Large" hidden="false" targetId="59d7-7273-b97c-0dff" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="8c5c-4d39-c87e-fbbe" hidden="false" targetId="a01f5f58-334c-8442-d861-15099ebdf5e5" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="3eaa-68be-6b55-fd71" name="Concord C3M4 Combat Drone" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="9bd9-0dee-12ac-0c1a" name="C3M4 Combat Drone" book="Rulebook &amp; pdf v2" page="164" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="13"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value=""/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bf46-be04-dedc-34a6" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7090-0e73-5cbb-fe49" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="de07-9c3a-39ae-1833" name="Upgrade" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="902c-e313-49d5-d06c" name="Self-Repair" hidden="false" targetId="1751-3fb6-cc2e-be8f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="10">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eec9-3c96-5bf9-1c9a" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="67f2-f4d6-ee61-3851" name="Weapon Options" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3b40-5914-a3a9-a513" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e946-826e-aa60-9ff7" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="f5ad-3da6-6cba-bf00" name="Fractal Cannon" hidden="false" targetId="ace6-ea6e-a45c-fb45" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="5">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="c2e3-3350-4a70-5620" name="Compression Cannon" hidden="false" targetId="320a-eea0-72d4-c09b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="5">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="de41-7c22-c539-e04f" name="Plasma Cannon" hidden="false" targetId="1c29-8394-0315-8140" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="bbe1-451f-0b25-f649" name="Drones" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="17be-7a1a-c114-4051" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ee6-8bb0-25a2-55ad" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c575-0413-5964-10c5" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="d50e-7440-bfa2-953b" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91c1-4dd0-e9ea-131a" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="e97c-fca9-7448-5292" name="Shield Drone" hidden="false" targetId="81b9-02e2-63b6-9c6e" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2983-4b95-2ec8-c427" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="239.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="af98-17af-2e7b-547a" name="Concord C3D2 Medium Support Drone" book="Rulebook &amp; pdf v2" page="163" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0e5b-1cab-1bcd-9ee5" name="Weapon Drone Unit" hidden="false" targetId="4513-5976-042c-d38c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="ef58-47a7-b89e-7965" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="de94-537e-05d0-c4d9" name="Concord C3D2 Medium Support Drone " hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="cc41-5124-38e2-20f1" name="C3D2 Medium Support Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="7"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="10"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5700-441b-5dee-b149" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d4db-c75d-cc91-c375" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="83.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="e038-25f4-ada8-7a6b" name="Drones" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="c9cd-dc7f-97fd-ed17" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e02-c225-9a43-8a16" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="54ed-501d-ebff-5beb" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4d5-9b9f-74d4-a5bd" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="d9e1-8e68-9535-9323" name="Shield Drone" hidden="false" targetId="81b9-02e2-63b6-9c6e" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ead-fafb-43e3-93ab" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="632a-12f3-045f-cf4f" name="Synchronizer Drone" hidden="false" targetId="3b29-0c16-4aa3-aca3" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95b4-0bdc-428d-a9c7" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="6fba-ea23-c288-ea25" name="Weapons" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5076-4610-8893-186c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0e60-bc84-8eeb-6670" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="0897-b0f4-edc1-d1ff" name="Plasma Light Support" hidden="false" targetId="eaa4-a3c1-d269-d3cb" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="45b6-27b8-97bc-8efc" name="Fractal Cannon" hidden="false" targetId="ace6-ea6e-a45c-fb45" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="10">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="2a47-2bb0-428a-8661" name="Compression Cannon" hidden="false" targetId="320a-eea0-72d4-c09b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="10">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="405e-48af-7a34-4db4" name="Plasma Cannon" hidden="false" targetId="1c29-8394-0315-8140" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="5">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d7f0-c95a-a6d7-4769" name="Upgrade" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="16ae-4355-199b-223c" name="Self-Repair" hidden="false" targetId="1751-3fb6-cc2e-be8f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="10">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52d3-7c1e-1f64-11f5" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="90f1-9b81-29a0-1006" name="Concord C3D1/GP Light General Purpose Drone" book="Rulebook &amp; pdf v2" page="167" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="899a-09ac-2e75-6425" name="C3D1/GP Light General Purpose Drone" book="Rulebook &amp; pdf v2" page="167" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="7"/>
+            <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="0"/>
+            <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+            <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="8"/>
+            <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+            <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+            <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="91c1-5d41-459e-cd4b" name="Weapon Drone Unit" hidden="false" targetId="4513-5976-042c-d38c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="e056-0d5a-b4fc-e073" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="3649-3dbd-5b53-1a4c" name="Drones" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="7ea2-8efa-9293-f77c" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="46b6-58fc-2856-e209" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="7f42-07e1-03c2-de50" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fbd2-c3b2-cbb2-739b" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="ece5-cd7d-32bc-c081" name="Shield Drone" hidden="false" targetId="81b9-02e2-63b6-9c6e" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3024-9b61-af2b-0856" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="f1f6-c9c6-beb1-773d" name="Synchronizer Drone" hidden="false" targetId="3b29-0c16-4aa3-aca3" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a0a-465d-47d4-ebed" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="aa62-81e5-c8f9-7b9d" name="Upgrade" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="dafa-146b-55c2-3395" name="Self-Repair" hidden="false" targetId="1751-3fb6-cc2e-be8f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="10">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d1e-b4e3-a27d-8f48" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="3d71-14e7-b9f1-cf67" name="Subverter Matrix" hidden="false" targetId="a7f9-0a45-15f9-2f79" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="20">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8486-8476-56fa-18d7" name="NuHu Mandarin" book="Rulebook &amp; pdf v2" page="161" hidden="false" collective="false" type="model">
+      <profiles>
+        <profile id="f041-e3a8-108c-2784" name="NuHu Mandarin" book="Rulebook &amp; pdf v2" page="161" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <characteristics>
+            <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+            <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+            <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="4"/>
+            <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(7)"/>
+            <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="9"/>
+            <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+            <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Hero, Follow, Leader 3"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules/>
+      <infoLinks>
+        <infoLink id="d5fd-8a38-9f20-bb8a" name="Limited Choice" hidden="false" targetId="8cb3-4c3e-dc5f-b952" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="2b3d-6213-fd44-64c1" name="Infantry Command Unit" hidden="false" targetId="0a6b-dcfb-ccc3-6a0d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ea4f-73e1-35a7-4448" name="Command" hidden="false" targetId="f001-a3be-81f7-f74f" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6e79-ce0b-7e5d-fad2" name="Follow" hidden="false" targetId="4bdd-65b7-6ee8-89b2" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="61d3-c14b-26c4-9fee" name="Leader 3" hidden="false" targetId="ce3b-c908-3ded-7a49" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ba9f-6cb4-aa9c-0849" name="Hero" hidden="false" targetId="e70c-a7b7-b782-acad" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="a03d-0761-74b1-3171" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="3609-0b3d-f53f-a6d4" name="New CategoryLink" hidden="false" targetId="c87d-5261-face-4643" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="a5a0-ab40-5729-8855" name="Drones" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="0fa3-ec1f-72a7-548f" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b1f-611b-6f0a-2a75" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="d5c9-537d-9f6f-3563" name="Medi-Drone" hidden="false" targetId="c3f0-2a1d-815e-b61a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3336-dac1-827c-de29" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="449e-c9ac-daef-09b2" name="Shield Drone" hidden="false" targetId="81b9-02e2-63b6-9c6e" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ead-f9c2-b957-a43c" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="c497-56f9-1d98-5ddb" name="Gun Drone (Plasma Carbine)" hidden="false" targetId="4387-b382-b19f-be83" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="209b-89a1-dca0-5b4a" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="6f30-7035-7287-a450" name="Nano Drone" hidden="false" targetId="553a-9310-02ea-dcc7" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cfa-fe81-cf57-d870" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7509-07b0-633d-a241" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="96cb-f549-51f2-1b65" name="Plasma Pistol" hidden="false" targetId="9851-4076-e2e9-3df8" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2de0-3a96-d371-d522" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13b9-3a27-253b-2669" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="f02c-5edb-c252-3d8a" name="IMTel Stave" hidden="false" targetId="cc8b-35e4-f568-c570" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4c2-eae5-cc77-ecaa" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b43-ca37-05b8-4a2f" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="130.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6455-e295-81f5-bbf7" name="C3 Interceptor Command Squad" book="Rulebook &amp; pdf v2" page="162" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="e45a-86d2-5b16-7404" name="Limited Choice" hidden="false" targetId="8cb3-4c3e-dc5f-b952" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f3e2-fc58-6c87-80ef" name="Mounted Command Unit" hidden="false" targetId="4294-13e8-90a8-2e17" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="43bf-4e9a-1939-7aaf" name="Fast" hidden="false" targetId="166d-5d48-1fc6-4a4b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="e3de-e377-c775-470e" name="Large" hidden="false" targetId="59d7-7273-b97c-0dff" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="5526-927c-6513-16eb" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="baa6-16f1-79e7-602b" name="New CategoryLink" hidden="false" targetId="c87d-5261-face-4643" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="86b6-9060-a547-6d8b" name="New CategoryLink" hidden="false" targetId="dadf-9bf7-c922-e3f3" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="badf-06e4-0b27-668a" name="Interceptor Commander" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="5fcb-7f3a-8de4-b15f" name="Interceptor Commander" book="Rulebook &amp; pdf v2" page="162" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(8)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value=""/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5957-2b40-065b-4c1c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8ab1-74e5-1258-bd5f" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="2d38-8677-4c3c-7a82" name="Leader Level (Up To 3)" hidden="false" targetId="6fc6-32a7-74b6-1b4b" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="148d-5f4a-36c9-26c8" name="Interceptor Trooper" hidden="false" collective="false" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="93fd-de7d-adf8-eaea" name="Interceptor Trooper" hidden="false" targetId="d4e2-2b19-03cd-9b76" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1729-2290-da9d-8edd" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ebe8-8587-7ca3-09f8" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="d2f9-6c90-5d29-e7b6" name="Drones" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="5593-f37f-2688-ff1d" name="Compactor Drone" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="506c-9077-36ec-8af5" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="aea3-46b5-3294-0f5e" name="Compactor Drone" hidden="false" targetId="440d-ac97-e975-c6d2" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9184-0938-c798-a85f" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="923d-f2ff-d61d-4310" name="Compactor Drone with Plasma Cannon" hidden="false" targetId="f5a9-5ae9-121e-7657" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f217-eb0d-cfe1-ea08" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="4959-daaf-e0a4-2447" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0654-84ba-413a-7de7" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1a11-4924-e03f-a1f8" name="Bike Weapon Options" page="" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e060-313f-68d9-0efb" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="526f-cad4-30cc-e21d" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="2727-e328-fec4-9a66" name="Twin Plasma Carbines" hidden="false" targetId="87b1-a87b-594d-257b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c07d-ab0c-1f2d-1348" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="d1c4-42c1-4cc3-7712" name="Plasma Lance" hidden="false" targetId="3017-11d8-80c9-ba77" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0684-f3db-691b-1c7d" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="ac09-50bb-7462-58d5" name="HL Booster" hidden="false" targetId="6c89-65f8-fa8e-7131" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fbb-28d0-2952-6042" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="020d-5f22-d66f-922a" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="f6db-9980-af2a-a635" name="Plasma Carbine" hidden="false" targetId="3877-96bf-06bb-ff8f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1df-daa9-c19f-59dd" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e55b-1513-d7e6-a4a2" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="eba5-cea4-d941-645e" name="Interceptor Bike" hidden="false" targetId="337d-13d3-81bd-c8c9" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f46-fc31-3f36-91e2" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9d0-4640-1832-b286" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="168.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ed78-9c54-6da3-0914" name="HL Armour Boost" hidden="false" collective="true" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b9e6-14e1-f275-b72f" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5d42-822d-7c2e-c5f7" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f7cc-5675-b0e5-e23f" name="Interceptor Bike" hidden="false" collective="true" type="upgrade">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="dfb2-ee83-0600-d335" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2d31-13d7-2385-2b4e" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries/>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f300-e939-bad0-0f60" name="C3 Interceptor Squad" book="Rulebook &amp; pdf v2" page="162" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="374e-09b1-ac44-9c0f" name="Mounted Unit" hidden="false" targetId="878e-3922-3d01-8f26" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="406c-d350-0aeb-9839" name="Fast" hidden="false" targetId="166d-5d48-1fc6-4a4b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6609-3c69-c7bb-928b" name="Large" hidden="false" targetId="59d7-7273-b97c-0dff" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers>
+        <modifier type="set" field="b21f-5e52-4f0c-2f80" value="-1">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6455-e295-81f5-bbf7" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b21f-5e52-4f0c-2f80" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="2462-4dda-9dcf-dda6" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="7eb9-8fce-5989-a4e9" name="New CategoryLink" hidden="false" targetId="dadf-9bf7-c922-e3f3" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="25b2-626f-af89-d688" name="Interceptor Leader" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="7f92-b2ac-3e49-dd48" name="Interceptor Leader" book="Rulebook &amp; pdf v2" page="162" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(8)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value=""/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2bd3-133c-b0e2-8efa" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4b04-1467-860f-f6a1" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="1ac7-5f44-42f7-f51b" name="Leader Level (Up To 2)" hidden="false" targetId="14a9-9070-281d-b6d6" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="887f-fd82-d4df-971c" name="Interceptor Trooper" hidden="false" collective="false" type="model">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="f6be-dae1-cf7c-b683" name="Interceptor Trooper" hidden="false" targetId="d4e2-2b19-03cd-9b76" type="profile">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8d14-850e-0ec2-f2e8" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5838-730c-0b5f-be25" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="14b5-0fca-df96-a635" name="Drones" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="85ef-491b-3e40-4d00" name="Compactor Drone" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1784-64b3-da5d-6297" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="6d07-8490-4a3c-1ceb" name="Compactor Drone" hidden="false" targetId="440d-ac97-e975-c6d2" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd3f-435b-d945-dc12" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="ff76-9c84-fd8d-194a" name="Compactor Drone with Plasma Cannon" hidden="false" targetId="f5a9-5ae9-121e-7657" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c59-62a8-f67e-3bd7" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="c5e7-964c-1ed8-2fae" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb9e-3ebb-915a-78ae" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="1f8b-fb4b-342d-3891" name="Bike Weapon Options" page="" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e81-6523-165a-1792" type="max"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf92-d431-3bf7-feca" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="8d64-fe9e-ac14-0105" name="Twin Plasma Carbines" hidden="false" targetId="87b1-a87b-594d-257b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="754c-cc08-6e81-fa67" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="dc7a-2e04-7a16-4a0f" name="Plasma Lance" hidden="false" targetId="3017-11d8-80c9-ba77" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3128-b9d3-a5ba-69f1" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="0d25-7c2b-fa3e-0a04" name="Interceptor Bike" hidden="false" targetId="337d-13d3-81bd-c8c9" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="860a-339b-385c-136f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6d0-f0d6-a81b-9870" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="9bb1-7a30-ecb5-1c8a" name="Plasma Carbine" hidden="false" targetId="3877-96bf-06bb-ff8f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2dc3-a901-6d5c-d8d7" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a430-0108-2695-17b1" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="ef6b-b319-5d5b-8c16" name="HL Armour Boost" hidden="false" targetId="ed78-9c54-6da3-0914" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ba4-11eb-9b3d-9a33" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6505-b9ff-ad48-f9a2" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="136.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f98c-ad14-c9df-b46d" name="Concord Drone Commander" book="CS &amp; pdf v2" page="68" hidden="false" collective="false" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="9288-f9d7-9446-2d96" name="Limited Choice" hidden="false" targetId="8cb3-4c3e-dc5f-b952" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="ee34-6da2-1fcd-2a4d" name="Weapon Drone Command" hidden="false" targetId="d6f2-8874-5225-1b13" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="fba3-3748-ec47-eb7f" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="36bd-4973-101b-fa66" name="New CategoryLink" hidden="false" targetId="c87d-5261-face-4643" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="b001-9c5f-168c-5171" name="Concord Drone Commander" book="CS" page="68" hidden="false" collective="false" type="upgrade">
+          <profiles>
+            <profile id="e47a-c0ac-576d-897c" name="Concord Drone Commander" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="7"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="8"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value=""/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f35a-4440-684a-a432" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="331f-be54-4643-f3e9" type="min"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="51.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="57d1-4ba7-5a3c-1d5f" name="Drones" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="63c8-cb29-fdba-efab" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2df8-3f2e-e169-240b" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="e90a-92d8-cd99-3874" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ef6-67d2-04d3-df3b" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="7298-0181-e7a5-aa09" name="Synchronizer Drone" hidden="false" targetId="3b29-0c16-4aa3-aca3" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6cf8-68e6-daad-08a1" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="fc38-4bca-539c-b36c" name="Shield Drone" hidden="false" targetId="81b9-02e2-63b6-9c6e" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff43-32b8-030f-903e" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="00f4-87d7-6e49-db88" name="Upgrade" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="f07a-a578-c949-53cc" name="Nano Probe Net" book="CS &amp; pdf force list v2" page="69" hidden="false" collective="false" type="unit">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="58cd-19fd-458d-a67d" name="Probe Unit" hidden="false" targetId="b8e9-1952-608c-accf" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ef9-6045-5043-e708" type="max"/>
+              </constraints>
+              <categoryLinks>
+                <categoryLink id="146a-1bff-d263-48aa" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="true">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                </categoryLink>
+              </categoryLinks>
+              <selectionEntries>
+                <selectionEntry id="2062-2055-9191-2c4c" name="Nano Probe Net" hidden="false" collective="false" type="model">
+                  <profiles>
+                    <profile id="df70-1223-6921-3b19" name="Nano Probe Net" book="CS &amp; pdf force list v2" page="69" hidden="false" profileTypeId="1650-77b3-10d1-6406" profileTypeName="Model">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                      <characteristics>
+                        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
+                        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
+                        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
+                        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
+                        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
+                        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
+                        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="02a9-c4a5-8227-4713" name="Shard" hidden="false" targetId="e1b9-e087-1984-fde7" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0f8f-b57f-b788-f2f4" type="min"/>
+                    <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f64a-82b6-62d9-4447" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="8b75-5735-4f6e-b41a" name="Leader Level (Up To 2)" hidden="false" targetId="14a9-9070-281d-b6d6" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="b671-1927-1e0f-ae85" name="Self-Repair" hidden="false" targetId="1751-3fb6-cc2e-be8f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10">
+                  <repeats>
+                    <repeat field="selections" scope="f98c-ad14-c9df-b46d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b001-9c5f-168c-5171" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="f98c-ad14-c9df-b46d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0544-d54a-9753-26af" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2217-6496-0c04-b505" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="0544-d54a-9753-26af" name="Concord C3D1 Light Support Drone **" hidden="false" targetId="0ef5-0ee9-1d9c-5f7a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c024-e054-9709-908f" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3b8b-10f2-fca8-036f" name="C3 Strike Command Squad" book="Rulebook &amp; pdf v2" page="160" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="2e7e-393e-f274-5050" name="Limited Choice" hidden="false" targetId="8cb3-4c3e-dc5f-b952" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3c75-6627-7cd9-ec94" name="Infantry Command Unit" hidden="false" targetId="0a6b-dcfb-ccc3-6a0d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="aa0d-c334-3259-30a0" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="a72f-3674-4119-6164" name="New CategoryLink" hidden="false" targetId="c87d-5261-face-4643" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="803f-eea0-05e3-7a66" name="New CategoryLink" hidden="false" targetId="dadf-9bf7-c922-e3f3" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="b24e-3b3d-8216-9d76" name="Strike Commander" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="c183-4bfd-2bb3-1b4a" name="Strike Commander" book="Rulebook &amp; pdf v2" page="160" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value=""/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks>
+            <infoLink id="e171-2c09-271a-cda7" name="Command" hidden="false" targetId="f001-a3be-81f7-f74f" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="1fca-4a9a-a8a1-487c" name="Follow" hidden="false" targetId="4bdd-65b7-6ee8-89b2" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7dea-bc2f-72c2-d050" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7fd2-5f91-d046-ac83" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="bac0-6bfa-7c1d-d65f" name="Specialist Ammo" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="a589-1ec9-37a4-cebd" name="SlingNet Ammo" hidden="false" targetId="6849-c480-4332-7ffc" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="5">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4900-8c9f-09a5-008d" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="499a-c477-0cc3-8144" name="HL Armour" hidden="false" targetId="f561-c73c-de8c-ae6f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f22c-c718-4a31-003b" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5339-22a1-8931-34dc" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="707c-dd1a-dba7-6801" name="Plasma Carbine" hidden="false" targetId="3877-96bf-06bb-ff8f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7d4-5a12-57c0-c0be" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f4d-ead1-2546-9ee6" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="d476-1e7a-45f7-7f72" name="X-Sling" hidden="false" targetId="e629-3c26-9e22-f80b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b1c-d44f-3a84-0791" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5f0-adde-7ccd-e410" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="9ddd-35f4-52c9-12e1" name="Leader Level (Up To 3)" hidden="false" targetId="6fc6-32a7-74b6-1b4b" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0e36-d3ab-87b3-f589" name="Drones" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="c195-2329-61a3-a3c6" name="Medi-Drone" hidden="false" targetId="c3f0-2a1d-815e-b61a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a66c-47f1-a3f7-6fe7" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="d883-3b32-8226-6047" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36a2-7b9c-2e0c-a592" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="9746-1ffa-b794-4a04" name="Synchronizer Drone" hidden="false" targetId="3b29-0c16-4aa3-aca3" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd34-6acc-8541-9d0a" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="22b9-271f-fc8c-3eb4" name="Weapons" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="d946-5e89-69e9-51bc" name="Plasma Grenades" hidden="false" targetId="76fa-75fa-aac0-aae1" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="3b8b-10f2-fca8-036f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b24e-3b3d-8216-9d76" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="3b8b-10f2-fca8-036f" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8ebc-f2c1-80de-3355" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="108a-3199-b94e-cf60" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="4cdf-9f6d-ad13-70bf" name="Upgrades" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="8ebc-f2c1-80de-3355" name="Strike Trooper" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="8490-fb1e-0438-64b5" name="Strike Trooper" hidden="false" targetId="afc3-bbc8-a54c-a565" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2392-9398-6414-fa22" type="min"/>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c3b7-a69e-f69a-061d" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="6c9b-8b99-40d7-8612" name="Plasma Carbine" hidden="false" targetId="3877-96bf-06bb-ff8f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1dae-77ca-2527-cfc8" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0de-bc6b-331c-46e8" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="959e-a895-a11e-0942" name="HL Armour" hidden="false" targetId="f561-c73c-de8c-ae6f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f54-5a3a-b468-22e8" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17b0-56d9-a0d5-f365" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="22.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="66.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3501-d057-3845-b85d" name="C3 Drop Command Squad" book="Rulebook &amp; pdf v2" page="161" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="0b0d-a653-0e77-f305" name="Limited Choice" hidden="false" targetId="8cb3-4c3e-dc5f-b952" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="bf7a-be17-842f-70d8" name="Infantry Command Unit" hidden="false" targetId="0a6b-dcfb-ccc3-6a0d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="e327-1c16-2f70-66d2" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="6f26-e764-aca5-a420" name="New CategoryLink" hidden="false" targetId="c87d-5261-face-4643" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="b8de-fdc3-2ce8-5eb5" name="New CategoryLink" hidden="false" targetId="dadf-9bf7-c922-e3f3" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="6a75-24a0-2eec-157d" name="Drop Commander" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="5f71-9239-d4d2-dc08" name="Drop Commander" book="Rulebook &amp; pdf v2" page="161" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5(6)"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Follow, Leader 2"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="32fb-ab25-63ac-d1cc" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a802-b8b0-893c-7ec2" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="51f6-12ed-67cb-12ab" name="Specialist Ammo" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="4ceb-6e3d-bc17-e109" name="SlingNet Ammo" hidden="false" targetId="6849-c480-4332-7ffc" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="5">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3d6-930f-d118-af4f" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="4204-9806-1b62-57a4" name="HL Armour" hidden="false" targetId="f561-c73c-de8c-ae6f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad78-ae55-57e0-6f8b" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41e9-8869-76e9-c684" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="d8b1-244b-38dd-50b3" name="Plasma Carbine" hidden="false" targetId="3877-96bf-06bb-ff8f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e4a-59d3-e374-f1f6" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="338a-88d5-ca22-49b4" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="ec96-7959-e7a7-24b8" name="AG Chute" hidden="false" targetId="af31-e0a9-a262-d18e" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ac7-47e0-8e44-4b3f" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d734-add2-4664-93e9" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="f18a-3af8-8c16-3331" name="X-Sling" hidden="false" targetId="e629-3c26-9e22-f80b" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8c1-0c4d-e9b3-4817" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a93e-1eda-54b4-6c90" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="fc13-b735-0881-38fa" name="Leader Level (Up To 3)" hidden="false" targetId="6fc6-32a7-74b6-1b4b" type="selectionEntryGroup">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6613-2753-ecb2-ffc4" name="Drones" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="58f6-f975-e0b4-b786" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdab-a800-c0ad-e8f0" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="8ae4-4b5d-4671-386d" name="Medi-Drone" hidden="false" targetId="c3f0-2a1d-815e-b61a" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66d2-48bc-e8a2-a489" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="2c25-1346-d888-0f45" name="Synchronizer Drone" hidden="false" targetId="3b29-0c16-4aa3-aca3" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7262-84d3-40aa-048e" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="8522-8009-e15f-b0de" name="Upgrade" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="4e9c-4449-4914-8b04" name="Drop Trooper" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="5cd9-afd5-caea-a17a" name="Drop Trooper" book="Rulebook &amp; pdf v2" page="161" hidden="false" targetId="73b2-5562-3199-aaa4" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="57a3-36cc-5303-b897" type="min"/>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3cac-7211-935e-4a00" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="30e6-3816-39ec-f887" name="HL Armour" hidden="false" targetId="f561-c73c-de8c-ae6f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b70e-572e-dfd4-8d5a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4497-6de4-cdbd-1536" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="f5be-6da9-20fc-1d7f" name="AG Chute" hidden="false" targetId="af31-e0a9-a262-d18e" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f8c-ffc6-1c6f-6b09" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f191-ffb4-bd8b-3e01" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="811d-415a-fd51-6175" name="X-Sling" hidden="false" targetId="e629-3c26-9e22-f80b" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3b00-e11c-5d13-d802" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4fe6-e7d1-9b61-0c59" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="27fa-6187-3d66-81e8" name="Plasma Carbine" hidden="false" targetId="3877-96bf-06bb-ff8f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a572-6bc0-3f63-3a09" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90a9-c313-f3bf-6350" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="27.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="ec40-0895-459d-9cb4" name="Grenades" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="0236-29ea-1a43-abf8" name="Plasma Grenades" hidden="false" targetId="76fa-75fa-aac0-aae1" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="3501-d057-3845-b85d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4e9c-4449-4914-8b04" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="3501-d057-3845-b85d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6a75-24a0-2eec-157d" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcaa-e34b-fe6f-2ff7" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="87.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1e94-c221-3417-75c9" name="C3 Drop Squad" book="Rulebook &amp; pdf v2" page="162" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="16a9-17b0-6db6-6f50" value="-1">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3501-d057-3845-b85d" type="atLeast"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="16a9-17b0-6db6-6f50" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="f6f8-676b-336d-a828" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="0819-44b0-1515-f00d" name="New CategoryLink" hidden="false" targetId="dadf-9bf7-c922-e3f3" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="d21f-6d51-3c15-4a16" name="Drop Leader" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="81a6-11d4-805b-8714" name="Drop Leader" book="Rulebook &amp; pdf v2" page="162" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5(6)"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value=""/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="53de-49a8-10ea-66a3" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e8d8-dc9e-d263-fcd8" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="6963-aa72-7023-3a30" name="Leader Level" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e56f-bab2-907a-6ca4" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7ed4-4815-3632-783f" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries>
+                <selectionEntry id="93f9-8f92-c6f4-21f1" name="Leader Two" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="b7cb-44f1-dbf9-c8aa" name="Leader 2" hidden="false" targetId="f7db-9f56-2fd9-fd72" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="10">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="53d6-7984-7d6e-0146" name="Leader Three" hidden="false" collective="false" type="upgrade">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks>
+                    <infoLink id="12d6-9223-d054-87b7" name="Leader 3" hidden="false" targetId="ce3b-c908-3ded-7a49" type="rule">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers/>
+                    </infoLink>
+                  </infoLinks>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="20">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints/>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks/>
+                  <costs>
+                    <cost name="pts" costTypeId="points" value="10.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="f710-b880-65d4-4d44" name="Leader 1" hidden="false" targetId="2b54-e8c3-b36d-8d52" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="6e06-5c75-0918-6f42" name="Specialist Ammo" hidden="false" collective="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="02cd-bdbb-18f4-0d13" name="SlingNet Ammo" hidden="false" targetId="6849-c480-4332-7ffc" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers>
+                    <modifier type="increment" field="points" value="5">
+                      <repeats/>
+                      <conditions/>
+                      <conditionGroups/>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0fea-b864-9c85-2631" type="max"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="216c-d7d7-7844-63a7" name="Drones" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="8dc1-f076-8b80-59bf" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30ac-a017-57d1-f15d" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="84da-4d4c-e418-3259" name="Synchronizer Drone" hidden="false" targetId="3b29-0c16-4aa3-aca3" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="876d-c51f-466e-2bfa" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="a254-eb23-0b1d-ac13" name="Upgrade" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="27f6-1012-2599-7307" name="Drop Trooper" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="e1c6-34b9-4ae3-98f5" name="Drop Trooper" book="Rulebook &amp; pdf v2" page="162" hidden="false" targetId="73b2-5562-3199-aaa4" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="94c6-8928-45c4-890e" type="min"/>
+                <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c07f-e7c7-bc62-d9a3" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks/>
+              <costs>
+                <cost name="pts" costTypeId="points" value="26.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="e761-710a-e6dc-043d" name="Weapon Upgrades" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="6054-1b7a-3f58-a721" name="Plasma Grenades" hidden="false" targetId="76fa-75fa-aac0-aae1" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="1e94-c221-3417-75c9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="27f6-1012-2599-7307" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="1e94-c221-3417-75c9" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d21f-6d51-3c15-4a16" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9997-5c7c-504c-3b6e" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="3a47-9db1-7d1f-9eb4" name="Plasma Lance" hidden="false" targetId="3017-11d8-80c9-ba77" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="5">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b3c-203b-2ed1-2e93" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e6d-1fd7-e151-9f2b" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="6f57-6310-89e0-ec10" name="AG Chute" hidden="false" targetId="af31-e0a9-a262-d18e" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="33dc-18a4-0a83-6cfd" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d526-9c70-6d70-fe82" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="4892-f425-7491-8119" name="HL Armour" hidden="false" targetId="f561-c73c-de8c-ae6f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="729a-fe3e-5865-80e9" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8697-27c7-055c-5c56" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="ef18-487e-9b00-9152" name="Plasma Carbine" hidden="false" targetId="3877-96bf-06bb-ff8f" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0c6-0456-b3f4-37ca" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aea1-ce05-13f5-fc61" type="max"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="9f0c-ac1a-b97f-f094" name="X-Sling" hidden="false" targetId="e629-3c26-9e22-f80b" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6c1-0186-261f-265f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef03-6792-9a5f-9bc4" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="42.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="57c6-ba82-53f7-68af" name="C3 Strike Squad" book="Rulebook &amp; pdf v2" page="161" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="4330-af70-dd6f-4584" name="Infantry Unit" hidden="false" targetId="9a87-2673-83b1-3986" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="de3f-01f4-a933-54c8" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="2f9d-de4a-56fe-233f" name="New CategoryLink" hidden="false" targetId="dadf-9bf7-c922-e3f3" primary="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries/>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c853-a6d4-7655-fca1" name="Drones" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="f1b6-9ebe-fe38-901b" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d93-6cef-bf32-720d" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="af20-ca47-2c59-4681" name="Synchronizer Drone" hidden="false" targetId="3b29-0c16-4aa3-aca3" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="596d-a187-5d4b-221d" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="be84-6daf-7ceb-831d" name="Leader" hidden="false" collective="false" defaultSelectionEntryId="81ef-192b-53ac-f5d5">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="aaae-b40c-935a-3370" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7cc2-089c-f8c4-19c5" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="81ef-192b-53ac-f5d5" name="Strike Leader" hidden="false" collective="false" type="model">
+              <profiles>
+                <profile id="538d-ea87-c0a4-2d66" name="Strike Leader" book="Rulebook &amp; pdf v2" page="161" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                    <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                    <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                    <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+                    <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                    <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                    <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a545-4f18-db44-31b2" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="b2fb-b7fb-4292-c9f3" name="Specialist Ammo" hidden="false" collective="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                  <selectionEntries/>
+                  <selectionEntryGroups/>
+                  <entryLinks>
+                    <entryLink id="cd2b-acfd-be91-4699" name="SlingNet Ammo" hidden="false" targetId="6849-c480-4332-7ffc" type="selectionEntry">
+                      <profiles/>
+                      <rules/>
+                      <infoLinks/>
+                      <modifiers>
+                        <modifier type="increment" field="points" value="5">
+                          <repeats/>
+                          <conditions/>
+                          <conditionGroups/>
+                        </modifier>
+                      </modifiers>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7132-4d45-f346-7acd" type="max"/>
+                      </constraints>
+                      <categoryLinks/>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="ced9-5642-178b-6e29" name="HL Armour" hidden="false" targetId="f561-c73c-de8c-ae6f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8e23-f06d-2e0e-40c6" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6583-4ea0-f42e-566c" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="7a61-6c8b-00e0-cd18" name="Plasma Carbine" hidden="false" targetId="3877-96bf-06bb-ff8f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5139-982b-3bb0-ad2d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0967-20cd-f571-70fc" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="df64-78d0-fff1-2428" name="X-Sling" hidden="false" targetId="e629-3c26-9e22-f80b" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28fb-45b4-5b8c-c3b7" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b61a-80f2-97ef-ebe8" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="5073-ab68-340d-9b55" name="Leader Level (Up To 2)" hidden="false" targetId="14a9-9070-281d-b6d6" type="selectionEntryGroup">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints/>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e8c4-b115-ef55-a1c3" name="Strike Leade Kai Lek Atastrin" hidden="false" collective="false" type="model">
+              <profiles>
+                <profile id="5c05-fc30-9f2b-9655" name="Strike Leader Kai Lek Atasrin" book="Rulebook" page="230" hidden="false" profileTypeId="1650-77b3-10d1-6406" profileTypeName="Model">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5 "/>
+                    <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+                    <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+                    <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="6(8)"/>
+                    <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+                    <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+                    <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="One for All, Wound, Leader 3"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules>
+                <rule id="f1ca-28d0-2e53-3352" name="One For All" book="Rulebook" page="230" hidden="false">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <description>• Lucky Hits allocated as normal
+• Next hit must be allocated to Kai Lek
+• Subsequent hits can also be allocated to Kai Lek</description>
+                </rule>
+              </rules>
+              <infoLinks>
+                <infoLink id="3174-1e58-9bf4-1f04" name="Wound" hidden="false" targetId="98a7-475a-f0ed-fa91" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+                <infoLink id="2a47-1d76-3c6f-483a" name="Leader 3" hidden="false" targetId="ce3b-c908-3ded-7a49" type="rule">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1cb4-a928-fa30-8356" type="max"/>
+                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="bdf9-7329-a7f4-5949" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="4c68-80a9-9b0e-7671" name="HL Armour" hidden="false" targetId="f561-c73c-de8c-ae6f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6ea-373c-2b26-ba1c" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3746-945f-8046-1334" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="718d-6732-5f70-80d8" name="Plasma Carbine" hidden="false" targetId="3877-96bf-06bb-ff8f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcc7-6d3d-b4a1-4175" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2745-e3ac-2e26-65c0" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="04b5-af5f-cbfd-31c4" name="X-Sling" hidden="false" targetId="e629-3c26-9e22-f80b" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c295-2b0f-3596-6a94" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a7b-f479-9455-7de8" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="21.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="7d6b-7bcb-a882-5817" name="Upgrade" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="423d-6be0-945e-5e5e" name="Strike Trooper" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="1f4a-4a76-2540-e625" name="Strike Trooper" book="Rulebook &amp; pdf v2" page="161" hidden="false" targetId="afc3-bbc8-a54c-a565" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ef31-7db2-1fa8-4f9d" type="min"/>
+                <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ae4a-8c29-a10e-b12b" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="13b2-467c-1b7c-73e4" name="HL Armour" hidden="false" targetId="f561-c73c-de8c-ae6f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b21-31dc-cb69-f5f8" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cfe-2161-0acd-f8c0" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="cdb7-55a9-3c6a-6b38" name="Plasma Carbine" hidden="false" targetId="3877-96bf-06bb-ff8f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8daf-9ea4-9af4-c9b3" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2cfb-0724-5875-7608" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="20.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="734f-3517-b614-e392" name="Weapon Upgrades" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="99f7-5851-12c5-6573" name="Plasma Grenades" hidden="false" targetId="76fa-75fa-aac0-aae1" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="57c6-ba82-53f7-68af" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="423d-6be0-945e-5e5e" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="57c6-ba82-53f7-68af" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e8c4-b115-ef55-a1c3" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="57c6-ba82-53f7-68af" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="81ef-192b-53ac-f5d5" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6496-b4d5-1362-ae7a" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="fb5b-48cb-9fa4-56d5" name="Plasma Lance" hidden="false" targetId="3017-11d8-80c9-ba77" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="3">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af3a-023b-58ac-de94" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="32.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="23ef-7122-b64d-e36a" name="Concord T7 Transporter Drone (Support)" book="Rulebook &amp; pdf v2" page="164" hidden="false" collective="false" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="9d63-e81a-23cb-7deb" name="MOD2" hidden="false" targetId="88ae-fedb-5c1c-3a7b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="33bf-dca3-39cb-bd7e" name="Large" hidden="false" targetId="59d7-7273-b97c-0dff" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="641b-e086-bdf1-ec0f" name="Transport 10" hidden="false" targetId="8509-6fcc-0fc0-21ae" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="10dc-53e9-ff5c-f214" name="Vehicle Unit" hidden="false" targetId="29d8-590a-bc46-d27a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers>
+        <modifier type="increment" field="5d5b-8bc7-cdf9-d259" value="1">
+          <repeats>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="57c6-ba82-53f7-68af" repeats="1" roundUp="false"/>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="3501-d057-3845-b85d" repeats="1" roundUp="false"/>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="1e94-c221-3417-75c9" repeats="1" roundUp="false"/>
+            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3b8b-10f2-fca8-036f" repeats="1" roundUp="false"/>
+          </repeats>
+          <conditions/>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d5b-8bc7-cdf9-d259" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="8a04-7708-f02a-99f8" name="New CategoryLink" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="c987-2d46-1a1e-45fc" name="Concord T7 Transporter Drone" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="02a2-6a1e-f350-637d" name="C3T7 Transporter Drone" hidden="false" profileTypeId="5f97-84dc-4c56-bbe5" profileTypeName="Transport">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="0b84-3b60-5c7d-efa5" value="13">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="23ef-7122-b64d-e36a" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="59e4-17fc-69c2-ad24" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="4f48-ad72-be82-1bf7" value="6">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="23ef-7122-b64d-e36a" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5496-3d45-6d41-9400" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="ef5f-c702-c74a-236d" value="8">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="23ef-7122-b64d-e36a" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5496-3d45-6d41-9400" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="c1ac-eacd-b766-3931" value="8">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="23ef-7122-b64d-e36a" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5496-3d45-6d41-9400" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="43b0-b2e6-6e84-43b5" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="4f48-ad72-be82-1bf7" value="5"/>
+                <characteristic name="Str" characteristicTypeId="e341-f364-940e-4b44" value="1"/>
+                <characteristic name="Res" characteristicTypeId="0b84-3b60-5c7d-efa5" value="11"/>
+                <characteristic name="Init" characteristicTypeId="ef5f-c702-c74a-236d" value="7"/>
+                <characteristic name="Co" characteristicTypeId="c1ac-eacd-b766-3931" value="7"/>
+                <characteristic name="Transport Capacity" characteristicTypeId="28cd-349f-14f4-0e36" value="10"/>
+                <characteristic name="Special" characteristicTypeId="68b5-aa47-fdb5-1640" value=""/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="357f-ee82-4cce-9337" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3cdc-83a2-e48e-8474" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="6b90-d866-bb78-775b" name="Drones" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="f3b2-5fc4-5b1f-5215" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="86e7-6b89-6188-e17a" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="7c61-f8a5-2b92-f2de" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a64-8036-9cf1-abe6" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="9383-e74c-5e99-5cac" name="Shield Drone" hidden="false" targetId="81b9-02e2-63b6-9c6e" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcdf-9f3f-bcfc-22e2" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="cfb2-bd93-ce25-178a" name="Upgrade" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="b63a-54fc-1f38-9729" name="Self-Repair" hidden="false" targetId="1751-3fb6-cc2e-be8f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="10">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f098-7d7a-b95f-0c05" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="59e4-17fc-69c2-ad24" name="Kinetic Armour Upgrade" hidden="false" targetId="e9fc-504e-c563-d233" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="48">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66ad-8e8b-6735-f9f9" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="5496-3d45-6d41-9400" name="Enhanced Machine Intelligence" hidden="false" targetId="f001-a39e-816a-a7d9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="10">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fd26-3655-5e96-131c" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="9471-1c25-5c54-d1f8" name="Weapons" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="84b8-8514-d29c-9ad2" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="7bda-f3fc-5141-dd7a" name="Plasma Light Support" hidden="false" targetId="eaa4-a3c1-d269-d3cb" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="40">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="bb46-dc15-a03d-5b01" name="Sensor Module" hidden="false" targetId="223b-0bbd-74d0-3322" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="30">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="96.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="809c-5e7f-8e29-4d0d" name="Concord T7 Transporter Drone (Strategic)" book="Rulebook &amp; pdf v2" page="164" hidden="false" collective="false" type="model">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="719b-af6e-a236-33ee" name="MOD2" hidden="false" targetId="88ae-fedb-5c1c-3a7b" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="f23c-1947-7f1c-0218" name="Large" hidden="false" targetId="59d7-7273-b97c-0dff" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="1dbb-e914-2f4c-0b62" name="Transport 10" hidden="false" targetId="8509-6fcc-0fc0-21ae" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="4390-b9d0-48b9-54e2" name="Vehicle Unit" hidden="false" targetId="29d8-590a-bc46-d27a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d77-5f68-4e2f-e596" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="dcf9-6f20-994a-f27f" name="New CategoryLink" hidden="false" targetId="a01f5f58-334c-8442-d861-15099ebdf5e5" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="ea4f-25c8-8974-00b4" name="Concord T7 Transporter Drone" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="0dd0-4cbe-857e-cf7d" name="C3T7 Transporter Drone" hidden="false" profileTypeId="5f97-84dc-4c56-bbe5" profileTypeName="Transport">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="0b84-3b60-5c7d-efa5" value="13">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="809c-5e7f-8e29-4d0d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0073-e667-90b7-944f" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="4f48-ad72-be82-1bf7" value="6">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="809c-5e7f-8e29-4d0d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f04a-242e-cb8d-82ba" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="ef5f-c702-c74a-236d" value="8">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="809c-5e7f-8e29-4d0d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f04a-242e-cb8d-82ba" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+                <modifier type="set" field="c1ac-eacd-b766-3931" value="8">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="809c-5e7f-8e29-4d0d" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f04a-242e-cb8d-82ba" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="43b0-b2e6-6e84-43b5" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="4f48-ad72-be82-1bf7" value="5"/>
+                <characteristic name="Str" characteristicTypeId="e341-f364-940e-4b44" value="1"/>
+                <characteristic name="Res" characteristicTypeId="0b84-3b60-5c7d-efa5" value="11"/>
+                <characteristic name="Init" characteristicTypeId="ef5f-c702-c74a-236d" value="7"/>
+                <characteristic name="Co" characteristicTypeId="c1ac-eacd-b766-3931" value="7"/>
+                <characteristic name="Transport Capacity" characteristicTypeId="28cd-349f-14f4-0e36" value="10"/>
+                <characteristic name="Special" characteristicTypeId="68b5-aa47-fdb5-1640" value=""/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e4c9-19bb-5589-61db" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2cee-babd-752f-4c7c" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2ac4-f3c0-a99f-6100" name="Drones" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="595a-8ef4-87e2-6c0c" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2183-4ee5-c3d0-6717" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="9582-03b4-63e2-c37b" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f957-8e9e-1020-4057" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="2894-388a-1628-a26a" name="Shield Drone" hidden="false" targetId="81b9-02e2-63b6-9c6e" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="763c-468d-d104-1a93" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="4ad6-29e5-8472-c75b" name="Upgrade" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="b5d4-cc23-7798-85e9" name="Self-Repair" hidden="false" targetId="1751-3fb6-cc2e-be8f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="10">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2310-14b0-f641-d985" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="0073-e667-90b7-944f" name="Kinetic Armour Upgrade" hidden="false" targetId="e9fc-504e-c563-d233" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="48">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0461-0b2b-6495-caa6" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="f04a-242e-cb8d-82ba" name="Enhanced Machine Intelligence" hidden="false" targetId="f001-a39e-816a-a7d9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="10">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad28-18a2-939e-35a5" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="dede-3d9e-e562-2ce9" name="Weapons" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00c7-b1cb-74d0-c92d" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="9643-09cd-35b6-eb06" name="Plasma Light Support" hidden="false" targetId="eaa4-a3c1-d269-d3cb" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="40">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="5769-57dc-f2ee-cfa1" name="Sensor Module" hidden="false" targetId="223b-0bbd-74d0-3322" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="points" value="30">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="96.0"/>
+      </costs>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
@@ -9698,6 +14249,79 @@
           </infoLinks>
           <modifiers/>
           <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="d61c-1033-2a05-788b" name="Promote one crew member to Leader" hidden="false" collective="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c02b-d26a-a3ad-7019" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8c8d-0c7f-b7f5-85e1" type="max"/>
+      </constraints>
+      <categoryLinks/>
+      <selectionEntries>
+        <selectionEntry id="a688-4fb1-1cf6-b9c2" name="Leader One" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="edda-6b54-f2ce-ee00" name="Leader" hidden="false" targetId="4675-d30d-3451-8672" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="points" value="10">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0659-696b-a4a4-f70b" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8cb2-5b2a-7a0d-d3f2" name="Leader Two" hidden="false" collective="false" type="upgrade">
+          <profiles/>
+          <rules/>
+          <infoLinks>
+            <infoLink id="89ec-9d2c-368a-bc0b" name="Leader 2" hidden="false" targetId="f7db-9f56-2fd9-fd72" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="increment" field="points" value="10">
+              <repeats/>
+              <conditions/>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="181d-18ba-13f9-f879" type="max"/>
+          </constraints>
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>
@@ -10117,7 +14741,7 @@
 • Ignore regular size units intervening when tracing LoS to Large unit
 • No cover bonus to Res</description>
     </rule>
-    <rule id="312f-bb03-ad1f-c984" name="Lava Spit" book="Rulebook" page="135" hidden="false">
+    <rule id="312f-bb03-ad1f-c984" name="Lava Spit" book="Rulebook" page="130" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -10527,7 +15151,7 @@
       <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="966f-4315-4b9b-5f01" name="Humungous Beast" hidden="false">
+    <rule id="966f-4315-4b9b-5f01" name="Humungous Beast Unit" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -10599,7 +15223,7 @@
       <infoLinks/>
       <modifiers/>
     </rule>
-    <rule id="d6f2-8874-5225-1b13" name="Weapon Drone Command" hidden="false">
+    <rule id="d6f2-8874-5225-1b13" name="Weapon Drone Command Unit" hidden="false">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -10953,6 +15577,21 @@
 • If hit by SV5+ unit takes extra pin
 • If equipped with Plasma Carbines can RF3</description>
     </rule>
+    <rule id="6921-a9d1-f6db-af27" name="Transport 15" book="Rulebook" page="137" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• May transport 15 human sized models.</description>
+    </rule>
+    <rule id="721b-f3e7-087c-177e" name="RF4" book="Rulebook" page="18, 35" hidden="false">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <description>• Can either fire single shot or 4 shots
+• -1 Acc if Rapid Fire</description>
+    </rule>
   </sharedRules>
   <sharedProfiles>
     <profile id="af66-926c-667f-6fb2" name="Plasma Pistol" page="68" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
@@ -10966,6 +15605,105 @@
         <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
         <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
         <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Hand Weapon"/>
+      </characteristics>
+    </profile>
+    <profile id="0657-a21b-613f-3ae8" name="Plasma Lance - Lance" book="Rulebook" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="4"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Choose Target, Inaccurate, Standard Weapon"/>
+      </characteristics>
+    </profile>
+    <profile id="8df9-0599-41c9-bda6" name="Plasma Lance - Scatter" book="Rulebook" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2, Standard Weapon"/>
+      </characteristics>
+    </profile>
+    <profile id="2033-5713-8944-6781" name="Plasma Lance - Single Shot" book="Rulebook" page="70" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
+        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
+        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
+        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
+        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Standard Weapon"/>
+      </characteristics>
+    </profile>
+    <profile id="5d9e-89a4-4f24-f8ae" name="AI Trooper Crew" book="" page="" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="5"/>
+        <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="6 (7)"/>
+        <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="7"/>
+        <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="8"/>
+        <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424"/>
+      </characteristics>
+    </profile>
+    <profile id="d4e2-2b19-03cd-9b76" name="Interceptor Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5 (8)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value=""/>
+      </characteristics>
+    </profile>
+    <profile id="afc3-bbc8-a54c-a565" name="Strike Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
+      </characteristics>
+    </profile>
+    <profile id="73b2-5562-3199-aaa4" name="Drop Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <characteristics>
+        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5(6)"/>
+        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
+        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
+        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Boromites.cat
+++ b/Boromites.cat
@@ -4257,76 +4257,6 @@
         <cost name="pts" costTypeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="2f50-145e-4f5a-220f" name="Scout Probe Shard" book="brb" page="189" hidden="false" collective="false" type="unit">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="01e3-c7e8-5ec2-b4ce" hidden="false" targetId="5660-b448-a09d-5338" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="2f50-145e-4f5a-220f-72807c5d-e370-9ddf-c2b7-de5d2797f24d" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="5752-7497-efd2-2786" name="Scout Probes" book="BRB" page="120" hidden="false" collective="false" type="upgrade">
-          <profiles>
-            <profile id="aec1-17f5-81d2-7812" name="Scout Probes" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <characteristics>
-                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
-                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
-                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
-                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
-                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
-                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
-                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <rules/>
-          <infoLinks>
-            <infoLink id="cea7-7b6a-22c7-4643" hidden="false" targetId="6dc1-69d0-6655-5615" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="3e21-2665-5c57-812b" name="Tas Geren&apos;do, Miner" book="CS" page="111" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules/>
@@ -5027,6 +4957,14 @@
           <constraints/>
         </categoryLink>
       </categoryLinks>
+    </entryLink>
+    <entryLink id="df6b-5167-5614-7c78" name="Scout Probe Shard" hidden="false" targetId="0c5c-da8a-4405-a1ce" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
     </entryLink>
   </entryLinks>
   <sharedSelectionEntries>

--- a/Concord.cat
+++ b/Concord.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="162d-cc8a-d6e7-6973" name="Concord" revision="19" battleScribeVersion="2.01" authorName="Glasvandrare / Vescarea" authorContact="tkjellberg@gmail.com" gameSystemId="c339-677a-60db-4060" gameSystemRevision="0" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="162d-cc8a-d6e7-6973" name="Concord" revision="19" battleScribeVersion="2.01" authorName="Dom Hine" authorContact="boltactionAB@gmail.com" gameSystemId="c339-677a-60db-4060" gameSystemRevision="0" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <profiles/>
   <rules/>
   <infoLinks/>
@@ -8,1470 +8,17 @@
   <categoryEntries/>
   <forceEntries/>
   <selectionEntries>
-    <selectionEntry id="e8e7-16fc-e243-8d1a" name="C3 Drop Command Squad " hidden="false" collective="false" type="unit">
+    <selectionEntry id="37f1-afbf-0787-df72" name="C3 Strike Support Team" book="Rulebook &amp; pdf v2" page="163" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="e8e7-16fc-e243-8d1a-481abf13-c03e-0dd0-d520-9f9837253cbe" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
+      <infoLinks>
+        <infoLink id="bb8e-3241-21ab-3ac4" name="Weapon Team Unit" hidden="false" targetId="3f2c-9814-0c0d-e4d7" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="0654-4b4e-d76b-a53d" name="&gt; Drop Commander" hidden="false" collective="false" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="23a7-b767-3191-f198" hidden="false" targetId="0f84-f206-4f28-921f" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="6f56-916b-f1fe-7c9b" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="1fa7-b041-f35b-d0cc" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="65d5-37a5-8e9e-bf1a" hidden="false" targetId="e745-6ace-c0d4-6e35" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="18b8-5fc7-c03f-bd11" hidden="false" targetId="6c13-252f-55b8-4de9" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="e507-6497-b477-6c5b" hidden="false" targetId="a90a-fea5-107f-a019" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="693d-3eec-3830-f627" name="New EntryLink" hidden="false" targetId="4cc6-d659-dbc1-3403" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="71.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="d1b3-dbb7-cee4-68b5" name="Drop Trooper" hidden="false" collective="false" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="be66-7c2e-8273-6f5c" hidden="false" targetId="1219-e29a-7fa7-a09e" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="93c9-fc99-73d8-fdc4" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="5c7c-c88f-83d8-65ea" hidden="false" targetId="e745-6ace-c0d4-6e35" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="5b51-0381-71d1-051e" hidden="false" targetId="6c13-252f-55b8-4de9" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="6d03-a5b2-cc25-3a13" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="30.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="edc6-50b7-d35f-bb72" name="&lt; Unit Options &gt;" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="7d9c-ddf6-192a-27ea" hidden="false" targetId="9f16-5a27-44b5-7471" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="points" value="6.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="e8e7-16fc-e243-8d1a" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d1b3-dbb7-cee4-68b5" type="atLeast"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="e8e7-16fc-e243-8d1a" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d1b3-dbb7-cee4-68b5" type="atLeast"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="28af-cbca-4fdb-d6f1" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="023c-d4fc-bc70-009a" hidden="false" targetId="057e-2e8a-1952-9de0" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="07d7-5e8b-8c30-dffa" name="New EntryLink" hidden="false" targetId="0ac6-5bdb-3d61-e6ce" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs/>
-    </selectionEntry>
-    <selectionEntry id="6459-ea8a-0c57-1278" name="C3 Drop Squad" hidden="true" collective="false" type="unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers>
-        <modifier type="set" field="hidden" value="false">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e8e7-16fc-e243-8d1a" type="equalTo"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-      </constraints>
-      <categoryLinks>
-        <categoryLink id="6459-ea8a-0c57-1278-481abf13-c03e-0dd0-d520-9f9837253cbe" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="3f1f-e456-24f8-eb1b" name="&gt; Drop Leader" hidden="false" collective="false" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="6482-ea66-8207-de6b" hidden="false" targetId="e18d-8dd1-d573-930f" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="26c5-191e-a634-3fd8" name="&lt; Leader &gt;" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e0a8-4aca-a5ef-219c" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="4dd0-a74a-be47-f9cf" hidden="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="9886-8000-84f8-2b78" hidden="false" targetId="9e56-0965-ea32-7ff4" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks>
-            <entryLink id="20fe-aedb-40f2-dd77" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="49a1-e23e-1226-5ab5" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="b815-3cfe-158d-b90e" hidden="false" targetId="6c13-252f-55b8-4de9" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="c9ec-f4c6-e17d-7d2e" hidden="false" targetId="e745-6ace-c0d4-6e35" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="0e61-b8e0-5e1d-35d3" name="New EntryLink" hidden="false" targetId="4cc6-d659-dbc1-3403" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="38.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="823f-b505-a915-8e27" name="Drop Trooper" hidden="false" collective="false" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="a8e9-302c-5a56-a3c3" hidden="false" targetId="1219-e29a-7fa7-a09e" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="5d06-d01f-15d3-1cc4" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="b2c6-6d61-9ac9-0a04" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="09c0-2ab9-cb8e-ce96" hidden="false" targetId="e745-6ace-c0d4-6e35" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="28.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="0742-5d15-198f-f65a" name="Plasma Lance" hidden="false" collective="false" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="1.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="a0b9-c282-b1a9-f7f4" name="Drop Trooper (Lance)" hidden="false" collective="false" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="f302-fb2e-ac27-fc18" hidden="false" targetId="1219-e29a-7fa7-a09e" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bc7d-c021-cf95-5044" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2acb-9c37-8188-c0cc" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="340d-143a-e047-ec0a" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="71f3-851a-f8d6-9a30" hidden="false" targetId="21a7-132d-6703-9ff6" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="45c9-d54d-e7b4-8337" hidden="false" targetId="e745-6ace-c0d4-6e35" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="29.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="b9fe-9de2-a5c8-8160" name="&lt; Unit Options &gt;" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="ceba-7a26-f028-d93c" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="c959-ea81-785f-fc70" hidden="false" targetId="9f16-5a27-44b5-7471" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="points" value="10.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="6459-ea8a-0c57-1278" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="823f-b505-a915-8e27" type="atLeast"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="6459-ea8a-0c57-1278" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="823f-b505-a915-8e27" type="atLeast"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="6459-ea8a-0c57-1278" value="6.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="823f-b505-a915-8e27" type="atLeast"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="6459-ea8a-0c57-1278" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0742-5d15-198f-f65a" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="de78-e1e0-54f6-1ac5" name="New EntryLink" hidden="false" targetId="0ac6-5bdb-3d61-e6ce" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs/>
-    </selectionEntry>
-    <selectionEntry id="0244-6cd5-9260-c12e" name="C3 Interceptor Command Squad" hidden="false" collective="false" type="unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="0244-6cd5-9260-c12e-5c47879b-41d0-1383-5fe5-a5989615db89" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="fa12-b792-1fff-89e3" name="&lt; Interceptor Commander" hidden="false" collective="false" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="5cac-dbde-7763-5ddd" hidden="false" targetId="9286-cbf7-0641-5ce1" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="ce12-0c6b-11e5-f498" name="&lt; Interceptor Commander Options &gt;" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="bd12-7ad6-eb09-08ba" hidden="false" targetId="a90a-fea5-107f-a019" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks>
-            <entryLink id="c8d2-d4de-e467-c706" hidden="false" targetId="12f1-610b-0dc9-4732" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="77c5-7b49-1b1a-443b" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="ea21-ecb8-ce22-00d3" hidden="false" targetId="658c-b2dd-98f4-dafb" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="8b1d-c9da-076d-d08e" name="Interceptor Trooper" hidden="false" collective="false" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="5f70-3d2c-69d6-3b63" hidden="false" targetId="34f9-12c5-7e7b-114c" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="3ad9-f6de-2222-14d7" hidden="false" targetId="12f1-610b-0dc9-4732" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="89fc-31e3-8d85-5d84" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="18db-e7fa-3661-289b" hidden="false" targetId="658c-b2dd-98f4-dafb" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="aba9-6548-4d89-9d71" name="&lt; Unit Options &gt;" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="01c1-76ad-1e19-2f22" name="&lt; Compactor Drone &gt;" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="7e3a-171d-c362-06f0" hidden="false" targetId="c87f-f5b0-1134-8ad9" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="792d-6942-fc08-f58a" hidden="false" targetId="d776-f344-44a4-c41b" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks>
-            <entryLink id="ffb4-8366-9f3a-ce9c" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="f8e2-982b-dc65-9be9" hidden="false" targetId="7dac-aa85-fc80-51d5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="168.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="2f44-92da-46f8-619d" name="C3 Interceptor Squad" hidden="false" collective="false" type="unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="2f44-92da-46f8-619d-5c47879b-41d0-1383-5fe5-a5989615db89" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="de4c-b135-70a3-c87b" name="&lt; Interceptor Leader" hidden="false" collective="false" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="27e0-cc93-d2c1-3dec" hidden="false" targetId="9ed6-e3f2-8847-d7a2" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="8166-a3dd-75ec-ccde" name="&lt; Interceptor Leader Options &gt;" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="27d8-164a-139b-f635" hidden="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks>
-            <entryLink id="0179-fa9f-3b06-4db2" hidden="false" targetId="12f1-610b-0dc9-4732" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="5b9e-0f99-9282-7ef1" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="dd0f-496a-c08e-56b4" hidden="false" targetId="658c-b2dd-98f4-dafb" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="8783-ed89-1004-1495" name="Interceptor Trooper" hidden="false" collective="false" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="5664-48f1-1957-c3d8" hidden="false" targetId="34f9-12c5-7e7b-114c" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="1c5e-3cc6-d497-2644" hidden="false" targetId="12f1-610b-0dc9-4732" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="1318-0d29-4a43-dd78" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="0628-7b69-d134-8ece" hidden="false" targetId="658c-b2dd-98f4-dafb" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="2de5-7dde-c917-f126" name="&lt; Unit Options &gt;" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="eadf-8b1d-d337-25ad" name="&lt; Compactor Drone &gt;" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="16b9-1f19-f7e7-0da5" hidden="false" targetId="c87f-f5b0-1134-8ad9" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="221b-0c10-d482-195e" hidden="false" targetId="d776-f344-44a4-c41b" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks>
-            <entryLink id="ca55-43e4-8b73-294c" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="f96c-a56c-c07e-6da4" hidden="false" targetId="7dac-aa85-fc80-51d5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="136.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="f53b-8cb2-f46e-ec68" name="C3 Strike Command Squad" hidden="false" collective="false" type="unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="f53b-8cb2-f46e-ec68-481abf13-c03e-0dd0-d520-9f9837253cbe" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="9217-51b5-1490-c20f" name="&lt; Strike Commander" hidden="false" collective="false" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="e5ba-45ac-5c32-8928" hidden="false" targetId="9686-36fa-7ae7-f4dc" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="4845-6259-0e92-0f04" name="&lt; Strike Commander Options &gt;" hidden="false" collective="false">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-              <selectionEntries>
-                <selectionEntry id="2d9d-8454-98ba-682e" name="Sling net ammo" hidden="false" collective="false" type="upgrade">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                  </constraints>
-                  <categoryLinks/>
-                  <selectionEntries/>
-                  <selectionEntryGroups/>
-                  <entryLinks/>
-                  <costs>
-                    <cost name="pts" costTypeId="points" value="5.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="6149-c82a-e122-2d99" hidden="false" targetId="a90a-fea5-107f-a019" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks>
-            <entryLink id="be34-e860-46d0-d7e6" hidden="false" targetId="6c13-252f-55b8-4de9" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="de1c-d5c3-afcd-f486" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="691a-aa46-2b4f-a09b" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="25b4-7c4e-e579-4fee" name="Strike Trooper" hidden="false" collective="false" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="4d3d-b808-7a51-2ddb" hidden="false" targetId="6688-b331-6578-fb30" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="f7b9-5bbf-7725-846a" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="4ffe-2e60-ece1-d9c4" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="22.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="67f6-07bc-f0ba-b0bd" name="&lt; Unit Options &gt;" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="d30a-66b4-b1ee-5cdd" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="ead8-0218-98ae-8ddd" hidden="false" targetId="057e-2e8a-1952-9de0" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="5aef-5d71-d3a9-8546" hidden="false" targetId="9f16-5a27-44b5-7471" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="points" value="6.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="f53b-8cb2-f46e-ec68" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="25b4-7c4e-e579-4fee" type="atLeast"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="f53b-8cb2-f46e-ec68" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="25b4-7c4e-e579-4fee" type="atLeast"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="d19c-d02c-15e8-3e2b" name="New EntryLink" hidden="false" targetId="0ac6-5bdb-3d61-e6ce" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="66.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="a2f5-7c0a-21e5-7b0b" name="C3 Strike Squad" hidden="false" collective="false" type="unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="a2f5-7c0a-21e5-7b0b-481abf13-c03e-0dd0-d520-9f9837253cbe" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="3dd7-c3aa-50ca-26b2" name="Strike Trooper" hidden="false" collective="false" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="cfe4-65fc-7598-d48f" hidden="false" targetId="6688-b331-6578-fb30" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="3d5b-1da9-8a1e-fdff" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="333b-de0f-7f92-165d" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="20.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="5ce3-0d5d-4909-be5b" name="&lt; Unit Options &gt;" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="826e-6c50-646d-62a2" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="482c-adc0-0ca1-f078" hidden="false" targetId="9f16-5a27-44b5-7471" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="2">
-                  <repeats>
-                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="f344-fd5e-1be4-343e" name="Plasma Lance" hidden="false" targetId="3dd4-3b5c-6873-e8f2" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="ce15-2326-e497-81dd" name="New EntryLink" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="dc42-0d29-c55c-77ab" name="New EntryLink" hidden="false" targetId="0ac6-5bdb-3d61-e6ce" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="b1e3-2d2a-8b67-fc51" name="Leader" hidden="false" collective="false" defaultSelectionEntryId="f0c2-69ee-8b90-7528">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries>
-            <selectionEntry id="f0c2-69ee-8b90-7528" name="&lt; Strike Leader" hidden="false" collective="false" type="model">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="68ed-3fd5-b951-fe6f" hidden="false" targetId="af6e-dcdb-77a5-b67e" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="53a6-45f6-5682-c4e8" name="&lt; Strike Leader Options &gt;" hidden="false" collective="false">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                  <selectionEntries>
-                    <selectionEntry id="80e9-9314-55b5-7258" name="Sling net ammo" hidden="false" collective="false" type="upgrade">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      </constraints>
-                      <categoryLinks/>
-                      <selectionEntries/>
-                      <selectionEntryGroups/>
-                      <entryLinks/>
-                      <costs>
-                        <cost name="pts" costTypeId="points" value="5.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <selectionEntryGroups/>
-                  <entryLinks>
-                    <entryLink id="4631-7558-0869-977f" hidden="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry">
-                      <profiles/>
-                      <rules/>
-                      <infoLinks/>
-                      <modifiers/>
-                      <constraints/>
-                      <categoryLinks/>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <entryLinks>
-                <entryLink id="eb5d-a6e4-347d-da46" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="b5e3-8a48-3fba-2582" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="40dd-425c-09d9-342d" hidden="false" targetId="6c13-252f-55b8-4de9" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="b6b5-59e8-0142-f157" name="&lt; Strike Leade Kai Lek Atastrin" hidden="false" collective="false" type="model">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="39fc-3f30-ab2f-a4ac" hidden="false" targetId="4d7e-f31f-84d4-d57a" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="9f91-1033-28eb-60f6" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="a807-bd9c-3407-8f70" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="8772-8d7c-d285-cc64" hidden="false" targetId="6c13-252f-55b8-4de9" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" costTypeId="points" value="21.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="32.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="37f1-afbf-0787-df72" name="C3 Strike Support Team" hidden="false" collective="false" type="unit">
-      <profiles>
-        <profile id="65ed-1aa6-1ac1-fef1" name="Strike Trooper crew Leader" hidden="true" profileTypeId="1650-77b3-10d1-6406">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers>
-            <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2">
-              <repeats/>
-              <conditions>
-                <condition field="selections" scope="37f1-afbf-0787-df72" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e31e-cc34-f520-8f22" type="equalTo"/>
-              </conditions>
-              <conditionGroups/>
-            </modifier>
-            <modifier type="set" field="hidden" value="false">
-              <repeats/>
-              <conditions/>
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="37f1-afbf-0787-df72" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cd4f-0ce9-a6a4-b34a" type="equalTo"/>
-                    <condition field="selections" scope="37f1-afbf-0787-df72" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="41bd-5499-889a-ab16" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-          <characteristics>
-            <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-            <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
-            <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
-            <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
-            <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
-            <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-            <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader"/>
-          </characteristics>
-        </profile>
-      </profiles>
-      <rules/>
-      <infoLinks/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
       <constraints/>
       <categoryLinks>
@@ -1483,34 +30,9 @@
           <constraints/>
         </categoryLink>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="6fd3-42ff-1e26-f82f" name="&lt; Strike Trooper Crew" hidden="false" collective="false" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="9b44-134d-0947-ad18" hidden="false" targetId="ce28-e8fe-4290-f477" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="15.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="ab45-bb28-303d-7786" name="&lt; Unit Options &gt;" hidden="false" collective="false">
+        <selectionEntryGroup id="ab45-bb28-303d-7786" name="Drones" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1520,61 +42,29 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="db05-8d5e-8d36-69a0" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+            <entryLink id="db05-8d5e-8d36-69a0" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5288-35d3-0405-9532" type="max"/>
+              </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="cc63-9a66-9dd6-3de7" hidden="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry">
+            <entryLink id="cc63-9a66-9dd6-3de7" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f428-44fb-de0f-b5d5" type="max"/>
+              </constraints>
               <categoryLinks/>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="37e9-4c4d-d67c-19ac" name="&lt; Promote &gt;" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="e31e-cc34-f520-8f22" hidden="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="points" value="20">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="87e7-1804-a911-dd27" hidden="false" targetId="41bd-5499-889a-ab16" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="a579-d4e9-1656-152c" name="&lt; Weapon Options &gt; " hidden="false" collective="false" defaultSelectionEntryId="0bfa-efdd-8bd7-0f3a">
+        <selectionEntryGroup id="a579-d4e9-1656-152c" name="Weapon Options" hidden="false" collective="false" defaultSelectionEntryId="0bfa-efdd-8bd7-0f3a">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1587,7 +77,21 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="7437-7bc1-490a-6628" hidden="false" targetId="10e6-b49c-4401-a1cd" type="selectionEntry">
+            <entryLink id="7437-7bc1-490a-6628" name="Plasma Cannon" hidden="false" targetId="1c29-8394-0315-8140" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="35">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="0bfa-efdd-8bd7-0f3a" name="X-Launcher" hidden="false" targetId="e2c7-1c85-2088-3005" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -1595,7 +99,67 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="0bfa-efdd-8bd7-0f3a" hidden="false" targetId="afc8-4f62-e1e2-1e4c" type="selectionEntry">
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="a2b5-940a-cf2a-b76f" name="Upgrade" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="e55d-5a2b-9b7f-9e8a" name="Strike Trooper Crew" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="ebae-c7bb-7b65-9c4c" name="Strike Trooper Crew" book="Rulebook &amp; pdf v2" page="163" hidden="false" targetId="db4b-0b86-8f9a-7a79" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d178-afc8-8673-08e8" type="min"/>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8ec4-a3b9-e25a-6620" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="5cf4-639f-0f02-56ba" name="HL Armour" hidden="false" targetId="f561-c73c-de8c-ae6f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c566-9d23-4501-03c5" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e39-e3ce-9832-71b4" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="4b32-4fe5-da3d-f648" name="Plasma Pistol" hidden="false" targetId="9851-4076-e2e9-3df8" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87d6-89ac-d01d-d6f3" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f831-f626-95ab-85b9" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="fb5f-916a-9569-4312" name="Promote one crew member to Leader" hidden="false" targetId="d61c-1033-2a05-788b" type="selectionEntryGroup">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -1606,52 +170,51 @@
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="10.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="48b0-cf3d-3699-f8a3" name="C3 Strike Heavy Support Team" hidden="false" collective="false" type="unit">
-      <profiles>
-        <profile id="b8eb-6958-badc-9897" name="Strike Trooper crew Leader" hidden="true" profileTypeId="1650-77b3-10d1-6406">
+      <entryLinks>
+        <entryLink id="bb95-40ed-84a9-8e26" name="Special Munitions" hidden="true" targetId="6dbe-a221-4d79-ff6a" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers>
-            <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2">
+            <modifier type="set" field="hidden" value="false">
               <repeats/>
               <conditions>
-                <condition field="selections" scope="48b0-cf3d-3699-f8a3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8673-cdb1-4966-8463" type="equalTo"/>
+                <condition field="selections" scope="37f1-afbf-0787-df72" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0bfa-efdd-8bd7-0f3a" type="atLeast"/>
               </conditions>
               <conditionGroups/>
             </modifier>
-            <modifier type="set" field="hidden" value="false">
-              <repeats/>
-              <conditions/>
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="48b0-cf3d-3699-f8a3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="68f5-c9b8-b86f-2e3e" type="equalTo"/>
-                    <condition field="selections" scope="48b0-cf3d-3699-f8a3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8673-cdb1-4966-8463" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
           </modifiers>
-          <characteristics>
-            <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-            <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
-            <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
-            <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
-            <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
-            <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-            <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader"/>
-          </characteristics>
-        </profile>
-      </profiles>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="48b0-cf3d-3699-f8a3" name="C3 Strike Heavy Support Team" book="pdf v2" hidden="false" collective="false" type="unit">
+      <profiles/>
       <rules/>
-      <infoLinks/>
+      <infoLinks>
+        <infoLink id="f775-ba08-0ce9-2889" name="Large" hidden="false" targetId="59d7-7273-b97c-0dff" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3527-e6d4-b412-bfc6" name="Slow" hidden="false" targetId="04bc-743b-092f-8c3a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="9d09-e35c-92ee-f41c" name="Weapon Team Unit" hidden="false" targetId="3f2c-9814-0c0d-e4d7" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
       <constraints/>
       <categoryLinks>
@@ -1663,121 +226,9 @@
           <constraints/>
         </categoryLink>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="0d6a-0bd6-38ee-e3b2" name="&lt; Strike Trooper Crew" hidden="false" collective="false" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="9ad4-375b-4388-7a6e" hidden="false" targetId="ce28-e8fe-4290-f477" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Large, Slow">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="b6de-5168-e608-a911" hidden="false" targetId="2f22-37fa-4076-d255" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="e4f5-f5f9-3728-2c55" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="15.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
+      <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="b4fb-8d86-82bb-335d" name="&lt; Unit Options &gt;" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="c254-b4a0-5dc9-ed34" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="2f8e-78f4-d6ec-ed5b" hidden="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="6850-687d-e5a8-d9b1" name="&lt; Promote &gt;" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="8673-cdb1-4966-8463" hidden="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="points" value="20.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="68f5-c9b8-b86f-2e3e" hidden="false" targetId="41bd-5499-889a-ab16" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="fb0c-20d6-1fc6-7258" name="&lt; Weapon Option &gt;" hidden="false" collective="false">
+        <selectionEntryGroup id="fb0c-20d6-1fc6-7258" name="Weapon Options" hidden="false" collective="false" defaultSelectionEntryId="0cad-26b2-4dad-13c0">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -1790,7 +241,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="27a3-0f7e-6222-8b71" hidden="false" targetId="1bc9-ce44-fdbe-ef90" type="selectionEntry">
+            <entryLink id="27a3-0f7e-6222-8b71" name="Plasma Bombard" hidden="false" targetId="4a45-8595-c131-0604" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -1804,7 +255,108 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="0cad-26b2-4dad-13c0" hidden="false" targetId="e2b4-a034-c8ce-e376" type="selectionEntry">
+            <entryLink id="0cad-26b2-4dad-13c0" name="X-Howitzer" hidden="false" targetId="ab2e-edc9-b214-f7d5" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="5552-4cf3-2c63-f324" name="Drones" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="dee2-a585-c053-a8d8" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c13-f180-82d8-4551" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2848-78a9-1081-884e" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="7b5d-888b-69d0-a4f2" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6fc0-62a6-984e-19b2" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="8bbb-d54f-c7bc-dc65" name="Upgrade" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="539b-333e-9405-3ad2" name="Strike Trooper Crew" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="95e2-d85d-cd73-ba37" name="Strike Trooper Crew" book="Rulebook &amp; pdf v2" page="163" hidden="false" targetId="db4b-0b86-8f9a-7a79" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="aa9f-0eeb-2889-70e1" type="min"/>
+                <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cf90-1a9a-7979-c7b3" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="c2ef-1ca8-8cb7-ad56" name="HL Armour" hidden="false" targetId="f561-c73c-de8c-ae6f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e7c-e480-e2e3-36ae" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6df6-e80d-e546-0f07" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="77d0-d4b3-61d2-44a7" name="Plasma Pistol" hidden="false" targetId="9851-4076-e2e9-3df8" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="906c-4c95-b38e-606c" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a469-6a16-33c5-2eb6" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="4a65-986d-373b-a3b3" name="Promote one crew member to Leader" hidden="false" targetId="d61c-1033-2a05-788b" type="selectionEntryGroup">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -1816,415 +368,56 @@
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="f37b-47c7-bddc-6bbe" hidden="false" targetId="e16f-acd1-265c-07f9" type="selectionEntry">
+        <entryLink id="48fb-b4eb-b901-b5a6" name="Special Munitions" hidden="true" targetId="6dbe-a221-4d79-ff6a" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
-          <modifiers/>
+          <modifiers>
+            <modifier type="set" field="hidden" value="false">
+              <repeats/>
+              <conditions>
+                <condition field="selections" scope="48b0-cf3d-3699-f8a3" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0cad-26b2-4dad-13c0" type="atLeast"/>
+              </conditions>
+              <conditionGroups/>
+            </modifier>
+          </modifiers>
           <constraints/>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="65.0"/>
+        <cost name="pts" costTypeId="points" value="55.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d626-a99a-6470-71ad" name="Concord C3D1 Light Support Drone " hidden="false" collective="false" type="unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="d626-a99a-6470-71ad-5c47879b-41d0-1383-5fe5-a5989615db89" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="37d5-656f-d5c1-4397" name="&lt; Weapon Drone" hidden="false" collective="false" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="7f94-248b-3341-8ab0" name="C3D1 Light Support Drone" hidden="false" targetId="18f2-0352-9cf8-66a5" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="dea6-97f2-41e3-988b" name="Plasma Light Support Gun (E)" hidden="false" targetId="c74e-2993-3474-7869" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1bde-057f-958d-ccce" type="min"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="19.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="cf0a-fdfc-c22e-fadb" name="&lt; Options &gt;" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="b508-d3f3-6f27-4975" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="50fc-d0da-6514-b4dd" hidden="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="e89f-034f-fda6-f951" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="ef1e-a1e3-ff9f-85f1" name="New EntryLink" hidden="false" targetId="0ac6-5bdb-3d61-e6ce" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="4da3-5d4c-1262-53ab" name="&lt; Weapon Drone Options &gt;" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="c7a3-afb1-fa42-b4d3" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="10">
-                  <repeats>
-                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d754-f78e-4c46-1d7d" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="8bdd-d11f-ed0d-dac8" name="Concord C3D1/GP Light General Purpose Drone" book="" hidden="false" collective="false" type="model">
+    <selectionEntry id="a829-1685-c4b5-55b6" name="Concord C3M25 Heavy Combat Drone" book="rulebook &amp; v2 pdf" page="165" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules/>
       <infoLinks>
-        <infoLink id="fd26-e2c7-0e4f-22ec" hidden="false" targetId="f9ce-3eb5-0335-1b53" type="profile">
+        <infoLink id="ef53-ded6-5329-3a1a" name="Vehicle Unit" hidden="false" targetId="29d8-590a-bc46-d27a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="47b0-3778-8039-1c81" name="MOD3" hidden="false" targetId="3297-97ec-8602-752c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="0d02-1318-59e4-36bb" name="Slow" hidden="false" targetId="04bc-743b-092f-8c3a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="6275-9f4d-d90a-c596" name="Large" hidden="false" targetId="59d7-7273-b97c-0dff" type="rule">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
         </infoLink>
       </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="8bdd-d11f-ed0d-dac8-72807c5d-e370-9ddf-c2b7-de5d2797f24d" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="97c5-cc1d-c9c0-ffae" name="&lt; Options &gt;" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="f352-1f01-ac1e-8066" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="48d4-a21e-073b-3f58" hidden="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="0297-f8df-bd9f-048b" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="40b9-2bd4-ed1e-8aca" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="10">
-                  <repeats>
-                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f29-c1d8-0015-11d0" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="1f37-5d78-1905-36cf" hidden="false" targetId="76e8-05d6-ff37-7205" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="fd55-8ca6-6585-172a" name="New EntryLink" hidden="false" targetId="0ac6-5bdb-3d61-e6ce" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="20.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="3601-a65d-7f14-cf86" name="Concord C3D2 Medium Support Drone " hidden="false" collective="false" type="unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="3601-a65d-7f14-cf86-5c47879b-41d0-1383-5fe5-a5989615db89" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="156e-1f5a-b7e7-1783" name="&lt; Weapon Drone" hidden="false" collective="false" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="bca1-3c81-da93-aefb" hidden="false" targetId="be8e-2c8f-8288-e92a" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="83.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="86e7-9193-c4cf-b4c7" name="&lt; Options &gt;" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="0f08-649f-cdb0-8d16" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="a405-a61d-2eb0-1e80" hidden="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="f787-39f9-566b-e5ff" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="ceff-865b-727c-eabd" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="points" value="10">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="d9f1-70b9-e6e9-9027" name="New EntryLink" hidden="false" targetId="0ac6-5bdb-3d61-e6ce" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="9c20-3b56-5f85-22e6" name="&lt; Weapon Option &gt;" hidden="false" collective="false" defaultSelectionEntryId="b0d5-e4fd-3700-f807">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6471-bfed-2c07-8278" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ab74-722f-4cfb-6655" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="b0d5-e4fd-3700-f807" hidden="false" targetId="62c2-106a-28aa-6cf5" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="0803-43c6-fe71-d14e" hidden="false" targetId="90ca-6c03-a803-a140" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="43e9-96e3-54d6-7746" hidden="false" targetId="80bf-613e-52b4-f160" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="points" value="10">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="a126-9625-8b33-3d85" hidden="false" targetId="5a7d-3845-90ba-32eb" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="a829-1685-c4b5-55b6" name="Concord C3M25 Heavy Combat Drone " hidden="false" collective="false" type="unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
       <modifiers/>
       <constraints/>
       <categoryLinks>
@@ -2237,17 +430,26 @@
         </categoryLink>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="9432-f296-0817-a41e" name="&lt; Heavy Combat Drone" hidden="false" collective="false" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="52d9-2f82-4813-deb1" hidden="false" targetId="1c7c-b76a-8d9f-4405" type="profile">
+        <selectionEntry id="9432-f296-0817-a41e" name="Concord C3M25 Heavy Combat Drone **" book="rulebook &amp; v2 pdf" page="165" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="b631-2d8c-c19d-896e" name="C3M25 Heavy Combat Drone" book="rulebook &amp; v2 pdf" page="165" hidden="false" profileTypeId="1650-77b3-10d1-6406">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-            </infoLink>
-          </infoLinks>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="15"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value=""/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
@@ -2256,26 +458,14 @@
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="fc27-7742-3460-32c5" hidden="false" targetId="c74e-2993-3474-7869" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf7c-2bc6-ef65-d7d4" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25b3-11ef-2d7d-eed5" type="min"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
+          <entryLinks/>
           <costs>
-            <cost name="pts" costTypeId="points" value="418.0"/>
+            <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="ba92-e188-5152-68a3" name="&lt; Options &gt;" hidden="false" collective="false">
+        <selectionEntryGroup id="ba92-e188-5152-68a3" name="Drones" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2285,47 +475,40 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="25d4-fe83-5977-2551" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+            <entryLink id="25d4-fe83-5977-2551" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b635-d471-dc39-26b3" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c54a-52bd-8ce5-332b" type="max"/>
+              </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="3866-b4ff-b88f-c46f" hidden="false" targetId="2750-e65f-4c66-8235" type="selectionEntry">
+            <entryLink id="3866-b4ff-b88f-c46f" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="77ad-ccc7-3ef6-4251" type="max"/>
+              </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="2bbd-905d-dab7-121e" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
+            <entryLink id="2bbd-905d-dab7-121e" name="Shield Drone" hidden="false" targetId="81b9-02e2-63b6-9c6e" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="3c1b-83a4-9f4f-3544" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="points" value="10">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0fe7-9835-feb6-90f8" type="max"/>
+              </constraints>
               <categoryLinks/>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="c91b-fa5e-67d8-abcd" name="&lt; Weapon Option &gt;" hidden="false" collective="false" defaultSelectionEntryId="603a-e2ee-2b70-fd24">
+        <selectionEntryGroup id="c91b-fa5e-67d8-abcd" name="Weapons" hidden="false" collective="false" defaultSelectionEntryId="603a-e2ee-2b70-fd24">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2338,15 +521,21 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="4567-1659-3af4-e20c" hidden="false" targetId="c521-ffae-2a9d-88f9" type="selectionEntry">
+            <entryLink id="4567-1659-3af4-e20c" name="Compression Bombard" hidden="false" targetId="fd51-200c-8f6e-00a0" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers/>
+              <modifiers>
+                <modifier type="increment" field="points" value="25">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="603a-e2ee-2b70-fd24" hidden="false" targetId="1bc9-ce44-fdbe-ef90" type="selectionEntry">
+            <entryLink id="603a-e2ee-2b70-fd24" name="Plasma Bombard" hidden="false" targetId="4a45-8595-c131-0604" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -2356,67 +545,7 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="3440-9714-d7d3-3653" name="Concord C3M4 Combat Drone " hidden="false" collective="false" type="model">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="3440-9714-d7d3-3653-a01f5f58-334c-8442-d861-15099ebdf5e5" hidden="false" targetId="a01f5f58-334c-8442-d861-15099ebdf5e5" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="c49a-cae5-0917-dff0" name="&lt; Weapon Drone" hidden="false" collective="false" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="9c84-78ff-fad3-093b" hidden="false" targetId="eda1-434f-1771-a790" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="3423-5aea-f880-01e4" name="New EntryLink" hidden="false" targetId="c74e-2993-3474-7869" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c77-f649-c306-7f94" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8a51-a2aa-bfac-9c7f" type="max"/>
-              </constraints>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="5980-fadb-0d1a-8e4b" name="&lt; Options &gt;" hidden="false" collective="false">
+        <selectionEntryGroup id="6079-0a10-62c8-7c5e" name="Upgrade" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2426,31 +555,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="1015-29dc-212b-dc4d" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="5087-2dc6-723c-788e" hidden="false" targetId="2750-e65f-4c66-8235" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="4ea5-d717-39c9-e705" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="156b-8c84-33fe-b740" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
+            <entryLink id="cb13-7599-d74b-698d" name="Self-Repair" hidden="false" targetId="1751-3fb6-cc2e-be8f" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -2461,75 +566,54 @@
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="6e7c-7ade-f9bf-460f" name="&lt; Weapon Option &gt;" hidden="false" collective="false" defaultSelectionEntryId="d67c-d9cf-6b61-1878">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a6ad-0b5c-3227-56d3" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="52db-5e2c-cc0e-0791" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="19c8-6a0c-389d-3c5b" hidden="false" targetId="69d9-b84f-3c40-15fb" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="c8d1-e6e4-46d1-56ce" hidden="false" targetId="80bf-613e-52b4-f160" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="points" value="5">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="d67c-d9cf-6b61-1878" hidden="false" targetId="3dfc-49e9-adcb-ae48" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b07-9232-6f21-a540" type="max"/>
+              </constraints>
               <categoryLinks/>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="8a63-270a-d4ff-0e7d" name="New EntryLink" hidden="false" targetId="e16f-acd1-265c-07f9" type="selectionEntry">
+        <entryLink id="d9fc-7dcd-6c31-a44c" name="Plasma Light Support" hidden="false" targetId="eaa4-a3c1-d269-d3cb" type="selectionEntry">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
-          <constraints/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="317e-ead6-4763-71be" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0331-c6ad-fe22-af11" type="min"/>
+          </constraints>
           <categoryLinks/>
         </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" costTypeId="points" value="249.0"/>
+        <cost name="pts" costTypeId="points" value="408.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9974-fc89-ef4b-59fe" name="Concord C3M50 Heavy Support Drone " hidden="false" collective="false" type="unit">
+    <selectionEntry id="9974-fc89-ef4b-59fe" name="Concord C3M50 Heavy Support Drone" book="Rulebook &amp; pdf v2" page="165" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules/>
-      <infoLinks/>
+      <infoLinks>
+        <infoLink id="6b31-0cd1-e70a-d2a0" name="MOD3" hidden="false" targetId="3297-97ec-8602-752c" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="2d8b-c715-b41e-92e5" name="Slow" hidden="false" targetId="04bc-743b-092f-8c3a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="1d47-94f2-462a-323d" name="Large" hidden="false" targetId="59d7-7273-b97c-0dff" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
       <constraints/>
       <categoryLinks>
@@ -2542,17 +626,26 @@
         </categoryLink>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="e948-5e36-fc7b-117e" name="&lt; Heavy Support Drone" hidden="false" collective="false" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="28a5-2f84-29d4-5268" hidden="false" targetId="684e-ba3e-5aab-8be8" type="profile">
+        <selectionEntry id="e948-5e36-fc7b-117e" name="Concord C3M50 Heavy Support Drone" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="a951-e8f0-719d-e50f" name="C3M50 Heavy Support Drone" book="Rulebook &amp; pdf v2" page="165" hidden="false" profileTypeId="1650-77b3-10d1-6406">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-            </infoLink>
-          </infoLinks>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="15"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value=""/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
           <modifiers/>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
@@ -2562,7 +655,7 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="3a35-6d29-813c-6f2d" hidden="false" targetId="c74e-2993-3474-7869" type="selectionEntry">
+            <entryLink id="3a35-6d29-813c-6f2d" name="Plasma Light Support" hidden="false" targetId="eaa4-a3c1-d269-d3cb" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -2575,12 +668,12 @@
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="408.0"/>
+            <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="d5e6-baf3-9376-d799" name="&lt; Options &gt;" hidden="false" collective="false">
+        <selectionEntryGroup id="d5e6-baf3-9376-d799" name="Drones" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2590,47 +683,40 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="cf51-b375-0b07-78ee" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+            <entryLink id="cf51-b375-0b07-78ee" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcf1-1694-820c-d3a3" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b1d0-a711-0472-a04e" type="min"/>
+              </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="678e-362c-18b7-85e3" hidden="false" targetId="2750-e65f-4c66-8235" type="selectionEntry">
+            <entryLink id="678e-362c-18b7-85e3" name="Batter Drone" hidden="false" targetId="becb-7e47-7963-5cd9" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f23-a946-8a8f-48b6" type="max"/>
+              </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="08b2-7bd2-ff20-2816" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
+            <entryLink id="08b2-7bd2-ff20-2816" name="Shield Drone" hidden="false" targetId="81b9-02e2-63b6-9c6e" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="21ca-17d7-7de6-911f" name="Self Repair" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="points" value="10">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f8d7-cf02-e583-ea55" type="max"/>
+              </constraints>
               <categoryLinks/>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="15a9-072d-9900-441b" name="&lt; Weapon Option &gt;" hidden="false" collective="false" defaultSelectionEntryId="eb9b-1596-b97a-038f">
+        <selectionEntryGroup id="15a9-072d-9900-441b" name="Weapons" hidden="false" collective="false" defaultSelectionEntryId="eb9b-1596-b97a-038f">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2643,7 +729,21 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="963a-027d-1496-af4a" name="Fractal Bombard" hidden="false" targetId="f482-b1f7-5e3a-1960" type="selectionEntry">
+            <entryLink id="963a-027d-1496-af4a" name="Fractal Bombard" hidden="false" targetId="e1aa-ab5e-a6bf-936f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="25">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints/>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="eb9b-1596-b97a-038f" name="X-Howitzer" hidden="false" targetId="ab2e-edc9-b214-f7d5" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -2651,15 +751,7 @@
               <constraints/>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="eb9b-1596-b97a-038f" name="X-Howitzer" hidden="false" targetId="e2b4-a034-c8ce-e376" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="a2c2-0bfc-1da6-45ad" name="Mag Mortar" hidden="false" targetId="eb71-6245-efd5-67c9" type="selectionEntry">
+            <entryLink id="a2c2-0bfc-1da6-45ad" name="Mag Mortar" hidden="false" targetId="61b9-9d2d-aa1a-1b3f" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -2669,145 +761,17 @@
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="c4d4-9418-6246-d85d" name="Concord C3T7 Transporter Drone " hidden="false" collective="false" type="model">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="c4d4-9418-6246-d85d-a01f5f58-334c-8442-d861-15099ebdf5e5" hidden="false" targetId="a01f5f58-334c-8442-d861-15099ebdf5e5" primary="true">
+        <selectionEntryGroup id="86a4-1d2f-a721-3da0" name="Upgrade" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints/>
-        </categoryLink>
-        <categoryLink id="cd14-56f7-dec2-56f4" name="New CategoryLink" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="288e-be87-ca44-03e8" name="&lt; Transporter Drone" hidden="false" collective="false" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="87f0-50e3-da01-55f0" name="C3T7 Transporter Drone" hidden="false" targetId="1aa8-c7f2-fa2d-324a" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="163d-d01b-864d-b63c" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="867b-d0c5-1974-b703" type="max"/>
-          </constraints>
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="460e-6cab-a7b9-878c" name="&lt; Options &gt;" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries>
-            <selectionEntry id="c5bf-84aa-fb1b-96ae" name="Sensor Module" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="874d-3396-841c-66d3" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="30.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="c357-9a61-4b22-1f15" name="Enhanced Machine Intelligence" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f780-d837-284d-c598" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="1479-0bf0-ce09-df37" name="Drone Kinetic Armour" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f382-6d00-1348-bd9d" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="48.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="9543-75e4-e4b2-ca03" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="03eb-ebb9-cdf3-ec98" name="Batter Drone" hidden="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="b6d4-1bbf-8e0d-d2ac" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="8efc-e74f-ba4e-938e" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
+            <entryLink id="9477-919e-d61d-ee20" name="Self-Repair" hidden="false" targetId="1751-3fb6-cc2e-be8f" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -2818,48 +782,83 @@
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="c458-dcfb-bba5-7338" name="Plasma Light Support Gun (E)" hidden="false" targetId="c74e-2993-3474-7869" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d10-d32c-d9ae-09ca" type="max"/>
+              </constraints>
               <categoryLinks/>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="96.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="6880-209f-8a1d-66e0" name="Commander Kamrana Josen" hidden="false" collective="false" type="model">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="182f-8079-ec5a-498b" hidden="false" targetId="218d-189c-09c7-3b45" type="profile">
+      <entryLinks>
+        <entryLink id="9e4c-daa6-3043-4403" name="Plasma Light Support" hidden="false" targetId="eaa4-a3c1-d269-d3cb" type="selectionEntry">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="62ce-3603-df69-cfaf" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c84e-8915-6f1a-b6d3" type="min"/>
+          </constraints>
+          <categoryLinks/>
+        </entryLink>
+        <entryLink id="b570-2b24-ff30-383f" name="Special Munitions" hidden="true" targetId="6dbe-a221-4d79-ff6a" type="selectionEntryGroup">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers>
-            <modifier type="set" field="f214-abe8-c922-c51b" value="5(8)">
+            <modifier type="set" field="hidden" value="false">
               <repeats/>
-              <conditions>
-                <condition field="selections" scope="6880-209f-8a1d-66e0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6030-d671-9f86-c945" type="equalTo"/>
-              </conditions>
-              <conditionGroups/>
+              <conditions/>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="9974-fc89-ef4b-59fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="eb9b-1596-b97a-038f" type="atLeast"/>
+                    <condition field="selections" scope="9974-fc89-ef4b-59fe" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a2c2-0bfc-1da6-45ad" type="atLeast"/>
+                  </conditions>
+                  <conditionGroups/>
+                </conditionGroup>
+              </conditionGroups>
             </modifier>
           </modifiers>
+          <constraints/>
+          <categoryLinks/>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" costTypeId="points" value="398.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="60b9-ccbf-a7af-4213" name="Commander Kamrana Josen" book="Rulebook &amp; pdf v2" page="228-229" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="bb15-13a7-c9a2-5ff1" name="Limited Choice" hidden="false" targetId="8cb3-4c3e-dc5f-b952" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="3d80-d943-134d-31d3" name="Infantry Command Unit" hidden="false" targetId="0a6b-dcfb-ccc3-6a0d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
         </infoLink>
       </infoLinks>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cef4-daeb-6649-b321" type="max"/>
+      </constraints>
       <categoryLinks>
-        <categoryLink id="6880-209f-8a1d-66e0-481abf13-c03e-0dd0-d520-9f9837253cbe" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
+        <categoryLink id="fbd1-5786-c39c-46e6" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="13a0-22e7-b0e8-70a3" name="New CategoryLink" hidden="false" targetId="c87d-5261-face-4643" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -2867,110 +866,106 @@
           <constraints/>
         </categoryLink>
       </categoryLinks>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="f086-dae6-6909-f7de" name="&lt; Unit Options &gt;" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries>
-            <selectionEntry id="008d-8ba9-1c63-93b5" name="Strike Trooper" hidden="false" collective="false" type="model">
+      <selectionEntries>
+        <selectionEntry id="b0eb-81c5-8459-fe46" name="Commander Kamrana Josen" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="4130-7585-f213-3378" name="Commander Kamrana Josen" book="Rulebook &amp; pdf v2" page="228-229" hidden="false" profileTypeId="1650-77b3-10d1-6406">
               <profiles/>
               <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="set" field="f214-abe8-c922-c51b" value="5(8)">
+                  <repeats/>
+                  <conditions>
+                    <condition field="selections" scope="b0eb-81c5-8459-fe46" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2062-1242-8162-5007" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="6"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="9"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value=""/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="551b-0d1a-2fb5-fc09" name="Unstoppable" hidden="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <description>• If unit fails Break test which would remove it then take all troops away and leave Josen unless the test roll is a 10</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink id="c524-cab5-7c84-0c42" name="Command" hidden="false" targetId="f001-a3be-81f7-f74f" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="4a84-fe81-f69e-de9f" name="Follow" hidden="false" targetId="4bdd-65b7-6ee8-89b2" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="b812-e709-1b1c-f402" name="Leader 3" hidden="false" targetId="ce3b-c908-3ded-7a49" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="fd3b-fe6c-a651-00c5" name="Hero" hidden="false" targetId="e70c-a7b7-b782-acad" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="86a3-98b4-3771-e201" name="Wound 3" hidden="false" targetId="6ea4-40e6-718c-0d2f" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+          </infoLinks>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f84e-b505-02fb-4c56" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="db0c-8a6d-80a8-cdc8" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="bbc4-31a7-fedd-9a70" name="Plasma Grenade Bandolier" hidden="false" collective="false" type="upgrade">
+              <profiles>
+                <profile id="657f-e951-9f0b-2fa5" name="Plasma Grenade Bandolier" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3" profileTypeName="Weapon">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <characteristics>
+                    <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
+                    <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
+                    <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
+                    <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
+                    <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, Hazardous H2H"/>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <rules/>
               <infoLinks>
-                <infoLink id="e57d-104e-c987-6e7a" hidden="false" targetId="6688-b331-6578-fb30" type="profile">
+                <infoLink id="8240-701c-a5b6-391a" name="Blast D4" hidden="false" targetId="805e-60a2-1b4a-46e9" type="rule">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
                   <modifiers/>
                 </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="ac02-ab26-6f62-e9fc" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="52f5-a617-55f3-24aa" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" costTypeId="points" value="22.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="4a2c-44b8-d548-19f4" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="1947-c19e-f8e5-1439" hidden="false" targetId="9f16-5a27-44b5-7471" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="increment" field="points" value="2.0">
-                  <repeats>
-                    <repeat field="selections" scope="6880-209f-8a1d-66e0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="008d-8ba9-1c63-93b5" repeats="1" roundUp="false"/>
-                  </repeats>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="increment" field="points" value="2.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="set" field="hidden" value="true">
-                  <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="6880-209f-8a1d-66e0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f7e5-aff8-59a3-fb0d" type="equalTo"/>
-                  </conditions>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="7d36-9ad2-0909-dddf" name="&lt; Commander Options &gt; " hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries>
-            <selectionEntry id="f7e5-aff8-59a3-fb0d" name="Plasma Grenade Bandoliers" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="4d4b-85f0-9e35-d04d" hidden="false" targetId="92a3-aaae-bc24-0d2d" type="profile">
+                <infoLink id="656b-98c8-3292-a1da" name="Hazardous H2H" hidden="false" targetId="0f95-2ca6-3bd9-35b4" type="rule">
                   <profiles/>
                   <rules/>
                   <infoLinks/>
@@ -2978,141 +973,78 @@
                 </infoLink>
               </infoLinks>
               <modifiers>
-                <modifier type="set" field="hidden" value="true">
+                <modifier type="increment" field="points" value="10">
                   <repeats/>
-                  <conditions>
-                    <condition field="selections" scope="6880-209f-8a1d-66e0" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1947-c19e-f8e5-1439" type="atLeast"/>
-                  </conditions>
+                  <conditions/>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1929-c368-fd1e-583b" type="max"/>
               </constraints>
               <categoryLinks/>
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
               <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
+                <cost name="pts" costTypeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="6030-d671-9f86-c945" name="Jurry-Rigged HL Booster" hidden="false" collective="false" type="upgrade">
+            <selectionEntry id="2062-1242-8162-5007" name="Jury Rigged HL Armour Boost" hidden="false" collective="true" type="upgrade">
               <profiles/>
               <rules/>
               <infoLinks/>
-              <modifiers/>
+              <modifiers>
+                <modifier type="increment" field="points" value="10">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b478-13fe-d25d-8a18" type="max"/>
               </constraints>
               <categoryLinks/>
               <selectionEntries/>
               <selectionEntryGroups/>
               <entryLinks/>
               <costs>
-                <cost name="pts" costTypeId="points" value="10.0"/>
+                <cost name="pts" costTypeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="53eb-6d1b-6804-c1e0" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="971d-3652-33ec-641a" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="138.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="fcb7-7abc-470a-26fe" name="Medi-Probe Shard" hidden="false" collective="false" type="unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="fcb7-7abc-470a-26fe-72807c5d-e370-9ddf-c2b7-de5d2797f24d" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="c7bd-920e-b6e5-ef99" name="&lt; Medi-probe" hidden="false" collective="false" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="d758-744a-7ac4-7804" hidden="false" targetId="078e-4753-3545-ba51" type="profile">
+          <entryLinks>
+            <entryLink id="47ff-2919-31b6-b1af" name="HL Armour" hidden="false" targetId="f561-c73c-de8c-ae6f" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c067-f707-8cf5-187f" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b31b-190c-cb4c-4fb8" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="21c6-b312-9a12-7a69" name="Plasma Carbine" hidden="false" targetId="3877-96bf-06bb-ff8f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ccd-d9ee-1093-6a94" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8453-f8a9-6954-8bee" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
           <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
+            <cost name="pts" costTypeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="6429-1b89-b557-736b" name="NuHu Mandarin" hidden="false" collective="false" type="model">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="6fd9-afd5-d70f-d751" hidden="false" targetId="41d1-a002-0258-c407" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="6429-1b89-b557-736b-481abf13-c03e-0dd0-d520-9f9837253cbe" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-      <selectionEntries/>
       <selectionEntryGroups>
-        <selectionEntryGroup id="ae11-f605-d815-9109" name="&lt; Options &gt;" hidden="false" collective="false">
+        <selectionEntryGroup id="327b-53a6-efed-7ba5" name="Drones" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3122,355 +1054,151 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="6fd3-49ff-c60c-3624" hidden="false" targetId="f095-7ba3-b868-32de" type="selectionEntry">
+            <entryLink id="4be6-9dcd-1969-9df8" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="bb6a-48bd-2cf1-f430" hidden="false" targetId="057e-2e8a-1952-9de0" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="775b-177d-e6ac-c3ac" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="2523-96e0-03f8-2625" hidden="false" targetId="5343-3c10-ccc3-0233" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de09-08cc-0904-677a" type="max"/>
+              </constraints>
               <categoryLinks/>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="1133-9cc8-d005-ca82" hidden="false" targetId="a2e9-2b00-2191-a410" type="selectionEntry">
+        <selectionEntryGroup id="7cb3-95ae-daac-d467" name="Weapons" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="f96b-f08d-6633-ca45" name="New EntryLink" hidden="false" targetId="2f22-37fa-4076-d255" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="aa11-6cf9-dbfd-1db9" name="New EntryLink" hidden="false" targetId="c7a8-840b-096e-e2b8" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="130.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="7780-9268-8805-991a" name="Scout Probe Shard" hidden="false" collective="false" type="unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="7780-9268-8805-991a-72807c5d-e370-9ddf-c2b7-de5d2797f24d" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="275e-c158-8f26-53c9" name="&lt; Scout Probe" hidden="false" collective="false" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="05b3-477e-3ab6-c2a4" hidden="false" targetId="56b9-5224-e0df-8218" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
           <categoryLinks/>
           <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="10.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="2fa1-035d-c0c1-e653" name="Target Probe Shard" hidden="false" collective="false" type="unit">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="2fa1-035d-c0c1-e653-72807c5d-e370-9ddf-c2b7-de5d2797f24d" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="70f6-51e9-f4f6-761f" name="&lt; Target Probe" hidden="false" collective="false" type="model">
-          <profiles/>
-          <rules/>
-          <infoLinks>
-            <infoLink id="ec43-8043-3ccc-fe21" hidden="false" targetId="9ce3-1277-65a2-7ab0" type="profile">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-            <infoLink id="5db6-68db-e938-2825" name="New InfoLink" hidden="false" targetId="2cc6-bd15-7a1c-602d" type="rule">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-            </infoLink>
-          </infoLinks>
-          <modifiers/>
-          <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-          </constraints>
-          <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks/>
-          <costs>
-            <cost name="pts" costTypeId="points" value="5.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="0e0b-c0f7-e3da-6539" name="Commander-in-Chief Josen C3 XEF" book="Xilos" page="119" hidden="false" collective="false" type="model">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="4414-465f-7e2d-dfed" name="" hidden="false" targetId="1a3d-0d39-30ed-090f" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints/>
-      <categoryLinks>
-        <categoryLink id="0e0b-c0f7-e3da-6539-481abf13-c03e-0dd0-d520-9f9837253cbe" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-        </categoryLink>
-      </categoryLinks>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="2b75-2734-0892-cea0" name="&lt; Unit Options &gt;" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries>
-            <selectionEntry id="21b5-45ed-a110-4b85" name="Strike Trooper" hidden="false" collective="false" type="model">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="bc89-0b52-96dd-4b3b" hidden="false" targetId="6688-b331-6578-fb30" type="profile">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6c61-1a1d-17f7-99b6" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks>
-                <entryLink id="b5f3-99f1-bf7d-1d1a" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-                <entryLink id="8048-19f4-81e9-3897" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                  <constraints/>
-                  <categoryLinks/>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name="pts" costTypeId="points" value="22.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="2e7f-f47b-97f5-b4c3" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="c23f-c9fe-cf58-8401" hidden="false" targetId="9f16-5a27-44b5-7471" type="selectionEntry">
+            <entryLink id="67ef-a646-d531-9a3f" name="Plasma Grenades" hidden="false" targetId="76fa-75fa-aac0-aae1" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers>
                 <modifier type="increment" field="points" value="2">
                   <repeats>
-                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="21b5-45ed-a110-4b85" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="60b9-ccbf-a7af-4213" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="b0eb-81c5-8459-fe46" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="60b9-ccbf-a7af-4213" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ee8b-b150-f7ad-c82c" repeats="1" roundUp="false"/>
                   </repeats>
                   <conditions/>
                   <conditionGroups/>
                 </modifier>
-                <modifier type="increment" field="points" value="2.0">
+                <modifier type="set" field="a986-3874-d169-e354" value="0.0">
                   <repeats/>
-                  <conditions/>
+                  <conditions>
+                    <condition field="selections" scope="60b9-ccbf-a7af-4213" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bbc4-31a7-fedd-9a70" type="equalTo"/>
+                  </conditions>
                   <conditionGroups/>
                 </modifier>
               </modifiers>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="1f8a-3804-4259-4579" name="New EntryLink" hidden="false" targetId="057e-2e8a-1952-9de0" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="00a6-5122-70d0-6d57" name="New EntryLink" hidden="false" targetId="0ac6-5bdb-3d61-e6ce" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a986-3874-d169-e354" type="max"/>
+              </constraints>
               <categoryLinks/>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
-        <selectionEntryGroup id="340d-7a90-fa25-7333" name="&lt; Commander Options &gt; " hidden="false" collective="false">
+        <selectionEntryGroup id="e532-25e0-8162-a3ae" name="Upgrades" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
           <modifiers/>
           <constraints/>
           <categoryLinks/>
-          <selectionEntries/>
-          <selectionEntryGroups/>
-          <entryLinks>
-            <entryLink id="9390-18d6-f77f-34a0" name="New EntryLink" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
+          <selectionEntries>
+            <selectionEntry id="ee8b-b150-f7ad-c82c" name="Strike Trooper" hidden="false" collective="false" type="model">
               <profiles/>
               <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="minSelections" value="0.0">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-                <modifier type="set" field="points" value="9">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
+              <infoLinks>
+                <infoLink id="f1dd-d81a-adc8-f1d0" name="Strike Trooper" hidden="false" targetId="afc3-bbc8-a54c-a565" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ec49-a78f-5fc9-d6fc" type="min"/>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8d4e-fb7d-1b64-111a" type="max"/>
+              </constraints>
               <categoryLinks/>
-            </entryLink>
-          </entryLinks>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="0ebd-6b58-4082-fc50" name="Plasma Carbine" hidden="false" targetId="3877-96bf-06bb-ff8f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c336-f90b-6533-71fd" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6499-235b-e544-6169" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="d781-0ab4-f4ec-8251" name="HL Armour" hidden="false" targetId="f561-c73c-de8c-ae6f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad03-2ef1-5688-7448" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca7f-83df-60d4-4aa3" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="22.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
         </selectionEntryGroup>
       </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="57d0-94c9-b0c4-5e42" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-        <entryLink id="2288-4532-8205-65da" name="New EntryLink" hidden="false" targetId="2f22-37fa-4076-d255" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-      </entryLinks>
+      <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="134.0"/>
+        <cost name="pts" costTypeId="points" value="66.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="04b2-53b9-29ce-09e1" name="Concord C3T7 Transporter Drone (Support)" hidden="false" collective="false" type="model">
+    <selectionEntry id="2347-0023-75c3-1db2" name="Commander-in-Chief Josen C3 XEF" book="BX" page="119" hidden="false" collective="false" type="unit">
       <profiles/>
       <rules/>
-      <infoLinks/>
+      <infoLinks>
+        <infoLink id="f081-c56f-feda-6fea" name="Limited Choice" hidden="false" targetId="8cb3-4c3e-dc5f-b952" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="b967-0b98-218d-75d0" name="Infantry Command Unit" hidden="false" targetId="0a6b-dcfb-ccc3-6a0d" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
       <modifiers/>
-      <constraints/>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8f5a-3d20-7ad7-512e" type="max"/>
+      </constraints>
       <categoryLinks>
-        <categoryLink id="0a8c-2584-2bc9-6a3d" name="New CategoryLink" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
+        <categoryLink id="ae74-8aff-0a98-e203" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+        <categoryLink id="3a46-5a27-da81-ddbf" name="New CategoryLink" hidden="false" targetId="c87d-5261-face-4643" primary="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3479,11 +1207,66 @@
         </categoryLink>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="f9ac-d2ab-9694-708a" name="&lt; Transporter Drone" hidden="false" collective="false" type="model">
-          <profiles/>
-          <rules/>
+        <selectionEntry id="988f-43ff-2dd1-ab89" name="Commander-in-Chief Josen C3 XEF" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="a272-8225-9c64-697c" name="Commander-in-Chief Josen C3 XEF" book="BX" page="119" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="6"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="9"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value=""/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules>
+            <rule id="78bb-a93e-e75b-19dc" name="Steady There Soldier" hidden="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <description>• Any unit that fails a Command test can reroll if Josen is in 10&quot;</description>
+            </rule>
+            <rule id="7f36-f5f0-813d-5df4" name="Very Well Prepared" hidden="false">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <description>• If using Josen and using Well Prepared then gains an additional Well Prepared for free</description>
+            </rule>
+          </rules>
           <infoLinks>
-            <infoLink id="9578-167d-7ced-c54e" hidden="false" targetId="1aa8-c7f2-fa2d-324a" type="profile">
+            <infoLink id="4c7a-d4bc-4298-18b9" name="Command" hidden="false" targetId="f001-a3be-81f7-f74f" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="043d-eb60-c838-d9f8" name="Follow" hidden="false" targetId="4bdd-65b7-6ee8-89b2" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="5685-9b26-e31a-f88b" name="Leader 3" hidden="false" targetId="ce3b-c908-3ded-7a49" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="e505-90be-8690-b0c4" name="Hero" hidden="false" targetId="e70c-a7b7-b782-acad" type="rule">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+            </infoLink>
+            <infoLink id="a91f-5370-dd18-8c95" name="Wound 3" hidden="false" targetId="6ea4-40e6-718c-0d2f" type="rule">
               <profiles/>
               <rules/>
               <infoLinks/>
@@ -3492,18 +1275,46 @@
           </infoLinks>
           <modifiers/>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d3a3-e724-f59a-ef8e" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="67ed-4c78-926d-f03d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ca17-f807-d159-d857" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d7d1-8544-150a-24e4" type="max"/>
           </constraints>
           <categoryLinks/>
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="9e62-1a0b-c17b-937a" hidden="false" targetId="c74e-2993-3474-7869" type="selectionEntry">
+            <entryLink id="aeac-6389-14d3-3a64" name="HL Armour" hidden="false" targetId="f561-c73c-de8c-ae6f" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5229-2778-4af0-5ea1" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dad2-956e-ec06-43bc" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="a533-b68d-2b64-cfe6" name="Plasma Pistol" hidden="false" targetId="9851-4076-e2e9-3df8" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5574-25ed-84dc-77e6" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2d3-502e-4f60-e819" type="min"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+            <entryLink id="5e47-4554-06ca-94fb" name="Plasma Carbine" hidden="false" targetId="3877-96bf-06bb-ff8f" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="9">
+                  <repeats/>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
               <constraints/>
               <categoryLinks/>
             </entryLink>
@@ -3514,7 +1325,7 @@
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="73e4-b9b5-fe5a-131c" name="&lt; Options &gt;" hidden="false" collective="false">
+        <selectionEntryGroup id="bd49-92b0-06ec-27da" name="Drones" hidden="false" collective="false">
           <profiles/>
           <rules/>
           <infoLinks/>
@@ -3524,50 +1335,213 @@
           <selectionEntries/>
           <selectionEntryGroups/>
           <entryLinks>
-            <entryLink id="7752-e2b3-f35b-3e35" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
+            <entryLink id="c527-2508-3bef-c91a" name="Spotter Drone" hidden="false" targetId="1da9-896b-0041-4098" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5efc-6a3c-a0fd-8126" type="max"/>
+              </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="9360-8fa3-a719-7ce8" hidden="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry">
+            <entryLink id="58d0-73c7-b1c2-dc89" name="Medi-Drone" hidden="false" targetId="c3f0-2a1d-815e-b61a" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4565-4385-2fe1-7a9e" type="max"/>
+              </constraints>
               <categoryLinks/>
             </entryLink>
-            <entryLink id="4176-2135-4247-39eb" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
+            <entryLink id="64d9-6578-0344-58a8" name="Synchronizer Drone" hidden="false" targetId="3b29-0c16-4aa3-aca3" type="selectionEntry">
               <profiles/>
               <rules/>
               <infoLinks/>
               <modifiers/>
-              <constraints/>
-              <categoryLinks/>
-            </entryLink>
-            <entryLink id="f7b2-3d64-f960-f48c" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers>
-                <modifier type="set" field="points" value="10">
-                  <repeats/>
-                  <conditions/>
-                  <conditionGroups/>
-                </modifier>
-              </modifiers>
-              <constraints/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8aba-8ff9-db70-791b" type="max"/>
+              </constraints>
               <categoryLinks/>
             </entryLink>
           </entryLinks>
         </selectionEntryGroup>
+        <selectionEntryGroup id="387a-99de-889c-f471" name="Weapons" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks>
+            <entryLink id="f419-c3e3-f55a-b07e" name="Plasma Grenades" hidden="false" targetId="76fa-75fa-aac0-aae1" type="selectionEntry">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers>
+                <modifier type="increment" field="points" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="2347-0023-75c3-1db2" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7192-3337-e664-4de3" repeats="1" roundUp="false"/>
+                    <repeat field="selections" scope="2347-0023-75c3-1db2" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="988f-43ff-2dd1-ab89" repeats="1" roundUp="false"/>
+                  </repeats>
+                  <conditions/>
+                  <conditionGroups/>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="546e-3261-ae72-0e59" type="max"/>
+              </constraints>
+              <categoryLinks/>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="2b7c-f886-ecda-5f27" name="Upgrades" hidden="false" collective="false">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+          <categoryLinks/>
+          <selectionEntries>
+            <selectionEntry id="7192-3337-e664-4de3" name="Strike Trooper" hidden="false" collective="false" type="model">
+              <profiles/>
+              <rules/>
+              <infoLinks>
+                <infoLink id="0520-0fa6-8547-f974" name="Strike Trooper" hidden="false" targetId="afc3-bbc8-a54c-a565" type="profile">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                </infoLink>
+              </infoLinks>
+              <modifiers/>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5963-5b12-fd1e-13bf" type="min"/>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c144-6dc4-6fd4-07b0" type="max"/>
+              </constraints>
+              <categoryLinks/>
+              <selectionEntries/>
+              <selectionEntryGroups/>
+              <entryLinks>
+                <entryLink id="8e00-5e30-c056-93d9" name="Plasma Carbine" hidden="false" targetId="3877-96bf-06bb-ff8f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6123-520c-5cd7-e62a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aacf-cf19-cdad-08e7" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+                <entryLink id="7dca-9aab-a1fb-5445" name="HL Armour" hidden="false" targetId="f561-c73c-de8c-ae6f" type="selectionEntry">
+                  <profiles/>
+                  <rules/>
+                  <infoLinks/>
+                  <modifiers/>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de92-3af9-d939-abc5" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87cc-187b-8090-a5be" type="min"/>
+                  </constraints>
+                  <categoryLinks/>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name="pts" costTypeId="points" value="22.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups/>
+          <entryLinks/>
+        </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks/>
       <costs>
-        <cost name="pts" costTypeId="points" value="194.0"/>
+        <cost name="pts" costTypeId="points" value="134.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5730-7dbe-6ae3-004b" name="Iso-Drone" book="CS &amp; pdf force list v2" page="68" hidden="false" collective="false" type="unit">
+      <profiles/>
+      <rules/>
+      <infoLinks>
+        <infoLink id="175e-979a-0cfe-78a5" name="Probe Unit" hidden="false" targetId="b8e9-1952-608c-accf" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="a62b-846d-1d35-2854" name="Iso-Shield" hidden="false" targetId="d584-98e1-53cc-4397" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="cf70-b586-caeb-596c" name="Slow" hidden="false" targetId="04bc-743b-092f-8c3a" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+        <infoLink id="fab9-f59c-2790-9261" name="Scramble Proof" hidden="false" targetId="377d-0cdc-6ba7-f1d2" type="rule">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+        </infoLink>
+      </infoLinks>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks>
+        <categoryLink id="ca22-4cf0-dff6-7c2f" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="true">
+          <profiles/>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints/>
+        </categoryLink>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="51a3-8835-ab57-72d7" name="Iso-Drone" hidden="false" collective="false" type="model">
+          <profiles>
+            <profile id="544c-8313-26d8-ed6e" name="Iso-Drone **" hidden="false" profileTypeId="1650-77b3-10d1-6406" profileTypeName="Model">
+              <profiles/>
+              <rules/>
+              <infoLinks/>
+              <modifiers/>
+              <characteristics>
+                <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="7"/>
+                <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="0"/>
+                <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
+                <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="10"/>
+                <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
+                <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
+                <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <rules/>
+          <infoLinks/>
+          <modifiers/>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0a5-3c47-44d3-0aba" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6435-4634-d0bb-4ba7" type="max"/>
+          </constraints>
+          <categoryLinks/>
+          <selectionEntries/>
+          <selectionEntryGroups/>
+          <entryLinks/>
+          <costs>
+            <cost name="pts" costTypeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups/>
+      <entryLinks/>
+      <costs>
+        <cost name="pts" costTypeId="points" value="25.0"/>
       </costs>
     </selectionEntry>
   </selectionEntries>
@@ -3588,2537 +1562,156 @@
         </categoryLink>
       </categoryLinks>
     </entryLink>
+    <entryLink id="f4ac-5c27-a9c0-77ac" name="Targeter Probe Shard" hidden="false" targetId="1fea-1f1e-73d8-9a98" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="9efd-5a80-4400-8e6d" name="Scout Probe Shard" hidden="false" targetId="0c5c-da8a-4405-a1ce" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="497f-465d-40c6-2954" name="Medi-Probe Shard" hidden="false" targetId="e36b-5fdf-7eed-4bd1" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="fa05-1c71-3168-b051" name="Concord C3D1 Light Support Drone **" hidden="false" targetId="0ef5-0ee9-1d9c-5f7a" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="bb98-e283-943d-605f" name="Concord C3M407 (CS) Combat Drone" hidden="false" targetId="e7ca-3a4b-4345-a0c6" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="74aa-b528-7f6f-84fa" name="Concord C3M4 Combat Drone" hidden="false" targetId="a496-fdcd-a5f6-d085" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="9e93-e2c1-4714-9a24" name="Concord C3D2 Medium Support Drone" hidden="false" targetId="af98-17af-2e7b-547a" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="04c0-47e7-f549-8dfa" name="Concord C3D1/GP Light General Purpose Drone" hidden="false" targetId="90f1-9b81-29a0-1006" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="8bea-5288-d87d-f6ac" name="Concord Drone Commander" hidden="false" targetId="f98c-ad14-c9df-b46d" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="b41d-c449-ad0c-e4c2" name="Concord T7 Transporter Drone (Strategic)" hidden="false" targetId="809c-5e7f-8e29-4d0d" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="c1eb-e0aa-4dab-2b3c" name="Concord T7 Transporter Drone (Support)" hidden="false" targetId="23ef-7122-b64d-e36a" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="1f14-0f67-fc7b-cb2f" name="NuHu Mandarin" hidden="false" targetId="8486-8476-56fa-18d7" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="f2c4-8448-1894-ff94" name="C3 Interceptor Command Squad" hidden="false" targetId="6455-e295-81f5-bbf7" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="4068-f329-6eb3-f7a7" name="C3 Interceptor Squad" hidden="false" targetId="f300-e939-bad0-0f60" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="8b31-13db-8591-699a" name="C3 Strike Command Squad" hidden="false" targetId="3b8b-10f2-fca8-036f" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="69c4-5efe-76f7-6f25" name="C3 Drop Command Squad" hidden="false" targetId="3501-d057-3845-b85d" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="a3a4-7022-82bd-2992" name="C3 Drop Squad" hidden="false" targetId="1e94-c221-3417-75c9" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="46e3-63ed-805a-45d5" name="C3 Strike Squad" hidden="false" targetId="57c6-ba82-53f7-68af" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
   </entryLinks>
-  <sharedSelectionEntries>
-    <selectionEntry id="e745-6ace-c0d4-6e35" name="AG Chute (E)" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="15b5-c59d-1faa-c57d" name="New InfoLink" hidden="false" targetId="7680-b7ff-1ca0-9855" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7591-2678-9f80-b4c7" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ef5-60ac-21e6-e376" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="3ac2-e4a6-9011-4985" name="Batter Drone" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="dd1c-70b2-fdb4-f17b" name="New InfoLink" hidden="false" targetId="178b-d746-0f1a-74ec" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="20.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="2750-e65f-4c66-8235" name="Batter Drone" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="8f0e-541d-462e-1ed9" name="New InfoLink" hidden="false" targetId="178b-d746-0f1a-74ec" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="20.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="c87f-f5b0-1134-8ad9" name="Compactor Drone" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="b42a-dcfc-05c4-6e11" name="New InfoLink" hidden="false" targetId="5ea5-7feb-caa1-9c83" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="5.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="d776-f344-44a4-c41b" name="Compactor Drone with Compacted Plasma Cannon" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="b2e8-9d64-9d68-23e5" hidden="false" targetId="ffe9-0b4e-fc35-d442" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="b5ce-ddf2-5e77-ce9e" name="New InfoLink" hidden="false" targetId="5ea5-7feb-caa1-9c83" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="25.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="c521-ffae-2a9d-88f9" name="Compression Bombard" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="a79e-c4ad-b89d-ac26" hidden="false" targetId="a854-0768-aa9e-8d94" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="25.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="80bf-613e-52b4-f160" name="Compression Cannon" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="d1d1-e3bd-e025-87c6" name="New InfoLink" hidden="false" targetId="fb4a-7317-0e7a-7278" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="f482-b1f7-5e3a-1960" name="Fractal Bombard" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="9156-5e49-d0a8-7993" hidden="false" targetId="cfed-0e3a-38c7-9618" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="25.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="90ca-6c03-a803-a140" name="Fractal Cannon" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="bc22-c5b0-170a-0ca8" hidden="false" targetId="e262-8ce4-a7d5-4d81" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="10.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="69d9-b84f-3c40-15fb" name="Fractal Cannon" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="4a79-2c10-c161-2234" hidden="false" targetId="e262-8ce4-a7d5-4d81" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="5.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="5343-3c10-ccc3-0233" name="Gun Drone" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="14.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="bf65-f7cb-1b50-d144" name="HL Armour (E)" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="12f1-610b-0dc9-4732" name="HL Armour Boost" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="c7a8-840b-096e-e2b8" name="IMTeL Stave (E)" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="807f-6cc8-5d42-4a43" name="New InfoLink" hidden="false" targetId="2ad2-5bc9-0916-9717" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="2768-723d-fabb-e340" name="New InfoLink" hidden="false" targetId="b3f8-2d95-65ab-e2ef" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="78ae-1c8e-9414-44b3" name="New InfoLink" hidden="false" targetId="9640-7a75-5c24-9cee" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="289c-6f08-035a-dee9" name="New InfoLink" hidden="false" targetId="7722-371b-7b8f-57ae" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="658c-b2dd-98f4-dafb" name="Interceptor Bike" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks>
-        <entryLink id="170c-6b3b-629f-6d53" name="New EntryLink" hidden="false" targetId="644d-6e23-abad-f086" type="selectionEntry">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="41bd-5499-889a-ab16" name="Leader" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="10.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="cd4f-0ce9-a6a4-b34a" name="Leader 2" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="10.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="a90a-fea5-107f-a019" name="Leader 3" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="10.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="9e56-0965-ea32-7ff4" name="Leader 3" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="20.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="eb71-6245-efd5-67c9" name="Mag Mortar" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="9df9-40f7-3d08-b560" hidden="false" targetId="5ba2-ac85-01a5-31be" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="0e6a-0256-18e1-20af" name="&lt; Munition &gt;" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries>
-            <selectionEntry id="a356-4661-a11e-41b8" name="Scrambler" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a24b-a381-fb00-eb9f" name="Arc" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="3925-0866-3aea-e356" name="Blur" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="0afe-04ff-398b-3496" name="Scoot" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="5271-6bc1-1ad7-e9ba" name="Net " hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="1cd3-e444-8b62-dc9b" name="All" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="15.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="4d2c-7d84-fe17-0c8f" name="Grip" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks/>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="057e-2e8a-1952-9de0" name="Medi-Drone" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="4934-520f-af2d-a522" name="New InfoLink" hidden="false" targetId="2ff2-534c-34fe-b56b" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="20.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="a2e9-2b00-2191-a410" name="Nano Drone (E)" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="c195-c40e-9022-d655" name="New InfoLink" hidden="false" targetId="4abc-52df-bbed-7b28" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="1bc9-ce44-fdbe-ef90" name="Plasma Bombard (E)" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="c3b5-10fe-6527-f82f" hidden="false" targetId="581f-ff61-2525-a4b4" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="10e6-b49c-4401-a1cd" name="Plasma Cannon" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="d5c2-2c99-c6f0-8b8e" hidden="false" targetId="ffe9-0b4e-fc35-d442" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="35.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="5a7d-3845-90ba-32eb" name="Plasma Cannon" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="96a4-2cce-4307-8f7b" hidden="false" targetId="ffe9-0b4e-fc35-d442" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="5.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="3dfc-49e9-adcb-ae48" name="Plasma Cannon" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="95ff-37b4-8a0c-72d9" hidden="false" targetId="ffe9-0b4e-fc35-d442" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="eafe-a83e-6cfd-0559" name="Plasma Carbine" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="a184-65ab-58d9-e876" hidden="false" targetId="4c0f-9a37-2cd9-3f28" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="fb83-6166-8d22-f6e2" hidden="false" targetId="acdc-a95e-a973-0c70" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="9f16-5a27-44b5-7471" name="Plasma Grenades" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="ae6b-5d5f-8311-739e" hidden="false" targetId="9c65-fbf8-41f5-47be" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="3dd4-3b5c-6873-e8f2" name="Plasma Lance" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="7122-7702-547f-efa1" hidden="false" targetId="3376-2497-6739-ec52" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="cc9d-d4f8-59db-be3c" hidden="false" targetId="db92-0aca-cde3-4d2d" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="6d1e-8151-bd04-c247" hidden="false" targetId="19f6-390a-0d7c-8acb" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="3.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="7dac-aa85-fc80-51d5" name="Plasma Lance (Bike)" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="95fd-068f-3527-ff41" hidden="false" targetId="3376-2497-6739-ec52" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="3303-cedc-7f35-8d8c" hidden="false" targetId="db92-0aca-cde3-4d2d" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="8d2b-05f1-d035-fca6" hidden="false" targetId="19f6-390a-0d7c-8acb" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="2.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="21a7-132d-6703-9ff6" name="Plasma Lance (E)" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="eae9-4fdc-d5ae-f150" hidden="false" targetId="3376-2497-6739-ec52" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="44f0-8649-d04a-801b" hidden="false" targetId="db92-0aca-cde3-4d2d" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="e52e-5001-8214-66e6" hidden="false" targetId="19f6-390a-0d7c-8acb" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="62c2-106a-28aa-6cf5" name="Plasma Light Support Gun" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="7d58-9532-baa3-0f50" hidden="false" targetId="2940-5bc4-f1ca-b78c" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="40.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="c74e-2993-3474-7869" name="Plasma Light Support Gun (E)" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="f652-56d4-3777-5ff0" hidden="false" targetId="2940-5bc4-f1ca-b78c" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="42fd-fa25-fdf2-ea52" type="min"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="40.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="2f22-37fa-4076-d255" name="Plasma Pistol (E)" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="f9da-9df8-37a5-92ff" hidden="false" targetId="23fa-052e-36db-13a3" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="8c55-0529-22ab-3fa6" name="Self Repair" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="de46-fbd5-d8f5-7454" name="Shield Drone " hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="ba8c-a727-26cc-2998" name="New InfoLink" hidden="false" targetId="ceb8-c520-5d71-02cc" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="10.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="5ed8-6bd4-d0f7-d7f0" name="Shield Drone" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="30f8-e04c-44b9-9ad8" name="New InfoLink" hidden="false" targetId="ceb8-c520-5d71-02cc" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="10.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="001a-9f15-b25b-b784" name="Spotter Drone " hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="6c15-21cf-1676-f352" name="New InfoLink" hidden="false" targetId="19d8-5c9a-2e1f-4d8e" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="10.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="f095-7ba3-b868-32de" name="Spotter Drone" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="5272-0f8a-13ca-85f5" name="New InfoLink" hidden="false" targetId="19d8-5c9a-2e1f-4d8e" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="10.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="e16f-acd1-265c-07f9" name="Spotter Drone (E)" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="76e8-05d6-ff37-7205" name="Subverter Matrix" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="866a-0edf-4673-dd85" name="New InfoLink" hidden="false" targetId="fb88-5cec-3af7-dff6" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="20.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="e2b4-a034-c8ce-e376" name="X-Howitzer (E)" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="a4a1-491f-e195-4e0d" hidden="false" targetId="d0b6-5e2a-243d-b6ea" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="4b18-33b8-84e0-5c2e" name="&lt; Munitions &gt;" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries>
-            <selectionEntry id="c518-dc83-0b3b-d5d0" name="Scrambler" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="4f17-4153-49e1-f6dc" hidden="false" targetId="0a09-eb21-a6c6-ad31" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="16ea-fdb9-4f62-644a" name="Arc" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="a50f-9b72-3685-ce99" hidden="false" targetId="4052-0eb4-88d7-cab0" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="d695-e1d4-70ad-ab44" name="Blur" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="e23c-a9f0-0a42-b621" hidden="false" targetId="1373-7755-bef3-50d6" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="8a3f-6c9d-84ab-7ff7" name="Scoot" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="5e49-ad1b-3c02-c442" hidden="false" targetId="f2cb-33fd-610a-eda3" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="f919-51c2-e1f0-fa33" name="Net" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="5eb1-95d1-6117-e8d2" hidden="false" targetId="b81d-9f77-4c39-3887" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="6967-929f-0dac-4c2e" name="Grip" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="a1ce-1d22-c641-6d9d" hidden="false" targetId="053b-a389-59c4-0e00" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="f58f-7571-0bda-13b5" name="All" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="c003-c2b5-f035-4444" hidden="false" targetId="4052-0eb4-88d7-cab0" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="2b2f-ad1c-6533-e2d7" hidden="false" targetId="1373-7755-bef3-50d6" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="7cae-5b3f-2e71-6e33" hidden="false" targetId="053b-a389-59c4-0e00" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="be82-4f21-bf38-ae68" hidden="false" targetId="b81d-9f77-4c39-3887" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="ebcd-e2be-4841-8020" hidden="false" targetId="f2cb-33fd-610a-eda3" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="5bab-a371-53ed-88d2" hidden="false" targetId="0a09-eb21-a6c6-ad31" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="15.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="afc8-4f62-e1e2-1e4c" name="X-Launcher (E)" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="d588-2e56-e502-10ec" hidden="false" targetId="b984-90ae-a8e5-83c8" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="c249-3049-66be-c18b" name="&lt; Munitions &gt;" hidden="false" collective="false">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-          <constraints/>
-          <categoryLinks/>
-          <selectionEntries>
-            <selectionEntry id="855b-3877-638b-99e8" name="Scrambler" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="594f-82ff-5ad7-c68d" hidden="false" targetId="0a09-eb21-a6c6-ad31" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="cf1c-5cab-dced-a300" name="Arc" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="8bce-b783-3ffc-92aa" hidden="false" targetId="4052-0eb4-88d7-cab0" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="bed3-8a4c-71e0-9a86" name="Blur" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="9be8-c879-a109-2f53" hidden="false" targetId="1373-7755-bef3-50d6" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="7207-1027-8e26-6930" name="Scoot" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="9bd6-49f8-24e5-7631" hidden="false" targetId="f2cb-33fd-610a-eda3" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="9b37-d7f7-9bb7-6061" name="Net" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="d053-1be2-c8f4-3f6c" hidden="false" targetId="b81d-9f77-4c39-3887" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="f569-f291-bc3a-fa3a" name="Grip" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="3be2-c872-ad5c-35f7" hidden="false" targetId="053b-a389-59c4-0e00" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="a6d2-1391-22e8-008b" name="All" hidden="false" collective="false" type="upgrade">
-              <profiles/>
-              <rules/>
-              <infoLinks>
-                <infoLink id="1741-ddc1-2f5f-3ff2" hidden="false" targetId="4052-0eb4-88d7-cab0" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="b229-c301-4b0d-2ccd" hidden="false" targetId="1373-7755-bef3-50d6" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="c3df-d0d2-6144-d3f9" hidden="false" targetId="053b-a389-59c4-0e00" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="ed17-cff8-54c6-cf4d" hidden="false" targetId="b81d-9f77-4c39-3887" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="ff70-9ddf-025e-0a2d" hidden="false" targetId="f2cb-33fd-610a-eda3" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-                <infoLink id="3125-0cd8-92ea-7904" hidden="false" targetId="0a09-eb21-a6c6-ad31" type="rule">
-                  <profiles/>
-                  <rules/>
-                  <infoLinks/>
-                  <modifiers/>
-                </infoLink>
-              </infoLinks>
-              <modifiers/>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-              </constraints>
-              <categoryLinks/>
-              <selectionEntries/>
-              <selectionEntryGroups/>
-              <entryLinks/>
-              <costs>
-                <cost name="pts" costTypeId="points" value="15.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups/>
-          <entryLinks/>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="6c13-252f-55b8-4de9" name="X-Sling (E)" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="2d1d-7464-b34a-31f5" hidden="false" targetId="7c13-1aa1-5557-6103" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="0ac6-5bdb-3d61-e6ce" name="Synchronizer Drone" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="35f7-4baf-8a1e-bba0" name="New InfoLink" hidden="false" targetId="1f5f-adad-fde7-b98e" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e479-7b6c-1873-d2c0" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="20.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="644d-6e23-abad-f086" name="Twin Plasma Carbines" hidden="false" collective="true" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="c947-a55c-1fc1-5a98" name="New InfoLink" hidden="false" targetId="a7b4-da59-18cb-d87c" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-        <infoLink id="7a4c-3189-16b1-d1b9" name="New InfoLink" hidden="false" targetId="828f-1195-680b-631f" type="profile">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="93b2-2832-f4d3-5edb" type="min"/>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b580-a4ea-0a19-b7c7" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="4cc6-d659-dbc1-3403" name="Slingnet Ammo" hidden="false" collective="false" type="upgrade">
-      <profiles/>
-      <rules/>
-      <infoLinks>
-        <infoLink id="964a-03bc-7f60-8952" name="New InfoLink" hidden="false" targetId="1b89-5e18-0f71-7dc5" type="rule">
-          <profiles/>
-          <rules/>
-          <infoLinks/>
-          <modifiers/>
-        </infoLink>
-      </infoLinks>
-      <modifiers/>
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5c4e-8158-bc4b-e0c0" type="max"/>
-      </constraints>
-      <categoryLinks/>
-      <selectionEntries/>
-      <selectionEntryGroups/>
-      <entryLinks/>
-      <costs>
-        <cost name="pts" costTypeId="points" value="5.0"/>
-      </costs>
-    </selectionEntry>
-  </sharedSelectionEntries>
+  <sharedSelectionEntries/>
   <sharedSelectionEntryGroups/>
-  <sharedRules>
-    <rule id="7680-b7ff-1ca0-9855" name="AG Chute" book="BtGoA" page="120" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>2M move and shoot when given advance order. +1 Ag. Treat difficult ground as suspensored vehicle. </description>
-    </rule>
-    <rule id="4052-0eb4-88d7-cab0" name="Special Munitions - Arc" book="BtGoA" page="88" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Creates 3&quot; sink area. Affects any shooter attemping to draw LOS and shoot through the arc. Roll a D10 if LOS goes through - 1-5 the shot is normal, 6-10 the shot automatically misses. Make test before rolling Acc to hit. OH shots are affected if the target is within 3&quot; of the marker. At end of turn on a 1-5 on a D10 remove the marker.</description>
-    </rule>
-    <rule id="178b-d746-0f1a-74ec" name="Drone - Batter" book="BtGoA" page="110" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Projects curved shield as template - must be positioned with outer side facing away from drone, no part of template more than 5&quot; from drone base. Template may be repositioned any time unit receives an order die. Enemy units shooting through shield suffer -2 ACC. Models positioned inside the shield do not receive the -2 ACC protection. Troops shooting from the inside convex side of the shield do not suffer the ACC penalty. No protection is offered for OH shots. Not cumulative.</description>
-    </rule>
-    <rule id="1cb7-4402-2f6c-b3cf" name="Blast D10" book="BtGoA" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Inflicts D10 hits on a successful shooting attack.</description>
-    </rule>
-    <rule id="82bc-e8ec-5e5a-56d2" name="Blast D3" book="BtGoA" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Inflicts D3 hits on a successful shooting attack.</description>
-    </rule>
-    <rule id="27db-c218-b60e-869b" name="Blast D4" book="BtGoA" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Inflicts D4 hits on a successful shooting attack.</description>
-    </rule>
-    <rule id="3934-2688-e509-dbc5" name="Blast D5" book="BtGoA" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Inflicts D5 hits on a successful shooting attack.</description>
-    </rule>
-    <rule id="1373-7755-bef3-50d6" name="Special Munitions - Blur" book="BtGoA" page="89" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Any unit within 3&quot; reduces Acc by D3 each time it shoots. If within two or more blur markers, roll a D3 for each and take highest. At end of turn on a 1-5 on a D10 remove the marker.</description>
-    </rule>
-    <rule id="5c9b-1bde-ee01-04a4" name="Command" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-    </rule>
-    <rule id="b0ca-8e7d-d03f-f027" name="Fast" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-    </rule>
-    <rule id="7bc9-5e98-2914-5abd" name="Follow" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-    </rule>
-    <rule id="053b-a389-59c4-0e00" name="Special Munitions - Grip" book="BtGoA" page="87" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Unit beginning its move within 3&quot; must take and pass an Ag test. If failed it may not move, if passed it can move half rate, failed on a 10 it takes a pin and cannot move. If a unit moves within 3&quot; it must take the Ag test as above. At end of turn on a 1-5 on a D10 remove the marker.</description>
-    </rule>
-    <rule id="3c64-6022-a5f1-9c04" name="Hero" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-    </rule>
-    <rule id="9d5f-b605-0d92-695d" name="HL Armor" book="BtGoA" page="93" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Ranges of 10&quot; or less, +1 to Res. Ranges of greater than 10&quot; +2 Res. Against any Blast hits, +3 Res. </description>
-    </rule>
-    <rule id="f62d-5e99-81f7-07dd" name="Inaccurate" book="BtGoA" page="70" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Additional -1 Acc penalty.</description>
-    </rule>
-    <rule id="a221-d53c-b4bd-b52c" name="Large" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-    </rule>
-    <rule id="e441-c3a6-7d61-2c63" name="Leader" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-    </rule>
-    <rule id="7850-89e7-bab8-86e9" name="Leader 2" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-    </rule>
-    <rule id="05bb-4d34-70cd-25d2" name="Leader 3" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-    </rule>
-    <rule id="d8dc-cf25-ef95-c94b" name="Limited Choice" book="" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-    </rule>
-    <rule id="2ff2-534c-34fe-b56b" name="Drone - Medi" book="BtGoA" page="113" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Can only attend humans - not machines or Skarks. Any friendly unit within 5&quot; may re-roll one failed Res test each time it is shot at, fights H2H, or otherwise suffers damage. Units within 5&quot; of more than one medi-drone may re-roll one failed Res test for each medi-drone. </description>
-    </rule>
-    <rule id="5565-ce10-1c78-1ee7" name="MOD2" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-    </rule>
-    <rule id="8151-2e24-94ee-0477" name="MOD3" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-    </rule>
-    <rule id="b81d-9f77-4c39-3887" name="Special Munitions - Net" book="BtGoA" page="88" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Roll to hit as normal for a blast weapon. Target does not suffer blast damage, rather suffers pins:
-
-X-Launcher: D3+1 pin
-X-Howitzer: D5+1 pin
-Mag Mortar: D10+1 pin
-
-Targets that would normally force an Acc re-roll suffer half the number of pins rounded down. Divide pins equally between two or more units as normal.</description>
-    </rule>
-    <rule id="4abc-52df-bbed-7b28" name="Drone - Nano" book="BtGoA" page="113" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Shots against the unit suffer –2 Acc. Does not combine with batter shield. Gives the NuHu unit the protection as with hyperlight armour and hyperlight booster. IMTel stave can be boosted.</description>
-    </rule>
-    <rule id="fbb8-f81a-2985-1273" name="Plasma Fade" book="BtGoA" page="76" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>On the Acc roll of a 10 to hit the shot is a miss and the unit goes down.</description>
-    </rule>
-    <rule id="f2cb-33fd-610a-eda3" name="Special Munitions - Scoot" book="BtGoA" page="88" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Only affects infantry, mounted, weapon team, beast, and humongous beast, command, and bike mounted units with living crew. Affects scramble proof units. Any affected unit within 3&quot; canno tbe given any order except run or down. Cannot make any reaction apart from go down. At end of turn on a 1-5 on a D10 remove the marker.</description>
-    </rule>
-    <rule id="0a09-eb21-a6c6-ad31" name="Special Munitions - Scrambler" book="BtGoA" page="88" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Enemy units within 3&quot; that are not scramble proof it loses Reflex Armor, Hyperlight Armor, and Phase Armor along with any bonuses. Units in Phase Armor cannot use their armor to go down. Weapon Drone and vehicles have Res reduced by 2 within 3&quot;. Buddy drones cease to function if the unit is within 3&quot;. Probes can do nothing at all while marker is within 3&quot;. Penalties are not cumulative. At end of turn on a 1-5 on a D10 remove the marker.</description>
-    </rule>
-    <rule id="3377-9408-33bb-6a02" name="Self Repair" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-    </rule>
-    <rule id="1c4c-aaaf-0a08-e69e" name="Self Repair" book="BtGoA" page="137" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Give unit rally order. If no pins exist after order, may attempt one repair on  immobilisation or weapon. 1-5 = success, 6-10 failure. Success = that function is working again.</description>
-    </rule>
-    <rule id="1b89-5e18-0f71-7dc5" name="Slingnet Ammo" book="BtGoA" page="112" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Fired direct unless from Micro X Launcher. Targets hit suffer no damage but take +1 additional pin. Cannot affect units that cannot be pinned when hit.</description>
-    </rule>
-    <rule id="7c88-64d4-50ad-2313" name="Slow" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-    </rule>
-    <rule id="19d8-5c9a-2e1f-4d8e" name="Drone - Spotter" book="BtGoA" page="114" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Unit may re-roll one miss each time it shoots as long as drone has LOS to target. Units may fire OH using drone as spotter as long as it has LOS to target. Spotter drones may spot through another spotter drone (within 20&quot;) with LOS to the target. Unit does not receive spotter re-roll as their spotter does not have LOS to target.</description>
-    </rule>
-    <rule id="ab37-33d8-41f3-7532" name="Transport 10" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-    </rule>
-    <rule id="3f71-546f-6b34-b449" name="Weapon Drone" book="BtGoA" page="115" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Always measure to model, not base. Not allowed to assault. Never take a break test, however auto-break if suffer pins equal to their Co stat. If drone fails a Res test, roll on Weapon Drone Damage Chart.
-
-D10 Result:
-1: Take one additional pin and go down.
-2: Take D3 additional pins and go down.
-3: Take D3 additional pins and go down. Immobilized.
-4: Take D3 additional pins and go down. Weapon malfunction.
-5: Take D6 additional pins and take a break test - destroyed if failed, go down if passed.
-6-10: Destroyed</description>
-    </rule>
-    <rule id="9640-7a75-5c24-9cee" name="Exhausted" book="BtGoA" page="67" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>When fighting using the nano drone boost, any Str or Acc roll of a 10 to hit means that not only can the shot/blow not be re‐rolled, but the stave has become temporarily exhausted. Make a test at the turn end phase. Roll a D10, on a 1‐5 the stave is still exhausted and on a 6‐10 it is replenished and can be used as normal.</description>
-    </rule>
-    <rule id="7722-371b-7b8f-57ae" name="3 Attacks" book="BtGoA" page="67" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>A NuHu equipped with an IMTel Stave has 3 attacks in hand‐to‐hand fighting.</description>
-    </rule>
-    <rule id="ceb8-c520-5d71-02cc" name="Drone - Shield" book="BtGoA" page="114" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Can intercept one hit. Once hits have been allocated, each shield drone can nullify one hit. Nullified hits have no effect and are treated as if they were never scored. Decide which hits are to be removed and roll a D10 for each. 1: The hit is nullified but the drone survives. 2‐9: The hit is removed and the drone is destroyed. 10: The hit is not removed but the drone survives. Can choose to intercept lucky hits allocated to any model in the unit, including to other drones or equipment. A lucky hit can be allocated to a shield drone and is removed without a dice roll.</description>
-    </rule>
-    <rule id="fb88-5cec-3af7-dff6" name="Subverter Matrix" book="BtGoA" page="122" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Targets every enemy: vehicle unit, mounted units riding machines, weapon drone units, probes and buddy drones within 15”. For buddy drones, targets if their parent unit is within 15”. Does not need LOS. Automatically targets units when the unit carrying it makes any action or reaction. Make the unit’s action first. Cannot target Scramble Proof. Each target makes a Co check. Targeted player decides the order to test. Units that are targets more than once only test once. If the test is passed, no effect. If a 1 the subverter matrix does not affect any further units that action. If the test is failed the opposing player must take one of his dice from the bag. If a 10 take two dice. If there are not enough dice in the bag then dice that are already in play are removed instead, and the player whose units are affected  decides which to take. If a probe is targeted then the probe is destroyed. At each Turn End Phase make a test for every contested dice. For each dice, both players roll a D10 – the highest score wins. If the owning player wins the dice goes back into the bag. If the other player wins the dice stays out for this turn. On ties, roll again. </description>
-    </rule>
-    <rule id="1f5f-adad-fde7-b98e" name="Drone - Synchronizer" book="BfX" page="79" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>If given an order, after finishing action, use with unit within 10”. Make a Co test, if successful, draw one dice, give second unit order. Can synchronise with a different unit each turn. Cannot synchronise to a third unit in one turn. Can&apos;t use at same time as Follow. Follow extends to 10”. Synchronised dice treated as if it had been drawn at random from the bag.</description>
-    </rule>
-    <rule id="2cc6-bd15-7a1c-602d" name="Probe - Targeter" book="BtGoA" page="120" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Mark single unit by moving into touch. Any number of targeters can mark a unit. Shooting at marked target +1 Acc for each mark to a maximum of +3.  OH reduces the distance scattered by 1” for every probe instead of Acc bonus. Can be shot at by that unit or other units in LOS to either a probe or to a model it is marking, hits allocated against all the targeters. </description>
-    </rule>
-    <rule id="5ea5-7feb-caa1-9c83" name="Drone - Compactor" book="BtGoA" page="112" hidden="false">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <description>Carry one: mounted unit’s bikes, support weapon, weapon drone unit and non-compactor drones, probe shard. Models carried are off table, order dice are not included. After unloading, dice are put in bag at the start of next turn. Indicate which compactor is carrying each unit. Can load/unload or mount/dismount at the end of any action/reaction. Anything carried invulnerable while loaded. If destroyed, unload and must decide which equipment to use, the other is lost. If mounts are unloaded riders must remount conventionally, i.e. must give up a fire order.</description>
-    </rule>
-  </sharedRules>
+  <sharedRules/>
   <sharedProfiles>
-    <profile id="18f2-0352-9cf8-66a5" name="C3D1 Light Support Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406" profileTypeName="Model">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="7"/>
-        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
-        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
-        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="8"/>
-        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
-        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value=""/>
-      </characteristics>
-    </profile>
-    <profile id="f9ce-3eb5-0335-1b53" name="C3D1/GP Light General Purpose Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="7"/>
-        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="0"/>
-        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
-        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="8"/>
-        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
-        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
-      </characteristics>
-    </profile>
-    <profile id="be8e-2c8f-8288-e92a" name="C3D2 Medium Support Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="7"/>
-        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
-        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
-        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="10"/>
-        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
-        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
-      </characteristics>
-    </profile>
-    <profile id="1c7c-b76a-8d9f-4405" name="C3M25 Heavy Combat Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
-        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
-        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="15"/>
-        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
-        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="MOD3, Slow, Large"/>
-      </characteristics>
-    </profile>
-    <profile id="eda1-434f-1771-a790" name="C3M4 Combat Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
-        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
-        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="13"/>
-        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
-        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="MOD2, Large"/>
-      </characteristics>
-    </profile>
-    <profile id="684e-ba3e-5aab-8be8" name="C3M50 Heavy Support Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
-        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
-        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="15"/>
-        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
-        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="MOD3, Slow, Large"/>
-      </characteristics>
-    </profile>
-    <profile id="1aa8-c7f2-fa2d-324a" name="C3T7 Transporter Drone" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
-        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
-        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="13"/>
-        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
-        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="MOD2, Transport 10, Large"/>
-      </characteristics>
-    </profile>
-    <profile id="218d-189c-09c7-3b45" name="Commander Kamrana Josen" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
-        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="6"/>
-        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
-        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="9"/>
-        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
-        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Follow, Hero, Wound 3, Leader3"/>
-      </characteristics>
-    </profile>
-    <profile id="a854-0768-aa9e-8d94" name="Compression Bombard" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-50"/>
-        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
-        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="150"/>
-        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="9/7/5"/>
-        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Cycle"/>
-      </characteristics>
-    </profile>
-    <profile id="fb4a-7317-0e7a-7278" name="Compression Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
-        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
-        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
-        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="7/4/2"/>
-        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Compressor, No Cover, Cycle"/>
-      </characteristics>
-    </profile>
-    <profile id="0f84-f206-4f28-921f" name="Drop Commander" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers>
-        <modifier type="set" field="3baa-9cfd-f273-822d" value="Command, Follow, Leader 3">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a90a-fea5-107f-a019" type="equalTo"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <characteristics>
-        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5(6)"/>
-        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
-        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
-        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
-        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
-        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
-        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Follow, Leader 2"/>
-      </characteristics>
-    </profile>
-    <profile id="e18d-8dd1-d573-930f" name="Drop Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers>
-        <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 3">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9e56-0965-ea32-7ff4" type="equalTo"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-        <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cd4f-0ce9-a6a4-b34a" type="equalTo"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <characteristics>
-        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5(6)"/>
-        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
-        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
-        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
-        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
-        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader"/>
-      </characteristics>
-    </profile>
-    <profile id="1219-e29a-7fa7-a09e" name="Drop Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5(6)"/>
-        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
-        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
-        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
-        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
-        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
-      </characteristics>
-    </profile>
-    <profile id="cfed-0e3a-38c7-9618" name="Fractal Bombard" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="50"/>
-        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
-        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="200"/>
-        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3 +2 max 10"/>
-        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock"/>
-      </characteristics>
-    </profile>
-    <profile id="e262-8ce4-a7d5-4d81" name="Fractal Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
-        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
-        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
-        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2 +1 max 10"/>
-        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Fractal Lock"/>
-      </characteristics>
-    </profile>
-    <profile id="34f9-12c5-7e7b-114c" name="Interceptor Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
-        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
-        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5 (8)"/>
-        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
-        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Fast, Large"/>
-      </characteristics>
-    </profile>
-    <profile id="9286-cbf7-0641-5ce1" name="Interceptor Commander" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers>
-        <modifier type="set" field="3baa-9cfd-f273-822d" value="Command, Follow, Fast, Large, Leader 3">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bd12-7ad6-eb09-08ba" type="equalTo"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <characteristics>
-        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
-        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
-        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(8)"/>
-        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
-        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
-        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Follow, Fast, Large, Leader 2"/>
-      </characteristics>
-    </profile>
-    <profile id="9ed6-e3f2-8847-d7a2" name="Interceptor Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers>
-        <modifier type="set" field="3baa-9cfd-f273-822d" value="Fast, Large, Leader 2">
-          <repeats/>
-          <conditions/>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <characteristics>
-        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
-        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
-        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(8)"/>
-        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
-        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Fast, Large, Leader"/>
-      </characteristics>
-    </profile>
-    <profile id="5ba2-ac85-01a5-31be" name="Mag Mortar" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
-        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
-        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
-        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
-        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OHx2, Blast D10, No Cover"/>
-      </characteristics>
-    </profile>
-    <profile id="078e-4753-3545-ba51" name="Medi-Probe" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
-        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
-        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
-        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
-        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
-        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
-        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Shard"/>
-      </characteristics>
-    </profile>
-    <profile id="74c6-e541-9bf3-7b75" name="New Profile" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd"/>
-        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d"/>
-        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145"/>
-        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b"/>
-        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e"/>
-        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20"/>
-        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d"/>
-      </characteristics>
-    </profile>
-    <profile id="41d1-a002-0258-c407" name="NuHu Mandarin" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
-        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="4"/>
-        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="4(7)"/>
-        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="9"/>
-        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
-        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Hero, Follow, Leader 3"/>
-      </characteristics>
-    </profile>
-    <profile id="581f-ff61-2525-a4b4" name="Plasma Bombard" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="50"/>
-        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
-        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="200"/>
-        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="7"/>
-        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Plasma Fade"/>
-      </characteristics>
-    </profile>
-    <profile id="ffe9-0b4e-fc35-d442" name="Plasma Cannon" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
-        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
-        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
-        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6"/>
-        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Plasma Fade"/>
-      </characteristics>
-    </profile>
-    <profile id="4c0f-9a37-2cd9-3f28" name="Plasma Carbine - Scatter" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
-        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
-        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
-        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2"/>
-      </characteristics>
-    </profile>
-    <profile id="acdc-a95e-a973-0c70" name="Plasma Carbine - Single Shot" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
-        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
-        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
-        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
-      </characteristics>
-    </profile>
-    <profile id="9c65-fbf8-41f5-47be" name="Plasma Grenade" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
-        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="None"/>
-        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
-        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
-        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
-      </characteristics>
-    </profile>
-    <profile id="92a3-aaae-bc24-0d2d" name="Plasma Grenade Bandolier" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="5"/>
-        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="-"/>
-        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
-        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
-        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D4, Hazardous H2H"/>
-      </characteristics>
-    </profile>
-    <profile id="3376-2497-6739-ec52" name="Plasma Lance - Lance" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
-        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
-        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="4"/>
-        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Choose Target, Inaccurate"/>
-      </characteristics>
-    </profile>
-    <profile id="19f6-390a-0d7c-8acb" name="Plasma Lance - Scatter" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
-        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
-        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
-        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2"/>
-      </characteristics>
-    </profile>
-    <profile id="db92-0aca-cde3-4d2d" name="Plasma Lance - Single Shot" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
-        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
-        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
-        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
-      </characteristics>
-    </profile>
-    <profile id="2940-5bc4-f1ca-b78c" name="Plasma Light Support Gun" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
-        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
-        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
-        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
-        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF3"/>
-      </characteristics>
-    </profile>
-    <profile id="23fa-052e-36db-13a3" name="Plasma Pistol" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
-        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
-        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="30"/>
-        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
-        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
-      </characteristics>
-    </profile>
-    <profile id="56b9-5224-e0df-8218" name="Scout Probe" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
-        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
-        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
-        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
-        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
-        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
-        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Shard"/>
-      </characteristics>
-    </profile>
-    <profile id="9686-36fa-7ae7-f4dc" name="Strike Commander" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers>
-        <modifier type="set" field="3baa-9cfd-f273-822d" value="Command, Follow, Leader 3">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a90a-fea5-107f-a019" type="equalTo"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <characteristics>
-        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
-        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
-        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
-        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
-        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
-        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Follow, Leader 2"/>
-      </characteristics>
-    </profile>
-    <profile id="af6e-dcdb-77a5-b67e" name="Strike Leader" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers>
-        <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2">
-          <repeats/>
-          <conditions>
-            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cd4f-0ce9-a6a4-b34a" type="equalTo"/>
-          </conditions>
-          <conditionGroups/>
-        </modifier>
-      </modifiers>
-      <characteristics>
-        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
-        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
-        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
-        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
-        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader"/>
-      </characteristics>
-    </profile>
-    <profile id="4d7e-f31f-84d4-d57a" name="Strike Leader Kai Lek Atasrin" hidden="false" profileTypeId="f9a2-eeae-3284-75fd">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Ag" characteristicTypeId="18c1-4764-7d08-708d" value="5 "/>
-        <characteristic name="Acc" characteristicTypeId="e39c-d7a4-86a8-d23d" value="5"/>
-        <characteristic name="Str" characteristicTypeId="0790-bfd5-1273-fe12" value="5"/>
-        <characteristic name="Res" characteristicTypeId="5b77-3595-2819-675c" value="6(8)"/>
-        <characteristic name="Init" characteristicTypeId="c0d8-f6fd-a474-1385" value="7"/>
-        <characteristic name="Co" characteristicTypeId="135d-efc3-5039-b6e6" value="9"/>
-        <characteristic name="Special" characteristicTypeId="ab43-4d1c-4651-b424" value="One for All, Wound, Leader 3"/>
-      </characteristics>
-    </profile>
-    <profile id="6688-b331-6578-fb30" name="Strike Trooper" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
-        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
-        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
-        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
-        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
-      </characteristics>
-    </profile>
-    <profile id="ce28-e8fe-4290-f477" name="Strike Trooper Crew" hidden="false" profileTypeId="1650-77b3-10d1-6406">
+    <profile id="db4b-0b86-8f9a-7a79" name="Strike Trooper Crew" hidden="false" profileTypeId="1650-77b3-10d1-6406">
       <profiles/>
       <rules/>
       <infoLinks/>
@@ -6131,170 +1724,6 @@ D10 Result:
         <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
         <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
         <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="-"/>
-      </characteristics>
-    </profile>
-    <profile id="7aba-2a70-034d-4b60" name="Strike Trooper crew Leader" hidden="true" profileTypeId="1650-77b3-10d1-6406">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
-        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="5"/>
-        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
-        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="7"/>
-        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="8"/>
-        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Leader"/>
-      </characteristics>
-    </profile>
-    <profile id="9ce3-1277-65a2-7ab0" name="Targeter Probe" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="-"/>
-        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="-"/>
-        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="-"/>
-        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5"/>
-        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="-"/>
-        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="-"/>
-        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Shard"/>
-      </characteristics>
-    </profile>
-    <profile id="d0b6-5e2a-243d-b6ea" name="X-Howitzer" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-50"/>
-        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="100"/>
-        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="250"/>
-        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
-        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D10, No Cover"/>
-      </characteristics>
-    </profile>
-    <profile id="b984-90ae-a8e5-83c8" name="X-Launcher" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10-30"/>
-        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="60"/>
-        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="120"/>
-        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="1"/>
-        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="OH, Blast D5, No Cover"/>
-      </characteristics>
-    </profile>
-    <profile id="7c13-1aa1-5557-6103" name="X-Sling" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
-        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="20"/>
-        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
-        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
-        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Blast D3"/>
-      </characteristics>
-    </profile>
-    <profile id="a7b4-da59-18cb-d87c" name="Twin Plasma Carbine - Scatter" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
-        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="None"/>
-        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="0"/>
-        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="RF2"/>
-      </characteristics>
-    </profile>
-    <profile id="828f-1195-680b-631f" name="Twin Plasma Carbine - Single Shot" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="30"/>
-        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="50"/>
-        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="2"/>
-        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="-"/>
-      </characteristics>
-    </profile>
-    <profile id="1a3d-0d39-30ed-090f" name="Commander-in-Chief Josen C3 XEF" book="Xilos" page="119" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="6"/>
-        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="6"/>
-        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="5(7)"/>
-        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="9"/>
-        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="9"/>
-        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="Command, Follow, Hero, Wound 3, Leader3, Steady There, Soldier! Very Well Prepared"/>
-      </characteristics>
-    </profile>
-    <profile id="2ad2-5bc9-0916-9717" name="IMTel Stave - Standard" book="BtGoA" page="67" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="10"/>
-        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="-"/>
-        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
-        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="3"/>
-        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="3 Attacks"/>
-      </characteristics>
-    </profile>
-    <profile id="b3f8-2d95-65ab-e2ef" name="IMTel Stave - Nano Drone Boost" book="BtGoA" page="67" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3" profileTypeName="Weapon">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="20"/>
-        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="-"/>
-        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="-"/>
-        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="6"/>
-        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="3 Attacks, Blast D3, Exhausted"/>
-      </characteristics>
-    </profile>
-    <profile id="d517-794b-2206-8522" name="C3T7 Transporter Drone (Support)" hidden="false" profileTypeId="1650-77b3-10d1-6406">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Ag" characteristicTypeId="cf30-f234-691c-47bd" value="5"/>
-        <characteristic name="Acc" characteristicTypeId="017a-9b43-b7b3-030d" value="5"/>
-        <characteristic name="Str" characteristicTypeId="8294-36f1-6431-2145" value="1"/>
-        <characteristic name="Res" characteristicTypeId="f214-abe8-c922-c51b" value="11"/>
-        <characteristic name="Init" characteristicTypeId="08b9-e038-7ba6-488e" value="8"/>
-        <characteristic name="Co" characteristicTypeId="3993-27b0-c3d9-de20" value="7"/>
-        <characteristic name="Special" characteristicTypeId="3baa-9cfd-f273-822d" value="MOD2, Transport 10, Large"/>
-      </characteristics>
-    </profile>
-    <profile id="8ac1-a450-3877-9bb4" name="Sensor Module" hidden="false" profileTypeId="ecae-8ac8-2c13-0dd3">
-      <profiles/>
-      <rules/>
-      <infoLinks/>
-      <modifiers/>
-      <characteristics>
-        <characteristic name="Effective" characteristicTypeId="c2de-17f1-10e2-2c0a" value="30"/>
-        <characteristic name="Long" characteristicTypeId="995e-b5e6-4c63-0baa" value="40"/>
-        <characteristic name="Extreme" characteristicTypeId="bf58-0ad5-c7ee-3fd9" value="80"/>
-        <characteristic name="Strike Value" characteristicTypeId="897c-d3c4-3983-896a" value="-"/>
-        <characteristic name="Special Rules" characteristicTypeId="7e87-2586-653f-d6ec" value="Targeter"/>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Concord_Drone_Force.cat
+++ b/Concord_Drone_Force.cat
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="2329-91de-6421-9c2d" name="Concord Drone Force" revision="1" battleScribeVersion="2.01" gameSystemId="c339-677a-60db-4060" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <profiles/>
+  <rules/>
+  <infoLinks/>
+  <costTypes/>
+  <profileTypes/>
+  <categoryEntries/>
+  <forceEntries/>
+  <selectionEntries/>
+  <entryLinks>
+    <entryLink id="9e24-ea61-cf2e-e029" name="Medi-Probe Shard" hidden="false" targetId="e36b-5fdf-7eed-4bd1" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="ed40-dc2d-00d0-2f84" name="Scout Probe Shard" hidden="false" targetId="0c5c-da8a-4405-a1ce" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="72aa-6b46-bd24-8155" name="Targeter Probe Shard" hidden="false" targetId="1fea-1f1e-73d8-9a98" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="83bd-e24b-8155-f2ed" name="Concord C3D1 Light Support Drone" hidden="false" targetId="0ef5-0ee9-1d9c-5f7a" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="00f7-990e-b24b-aba4" name="Concord C3M407 (CS) Combat Drone" hidden="false" targetId="e7ca-3a4b-4345-a0c6" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="7eef-5a5a-35f1-d92d" name="Concord C3M4 Combat Drone" hidden="false" targetId="a496-fdcd-a5f6-d085" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="8ffb-ade5-22e7-15ec" name="Concord C3D2 Medium Support Drone" hidden="false" targetId="af98-17af-2e7b-547a" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="9a3f-f350-726f-f3b0" name="Concord C3D1/GP Light General Purpose Drone" hidden="false" targetId="90f1-9b81-29a0-1006" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="204d-137f-335c-2770" name="Concord Drone Commander" hidden="false" targetId="f98c-ad14-c9df-b46d" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="c517-8867-1dd2-9ba9" name="Concord T7 Transporter Drone (Strategic)" hidden="false" targetId="809c-5e7f-8e29-4d0d" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="d494-2fd8-a342-8e10" name="Concord T7 Transporter Drone (Support)" hidden="false" targetId="23ef-7122-b64d-e36a" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="2aac-5908-d8d3-a455" name="C3 Interceptor Command Squad" hidden="false" targetId="6455-e295-81f5-bbf7" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="4ebc-8efd-5103-1a8c" value="-1">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8486-8476-56fa-18d7" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ebc-8efd-5103-1a8c" type="max"/>
+      </constraints>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="82c3-874a-b31e-ec8e" name="C3 Interceptor Squad" hidden="false" targetId="f300-e939-bad0-0f60" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="f1e0-c5ec-8ee0-51a9" value="-1">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8486-8476-56fa-18d7" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1e0-c5ec-8ee0-51a9" type="max"/>
+      </constraints>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="bc89-7019-a0f6-7a6c" name="C3 Drop Command Squad" hidden="false" targetId="3501-d057-3845-b85d" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="7eee-3ed1-83e7-beed" value="-1">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8486-8476-56fa-18d7" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7eee-3ed1-83e7-beed" type="max"/>
+      </constraints>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="88d2-5229-f13b-9d7b" name="C3 Drop Squad" hidden="false" targetId="1e94-c221-3417-75c9" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="8d52-63d0-174c-b338" value="-1">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8486-8476-56fa-18d7" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d52-63d0-174c-b338" type="max"/>
+      </constraints>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="8fd0-03b7-8698-ead6" name="NuHu Mandarin" hidden="false" targetId="8486-8476-56fa-18d7" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="9768-4f5a-a419-e3c7" name="C3 Strike Command Squad" hidden="false" targetId="3b8b-10f2-fca8-036f" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="fb7d-9311-f4b2-5f24" value="-1">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8486-8476-56fa-18d7" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb7d-9311-f4b2-5f24" type="max"/>
+      </constraints>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="de7c-b5eb-46c6-5f95" name="C3 Strike Squad" hidden="false" targetId="57c6-ba82-53f7-68af" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="c6d2-ce09-ff6b-7e28" value="-1">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8486-8476-56fa-18d7" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6d2-ce09-ff6b-7e28" type="max"/>
+      </constraints>
+      <categoryLinks/>
+    </entryLink>
+  </entryLinks>
+  <sharedSelectionEntries/>
+  <sharedSelectionEntryGroups/>
+  <sharedRules/>
+  <sharedProfiles/>
+</catalogue>

--- a/Concord_Rapid_Reaction_Force.cat
+++ b/Concord_Rapid_Reaction_Force.cat
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="3e77-8e4d-eb06-d0c2" name="Concord Rapid Reaction Force" revision="1" battleScribeVersion="2.01" gameSystemId="c339-677a-60db-4060" gameSystemRevision="19" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <profiles/>
+  <rules/>
+  <infoLinks/>
+  <costTypes/>
+  <profileTypes/>
+  <categoryEntries/>
+  <forceEntries/>
+  <selectionEntries/>
+  <entryLinks>
+    <entryLink id="9e24-ea61-cf2e-e029" name="Medi-Probe Shard" hidden="false" targetId="e36b-5fdf-7eed-4bd1" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="ed40-dc2d-00d0-2f84" name="Scout Probe Shard" hidden="false" targetId="0c5c-da8a-4405-a1ce" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="72aa-6b46-bd24-8155" name="Targeter Probe Shard" hidden="false" targetId="1fea-1f1e-73d8-9a98" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="83bd-e24b-8155-f2ed" name="Concord C3D1 Light Support Drone" hidden="false" targetId="0ef5-0ee9-1d9c-5f7a" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="00f7-990e-b24b-aba4" name="Concord C3M407 (CS) Combat Drone" hidden="false" targetId="e7ca-3a4b-4345-a0c6" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="7eef-5a5a-35f1-d92d" name="Concord C3M4 Combat Drone" hidden="false" targetId="a496-fdcd-a5f6-d085" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="8ffb-ade5-22e7-15ec" name="Concord C3D2 Medium Support Drone" hidden="false" targetId="af98-17af-2e7b-547a" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="9a3f-f350-726f-f3b0" name="Concord C3D1/GP Light General Purpose Drone" hidden="false" targetId="90f1-9b81-29a0-1006" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="204d-137f-335c-2770" name="Concord Drone Commander" hidden="false" targetId="f98c-ad14-c9df-b46d" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="c517-8867-1dd2-9ba9" name="Concord T7 Transporter Drone (Strategic)" hidden="false" targetId="809c-5e7f-8e29-4d0d" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="d494-2fd8-a342-8e10" name="Concord T7 Transporter Drone (Support)" hidden="false" targetId="23ef-7122-b64d-e36a" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="2aac-5908-d8d3-a455" name="C3 Interceptor Command Squad" hidden="false" targetId="6455-e295-81f5-bbf7" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="4ebc-8efd-5103-1a8c" value="-1">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8486-8476-56fa-18d7" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ebc-8efd-5103-1a8c" type="max"/>
+      </constraints>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="82c3-874a-b31e-ec8e" name="C3 Interceptor Squad" hidden="false" targetId="f300-e939-bad0-0f60" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers>
+        <modifier type="set" field="f1e0-c5ec-8ee0-51a9" value="-1">
+          <repeats/>
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8486-8476-56fa-18d7" type="equalTo"/>
+          </conditions>
+          <conditionGroups/>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1e0-c5ec-8ee0-51a9" type="max"/>
+      </constraints>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="bc89-7019-a0f6-7a6c" name="C3 Drop Command Squad" hidden="false" targetId="3501-d057-3845-b85d" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+    <entryLink id="88d2-5229-f13b-9d7b" name="C3 Drop Squad" hidden="false" targetId="1e94-c221-3417-75c9" type="selectionEntry">
+      <profiles/>
+      <rules/>
+      <infoLinks/>
+      <modifiers/>
+      <constraints/>
+      <categoryLinks/>
+    </entryLink>
+  </entryLinks>
+  <sharedSelectionEntries/>
+  <sharedSelectionEntryGroups/>
+  <sharedRules/>
+  <sharedProfiles/>
+</catalogue>


### PR DESCRIPTION
Fixes:
1. Algoryn: Minimum Tactical requirement at 1000 points is 4 units, not 5.
2. Algoryn: Army Options not showing
3. Algoryn: Swapping micro-x launcher for mag gun triggered an error
4. Algoryn: Improved handling of units that start with at least one type of drone equipped
5. Algoryn: Liberators not showing initial weapon selections being chosen

Boromite:
1. Updated to v2 pdf costs and tweaks
2. Various fixes (unlisted)
3. Fixed Engineer unit and options
4. Fixed 25% weapon teams in Survey list
5. Fixed Clan limits over 1000 points to set every category to zero
6. Minor file rebuild

Concord:
1. Updated to v2 pdf costs and tweaks
2. File rebuild
3. Added in Drone Commander, nano net, C3M407 (CS)
4. Fixed self-repair showing in random places
5. Fix to Strategic unit limits
6. Built Strike force and Rapid Reaction force lists

General:
1. Improved how unit options are displayed for Algoryn, Boromites and C3 (will be rolled to other races as updated)