### PR TITLE
Isorian touch ups

### DIFF
--- a/Algoryn.cat
+++ b/Algoryn.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="4868-1e60-4bba-a4b2" name="Algoryn" revision="11" battleScribeVersion="2.02" authorName="Dom Hine" authorContact="boltactionAB@gmail.com" authorUrl="https://www.facebook.com/groups/547335118761237/?hc_location=ufi" library="false" gameSystemId="c339-677a-60db-4060" gameSystemRevision="0" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="4868-1e60-4bba-a4b2" name="Algoryn" revision="12" battleScribeVersion="2.02" authorName="Dom Hine" authorContact="boltactionAB@gmail.com" authorUrl="https://www.facebook.com/groups/547335118761237/?hc_location=ufi" library="false" gameSystemId="c339-677a-60db-4060" gameSystemRevision="0" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="4868-1e60-pubN65566" name="Rulebook &amp; pdf force list v2"/>
     <publication id="4868-1e60-pubN68627" name="Rulebook"/>

--- a/Isorian.cat
+++ b/Isorian.cat
@@ -1,11177 +1,2467 @@
-<?xml version="1.0" encoding="UTF-8"?><catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" battleScribeVersion="2.02" id="eaf6-3f46-6191-754c" name="Isorian" revision="11" authorName="Lee Long" authorContact="beasturr@live.co.uk" gameSystemId="c339-677a-60db-4060" gameSystemRevision="0">
-    <publications>
-        <publication id="eaf6-3f46-pubN65565" name="Xilos"/>
-        <publication id="eaf6-3f46-pubN79807" name="For Drones"/>
-        <publication id="eaf6-3f46-pubN79859" name="BtGoA"/>
-    </publications>
-      
-    <profiles/>
-      
-    <rules/>
-      
-    <infoLinks/>
-      
-    <costTypes/>
-      
-    <profileTypes/>
-      
-    <categoryEntries/>
-      
-    <forceEntries/>
-      
-    <selectionEntries>
-            
-        <selectionEntry id="a3e3-761c-74f3-d2f2" name="Drone Commander Xan Tu" publicationId="eaf6-3f46-pubN65565" page="117" hidden="false" collective="false" type="unit">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints/>
-                  
-            <categoryLinks>
-                        
-                <categoryLink id="a3e3-761c-74f3-d2f2-481abf13-c03e-0dd0-d520-9f9837253cbe" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                            
-                </categoryLink>
-                      
-            </categoryLinks>
-                  
-            <selectionEntries>
-                        
-                <selectionEntry id="f02d-da46-f322-5933" name="Weapon Drone" hidden="false" collective="false" type="model">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks>
-                                    
-                        <infoLink id="1637-0842-665f-7baf" hidden="false" targetId="18f2-0352-9cf8-66a5" type="profile">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                        
-                        </infoLink>
-                                  
-                    </infoLinks>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks/>
-                              
-                    <costs>
-                                    
-                        <cost typeId="points" name="pts" value="59.0"/>
-                                  
-                    </costs>
-                            
-                </selectionEntry>
-                        
-                <selectionEntry id="f53a-1444-1c40-5103" name="Drone Commander" hidden="false" collective="false" type="model">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks>
-                                    
-                        <infoLink id="4445-ab9e-a23d-34b5" hidden="false" targetId="bed7-2549-f395-f271" type="profile">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                        
-                        </infoLink>
-                                  
-                    </infoLinks>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks/>
-                              
-                    <costs>
-                                    
-                        <cost typeId="points" name="pts" value="61.0"/>
-                                  
-                    </costs>
-                            
-                </selectionEntry>
-                      
-            </selectionEntries>
-                  
-            <selectionEntryGroups>
-                        
-                <selectionEntryGroup id="ac26-bdf5-0bcf-d3a4" name="&lt; Options &gt;" hidden="false" collective="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="47d2-db02-12fe-cbad" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="3804-b86f-9c05-9420" hidden="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="fdb0-a151-6fac-8967" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="db77-785d-6eda-c4ba" hidden="false" targetId="651f-9469-74a5-505a" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                            
-                </selectionEntryGroup>
-                        
-                <selectionEntryGroup id="5ce9-5bd3-c6d5-879e" name="&lt; Weapon Drone Options &gt;" hidden="false" collective="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="3983-cb40-246a-1004" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers>
-                                                
-                                <modifier type="increment" field="points" value="10">
-                                                      
-                                    <repeats>
-                                                            
-                                        <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                                                          
-                                    </repeats>
-                                                      
-                                    <conditions/>
-                                                      
-                                    <conditionGroups/>
-                                                    
-                                </modifier>
-                                              
-                            </modifiers>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ba7-5fd6-ddd2-2ce2" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="31a4-5549-4299-cd23" hidden="false" targetId="9801-e697-4e03-1582" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers>
-                                                
-                                <modifier type="increment" field="points" value="10">
-                                                      
-                                    <repeats>
-                                                            
-                                        <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                                                          
-                                    </repeats>
-                                                      
-                                    <conditions/>
-                                                      
-                                    <conditionGroups/>
-                                                    
-                                </modifier>
-                                              
-                            </modifiers>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f88-f3c2-6b6d-987c" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="2647-c41d-56e3-2be2" hidden="false" targetId="62c2-106a-28aa-6cf5" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                            
-                </selectionEntryGroup>
-                      
-            </selectionEntryGroups>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue id="eaf6-3f46-6191-754c" name="Isorian" revision="12" battleScribeVersion="2.02" authorName="Lee Long" authorContact="beasturr@live.co.uk" library="false" gameSystemId="c339-677a-60db-4060" gameSystemRevision="0" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <publications>
+    <publication id="eaf6-3f46-pubN65565" name="Xilos"/>
+    <publication id="eaf6-3f46-pubN79807" name="For Drones"/>
+    <publication id="eaf6-3f46-pubN79859" name="BtGoA"/>
+  </publications>
+  <selectionEntries>
+    <selectionEntry id="a3e3-761c-74f3-d2f2" name="Drone Commander Xan Tu" publicationId="eaf6-3f46-pubN65565" page="117" hidden="false" collective="false" type="unit">
+      <categoryLinks>
+        <categoryLink id="a3e3-761c-74f3-d2f2-481abf13-c03e-0dd0-d520-9f9837253cbe" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="f02d-da46-f322-5933" name="Weapon Drone" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="1637-0842-665f-7baf" hidden="false" targetId="18f2-0352-9cf8-66a5" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="59.0"/>
+          </costs>
         </selectionEntry>
-            
-        <selectionEntry id="3601-a65d-7f14-cf86" name="Isorian Andhak SC2 Medium Support Drone" hidden="false" collective="false" type="unit">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints/>
-                  
-            <categoryLinks>
-                        
-                <categoryLink id="3601-a65d-7f14-cf86-5c47879b-41d0-1383-5fe5-a5989615db89" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                            
-                </categoryLink>
-                      
-            </categoryLinks>
-                  
-            <selectionEntries>
-                        
-                <selectionEntry id="156e-1f5a-b7e7-1783" name="&lt; Weapon Drone" hidden="false" collective="false" type="model">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks>
-                                    
-                        <infoLink id="bca1-3c81-da93-aefb" hidden="false" targetId="be8e-2c8f-8288-e92a" type="profile">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                        
-                        </infoLink>
-                                  
-                    </infoLinks>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks/>
-                              
-                    <costs>
-                                    
-                        <cost typeId="points" name="pts" value="83.0"/>
-                                  
-                    </costs>
-                            
-                </selectionEntry>
-                      
-            </selectionEntries>
-                  
-            <selectionEntryGroups>
-                        
-                <selectionEntryGroup id="86e7-9193-c4cf-b4c7" name="&lt; Options &gt;" hidden="false" collective="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="0f08-649f-cdb0-8d16" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="a405-a61d-2eb0-1e80" hidden="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="f787-39f9-566b-e5ff" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="e4de-9a06-22cb-6fd2" name="New EntryLink" hidden="false" targetId="651f-9469-74a5-505a" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                            
-                </selectionEntryGroup>
-                        
-                <selectionEntryGroup id="f298-b1a6-4486-7b3a" name="&lt; Weapon Drone Options &gt;" hidden="false" collective="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups>
-                                    
-                        <selectionEntryGroup id="34a7-a9ba-8af3-becb" name="&lt; Weapon Option &gt;" hidden="false" collective="false" defaultSelectionEntryId="d929-5f73-e58b-90d8">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks>
-                                                
-                                <entryLink id="d929-5f73-e58b-90d8" hidden="false" targetId="62c2-106a-28aa-6cf5" type="selectionEntry">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                    
-                                </entryLink>
-                                                
-                                <entryLink id="907e-68db-aaaf-9a2f" hidden="false" targetId="90ca-6c03-a803-a140" type="selectionEntry">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                    
-                                </entryLink>
-                                                
-                                <entryLink id="b25e-f181-2b5c-7cc4" hidden="false" targetId="6ded-5798-dd23-8e6f" type="selectionEntry">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                    
-                                </entryLink>
-                                                
-                                <entryLink id="2100-0b04-3ec7-174f" hidden="false" targetId="5a7d-3845-90ba-32eb" type="selectionEntry">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                    
-                                </entryLink>
-                                              
-                            </entryLinks>
-                                        
-                        </selectionEntryGroup>
-                                  
-                    </selectionEntryGroups>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="4064-6c5e-df77-f08e" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers>
-                                                
-                                <modifier type="set" field="points" value="10">
-                                                      
-                                    <repeats/>
-                                                      
-                                    <conditions/>
-                                                      
-                                    <conditionGroups/>
-                                                    
-                                </modifier>
-                                              
-                            </modifiers>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="56c2-caa3-3666-bf3e" hidden="false" targetId="a8d9-6fae-a541-9f4f" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                            
-                </selectionEntryGroup>
-                      
-            </selectionEntryGroups>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
+        <selectionEntry id="f53a-1444-1c40-5103" name="Drone Commander" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="4445-ab9e-a23d-34b5" hidden="false" targetId="bed7-2549-f395-f271" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="61.0"/>
+          </costs>
         </selectionEntry>
-            
-        <selectionEntry id="d626-a99a-6470-71ad" name="Isorian Nhamak SC Light Support Drone" hidden="false" collective="false" type="unit">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints/>
-                  
-            <categoryLinks>
-                        
-                <categoryLink id="d626-a99a-6470-71ad-5c47879b-41d0-1383-5fe5-a5989615db89" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                            
-                </categoryLink>
-                      
-            </categoryLinks>
-                  
-            <selectionEntries>
-                        
-                <selectionEntry id="37d5-656f-d5c1-4397" name="&lt; Weapon Drone" hidden="false" collective="false" type="model">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks>
-                                    
-                        <infoLink id="7f94-248b-3341-8ab0" hidden="false" targetId="18f2-0352-9cf8-66a5" type="profile">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                        
-                        </infoLink>
-                                  
-                    </infoLinks>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                                    
-                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="b801-9978-ef95-81bc" hidden="false" targetId="c74e-2993-3474-7869" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                              
-                    <costs>
-                                    
-                        <cost typeId="points" name="pts" value="59.0"/>
-                                  
-                    </costs>
-                            
-                </selectionEntry>
-                      
-            </selectionEntries>
-                  
-            <selectionEntryGroups>
-                        
-                <selectionEntryGroup id="cf0a-fdfc-c22e-fadb" name="&lt; Options &gt;" hidden="false" collective="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="b508-d3f3-6f27-4975" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="50fc-d0da-6514-b4dd" hidden="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="e89f-034f-fda6-f951" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="6c79-fd92-24f0-e11d" name="New EntryLink" hidden="false" targetId="651f-9469-74a5-505a" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                            
-                </selectionEntryGroup>
-                        
-                <selectionEntryGroup id="4da3-5d4c-1262-53ab" name="&lt; Weapon Drone Options &gt;" hidden="false" collective="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="c7a3-afb1-fa42-b4d3" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers>
-                                                
-                                <modifier type="increment" field="points" value="10">
-                                                      
-                                    <repeats>
-                                                            
-                                        <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                                                          
-                                    </repeats>
-                                                      
-                                    <conditions/>
-                                                      
-                                    <conditionGroups/>
-                                                    
-                                </modifier>
-                                              
-                            </modifiers>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4bc5-e0a7-1998-e64c" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="e462-4fcd-a5ee-e85b" hidden="false" targetId="9801-e697-4e03-1582" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers>
-                                                
-                                <modifier type="increment" field="points" value="10">
-                                                      
-                                    <repeats>
-                                                            
-                                        <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                                                          
-                                    </repeats>
-                                                      
-                                    <conditions/>
-                                                      
-                                    <conditionGroups/>
-                                                    
-                                </modifier>
-                                              
-                            </modifiers>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee85-d215-eb2e-7ddf" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                            
-                </selectionEntryGroup>
-                      
-            </selectionEntryGroups>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="c93d-d42c-8771-aa98" name="Senatex Phase Sniper" hidden="false" collective="false" type="unit">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints/>
-                  
-            <categoryLinks>
-                        
-                <categoryLink id="c93d-d42c-8771-aa98-5c47879b-41d0-1383-5fe5-a5989615db89" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                            
-                </categoryLink>
-                      
-            </categoryLinks>
-                  
-            <selectionEntries>
-                        
-                <selectionEntry id="1518-7b74-035c-3c4e" name="Phase Sniper" hidden="false" collective="false" type="model">
-                              
-                    <profiles>
-                                    
-                        <profile typeId="1650-77b3-10d1-6406" typeName="" id="dc3a-0672-55ef-4cd8" name="Phase Sniper" hidden="false">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <characteristics>
-                                                
-                                <characteristic typeId="cf30-f234-691c-47bd" name="Ag">5</characteristic>
-                                                
-                                <characteristic typeId="017a-9b43-b7b3-030d" name="Acc">8</characteristic>
-                                                
-                                <characteristic typeId="8294-36f1-6431-2145" name="Str">5</characteristic>
-                                                
-                                <characteristic typeId="f214-abe8-c922-c51b" name="Res">5 (7)</characteristic>
-                                                
-                                <characteristic typeId="08b9-e038-7ba6-488e" name="Init">7</characteristic>
-                                                
-                                <characteristic typeId="3993-27b0-c3d9-de20" name="Co">8</characteristic>
-                                                
-                                <characteristic typeId="3baa-9cfd-f273-822d" name="Special"/>
-                                              
-                            </characteristics>
-                                        
-                        </profile>
-                                  
-                    </profiles>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="6fe6-c5a9-9088-53ee" name="Phase Armour (E)" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="8ba0-9319-020d-6785" hidden="false" targetId="2f22-37fa-4076-d255" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="913c-082e-c79c-e861" hidden="false" targetId="9443-effe-72e1-2f51" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="359a-5209-73a4-b906" name="Spotter Drone (E)" hidden="false" targetId="e16f-acd1-265c-07f9" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                              
-                    <costs>
-                                    
-                        <cost typeId="points" name="pts" value="56.0"/>
-                                  
-                    </costs>
-                            
-                </selectionEntry>
-                      
-            </selectionEntries>
-                  
-            <selectionEntryGroups>
-                        
-                <selectionEntryGroup id="1aae-f5f3-cbb1-4b8c" name="&lt; Unit Options &gt;" hidden="false" collective="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="ed05-2035-2eaa-d820" name="Shield Drone " hidden="false" targetId="de46-fbd5-d8f5-7454" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="2ee2-a4b2-6698-7f32" name="Leader 2" hidden="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="5ef8-5d7c-c5e8-9c90" name="Leader" hidden="false" targetId="41bd-5499-889a-ab16" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="b799-7e5e-0b8c-164c" name="Camo Drone " hidden="false" targetId="b63d-0e1c-d14a-c3e4" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="30ce-8d6a-10df-6b1b" name="Spotter Drone " hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                            
-                </selectionEntryGroup>
-                      
-            </selectionEntryGroups>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="5265-231f-43ab-5d20" name="Isorian Support Team" hidden="false" collective="false" type="unit">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints/>
-                  
-            <categoryLinks>
-                        
-                <categoryLink id="5265-231f-43ab-5d20-a01f5f58-334c-8442-d861-15099ebdf5e5" hidden="false" targetId="a01f5f58-334c-8442-d861-15099ebdf5e5" primary="true">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                            
-                </categoryLink>
-                      
-            </categoryLinks>
-                  
-            <selectionEntries>
-                        
-                <selectionEntry id="7750-57ad-7e30-28c5" name="Phase Trooper" hidden="false" collective="false" type="model">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks>
-                                    
-                        <infoLink id="fe22-4c0b-a4c9-d753" hidden="false" targetId="6688-b331-6578-fb30" type="profile">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                        
-                        </infoLink>
-                                  
-                    </infoLinks>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                                    
-                        <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="5394-4256-ad47-a91d" name="Phase Armour (E)" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="109b-020a-b406-1392" hidden="false" targetId="2f22-37fa-4076-d255" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                              
-                    <costs>
-                                    
-                        <cost typeId="points" name="pts" value="15.0"/>
-                                  
-                    </costs>
-                            
-                </selectionEntry>
-                        
-                <selectionEntry id="d573-9875-ce6b-11e4" name="Spotter Drone" hidden="false" collective="false" type="upgrade">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9307-e411-8f78-9039" type="max"/>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fab-22c1-2fa9-801f" type="min"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks/>
-                              
-                    <costs/>
-                            
-                </selectionEntry>
-                      
-            </selectionEntries>
-                  
-            <selectionEntryGroups>
-                        
-                <selectionEntryGroup id="2a6c-9381-d88e-8bd2" name="&lt; Unit Options &gt;" hidden="false" collective="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries>
-                                    
-                        <selectionEntry id="4c69-d553-3aa1-815e" name="Spotter Drone" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44fd-05a8-b3b8-b3fb" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="10.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                  
-                    </selectionEntries>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="651e-28ab-855b-7c6a" name="Batter Drone" hidden="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="e7ec-80b1-f4f0-1541" hidden="false" targetId="41bd-5499-889a-ab16" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="e1bf-ad76-2471-3df5" name="Leader 2" hidden="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                            
-                </selectionEntryGroup>
-                        
-                <selectionEntryGroup id="b7f0-1a66-b10d-b12d" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="2b56-aec8-3185-d63f">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcdf-2c01-67a1-6c7c" type="max"/>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9d8-15c9-5021-0392" type="min"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="fc4b-fad0-8104-85ae" name="Plasma Bombard (E)" hidden="false" targetId="1bc9-ce44-fdbe-ef90" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers>
-                                                
-                                <modifier type="increment" field="points" value="10">
-                                                      
-                                    <repeats/>
-                                                      
-                                    <conditions/>
-                                                      
-                                    <conditionGroups/>
-                                                    
-                                </modifier>
-                                              
-                            </modifiers>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="2b56-aec8-3185-d63f" name="X-Launcher (E)" hidden="false" targetId="afc8-4f62-e1e2-1e4c" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                            
-                </selectionEntryGroup>
-                      
-            </selectionEntryGroups>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="65.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="a829-1685-c4b5-55b6" name="Kahloc KV Heavy Battle Drone" hidden="false" collective="false" type="unit">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints/>
-                  
-            <categoryLinks>
-                        
-                <categoryLink id="a829-1685-c4b5-55b6-a01f5f58-334c-8442-d861-15099ebdf5e5" hidden="false" targetId="a01f5f58-334c-8442-d861-15099ebdf5e5" primary="true">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                            
-                </categoryLink>
-                      
-            </categoryLinks>
-                  
-            <selectionEntries>
-                        
-                <selectionEntry id="9432-f296-0817-a41e" name="&lt; Heavy Combat Drone" hidden="false" collective="false" type="model">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks>
-                                    
-                        <infoLink id="52d9-2f82-4813-deb1" name="Kahloc KV Heavy Battle Drone" hidden="false" targetId="1c7c-b76a-8d9f-4405" type="profile">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                        
-                        </infoLink>
-                                  
-                    </infoLinks>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="fc27-7742-3460-32c5" name="Plasma Light Support Gun (E)" hidden="false" targetId="c74e-2993-3474-7869" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                              
-                    <costs>
-                                    
-                        <cost typeId="points" name="pts" value="408.0"/>
-                                  
-                    </costs>
-                            
-                </selectionEntry>
-                        
-                <selectionEntry id="fea5-0db1-26b1-fc3a" name="Spotter Drone" hidden="false" collective="false" type="upgrade">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b262-db6a-beaf-86df" type="max"/>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="624a-22aa-2902-3e4f" type="min"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks/>
-                              
-                    <costs/>
-                            
-                </selectionEntry>
-                      
-            </selectionEntries>
-                  
-            <selectionEntryGroups>
-                        
-                <selectionEntryGroup id="ba92-e188-5152-68a3" name="&lt; Options &gt;" hidden="false" collective="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="25d4-fe83-5977-2551" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="3866-b4ff-b88f-c46f" hidden="false" targetId="2750-e65f-4c66-8235" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="2bbd-905d-dab7-121e" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                            
-                </selectionEntryGroup>
-                        
-                <selectionEntryGroup id="232d-2ec2-4ebb-33e8" name="&lt; Weapon Drone Options &gt;" hidden="false" collective="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups>
-                                    
-                        <selectionEntryGroup id="ab1d-b82e-4fa4-af4b" name="&lt; Weapon Option &gt;" hidden="false" collective="false" defaultSelectionEntryId="1f48-758b-70a2-1b46">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks>
-                                                
-                                <entryLink id="1f48-758b-70a2-1b46" hidden="false" targetId="1bc9-ce44-fdbe-ef90" type="selectionEntry">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                    
-                                </entryLink>
-                                                
-                                <entryLink id="a40d-ad44-0834-d4bf" name="New EntryLink" hidden="false" targetId="f482-b1f7-5e3a-1960" type="selectionEntry">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                    
-                                </entryLink>
-                                                
-                                <entryLink id="1f2e-eeb6-6c2d-e925" name="New EntryLink" hidden="false" targetId="eb71-6245-efd5-67c9" type="selectionEntry">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                    
-                                </entryLink>
-                                                
-                                <entryLink id="81db-faca-b484-f3a8" name="New EntryLink" hidden="false" targetId="e2b4-a034-c8ce-e376" type="selectionEntry">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                    
-                                </entryLink>
-                                              
-                            </entryLinks>
-                                        
-                        </selectionEntryGroup>
-                                  
-                    </selectionEntryGroups>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="c984-ceed-ca03-2965" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers>
-                                                
-                                <modifier type="set" field="points" value="10">
-                                                      
-                                    <repeats/>
-                                                      
-                                    <conditions/>
-                                                      
-                                    <conditionGroups/>
-                                                    
-                                </modifier>
-                                              
-                            </modifiers>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="c421-df4b-ccea-aa78" hidden="false" targetId="a8d9-6fae-a541-9f4f" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                            
-                </selectionEntryGroup>
-                      
-            </selectionEntryGroups>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="3440-9714-d7d3-3653" name="Mahran Vesh MV5 Combat Drone" hidden="false" collective="false" type="model">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints/>
-                  
-            <categoryLinks>
-                        
-                <categoryLink id="3440-9714-d7d3-3653-a01f5f58-334c-8442-d861-15099ebdf5e5" hidden="false" targetId="a01f5f58-334c-8442-d861-15099ebdf5e5" primary="true">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                            
-                </categoryLink>
-                      
-            </categoryLinks>
-                  
-            <selectionEntries>
-                        
-                <selectionEntry id="c49a-cae5-0917-dff0" name="&lt; Weapon Drone" hidden="false" collective="false" type="model">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks>
-                                    
-                        <infoLink id="9c84-78ff-fad3-093b" hidden="false" targetId="eda1-434f-1771-a790" type="profile">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                        
-                        </infoLink>
-                                  
-                    </infoLinks>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks/>
-                              
-                    <costs>
-                                    
-                        <cost typeId="points" name="pts" value="0.0"/>
-                                  
-                    </costs>
-                            
-                </selectionEntry>
-                      
-            </selectionEntries>
-                  
-            <selectionEntryGroups>
-                        
-                <selectionEntryGroup id="5980-fadb-0d1a-8e4b" name="&lt; Options &gt;" hidden="false" collective="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="1015-29dc-212b-dc4d" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="5087-2dc6-723c-788e" hidden="false" targetId="2750-e65f-4c66-8235" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="4ea5-d717-39c9-e705" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                            
-                </selectionEntryGroup>
-                        
-                <selectionEntryGroup id="91d2-c0ae-c028-4591" name="&lt; Weapon Drone Options &gt;" hidden="false" collective="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups>
-                                    
-                        <selectionEntryGroup id="fb98-64e6-ce83-57f9" name="&lt; Weapon Option &gt;" hidden="false" collective="false" defaultSelectionEntryId="d8ef-55c7-2efb-ec04">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks>
-                                                
-                                <entryLink id="6062-8f75-90de-9604" hidden="false" targetId="69d9-b84f-3c40-15fb" type="selectionEntry">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                    
-                                </entryLink>
-                                                
-                                <entryLink id="d0f0-9069-c124-7cd2" hidden="false" targetId="80bf-613e-52b4-f160" type="selectionEntry">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                    
-                                </entryLink>
-                                                
-                                <entryLink id="d8ef-55c7-2efb-ec04" hidden="false" targetId="3dfc-49e9-adcb-ae48" type="selectionEntry">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                    
-                                </entryLink>
-                                              
-                            </entryLinks>
-                                        
-                        </selectionEntryGroup>
-                                  
-                    </selectionEntryGroups>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="04e7-e796-57e1-9c2e" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers>
-                                                
-                                <modifier type="set" field="points" value="10">
-                                                      
-                                    <repeats/>
-                                                      
-                                    <conditions/>
-                                                      
-                                    <conditionGroups/>
-                                                    
-                                </modifier>
-                                              
-                            </modifiers>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="7587-847d-9f8d-31dd" hidden="false" targetId="a8d9-6fae-a541-9f4f" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                            
-                </selectionEntryGroup>
-                      
-            </selectionEntryGroups>
-                  
-            <entryLinks>
-                        
-                <entryLink id="ad84-1f7d-5b85-ad4a" hidden="false" targetId="e16f-acd1-265c-07f9" type="selectionEntry">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                            
-                </entryLink>
-                        
-                <entryLink id="7d08-c97c-53ca-06ab" hidden="false" targetId="c74e-2993-3474-7869" type="selectionEntry">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                            
-                </entryLink>
-                      
-            </entryLinks>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="249.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="fcb7-7abc-470a-26fe" name="Medi-Probe Shard" hidden="false" collective="false" type="unit">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints/>
-                  
-            <categoryLinks>
-                        
-                <categoryLink id="fcb7-7abc-470a-26fe-72807c5d-e370-9ddf-c2b7-de5d2797f24d" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="true">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                            
-                </categoryLink>
-                      
-            </categoryLinks>
-                  
-            <selectionEntries>
-                        
-                <selectionEntry id="c7bd-920e-b6e5-ef99" name="&lt; Medi-probe" hidden="false" collective="false" type="model">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks>
-                                    
-                        <infoLink id="d758-744a-7ac4-7804" hidden="false" targetId="078e-4753-3545-ba51" type="profile">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                        
-                        </infoLink>
-                                  
-                    </infoLinks>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                                    
-                        <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks/>
-                              
-                    <costs>
-                                    
-                        <cost typeId="points" name="pts" value="10.0"/>
-                                  
-                    </costs>
-                            
-                </selectionEntry>
-                      
-            </selectionEntries>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs/>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="0d09-f1bc-5547-135f" name="Nano Probe Net Shard" hidden="false" collective="false" type="unit">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers>
-                        
-                <modifier type="increment" field="maxInForce" value="1.0">
-                              
-                    <repeats>
-                                    
-                        <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3e3-761c-74f3-d2f2" repeats="1" roundUp="false"/>
-                                  
-                    </repeats>
-                              
-                    <conditions>
-                                    
-                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3e3-761c-74f3-d2f2" type="equalTo"/>
-                                  
-                    </conditions>
-                              
-                    <conditionGroups/>
-                            
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ac26-bdf5-0bcf-d3a4" name="Options" hidden="false" collective="false">
+          <entryLinks>
+            <entryLink id="47d2-db02-12fe-cbad" hidden="false" collective="false" targetId="001a-9f15-b25b-b784" type="selectionEntry"/>
+            <entryLink id="3804-b86f-9c05-9420" hidden="false" collective="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry"/>
+            <entryLink id="fdb0-a151-6fac-8967" hidden="false" collective="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry"/>
+            <entryLink id="db77-785d-6eda-c4ba" hidden="false" collective="false" targetId="651f-9469-74a5-505a" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="5ce9-5bd3-c6d5-879e" name="Weapon Drone Options" hidden="false" collective="false" defaultSelectionEntryId="2647-c41d-56e3-2be2">
+          <entryLinks>
+            <entryLink id="3983-cb40-246a-1004" hidden="false" collective="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="10">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
                 </modifier>
-                      
-            </modifiers>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries>
-                        
-                <selectionEntry id="34f8-26e7-c193-56eb" name="Nano Probe" hidden="false" collective="false" type="model">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks>
-                                    
-                        <infoLink id="ecb4-f327-4797-5d94" hidden="false" targetId="16bf-fee9-f1bf-8600" type="profile">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                        
-                        </infoLink>
-                                  
-                    </infoLinks>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                                    
-                        <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks/>
-                              
-                    <costs>
-                                    
-                        <cost typeId="points" name="pts" value="5.0"/>
-                                  
-                    </costs>
-                            
-                </selectionEntry>
-                      
-            </selectionEntries>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="10.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="6429-1b89-b557-736b" name="NuHu Senatexis" hidden="false" collective="false" type="model">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks>
-                        
-                <infoLink id="6fd9-afd5-d70f-d751" name="NuHu Senatexis" hidden="false" targetId="41d1-a002-0258-c407" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                      
-            </infoLinks>
-                  
-            <modifiers/>
-                  
-            <constraints/>
-                  
-            <categoryLinks>
-                        
-                <categoryLink id="6429-1b89-b557-736b-481abf13-c03e-0dd0-d520-9f9837253cbe" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                            
-                </categoryLink>
-                      
-            </categoryLinks>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups>
-                        
-                <selectionEntryGroup id="ae11-f605-d815-9109" name="&lt; Options &gt;" hidden="false" collective="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="6fd3-49ff-c60c-3624" name="Spotter Drone" hidden="false" targetId="f095-7ba3-b868-32de" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2d3-3b56-ccfa-9753" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="bb6a-48bd-2cf1-f430" hidden="false" targetId="057e-2e8a-1952-9de0" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="775b-177d-e6ac-c3ac" name="Shield Drone" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="2523-96e0-03f8-2625" hidden="false" targetId="5343-3c10-ccc3-0233" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                            
-                </selectionEntryGroup>
-                      
-            </selectionEntryGroups>
-                  
-            <entryLinks>
-                        
-                <entryLink id="1133-9cc8-d005-ca82" hidden="false" targetId="a2e9-2b00-2191-a410" type="selectionEntry">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                            
-                </entryLink>
-                        
-                <entryLink id="e3c8-4234-d63f-b52c" hidden="false" targetId="2f22-37fa-4076-d255" type="selectionEntry">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                            
-                </entryLink>
-                        
-                <entryLink id="b702-73ca-4a1f-e0f5" hidden="false" targetId="c7a8-840b-096e-e2b8" type="selectionEntry">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                            
-                </entryLink>
-                      
-            </entryLinks>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="130.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="0244-6cd5-9260-c12e" name="Pulse Bike Command Squad" hidden="false" collective="false" type="unit">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints/>
-                  
-            <categoryLinks>
-                        
-                <categoryLink id="0244-6cd5-9260-c12e-481abf13-c03e-0dd0-d520-9f9837253cbe" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                            
-                </categoryLink>
-                      
-            </categoryLinks>
-                  
-            <selectionEntries>
-                        
-                <selectionEntry id="fa12-b792-1fff-89e3" name="&lt; Pulse Bike Commander" hidden="false" collective="false" type="model">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks>
-                                    
-                        <infoLink id="5cac-dbde-7763-5ddd" hidden="false" targetId="9286-cbf7-0641-5ce1" type="profile">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                        
-                        </infoLink>
-                                  
-                    </infoLinks>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups>
-                                    
-                        <selectionEntryGroup id="ce12-0c6b-11e5-f498" name="&lt; Pulse Bike Commander Options &gt;" hidden="false" collective="false">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks>
-                                                
-                                <entryLink id="bd12-7ad6-eb09-08ba" hidden="false" targetId="a90a-fea5-107f-a019" type="selectionEntry">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                    
-                                </entryLink>
-                                              
-                            </entryLinks>
-                                        
-                        </selectionEntryGroup>
-                                  
-                    </selectionEntryGroups>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="c8d2-d4de-e467-c706" hidden="false" targetId="12f1-610b-0dc9-4732" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="77c5-7b49-1b1a-443b" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="ea21-ecb8-ce22-00d3" hidden="false" targetId="658c-b2dd-98f4-dafb" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                              
-                    <costs>
-                                    
-                        <cost typeId="points" name="pts" value="0.0"/>
-                                  
-                    </costs>
-                            
-                </selectionEntry>
-                        
-                <selectionEntry id="8b1d-c9da-076d-d08e" name="Pulse Bike Trooper" hidden="false" collective="false" type="model">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks>
-                                    
-                        <infoLink id="5f70-3d2c-69d6-3b63" hidden="false" targetId="34f9-12c5-7e7b-114c" type="profile">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                        
-                        </infoLink>
-                                  
-                    </infoLinks>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="3ad9-f6de-2222-14d7" hidden="false" targetId="12f1-610b-0dc9-4732" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="89fc-31e3-8d85-5d84" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="18db-e7fa-3661-289b" hidden="false" targetId="658c-b2dd-98f4-dafb" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                              
-                    <costs>
-                                    
-                        <cost typeId="points" name="pts" value="0.0"/>
-                                  
-                    </costs>
-                            
-                </selectionEntry>
-                      
-            </selectionEntries>
-                  
-            <selectionEntryGroups>
-                        
-                <selectionEntryGroup id="aba9-6548-4d89-9d71" name="&lt; Unit Options &gt;" hidden="false" collective="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups>
-                                    
-                        <selectionEntryGroup id="01c1-76ad-1e19-2f22" name="&lt; Compactor Drone &gt;" hidden="false" collective="false">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks>
-                                                
-                                <entryLink id="7e3a-171d-c362-06f0" hidden="false" targetId="c87f-f5b0-1134-8ad9" type="selectionEntry">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                    
-                                </entryLink>
-                                                
-                                <entryLink id="792d-6942-fc08-f58a" hidden="false" targetId="d776-f344-44a4-c41b" type="selectionEntry">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                    
-                                </entryLink>
-                                              
-                            </entryLinks>
-                                        
-                        </selectionEntryGroup>
-                                  
-                    </selectionEntryGroups>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="ffb4-8366-9f3a-ce9c" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="f8e2-982b-dc65-9be9" name="Plasma Lance (Bike)" hidden="false" targetId="7dac-aa85-fc80-51d5" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                            
-                </selectionEntryGroup>
-                      
-            </selectionEntryGroups>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="165.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="2f44-92da-46f8-619d" name="Pulse Bike Squad" hidden="false" collective="false" type="unit">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers>
-                        
-                <modifier type="set" field="hidden" value="false">
-                              
-                    <repeats/>
-                              
-                    <conditions>
-                                    
-                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0244-6cd5-9260-c12e" type="equalTo"/>
-                                  
-                    </conditions>
-                              
-                    <conditionGroups/>
-                            
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ba7-5fd6-ddd2-2ce2" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="31a4-5549-4299-cd23" name="Phaseshift Shield" hidden="false" collective="false" targetId="9801-e697-4e03-1582" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="10">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
                 </modifier>
-                      
-            </modifiers>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                      
-            </constraints>
-                  
-            <categoryLinks>
-                        
-                <categoryLink id="2f44-92da-46f8-619d-481abf13-c03e-0dd0-d520-9f9837253cbe" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                            
-                </categoryLink>
-                      
-            </categoryLinks>
-                  
-            <selectionEntries>
-                        
-                <selectionEntry id="de4c-b135-70a3-c87b" name="&lt; Pulse Bike Leader" hidden="false" collective="false" type="model">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks>
-                                    
-                        <infoLink id="27e0-cc93-d2c1-3dec" hidden="false" targetId="9ed6-e3f2-8847-d7a2" type="profile">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                        
-                        </infoLink>
-                                  
-                    </infoLinks>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups>
-                                    
-                        <selectionEntryGroup id="8166-a3dd-75ec-ccde" name="&lt; Pulse Bike Leader Options &gt;" hidden="false" collective="false">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks>
-                                                
-                                <entryLink id="27d8-164a-139b-f635" hidden="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                    
-                                </entryLink>
-                                              
-                            </entryLinks>
-                                        
-                        </selectionEntryGroup>
-                                  
-                    </selectionEntryGroups>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="0179-fa9f-3b06-4db2" hidden="false" targetId="12f1-610b-0dc9-4732" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="5b9e-0f99-9282-7ef1" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="dd0f-496a-c08e-56b4" hidden="false" targetId="658c-b2dd-98f4-dafb" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                              
-                    <costs>
-                                    
-                        <cost typeId="points" name="pts" value="0.0"/>
-                                  
-                    </costs>
-                            
-                </selectionEntry>
-                        
-                <selectionEntry id="8783-ed89-1004-1495" name="Pulse Bike Trooper" hidden="false" collective="false" type="model">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks>
-                                    
-                        <infoLink id="5664-48f1-1957-c3d8" hidden="false" targetId="34f9-12c5-7e7b-114c" type="profile">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                        
-                        </infoLink>
-                                  
-                    </infoLinks>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="1c5e-3cc6-d497-2644" hidden="false" targetId="12f1-610b-0dc9-4732" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="1318-0d29-4a43-dd78" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="0628-7b69-d134-8ece" hidden="false" targetId="658c-b2dd-98f4-dafb" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                              
-                    <costs>
-                                    
-                        <cost typeId="points" name="pts" value="0.0"/>
-                                  
-                    </costs>
-                            
-                </selectionEntry>
-                      
-            </selectionEntries>
-                  
-            <selectionEntryGroups>
-                        
-                <selectionEntryGroup id="2de5-7dde-c917-f126" name="&lt; Unit Options &gt;" hidden="false" collective="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups>
-                                    
-                        <selectionEntryGroup id="eadf-8b1d-d337-25ad" name="&lt; Compactor Drone &gt;" hidden="false" collective="false">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks>
-                                                
-                                <entryLink id="16b9-1f19-f7e7-0da5" hidden="false" targetId="c87f-f5b0-1134-8ad9" type="selectionEntry">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                    
-                                </entryLink>
-                                                
-                                <entryLink id="221b-0c10-d482-195e" hidden="false" targetId="d776-f344-44a4-c41b" type="selectionEntry">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                    
-                                </entryLink>
-                                              
-                            </entryLinks>
-                                        
-                        </selectionEntryGroup>
-                                  
-                    </selectionEntryGroups>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="ca55-43e4-8b73-294c" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="f96c-a56c-c07e-6da4" name="Plasma Lance (Bike)" hidden="false" targetId="7dac-aa85-fc80-51d5" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="0ecf-b9d9-f50e-90b3" hidden="false" targetId="651f-9469-74a5-505a" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                            
-                </selectionEntryGroup>
-                      
-            </selectionEntryGroups>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="133.0"/>
-                      
-            </costs>
-                
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f88-f3c2-6b6d-987c" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="2647-c41d-56e3-2be2" hidden="false" collective="false" targetId="62c2-106a-28aa-6cf5" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3601-a65d-7f14-cf86" name="Andhak SC2 Medium Support Drone" hidden="false" collective="false" type="unit">
+      <categoryLinks>
+        <categoryLink id="3601-a65d-7f14-cf86-5c47879b-41d0-1383-5fe5-a5989615db89" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="156e-1f5a-b7e7-1783" name="Weapon Drone" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="bca1-3c81-da93-aefb" name="Isorian Andhak SC2 Medium Support Drone" hidden="false" targetId="be8e-2c8f-8288-e92a" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="83.0"/>
+          </costs>
         </selectionEntry>
-            
-        <selectionEntry id="7780-9268-8805-991a" name="Scout Probe Shard" hidden="false" collective="false" type="unit">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints/>
-                  
-            <categoryLinks>
-                        
-                <categoryLink id="7780-9268-8805-991a-72807c5d-e370-9ddf-c2b7-de5d2797f24d" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="true">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                            
-                </categoryLink>
-                      
-            </categoryLinks>
-                  
-            <selectionEntries>
-                        
-                <selectionEntry id="275e-c158-8f26-53c9" name="&lt; Scout Probe" hidden="false" collective="false" type="model">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks>
-                                    
-                        <infoLink id="05b3-477e-3ab6-c2a4" hidden="false" targetId="56b9-5224-e0df-8218" type="profile">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                        
-                        </infoLink>
-                                  
-                    </infoLinks>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                                    
-                        <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks/>
-                              
-                    <costs>
-                                    
-                        <cost typeId="points" name="pts" value="10.0"/>
-                                  
-                    </costs>
-                            
-                </selectionEntry>
-                      
-            </selectionEntries>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="86e7-9193-c4cf-b4c7" name="Options" hidden="false" collective="false">
+          <entryLinks>
+            <entryLink id="0f08-649f-cdb0-8d16" hidden="false" collective="false" targetId="001a-9f15-b25b-b784" type="selectionEntry"/>
+            <entryLink id="a405-a61d-2eb0-1e80" hidden="false" collective="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry"/>
+            <entryLink id="f787-39f9-566b-e5ff" hidden="false" collective="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry"/>
+            <entryLink id="e4de-9a06-22cb-6fd2" name="New EntryLink" hidden="false" collective="false" targetId="651f-9469-74a5-505a" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="f298-b1a6-4486-7b3a" name="Weapon Drone Options" hidden="false" collective="false">
+          <selectionEntryGroups>
+            <selectionEntryGroup id="34a7-a9ba-8af3-becb" name="Weapon Option" hidden="false" collective="false" defaultSelectionEntryId="a9f2-f30a-51f0-886d">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="907e-68db-aaaf-9a2f" name="Fractal Cannon" hidden="false" collective="false" targetId="90ca-6c03-a803-a140" type="selectionEntry"/>
+                <entryLink id="b25e-f181-2b5c-7cc4" name="Compression Cannon" hidden="false" collective="false" targetId="6ded-5798-dd23-8e6f" type="selectionEntry"/>
+                <entryLink id="2100-0b04-3ec7-174f" name="Plasma Cannon" hidden="false" collective="false" targetId="5a7d-3845-90ba-32eb" type="selectionEntry"/>
+                <entryLink id="f530-d1e6-58fb-e6fb" name="Phase-Shift Projector" hidden="false" collective="false" targetId="1201-b017-518c-6bf2" type="selectionEntry"/>
+                <entryLink id="a9f2-f30a-51f0-886d" name="Plasma Light Support" hidden="false" collective="false" targetId="eaa4-a3c1-d269-d3cb" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="4064-6c5e-df77-f08e" hidden="false" collective="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="points" value="10"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="56c2-caa3-3666-bf3e" name="Phaseshift Shield" hidden="false" collective="false" targetId="a8d9-6fae-a541-9f4f" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d626-a99a-6470-71ad" name="Isorian Nhamak SC Light Support Drone" hidden="false" collective="false" type="unit">
+      <categoryLinks>
+        <categoryLink id="d626-a99a-6470-71ad-5c47879b-41d0-1383-5fe5-a5989615db89" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="37d5-656f-d5c1-4397" name="Weapon Drone" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="7f94-248b-3341-8ab0" hidden="false" targetId="18f2-0352-9cf8-66a5" type="profile"/>
+          </infoLinks>
+          <entryLinks>
+            <entryLink id="b801-9978-ef95-81bc" hidden="false" collective="false" targetId="c74e-2993-3474-7869" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="59.0"/>
+          </costs>
         </selectionEntry>
-            
-        <selectionEntry id="f53b-8cb2-f46e-ec68" name="Senatex Command Squad" hidden="false" collective="false" type="unit">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints/>
-                  
-            <categoryLinks>
-                        
-                <categoryLink id="f53b-8cb2-f46e-ec68-481abf13-c03e-0dd0-d520-9f9837253cbe" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                            
-                </categoryLink>
-                      
-            </categoryLinks>
-                  
-            <selectionEntries>
-                        
-                <selectionEntry id="9217-51b5-1490-c20f" name="&lt; Senatex Commander" hidden="false" collective="false" type="model">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks>
-                                    
-                        <infoLink id="e5ba-45ac-5c32-8928" hidden="false" targetId="9686-36fa-7ae7-f4dc" type="profile">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                        
-                        </infoLink>
-                                  
-                    </infoLinks>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                                    
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="cf0a-fdfc-c22e-fadb" name="Options" hidden="false" collective="false">
+          <entryLinks>
+            <entryLink id="b508-d3f3-6f27-4975" hidden="false" collective="false" targetId="001a-9f15-b25b-b784" type="selectionEntry"/>
+            <entryLink id="50fc-d0da-6514-b4dd" hidden="false" collective="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry"/>
+            <entryLink id="e89f-034f-fda6-f951" hidden="false" collective="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry"/>
+            <entryLink id="6c79-fd92-24f0-e11d" name="New EntryLink" hidden="false" collective="false" targetId="651f-9469-74a5-505a" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="4da3-5d4c-1262-53ab" name="Weapon Drone Options" hidden="false" collective="false">
+          <entryLinks>
+            <entryLink id="c7a3-afb1-fa42-b4d3" hidden="false" collective="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="10">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4bc5-e0a7-1998-e64c" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="e462-4fcd-a5ee-e85b" hidden="false" collective="false" targetId="9801-e697-4e03-1582" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="10">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee85-d215-eb2e-7ddf" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c93d-d42c-8771-aa98" name="Senatex Phase Sniper" hidden="false" collective="false" type="unit">
+      <categoryLinks>
+        <categoryLink id="c93d-d42c-8771-aa98-5c47879b-41d0-1383-5fe5-a5989615db89" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="1518-7b74-035c-3c4e" name="Phase Sniper" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="dc3a-0672-55ef-4cd8" name="Phase Sniper" hidden="false" typeId="1650-77b3-10d1-6406" typeName="">
+              <characteristics>
+                <characteristic name="Ag" typeId="cf30-f234-691c-47bd">5</characteristic>
+                <characteristic name="Acc" typeId="017a-9b43-b7b3-030d">8</characteristic>
+                <characteristic name="Str" typeId="8294-36f1-6431-2145">5</characteristic>
+                <characteristic name="Res" typeId="f214-abe8-c922-c51b">5 (7)</characteristic>
+                <characteristic name="Init" typeId="08b9-e038-7ba6-488e">7</characteristic>
+                <characteristic name="Co" typeId="3993-27b0-c3d9-de20">8</characteristic>
+                <characteristic name="Special" typeId="3baa-9cfd-f273-822d"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <entryLinks>
+            <entryLink id="6fe6-c5a9-9088-53ee" name="Phase Armour (E)" hidden="false" collective="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry"/>
+            <entryLink id="8ba0-9319-020d-6785" hidden="false" collective="false" targetId="2f22-37fa-4076-d255" type="selectionEntry"/>
+            <entryLink id="913c-082e-c79c-e861" hidden="false" collective="false" targetId="9443-effe-72e1-2f51" type="selectionEntry"/>
+            <entryLink id="359a-5209-73a4-b906" name="Spotter Drone (E)" hidden="false" collective="false" targetId="e16f-acd1-265c-07f9" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="56.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="1aae-f5f3-cbb1-4b8c" name="Unit Options" hidden="false" collective="false">
+          <entryLinks>
+            <entryLink id="ed05-2035-2eaa-d820" name="Shield Drone " hidden="false" collective="false" targetId="de46-fbd5-d8f5-7454" type="selectionEntry"/>
+            <entryLink id="2ee2-a4b2-6698-7f32" name="Leader 2" hidden="false" collective="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry"/>
+            <entryLink id="5ef8-5d7c-c5e8-9c90" name="Leader" hidden="false" collective="false" targetId="41bd-5499-889a-ab16" type="selectionEntry"/>
+            <entryLink id="b799-7e5e-0b8c-164c" name="Camo Drone " hidden="false" collective="false" targetId="b63d-0e1c-d14a-c3e4" type="selectionEntry"/>
+            <entryLink id="30ce-8d6a-10df-6b1b" name="Spotter Drone " hidden="false" collective="false" targetId="001a-9f15-b25b-b784" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5265-231f-43ab-5d20" name="Heavy Support Team" hidden="false" collective="false" type="unit">
+      <categoryLinks>
+        <categoryLink id="5265-231f-43ab-5d20-a01f5f58-334c-8442-d861-15099ebdf5e5" hidden="false" targetId="a01f5f58-334c-8442-d861-15099ebdf5e5" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="7750-57ad-7e30-28c5" name="Phase Trooper" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="5.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="fe22-4c0b-a4c9-d753" hidden="false" targetId="6688-b331-6578-fb30" type="profile"/>
+          </infoLinks>
+          <entryLinks>
+            <entryLink id="5394-4256-ad47-a91d" name="Phase Armour (E)" hidden="false" collective="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry"/>
+            <entryLink id="109b-020a-b406-1392" hidden="false" collective="false" targetId="2f22-37fa-4076-d255" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="15.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="d573-9875-ce6b-11e4" name="Spotter Drone" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9307-e411-8f78-9039" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fab-22c1-2fa9-801f" type="min"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2a6c-9381-d88e-8bd2" name="Unit Options" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="4c69-d553-3aa1-815e" name="Spotter Drone" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44fd-05a8-b3b8-b3fb" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="651e-28ab-855b-7c6a" name="Batter Drone" hidden="false" collective="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry"/>
+            <entryLink id="e7ec-80b1-f4f0-1541" hidden="false" collective="false" targetId="41bd-5499-889a-ab16" type="selectionEntry"/>
+            <entryLink id="e1bf-ad76-2471-3df5" name="Leader 2" hidden="false" collective="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="b7f0-1a66-b10d-b12d" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="2190-fb2c-bb3e-9ed1">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcdf-2c01-67a1-6c7c" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9d8-15c9-5021-0392" type="min"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="fc4b-fad0-8104-85ae" name="Plasma Bombard (E)" hidden="false" collective="false" targetId="1bc9-ce44-fdbe-ef90" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="10"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="2190-fb2c-bb3e-9ed1" name="X-Howitzer" hidden="false" collective="false" targetId="ab2e-edc9-b214-f7d5" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="65.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a829-1685-c4b5-55b6" name="Kahloc KV Heavy Battle Drone" hidden="false" collective="false" type="unit">
+      <categoryLinks>
+        <categoryLink id="a829-1685-c4b5-55b6-a01f5f58-334c-8442-d861-15099ebdf5e5" hidden="false" targetId="a01f5f58-334c-8442-d861-15099ebdf5e5" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="9432-f296-0817-a41e" name="Heavy Combat Drone" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="52d9-2f82-4813-deb1" name="Kahloc KV Heavy Battle Drone" hidden="false" targetId="1c7c-b76a-8d9f-4405" type="profile"/>
+          </infoLinks>
+          <entryLinks>
+            <entryLink id="fc27-7742-3460-32c5" name="Plasma Light Support Gun (E)" hidden="false" collective="false" targetId="c74e-2993-3474-7869" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="408.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="fea5-0db1-26b1-fc3a" name="Spotter Drone" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b262-db6a-beaf-86df" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="624a-22aa-2902-3e4f" type="min"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ba92-e188-5152-68a3" name="Options" hidden="false" collective="false">
+          <entryLinks>
+            <entryLink id="25d4-fe83-5977-2551" hidden="false" collective="false" targetId="001a-9f15-b25b-b784" type="selectionEntry"/>
+            <entryLink id="3866-b4ff-b88f-c46f" hidden="false" collective="false" targetId="2750-e65f-4c66-8235" type="selectionEntry"/>
+            <entryLink id="2bbd-905d-dab7-121e" hidden="false" collective="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="232d-2ec2-4ebb-33e8" name="Weapon Drone Options" hidden="false" collective="false">
+          <selectionEntryGroups>
+            <selectionEntryGroup id="ab1d-b82e-4fa4-af4b" name="Weapon Option" hidden="false" collective="false" defaultSelectionEntryId="1f48-758b-70a2-1b46">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="1f48-758b-70a2-1b46" hidden="false" collective="false" targetId="1bc9-ce44-fdbe-ef90" type="selectionEntry"/>
+                <entryLink id="a40d-ad44-0834-d4bf" name="New EntryLink" hidden="false" collective="false" targetId="f482-b1f7-5e3a-1960" type="selectionEntry"/>
+                <entryLink id="1f2e-eeb6-6c2d-e925" name="New EntryLink" hidden="false" collective="false" targetId="eb71-6245-efd5-67c9" type="selectionEntry"/>
+                <entryLink id="81db-faca-b484-f3a8" name="New EntryLink" hidden="false" collective="false" targetId="e2b4-a034-c8ce-e376" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="c984-ceed-ca03-2965" hidden="false" collective="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="points" value="10"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="c421-df4b-ccea-aa78" hidden="false" collective="false" targetId="a8d9-6fae-a541-9f4f" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3440-9714-d7d3-3653" name="Mahran Vesh MV5 Combat Drone" hidden="false" collective="false" type="model">
+      <categoryLinks>
+        <categoryLink id="3440-9714-d7d3-3653-a01f5f58-334c-8442-d861-15099ebdf5e5" hidden="false" targetId="a01f5f58-334c-8442-d861-15099ebdf5e5" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="c49a-cae5-0917-dff0" name="Weapon Drone" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="9c84-78ff-fad3-093b" hidden="false" targetId="eda1-434f-1771-a790" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5980-fadb-0d1a-8e4b" name="Options" hidden="false" collective="false">
+          <entryLinks>
+            <entryLink id="1015-29dc-212b-dc4d" hidden="false" collective="false" targetId="001a-9f15-b25b-b784" type="selectionEntry"/>
+            <entryLink id="5087-2dc6-723c-788e" hidden="false" collective="false" targetId="2750-e65f-4c66-8235" type="selectionEntry"/>
+            <entryLink id="4ea5-d717-39c9-e705" hidden="false" collective="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="91d2-c0ae-c028-4591" name="Weapon Drone Options" hidden="false" collective="false">
+          <selectionEntryGroups>
+            <selectionEntryGroup id="fb98-64e6-ce83-57f9" name="Weapon Option" hidden="false" collective="false" defaultSelectionEntryId="d8ef-55c7-2efb-ec04">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="6062-8f75-90de-9604" hidden="false" collective="false" targetId="69d9-b84f-3c40-15fb" type="selectionEntry"/>
+                <entryLink id="d0f0-9069-c124-7cd2" hidden="false" collective="false" targetId="80bf-613e-52b4-f160" type="selectionEntry"/>
+                <entryLink id="d8ef-55c7-2efb-ec04" hidden="false" collective="false" targetId="3dfc-49e9-adcb-ae48" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="04e7-e796-57e1-9c2e" hidden="false" collective="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="points" value="10"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="7587-847d-9f8d-31dd" hidden="false" collective="false" targetId="a8d9-6fae-a541-9f4f" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="ad84-1f7d-5b85-ad4a" hidden="false" collective="false" targetId="e16f-acd1-265c-07f9" type="selectionEntry"/>
+        <entryLink id="7d08-c97c-53ca-06ab" hidden="false" collective="false" targetId="c74e-2993-3474-7869" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="249.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fcb7-7abc-470a-26fe" name="Medi-Probe Shard" hidden="false" collective="false" type="unit">
+      <categoryLinks>
+        <categoryLink id="fcb7-7abc-470a-26fe-72807c5d-e370-9ddf-c2b7-de5d2797f24d" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="c7bd-920e-b6e5-ef99" name="Medi-Probe" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="d758-744a-7ac4-7804" hidden="false" targetId="078e-4753-3545-ba51" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0d09-f1bc-5547-135f" name="Nano Probe Net Shard" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="increment" field="maxInForce" value="1.0">
+          <repeats>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3e3-761c-74f3-d2f2" repeats="1" roundUp="false"/>
+          </repeats>
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a3e3-761c-74f3-d2f2" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="maxInForce" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="34f8-26e7-c193-56eb" name="Nano Probe" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="ecb4-f327-4797-5d94" hidden="false" targetId="16bf-fee9-f1bf-8600" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6429-1b89-b557-736b" name="NuHu Senatexis" hidden="false" collective="false" type="model">
+      <infoLinks>
+        <infoLink id="6fd9-afd5-d70f-d751" name="NuHu Senatexis" hidden="false" targetId="41d1-a002-0258-c407" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="6429-1b89-b557-736b-481abf13-c03e-0dd0-d520-9f9837253cbe" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ae11-f605-d815-9109" name="Options" hidden="false" collective="false">
+          <entryLinks>
+            <entryLink id="6fd3-49ff-c60c-3624" name="Spotter Drone" hidden="false" collective="false" targetId="f095-7ba3-b868-32de" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2d3-3b56-ccfa-9753" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="bb6a-48bd-2cf1-f430" hidden="false" collective="false" targetId="057e-2e8a-1952-9de0" type="selectionEntry"/>
+            <entryLink id="775b-177d-e6ac-c3ac" name="Shield Drone" hidden="false" collective="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry"/>
+            <entryLink id="2523-96e0-03f8-2625" hidden="false" collective="false" targetId="5343-3c10-ccc3-0233" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="1133-9cc8-d005-ca82" hidden="false" collective="false" targetId="a2e9-2b00-2191-a410" type="selectionEntry"/>
+        <entryLink id="e3c8-4234-d63f-b52c" hidden="false" collective="false" targetId="2f22-37fa-4076-d255" type="selectionEntry"/>
+        <entryLink id="b702-73ca-4a1f-e0f5" name="IMTeL Stave (E)" hidden="false" collective="false" targetId="c7a8-840b-096e-e2b8" type="selectionEntry"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="130.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0244-6cd5-9260-c12e" name="Pulse Bike Command Squad" hidden="false" collective="false" type="unit">
+      <categoryLinks>
+        <categoryLink id="0244-6cd5-9260-c12e-481abf13-c03e-0dd0-d520-9f9837253cbe" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="fa12-b792-1fff-89e3" name="Pulse Bike Commander" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="5cac-dbde-7763-5ddd" hidden="false" targetId="9286-cbf7-0641-5ce1" type="profile"/>
+          </infoLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="ce12-0c6b-11e5-f498" name="Pulse Bike Commander Options" hidden="false" collective="false">
+              <entryLinks>
+                <entryLink id="bd12-7ad6-eb09-08ba" hidden="false" collective="false" targetId="a90a-fea5-107f-a019" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="c8d2-d4de-e467-c706" hidden="false" collective="false" targetId="12f1-610b-0dc9-4732" type="selectionEntry"/>
+            <entryLink id="77c5-7b49-1b1a-443b" name="Plasma Carbine (E)" hidden="false" collective="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry"/>
+            <entryLink id="ea21-ecb8-ce22-00d3" hidden="false" collective="false" targetId="658c-b2dd-98f4-dafb" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8b1d-c9da-076d-d08e" name="Pulse Bike Trooper" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="5f70-3d2c-69d6-3b63" hidden="false" targetId="34f9-12c5-7e7b-114c" type="profile"/>
+          </infoLinks>
+          <entryLinks>
+            <entryLink id="3ad9-f6de-2222-14d7" hidden="false" collective="false" targetId="12f1-610b-0dc9-4732" type="selectionEntry"/>
+            <entryLink id="89fc-31e3-8d85-5d84" hidden="false" collective="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry"/>
+            <entryLink id="18db-e7fa-3661-289b" hidden="false" collective="false" targetId="658c-b2dd-98f4-dafb" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="aba9-6548-4d89-9d71" name="Unit Options" hidden="false" collective="false">
+          <selectionEntryGroups>
+            <selectionEntryGroup id="01c1-76ad-1e19-2f22" name="Compactor Drone" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="7e3a-171d-c362-06f0" hidden="false" collective="false" targetId="c87f-f5b0-1134-8ad9" type="selectionEntry"/>
+                <entryLink id="792d-6942-fc08-f58a" hidden="false" collective="false" targetId="d776-f344-44a4-c41b" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="ffb4-8366-9f3a-ce9c" hidden="false" collective="false" targetId="001a-9f15-b25b-b784" type="selectionEntry"/>
+            <entryLink id="f8e2-982b-dc65-9be9" name="Plasma Lance (Bike)" hidden="false" collective="false" targetId="7dac-aa85-fc80-51d5" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="165.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2f44-92da-46f8-619d" name="Pulse Bike Squad" hidden="false" collective="false" type="unit">
+      <modifiers>
+        <modifier type="set" field="2b26-47e5-340b-a1a0" value="-1">
+          <conditions>
+            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0244-6cd5-9260-c12e" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2b26-47e5-340b-a1a0" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="2f44-92da-46f8-619d-481abf13-c03e-0dd0-d520-9f9837253cbe" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="de4c-b135-70a3-c87b" name="Pulse Bike Leader" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="27e0-cc93-d2c1-3dec" hidden="false" targetId="9ed6-e3f2-8847-d7a2" type="profile"/>
+          </infoLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="8166-a3dd-75ec-ccde" name="Pulse Bike Leader Options" hidden="false" collective="false">
+              <entryLinks>
+                <entryLink id="27d8-164a-139b-f635" hidden="false" collective="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="0179-fa9f-3b06-4db2" name="Phase Armour Boost (E)" hidden="false" collective="false" targetId="12f1-610b-0dc9-4732" type="selectionEntry"/>
+            <entryLink id="5b9e-0f99-9282-7ef1" hidden="false" collective="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry"/>
+            <entryLink id="dd0f-496a-c08e-56b4" hidden="false" collective="false" targetId="658c-b2dd-98f4-dafb" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="8783-ed89-1004-1495" name="Pulse Bike Trooper" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="5664-48f1-1957-c3d8" hidden="false" targetId="34f9-12c5-7e7b-114c" type="profile"/>
+          </infoLinks>
+          <entryLinks>
+            <entryLink id="1c5e-3cc6-d497-2644" hidden="false" collective="false" targetId="12f1-610b-0dc9-4732" type="selectionEntry"/>
+            <entryLink id="1318-0d29-4a43-dd78" hidden="false" collective="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry"/>
+            <entryLink id="0628-7b69-d134-8ece" hidden="false" collective="false" targetId="658c-b2dd-98f4-dafb" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="2de5-7dde-c917-f126" name="Unit Options" hidden="false" collective="false">
+          <selectionEntryGroups>
+            <selectionEntryGroup id="eadf-8b1d-d337-25ad" name="Compactor Drone" hidden="false" collective="false">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="16b9-1f19-f7e7-0da5" hidden="false" collective="false" targetId="c87f-f5b0-1134-8ad9" type="selectionEntry"/>
+                <entryLink id="221b-0c10-d482-195e" hidden="false" collective="false" targetId="d776-f344-44a4-c41b" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="ca55-43e4-8b73-294c" name="Spotter Drone " hidden="false" collective="false" targetId="001a-9f15-b25b-b784" type="selectionEntry"/>
+            <entryLink id="f96c-a56c-c07e-6da4" name="Plasma Lance (Bike)" hidden="false" collective="false" targetId="7dac-aa85-fc80-51d5" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="133.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7780-9268-8805-991a" name="Scout Probe Shard" hidden="false" collective="false" type="unit">
+      <categoryLinks>
+        <categoryLink id="7780-9268-8805-991a-72807c5d-e370-9ddf-c2b7-de5d2797f24d" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="275e-c158-8f26-53c9" name="Scout Probe" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="05b3-477e-3ab6-c2a4" hidden="false" targetId="56b9-5224-e0df-8218" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="10.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f53b-8cb2-f46e-ec68" name="Senatex Command Squad" hidden="false" collective="false" type="unit">
+      <categoryLinks>
+        <categoryLink id="f53b-8cb2-f46e-ec68-481abf13-c03e-0dd0-d520-9f9837253cbe" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="9217-51b5-1490-c20f" name="Senatex Commander" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="e5ba-45ac-5c32-8928" hidden="false" targetId="9686-36fa-7ae7-f4dc" type="profile"/>
+          </infoLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="4845-6259-0e92-0f04" name="Senatex Commander Options" hidden="false" collective="false">
+              <selectionEntries>
+                <selectionEntry id="2d9d-8454-98ba-682e" name="Sling net ammo" hidden="false" collective="false" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <entryLinks>
+                <entryLink id="6149-c82a-e122-2d99" name="Leader 3" hidden="false" collective="false" targetId="a90a-fea5-107f-a019" type="selectionEntry"/>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="be34-e860-46d0-d7e6" hidden="false" collective="false" targetId="6c13-252f-55b8-4de9" type="selectionEntry"/>
+            <entryLink id="de1c-d5c3-afcd-f486" hidden="false" collective="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry"/>
+            <entryLink id="691a-aa46-2b4f-a09b" hidden="false" collective="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="25b4-7c4e-e579-4fee" name="Strike Trooper" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="4d3d-b808-7a51-2ddb" hidden="false" targetId="2966-969b-3981-06ed" type="profile"/>
+          </infoLinks>
+          <entryLinks>
+            <entryLink id="f7b9-5bbf-7725-846a" hidden="false" collective="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry"/>
+            <entryLink id="4ffe-2e60-ece1-d9c4" hidden="false" collective="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="22.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="67f6-07bc-f0ba-b0bd" name="Unit Options" hidden="false" collective="false">
+          <entryLinks>
+            <entryLink id="d30a-66b4-b1ee-5cdd" hidden="false" collective="false" targetId="001a-9f15-b25b-b784" type="selectionEntry"/>
+            <entryLink id="ead8-0218-98ae-8ddd" hidden="false" collective="false" targetId="057e-2e8a-1952-9de0" type="selectionEntry"/>
+            <entryLink id="5aef-5d71-d3a9-8546" hidden="false" collective="false" targetId="9f16-5a27-44b5-7471" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="points" value="6.0"/>
+                <modifier type="increment" field="points" value="2.0">
+                  <conditions>
+                    <condition field="selections" scope="f53b-8cb2-f46e-ec68" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="25b4-7c4e-e579-4fee" type="atLeast"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <conditions>
+                    <condition field="selections" scope="f53b-8cb2-f46e-ec68" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="25b4-7c4e-e579-4fee" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="564f-776c-af3e-92fd" name="New EntryLink" hidden="false" collective="false" targetId="651f-9469-74a5-505a" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="66.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a2f5-7c0a-21e5-7b0b" name="Senatex Phase Squad" hidden="false" collective="false" type="unit">
+      <categoryLinks>
+        <categoryLink id="a2f5-7c0a-21e5-7b0b-481abf13-c03e-0dd0-d520-9f9837253cbe" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="3dd7-c3aa-50ca-26b2" name="Phase Trooper" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="cfe4-65fc-7598-d48f" hidden="false" targetId="6688-b331-6578-fb30" type="profile"/>
+          </infoLinks>
+          <entryLinks>
+            <entryLink id="3d5b-1da9-8a1e-fdff" hidden="false" collective="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry"/>
+            <entryLink id="333b-de0f-7f92-165d" hidden="false" collective="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="20.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="da65-0727-324a-34da" name="Plasma Lance" hidden="false" collective="false" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="73c1-5b5c-b994-a075" hidden="false" collective="false" targetId="21a7-132d-6703-9ff6" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="3.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="5ce3-0d5d-4909-be5b" name="Unit Options" hidden="false" collective="false">
+          <entryLinks>
+            <entryLink id="826e-6c50-646d-62a2" hidden="false" collective="false" targetId="001a-9f15-b25b-b784" type="selectionEntry"/>
+            <entryLink id="482c-adc0-0ca1-f078" hidden="false" collective="false" targetId="9f16-5a27-44b5-7471" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="2">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="d201-587c-ae9f-ac75" hidden="false" collective="false" targetId="651f-9469-74a5-505a" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="b1e3-2d2a-8b67-fc51" name="Leader" hidden="false" collective="false" defaultSelectionEntryId="f0c2-69ee-8b90-7528">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f0c2-69ee-8b90-7528" name="Strike Leader" hidden="false" collective="false" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="68ed-3fd5-b951-fe6f" hidden="false" targetId="af6e-dcdb-77a5-b67e" type="profile"/>
+              </infoLinks>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="53a6-45f6-5682-c4e8" name="Strike Leader Options" hidden="false" collective="false">
+                  <selectionEntries>
+                    <selectionEntry id="80e9-9314-55b5-7258" name="Sling net ammo" hidden="false" collective="false" type="upgrade">
+                      <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups>
-                                    
-                        <selectionEntryGroup id="4845-6259-0e92-0f04" name="&lt; Senatex Commander Options &gt;" hidden="false" collective="false">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries>
-                                                
-                                <selectionEntry id="2d9d-8454-98ba-682e" name="Sling net ammo" hidden="false" collective="false" type="upgrade">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints>
-                                                            
-                                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                                          
-                                    </constraints>
-                                                      
-                                    <categoryLinks/>
-                                                      
-                                    <selectionEntries/>
-                                                      
-                                    <selectionEntryGroups/>
-                                                      
-                                    <entryLinks/>
-                                                      
-                                    <costs>
-                                                            
-                                        <cost typeId="points" name="pts" value="5.0"/>
-                                                          
-                                    </costs>
-                                                    
-                                </selectionEntry>
-                                              
-                            </selectionEntries>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks>
-                                                
-                                <entryLink id="6149-c82a-e122-2d99" name="Leader 3" hidden="false" targetId="a90a-fea5-107f-a019" type="selectionEntry">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                    
-                                </entryLink>
-                                              
-                            </entryLinks>
-                                        
-                        </selectionEntryGroup>
-                                  
-                    </selectionEntryGroups>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="be34-e860-46d0-d7e6" hidden="false" targetId="6c13-252f-55b8-4de9" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="de1c-d5c3-afcd-f486" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="691a-aa46-2b4f-a09b" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                              
-                    <costs>
-                                    
-                        <cost typeId="points" name="pts" value="0.0"/>
-                                  
-                    </costs>
-                            
-                </selectionEntry>
-                        
-                <selectionEntry id="25b4-7c4e-e579-4fee" name="Strike Trooper" hidden="false" collective="false" type="model">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks>
-                                    
-                        <infoLink id="4d3d-b808-7a51-2ddb" hidden="false" targetId="2966-969b-3981-06ed" type="profile">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                        
-                        </infoLink>
-                                  
-                    </infoLinks>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                                    
-                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="f7b9-5bbf-7725-846a" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="4ffe-2e60-ece1-d9c4" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                              
-                    <costs>
-                                    
-                        <cost typeId="points" name="pts" value="22.0"/>
-                                  
-                    </costs>
-                            
-                </selectionEntry>
-                      
-            </selectionEntries>
-                  
-            <selectionEntryGroups>
-                        
-                <selectionEntryGroup id="67f6-07bc-f0ba-b0bd" name="&lt; Unit Options &gt;" hidden="false" collective="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="d30a-66b4-b1ee-5cdd" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="ead8-0218-98ae-8ddd" hidden="false" targetId="057e-2e8a-1952-9de0" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="5aef-5d71-d3a9-8546" hidden="false" targetId="9f16-5a27-44b5-7471" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers>
-                                                
-                                <modifier type="set" field="points" value="6.0">
-                                                      
-                                    <repeats/>
-                                                      
-                                    <conditions/>
-                                                      
-                                    <conditionGroups/>
-                                                    
-                                </modifier>
-                                                
-                                <modifier type="increment" field="points" value="2.0">
-                                                      
-                                    <repeats/>
-                                                      
-                                    <conditions>
-                                                            
-                                        <condition field="selections" scope="f53b-8cb2-f46e-ec68" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="25b4-7c4e-e579-4fee" type="atLeast"/>
-                                                          
-                                    </conditions>
-                                                      
-                                    <conditionGroups/>
-                                                    
-                                </modifier>
-                                                
-                                <modifier type="increment" field="points" value="2.0">
-                                                      
-                                    <repeats/>
-                                                      
-                                    <conditions>
-                                                            
-                                        <condition field="selections" scope="f53b-8cb2-f46e-ec68" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="25b4-7c4e-e579-4fee" type="atLeast"/>
-                                                          
-                                    </conditions>
-                                                      
-                                    <conditionGroups/>
-                                                    
-                                </modifier>
-                                              
-                            </modifiers>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="564f-776c-af3e-92fd" name="New EntryLink" hidden="false" targetId="651f-9469-74a5-505a" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                            
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="points" value="5.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <entryLinks>
+                    <entryLink id="4631-7558-0869-977f" hidden="false" collective="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry"/>
+                  </entryLinks>
                 </selectionEntryGroup>
-                      
-            </selectionEntryGroups>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="66.0"/>
-                      
-            </costs>
-                
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="eb5d-a6e4-347d-da46" hidden="false" collective="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry"/>
+                <entryLink id="b5e3-8a48-3fba-2582" hidden="false" collective="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry"/>
+                <entryLink id="40dd-425c-09d9-342d" hidden="false" collective="false" targetId="6c13-252f-55b8-4de9" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="32.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b8a7-06c0-e922-02c2" name="Senatex Support Team" hidden="false" collective="false" type="unit">
+      <categoryLinks>
+        <categoryLink id="b8a7-06c0-e922-02c2-5c47879b-41d0-1383-5fe5-a5989615db89" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="00bb-ced5-3641-b54c" name="Phase Trooper" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="41f9-49bf-1fb6-3278" name="" hidden="false" targetId="6688-b331-6578-fb30" type="profile"/>
+          </infoLinks>
+          <entryLinks>
+            <entryLink id="9523-c45f-ae8e-f7f8" hidden="false" collective="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry"/>
+            <entryLink id="51a8-2e2a-8c37-d728" hidden="false" collective="false" targetId="2f22-37fa-4076-d255" type="selectionEntry"/>
+            <entryLink id="712f-091e-2c01-aaad" name="New EntryLink" hidden="false" collective="false" targetId="41bd-5499-889a-ab16" type="selectionEntry"/>
+            <entryLink id="0474-801c-0241-22f8" name="New EntryLink" hidden="false" collective="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="15.0"/>
+          </costs>
         </selectionEntry>
-            
-        <selectionEntry id="a2f5-7c0a-21e5-7b0b" name="Senatex Phase Squad" hidden="false" collective="false" type="unit">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints/>
-                  
-            <categoryLinks>
-                        
-                <categoryLink id="a2f5-7c0a-21e5-7b0b-481abf13-c03e-0dd0-d520-9f9837253cbe" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                            
-                </categoryLink>
-                      
-            </categoryLinks>
-                  
-            <selectionEntries>
-                        
-                <selectionEntry id="3dd7-c3aa-50ca-26b2" name="Phase Trooper" hidden="false" collective="false" type="model">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks>
-                                    
-                        <infoLink id="cfe4-65fc-7598-d48f" hidden="false" targetId="6688-b331-6578-fb30" type="profile">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                        
-                        </infoLink>
-                                  
-                    </infoLinks>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                                    
-                        <constraint field="selections" scope="parent" value="7.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="3d5b-1da9-8a1e-fdff" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="333b-de0f-7f92-165d" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                              
-                    <costs>
-                                    
-                        <cost typeId="points" name="pts" value="20.0"/>
-                                  
-                    </costs>
-                            
-                </selectionEntry>
-                        
-                <selectionEntry id="da65-0727-324a-34da" name="Plasma Lance" hidden="false" collective="false" type="upgrade">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="73c1-5b5c-b994-a075" hidden="false" targetId="21a7-132d-6703-9ff6" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                              
-                    <costs>
-                                    
-                        <cost typeId="points" name="pts" value="3.0"/>
-                                  
-                    </costs>
-                            
-                </selectionEntry>
-                      
-            </selectionEntries>
-                  
-            <selectionEntryGroups>
-                        
-                <selectionEntryGroup id="5ce3-0d5d-4909-be5b" name="&lt; Unit Options &gt;" hidden="false" collective="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="826e-6c50-646d-62a2" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="482c-adc0-0ca1-f078" hidden="false" targetId="9f16-5a27-44b5-7471" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers>
-                                                
-                                <modifier type="increment" field="points" value="2">
-                                                      
-                                    <repeats>
-                                                            
-                                        <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
-                                                          
-                                    </repeats>
-                                                      
-                                    <conditions/>
-                                                      
-                                    <conditionGroups/>
-                                                    
-                                </modifier>
-                                              
-                            </modifiers>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="d201-587c-ae9f-ac75" hidden="false" targetId="651f-9469-74a5-505a" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                            
-                </selectionEntryGroup>
-                        
-                <selectionEntryGroup id="b1e3-2d2a-8b67-fc51" name="Leader" hidden="false" collective="false" defaultSelectionEntryId="f0c2-69ee-8b90-7528">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries>
-                                    
-                        <selectionEntry id="f0c2-69ee-8b90-7528" name="&lt; Strike Leader" hidden="false" collective="false" type="model">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks>
-                                                
-                                <infoLink id="68ed-3fd5-b951-fe6f" hidden="false" targetId="af6e-dcdb-77a5-b67e" type="profile">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                              
-                            </infoLinks>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups>
-                                                
-                                <selectionEntryGroup id="53a6-45f6-5682-c4e8" name="&lt; Strike Leader Options &gt;" hidden="false" collective="false">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                      
-                                    <selectionEntries>
-                                                            
-                                        <selectionEntry id="80e9-9314-55b5-7258" name="Sling net ammo" hidden="false" collective="false" type="upgrade">
-                                                                  
-                                            <profiles/>
-                                                                  
-                                            <rules/>
-                                                                  
-                                            <infoLinks/>
-                                                                  
-                                            <modifiers/>
-                                                                  
-                                            <constraints>
-                                                                        
-                                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                                                      
-                                            </constraints>
-                                                                  
-                                            <categoryLinks/>
-                                                                  
-                                            <selectionEntries/>
-                                                                  
-                                            <selectionEntryGroups/>
-                                                                  
-                                            <entryLinks/>
-                                                                  
-                                            <costs>
-                                                                        
-                                                <cost typeId="points" name="pts" value="5.0"/>
-                                                                      
-                                            </costs>
-                                                                
-                                        </selectionEntry>
-                                                          
-                                    </selectionEntries>
-                                                      
-                                    <selectionEntryGroups/>
-                                                      
-                                    <entryLinks>
-                                                            
-                                        <entryLink id="4631-7558-0869-977f" hidden="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry">
-                                                                  
-                                            <profiles/>
-                                                                  
-                                            <rules/>
-                                                                  
-                                            <infoLinks/>
-                                                                  
-                                            <modifiers/>
-                                                                  
-                                            <constraints/>
-                                                                  
-                                            <categoryLinks/>
-                                                                
-                                        </entryLink>
-                                                          
-                                    </entryLinks>
-                                                    
-                                </selectionEntryGroup>
-                                              
-                            </selectionEntryGroups>
-                                          
-                            <entryLinks>
-                                                
-                                <entryLink id="eb5d-a6e4-347d-da46" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                    
-                                </entryLink>
-                                                
-                                <entryLink id="b5e3-8a48-3fba-2582" hidden="false" targetId="eafe-a83e-6cfd-0559" type="selectionEntry">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                    
-                                </entryLink>
-                                                
-                                <entryLink id="40dd-425c-09d9-342d" hidden="false" targetId="6c13-252f-55b8-4de9" type="selectionEntry">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                    
-                                </entryLink>
-                                              
-                            </entryLinks>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="0.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                  
-                    </selectionEntries>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks/>
-                            
-                </selectionEntryGroup>
-                      
-            </selectionEntryGroups>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="32.0"/>
-                      
-            </costs>
-                
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="8dc3-d26a-9d90-5bf3" name="Unit Options" hidden="false" collective="false">
+          <entryLinks>
+            <entryLink id="3154-474d-e038-f888" hidden="false" collective="false" targetId="001a-9f15-b25b-b784" type="selectionEntry"/>
+            <entryLink id="75a1-ea51-ec68-4911" name="New EntryLink" hidden="false" collective="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="34c8-92d1-548b-d72e" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="5ca6-b792-5b22-8784">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="5ca6-b792-5b22-8784" hidden="false" collective="false" targetId="afc8-4f62-e1e2-1e4c" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="10.0"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="2183-f7dc-0030-ca25" hidden="false" collective="false" targetId="3dfc-49e9-adcb-ae48" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="points" value="35"/>
+              </modifiers>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2fa1-035d-c0c1-e653" name="Target Probe Shard" hidden="false" collective="false" type="unit">
+      <categoryLinks>
+        <categoryLink id="2fa1-035d-c0c1-e653-72807c5d-e370-9ddf-c2b7-de5d2797f24d" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="70f6-51e9-f4f6-761f" name="Target Probe" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="ec43-8043-3ccc-fe21" hidden="false" targetId="9ce3-1277-65a2-7ab0" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+          </costs>
         </selectionEntry>
-            
-        <selectionEntry id="b8a7-06c0-e922-02c2" name="Senatex Support Team" hidden="false" collective="false" type="unit">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints/>
-                  
-            <categoryLinks>
-                        
-                <categoryLink id="b8a7-06c0-e922-02c2-5c47879b-41d0-1383-5fe5-a5989615db89" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                            
-                </categoryLink>
-                      
-            </categoryLinks>
-                  
-            <selectionEntries>
-                        
-                <selectionEntry id="00bb-ced5-3641-b54c" name="Phase Trooper" hidden="false" collective="false" type="model">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks>
-                                    
-                        <infoLink id="41f9-49bf-1fb6-3278" name="" hidden="false" targetId="6688-b331-6578-fb30" type="profile">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                        
-                        </infoLink>
-                                  
-                    </infoLinks>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                                    
-                        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="9523-c45f-ae8e-f7f8" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="51a8-2e2a-8c37-d728" hidden="false" targetId="2f22-37fa-4076-d255" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="712f-091e-2c01-aaad" name="New EntryLink" hidden="false" targetId="41bd-5499-889a-ab16" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="0474-801c-0241-22f8" name="New EntryLink" hidden="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                              
-                    <costs>
-                                    
-                        <cost typeId="points" name="pts" value="15.0"/>
-                                  
-                    </costs>
-                            
-                </selectionEntry>
-                      
-            </selectionEntries>
-                  
-            <selectionEntryGroups>
-                        
-                <selectionEntryGroup id="8dc3-d26a-9d90-5bf3" name="&lt; Unit Options &gt;" hidden="false" collective="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="3154-474d-e038-f888" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="75a1-ea51-ec68-4911" name="New EntryLink" hidden="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                            
-                </selectionEntryGroup>
-                        
-                <selectionEntryGroup id="34c8-92d1-548b-d72e" name="Weapon" hidden="false" collective="false" defaultSelectionEntryId="5ca6-b792-5b22-8784">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="5ca6-b792-5b22-8784" hidden="false" targetId="afc8-4f62-e1e2-1e4c" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers>
-                                                
-                                <modifier type="increment" field="points" value="10.0">
-                                                      
-                                    <repeats/>
-                                                      
-                                    <conditions/>
-                                                      
-                                    <conditionGroups/>
-                                                    
-                                </modifier>
-                                              
-                            </modifiers>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="2183-f7dc-0030-ca25" hidden="false" targetId="3dfc-49e9-adcb-ae48" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers>
-                                                
-                                <modifier type="set" field="points" value="35">
-                                                      
-                                    <repeats/>
-                                                      
-                                    <conditions/>
-                                                      
-                                    <conditionGroups/>
-                                                    
-                                </modifier>
-                                              
-                            </modifiers>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                            
-                </selectionEntryGroup>
-                      
-            </selectionEntryGroups>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
+      </selectionEntries>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c4d4-9418-6246-d85d" name="Tograh MV2 Transporter Drone " hidden="false" collective="false" type="model">
+      <categoryLinks>
+        <categoryLink id="765a-a804-2e3b-1c18" name="New CategoryLink" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="288e-be87-ca44-03e8" name="Transporter Drone" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="87f0-50e3-da01-55f0" hidden="false" targetId="1aa8-c7f2-fa2d-324a" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
         </selectionEntry>
-            
-        <selectionEntry id="2fa1-035d-c0c1-e653" name="Target Probe Shard" hidden="false" collective="false" type="unit">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints/>
-                  
-            <categoryLinks>
-                        
-                <categoryLink id="2fa1-035d-c0c1-e653-72807c5d-e370-9ddf-c2b7-de5d2797f24d" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="true">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                            
-                </categoryLink>
-                      
-            </categoryLinks>
-                  
-            <selectionEntries>
-                        
-                <selectionEntry id="70f6-51e9-f4f6-761f" name="&lt; Target Probe" hidden="false" collective="false" type="model">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks>
-                                    
-                        <infoLink id="ec43-8043-3ccc-fe21" hidden="false" targetId="9ce3-1277-65a2-7ab0" type="profile">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                        
-                        </infoLink>
-                                  
-                    </infoLinks>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                                    
-                        <constraint field="selections" scope="parent" value="6.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks/>
-                              
-                    <costs>
-                                    
-                        <cost typeId="points" name="pts" value="5.0"/>
-                                  
-                    </costs>
-                            
-                </selectionEntry>
-                      
-            </selectionEntries>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="c4d4-9418-6246-d85d" name="Tograh MV2 Transporter Drone " hidden="false" collective="false" type="model">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints/>
-                  
-            <categoryLinks>
-                        
-                <categoryLink id="765a-a804-2e3b-1c18" name="New CategoryLink" hidden="false" targetId="5c47879b-41d0-1383-5fe5-a5989615db89" primary="true">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                            
-                </categoryLink>
-                      
-            </categoryLinks>
-                  
-            <selectionEntries>
-                        
-                <selectionEntry id="288e-be87-ca44-03e8" name="&lt; Transporter Drone" hidden="false" collective="false" type="model">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks>
-                                    
-                        <infoLink id="87f0-50e3-da01-55f0" hidden="false" targetId="1aa8-c7f2-fa2d-324a" type="profile">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                        
-                        </infoLink>
-                                  
-                    </infoLinks>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks/>
-                              
-                    <costs>
-                                    
-                        <cost typeId="points" name="pts" value="0.0"/>
-                                  
-                    </costs>
-                            
-                </selectionEntry>
-                      
-            </selectionEntries>
-                  
-            <selectionEntryGroups>
-                        
-                <selectionEntryGroup id="460e-6cab-a7b9-878c" name="&lt; Options &gt;" hidden="false" collective="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="9543-75e4-e4b2-ca03" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="03eb-ebb9-cdf3-ec98" name="" hidden="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="b6d4-1bbf-8e0d-d2ac" name="" hidden="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                            
-                </selectionEntryGroup>
-                        
-                <selectionEntryGroup id="c909-6003-f9c2-386e" name="&lt; Transporter Drone Options &gt;" hidden="false" collective="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries>
-                                    
-                        <selectionEntry id="c876-e992-a347-2d38" name="Sensor Module" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="289c-f0ef-81d4-2e97" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="30.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                    
-                        <selectionEntry id="ad24-50c3-476f-8cab" name="Plasma Light Support" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles>
-                                                
-                                <profile typeId="ecae-8ac8-2c13-0dd3" typeName="Weapon" id="2c92-838c-175b-2b7d" name="Plasma Light Support" hidden="false">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <characteristics>
-                                                            
-                                        <characteristic typeId="c2de-17f1-10e2-2c0a" name="Effective">20</characteristic>
-                                                            
-                                        <characteristic typeId="995e-b5e6-4c63-0baa" name="Long"/>
-                                                            
-                                        <characteristic typeId="bf58-0ad5-c7ee-3fd9" name="Extreme"/>
-                                                            
-                                        <characteristic typeId="897c-d3c4-3983-896a" name="Strike Value"/>
-                                                            
-                                        <characteristic typeId="7e87-2586-653f-d6ec" name="Special Rules"/>
-                                                          
-                                    </characteristics>
-                                                    
-                                </profile>
-                                              
-                            </profiles>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a126-c7cd-c9bb-e3bb" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="40.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                    
-                        <selectionEntry id="21c3-6e14-8682-2728" name="Kinetic Armour Upgrade" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a1c-1003-4ca1-b71d" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="48.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                    
-                        <selectionEntry id="7548-82d4-26c4-ca33" name="Enhanced Machine Intelligence" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c74a-9420-b9e4-fa5e" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs/>
-                                        
-                        </selectionEntry>
-                                  
-                    </selectionEntries>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="daf1-967b-4024-7ec8" name="Self Repair" hidden="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers>
-                                                
-                                <modifier type="set" field="points" value="10">
-                                                      
-                                    <repeats/>
-                                                      
-                                    <conditions/>
-                                                      
-                                    <conditionGroups/>
-                                                    
-                                </modifier>
-                                              
-                            </modifiers>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="e50e-ac32-0154-fc96" hidden="false" targetId="a8d9-6fae-a541-9f4f" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                            
-                </selectionEntryGroup>
-                      
-            </selectionEntryGroups>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="96.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="a82b-95e0-b4e1-14fc" name="Tsan Ra Phase Squad" hidden="false" collective="false" type="unit">
-                  
-            <profiles>
-                        
-                <profile typeId="ecae-8ac8-2c13-0dd3" typeName="Weapon" id="fe50-9862-ecf1-e371" name="Compressor Torus" hidden="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <characteristics>
-                                    
-                        <characteristic typeId="c2de-17f1-10e2-2c0a" name="Effective">10</characteristic>
-                                    
-                        <characteristic typeId="995e-b5e6-4c63-0baa" name="Long">20</characteristic>
-                                    
-                        <characteristic typeId="bf58-0ad5-c7ee-3fd9" name="Extreme">30</characteristic>
-                                    
-                        <characteristic typeId="897c-d3c4-3983-896a" name="Strike Value">3/2/0</characteristic>
-                                    
-                        <characteristic typeId="7e87-2586-653f-d6ec" name="Special Rules">Compressor, No Cover</characteristic>
-                                  
-                    </characteristics>
-                            
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="460e-6cab-a7b9-878c" name="Options" hidden="false" collective="false">
+          <entryLinks>
+            <entryLink id="9543-75e4-e4b2-ca03" hidden="false" collective="false" targetId="001a-9f15-b25b-b784" type="selectionEntry"/>
+            <entryLink id="03eb-ebb9-cdf3-ec98" name="" hidden="false" collective="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry"/>
+            <entryLink id="b6d4-1bbf-8e0d-d2ac" name="" hidden="false" collective="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="c909-6003-f9c2-386e" name="Transporter Drone Options" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="c876-e992-a347-2d38" name="Sensor Module" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="289c-f0ef-81d4-2e97" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="30.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="ad24-50c3-476f-8cab" name="Plasma Light Support" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a126-c7cd-c9bb-e3bb" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="2c92-838c-175b-2b7d" name="Plasma Light Support" hidden="false" typeId="ecae-8ac8-2c13-0dd3" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Effective" typeId="c2de-17f1-10e2-2c0a">20</characteristic>
+                    <characteristic name="Long" typeId="995e-b5e6-4c63-0baa"/>
+                    <characteristic name="Extreme" typeId="bf58-0ad5-c7ee-3fd9"/>
+                    <characteristic name="Strike Value" typeId="897c-d3c4-3983-896a"/>
+                    <characteristic name="Special Rules" typeId="7e87-2586-653f-d6ec"/>
+                  </characteristics>
                 </profile>
-                      
-            </profiles>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints/>
-                  
-            <categoryLinks>
-                        
-                <categoryLink id="a82b-95e0-b4e1-14fc-481abf13-c03e-0dd0-d520-9f9837253cbe" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                            
-                </categoryLink>
-                      
-            </categoryLinks>
-                  
-            <selectionEntries>
-                        
-                <selectionEntry id="a70a-f477-4d54-af31" name="Tsan Trooper" hidden="false" collective="false" type="model">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks>
-                                    
-                        <infoLink id="c744-bf9b-df2c-c292" name="Tsan Trooper" hidden="false" targetId="c626-1591-8fa9-bdf0" type="profile">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                        
-                        </infoLink>
-                                  
-                    </infoLinks>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                                    
-                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="666b-8a2f-c33c-7b17" name="Phase Armour (E)" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="840d-bc4c-6ce5-20e0" hidden="false" targetId="86a3-8659-018c-f8a1" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                              
-                    <costs>
-                                    
-                        <cost typeId="points" name="pts" value="27.0"/>
-                                  
-                    </costs>
-                            
-                </selectionEntry>
-                      
-            </selectionEntries>
-                  
-            <selectionEntryGroups>
-                        
-                <selectionEntryGroup id="bb3b-c728-9ab4-049d" name="Unit Options" hidden="false" collective="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="be29-fbfe-358b-6a61" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="80ba-4bd8-0948-31eb" hidden="false" targetId="9f16-5a27-44b5-7471" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers>
-                                                
-                                <modifier type="increment" field="points" value="2.0">
-                                                      
-                                    <repeats/>
-                                                      
-                                    <conditions>
-                                                            
-                                        <condition field="selections" scope="a82b-95e0-b4e1-14fc" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a70a-f477-4d54-af31" type="atLeast"/>
-                                                          
-                                    </conditions>
-                                                      
-                                    <conditionGroups/>
-                                                    
-                                </modifier>
-                                                
-                                <modifier type="increment" field="points" value="2.0">
-                                                      
-                                    <repeats/>
-                                                      
-                                    <conditions>
-                                                            
-                                        <condition field="selections" scope="a82b-95e0-b4e1-14fc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="abe0-9a11-c0cf-025a" type="equalTo"/>
-                                                          
-                                    </conditions>
-                                                      
-                                    <conditionGroups/>
-                                                    
-                                </modifier>
-                                                
-                                <modifier type="increment" field="points" value="2.0">
-                                                      
-                                    <repeats/>
-                                                      
-                                    <conditions>
-                                                            
-                                        <condition field="selections" scope="a82b-95e0-b4e1-14fc" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a70a-f477-4d54-af31" type="atLeast"/>
-                                                          
-                                    </conditions>
-                                                      
-                                    <conditionGroups/>
-                                                    
-                                </modifier>
-                                                
-                                <modifier type="increment" field="points" value="2.0">
-                                                      
-                                    <repeats/>
-                                                      
-                                    <conditions>
-                                                            
-                                        <condition field="selections" scope="a82b-95e0-b4e1-14fc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a70a-f477-4d54-af31" type="atLeast"/>
-                                                          
-                                    </conditions>
-                                                      
-                                    <conditionGroups/>
-                                                    
-                                </modifier>
-                                                
-                                <modifier type="increment" field="points" value="2.0">
-                                                      
-                                    <repeats/>
-                                                      
-                                    <conditions>
-                                                            
-                                        <condition field="selections" scope="a82b-95e0-b4e1-14fc" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a70a-f477-4d54-af31" type="atLeast"/>
-                                                          
-                                    </conditions>
-                                                      
-                                    <conditionGroups/>
-                                                    
-                                </modifier>
-                                              
-                            </modifiers>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="88e2-f4ed-6791-12a6" hidden="false" targetId="651f-9469-74a5-505a" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                            
-                </selectionEntryGroup>
-                        
-                <selectionEntryGroup id="541d-88e5-07fd-a7c4" name="Leader" hidden="false" collective="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                                    
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="40.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="21c3-6e14-8682-2728" name="Kinetic Armour Upgrade" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a1c-1003-4ca1-b71d" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="48.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7548-82d4-26c4-ca33" name="Enhanced Machine Intelligence" hidden="false" collective="false" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c74a-9420-b9e4-fa5e" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="10.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="daf1-967b-4024-7ec8" name="Self Repair" hidden="false" collective="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="points" value="10"/>
+              </modifiers>
+            </entryLink>
+            <entryLink id="e50e-ac32-0154-fc96" hidden="false" collective="false" targetId="a8d9-6fae-a541-9f4f" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="96.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a82b-95e0-b4e1-14fc" name="Tsan Ra Phase Squad" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="fe50-9862-ecf1-e371" name="Compressor Torus" hidden="false" typeId="ecae-8ac8-2c13-0dd3" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Effective" typeId="c2de-17f1-10e2-2c0a">10</characteristic>
+            <characteristic name="Long" typeId="995e-b5e6-4c63-0baa">20</characteristic>
+            <characteristic name="Extreme" typeId="bf58-0ad5-c7ee-3fd9">30</characteristic>
+            <characteristic name="Strike Value" typeId="897c-d3c4-3983-896a">3/2/0</characteristic>
+            <characteristic name="Special Rules" typeId="7e87-2586-653f-d6ec">Compressor, No Cover</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink id="a82b-95e0-b4e1-14fc-481abf13-c03e-0dd0-d520-9f9837253cbe" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="a70a-f477-4d54-af31" name="Tsan Trooper" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="c744-bf9b-df2c-c292" name="Tsan Trooper" hidden="false" targetId="c626-1591-8fa9-bdf0" type="profile"/>
+          </infoLinks>
+          <entryLinks>
+            <entryLink id="666b-8a2f-c33c-7b17" name="Phase Armour (E)" hidden="false" collective="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry"/>
+            <entryLink id="840d-bc4c-6ce5-20e0" hidden="false" collective="false" targetId="86a3-8659-018c-f8a1" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="27.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="bb3b-c728-9ab4-049d" name="Unit Options" hidden="false" collective="false">
+          <entryLinks>
+            <entryLink id="be29-fbfe-358b-6a61" hidden="false" collective="false" targetId="001a-9f15-b25b-b784" type="selectionEntry"/>
+            <entryLink id="80ba-4bd8-0948-31eb" hidden="false" collective="false" targetId="9f16-5a27-44b5-7471" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="2.0">
+                  <conditions>
+                    <condition field="selections" scope="a82b-95e0-b4e1-14fc" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a70a-f477-4d54-af31" type="atLeast"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <conditions>
+                    <condition field="selections" scope="a82b-95e0-b4e1-14fc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="abe0-9a11-c0cf-025a" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <conditions>
+                    <condition field="selections" scope="a82b-95e0-b4e1-14fc" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a70a-f477-4d54-af31" type="atLeast"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <conditions>
+                    <condition field="selections" scope="a82b-95e0-b4e1-14fc" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a70a-f477-4d54-af31" type="atLeast"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <conditions>
+                    <condition field="selections" scope="a82b-95e0-b4e1-14fc" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a70a-f477-4d54-af31" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="88e2-f4ed-6791-12a6" hidden="false" collective="false" targetId="651f-9469-74a5-505a" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="541d-88e5-07fd-a7c4" name="Leader" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="abe0-9a11-c0cf-025a" name="Tsan Leader" hidden="false" collective="false" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d024-bd76-05d9-46f0" hidden="false" targetId="e480-7c4e-fa39-3a68" type="profile"/>
+              </infoLinks>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="e2c1-0bb8-c914-f0a7" name="Tsan Leader Options" hidden="false" collective="false">
+                  <selectionEntries>
+                    <selectionEntry id="3c98-0948-998b-1f76" name="Sling net ammo" hidden="false" collective="false" type="upgrade">
+                      <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries>
-                                    
-                        <selectionEntry id="abe0-9a11-c0cf-025a" name="Tsan Leader" hidden="false" collective="false" type="model">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks>
-                                                
-                                <infoLink id="d024-bd76-05d9-46f0" hidden="false" targetId="e480-7c4e-fa39-3a68" type="profile">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                              
-                            </infoLinks>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups>
-                                                
-                                <selectionEntryGroup id="e2c1-0bb8-c914-f0a7" name="Tsan Leader Options" hidden="false" collective="false">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                      
-                                    <selectionEntries>
-                                                            
-                                        <selectionEntry id="3c98-0948-998b-1f76" name="Sling net ammo" hidden="false" collective="false" type="upgrade">
-                                                                  
-                                            <profiles/>
-                                                                  
-                                            <rules/>
-                                                                  
-                                            <infoLinks/>
-                                                                  
-                                            <modifiers/>
-                                                                  
-                                            <constraints>
-                                                                        
-                                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                                                      
-                                            </constraints>
-                                                                  
-                                            <categoryLinks/>
-                                                                  
-                                            <selectionEntries/>
-                                                                  
-                                            <selectionEntryGroups/>
-                                                                  
-                                            <entryLinks/>
-                                                                  
-                                            <costs>
-                                                                        
-                                                <cost typeId="points" name="pts" value="5.0"/>
-                                                                      
-                                            </costs>
-                                                                
-                                        </selectionEntry>
-                                                          
-                                    </selectionEntries>
-                                                      
-                                    <selectionEntryGroups/>
-                                                      
-                                    <entryLinks>
-                                                            
-                                        <entryLink id="0499-6b2b-9f0e-e301" hidden="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry">
-                                                                  
-                                            <profiles/>
-                                                                  
-                                            <rules/>
-                                                                  
-                                            <infoLinks/>
-                                                                  
-                                            <modifiers/>
-                                                                  
-                                            <constraints/>
-                                                                  
-                                            <categoryLinks/>
-                                                                
-                                        </entryLink>
-                                                          
-                                    </entryLinks>
-                                                    
-                                </selectionEntryGroup>
-                                              
-                            </selectionEntryGroups>
-                                          
-                            <entryLinks>
-                                                
-                                <entryLink id="f252-9b73-66a0-84c2" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                    
-                                </entryLink>
-                                                
-                                <entryLink id="5317-a3d7-5287-fb45" hidden="false" targetId="86a3-8659-018c-f8a1" type="selectionEntry">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                    
-                                </entryLink>
-                                                
-                                <entryLink id="f607-7026-ae69-f1bc" hidden="false" targetId="6c13-252f-55b8-4de9" type="selectionEntry">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                    
-                                </entryLink>
-                                              
-                            </entryLinks>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="39.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                  
-                    </selectionEntries>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks/>
-                            
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="points" value="5.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <entryLinks>
+                    <entryLink id="0499-6b2b-9f0e-e301" hidden="false" collective="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry"/>
+                  </entryLinks>
                 </selectionEntryGroup>
-                      
-            </selectionEntryGroups>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="f252-9b73-66a0-84c2" hidden="false" collective="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry"/>
+                <entryLink id="5317-a3d7-5287-fb45" hidden="false" collective="false" targetId="86a3-8659-018c-f8a1" type="selectionEntry"/>
+                <entryLink id="f607-7026-ae69-f1bc" hidden="false" collective="false" targetId="6c13-252f-55b8-4de9" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="39.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3cad-67dd-7378-8d8d" name="Iso-Drone" hidden="false" collective="false" type="upgrade">
+      <profiles>
+        <profile id="3a04-72cb-d6c6-8971" name="Iso-Drone" hidden="false" typeId="1650-77b3-10d1-6406" typeName="Model">
+          <characteristics>
+            <characteristic name="Ag" typeId="cf30-f234-691c-47bd">7</characteristic>
+            <characteristic name="Acc" typeId="017a-9b43-b7b3-030d">0</characteristic>
+            <characteristic name="Str" typeId="8294-36f1-6431-2145">1</characteristic>
+            <characteristic name="Res" typeId="f214-abe8-c922-c51b">10</characteristic>
+            <characteristic name="Init" typeId="08b9-e038-7ba6-488e">8</characteristic>
+            <characteristic name="Co" typeId="3993-27b0-c3d9-de20">8</characteristic>
+            <characteristic name="Special" typeId="3baa-9cfd-f273-822d">Slow, Iso-Shield, Scramble Proof</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <rules>
+        <rule id="ad38-fda4-ad6c-d443" name="Scramble Proof" hidden="false"/>
+        <rule id="200e-f7fd-a3d3-aee4" name="Iso-Shield" hidden="false"/>
+      </rules>
+      <infoLinks>
+        <infoLink id="567c-ff9e-deb1-a44b" name="Slow" hidden="false" targetId="7c88-64d4-50ad-2313" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="848f-03cc-335c-6032" name="New CategoryLink" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a915-b4eb-2c22-6df8" name="Tsan Ra Torus Squad" hidden="false" collective="false" type="upgrade">
+      <categoryLinks>
+        <categoryLink id="f7db-fa1b-2b6a-5089" name="New CategoryLink" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="1f40-fa7f-66ab-c6bf" name="Tsan Trooper" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d6f6-5942-21b0-5b38" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="812f-f2b1-a4f6-8402" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="1d38-3841-ca6d-d0e4" name="Tsan Trooper" hidden="false" targetId="c626-1591-8fa9-bdf0" type="profile"/>
+            <infoLink id="b0df-e788-0228-83d6" name="Compressor Torus" hidden="false" targetId="7f76-db01-256f-c0df" type="profile"/>
+            <infoLink id="081d-e342-00f5-06e2" name="Compressor Torus - H2H" hidden="false" targetId="04ce-712e-6e8c-b950" type="profile"/>
+          </infoLinks>
+          <entryLinks>
+            <entryLink id="2d0a-5238-7e77-4ba5" name="Phase Armour (E)" hidden="false" collective="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="27.0"/>
+          </costs>
         </selectionEntry>
-            
-        <selectionEntry id="3cad-67dd-7378-8d8d" name="Iso-Drone" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles>
-                        
-                <profile typeId="1650-77b3-10d1-6406" typeName="Model" id="3a04-72cb-d6c6-8971" name="Iso-Drone" hidden="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <characteristics>
-                                    
-                        <characteristic typeId="cf30-f234-691c-47bd" name="Ag">7</characteristic>
-                                    
-                        <characteristic typeId="017a-9b43-b7b3-030d" name="Acc">0</characteristic>
-                                    
-                        <characteristic typeId="8294-36f1-6431-2145" name="Str">1</characteristic>
-                                    
-                        <characteristic typeId="f214-abe8-c922-c51b" name="Res">10</characteristic>
-                                    
-                        <characteristic typeId="08b9-e038-7ba6-488e" name="Init">8</characteristic>
-                                    
-                        <characteristic typeId="3993-27b0-c3d9-de20" name="Co">8</characteristic>
-                                    
-                        <characteristic typeId="3baa-9cfd-f273-822d" name="Special">Slow, Iso-Shield, Scramble Proof</characteristic>
-                                  
-                    </characteristics>
-                            
-                </profile>
-                      
-            </profiles>
-                  
-            <rules>
-                        
-                <rule id="ad38-fda4-ad6c-d443" name="Scramble Proof" hidden="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </rule>
-                        
-                <rule id="200e-f7fd-a3d3-aee4" name="Iso-Shield" hidden="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </rule>
-                      
-            </rules>
-                  
-            <infoLinks>
-                        
-                <infoLink id="567c-ff9e-deb1-a44b" name="Slow" hidden="false" targetId="7c88-64d4-50ad-2313" type="rule">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                      
-            </infoLinks>
-                  
-            <modifiers/>
-                  
-            <constraints/>
-                  
-            <categoryLinks>
-                        
-                <categoryLink id="848f-03cc-335c-6032" name="New CategoryLink" hidden="false" targetId="72807c5d-e370-9ddf-c2b7-de5d2797f24d" primary="true">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                            
-                </categoryLink>
-                      
-            </categoryLinks>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="25.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="a915-b4eb-2c22-6df8" name="Tsan Ra Torus Squad" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints/>
-                  
-            <categoryLinks>
-                        
-                <categoryLink id="f7db-fa1b-2b6a-5089" name="New CategoryLink" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                            
-                </categoryLink>
-                      
-            </categoryLinks>
-                  
-            <selectionEntries>
-                        
-                <selectionEntry id="1f40-fa7f-66ab-c6bf" name="Tsan Trooper" hidden="false" collective="false" type="model">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks>
-                                    
-                        <infoLink id="1d38-3841-ca6d-d0e4" name="Tsan Trooper" hidden="false" targetId="c626-1591-8fa9-bdf0" type="profile">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                        
-                        </infoLink>
-                                    
-                        <infoLink id="b0df-e788-0228-83d6" name="Compressor Torus" hidden="false" targetId="7f76-db01-256f-c0df" type="profile">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                        
-                        </infoLink>
-                                    
-                        <infoLink id="081d-e342-00f5-06e2" name="Compressor Torus - H2H" hidden="false" targetId="04ce-712e-6e8c-b950" type="profile">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                        
-                        </infoLink>
-                                  
-                    </infoLinks>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d6f6-5942-21b0-5b38" type="min"/>
-                                    
-                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="812f-f2b1-a4f6-8402" type="max"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="2d0a-5238-7e77-4ba5" name="Phase Armour (E)" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                              
-                    <costs>
-                                    
-                        <cost typeId="points" name="pts" value="27.0"/>
-                                  
-                    </costs>
-                            
-                </selectionEntry>
-                      
-            </selectionEntries>
-                  
-            <selectionEntryGroups>
-                        
-                <selectionEntryGroup id="ac32-2821-b001-99e0" name="Leader" hidden="false" collective="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d678-4504-c4fa-5237" type="min"/>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fa8a-16eb-2e61-d7d1" type="max"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries>
-                                    
-                        <selectionEntry id="e992-1d75-438e-b2eb" name="Tsan Leader" hidden="false" collective="false" type="model">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks>
-                                                
-                                <infoLink id="4cfb-0681-bab3-f934" name="Tsan Leader" hidden="false" targetId="e480-7c4e-fa39-3a68" type="profile">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                                
-                                <infoLink id="15b6-6802-6c73-ee4e" name="Compressor Torus" hidden="false" targetId="7f76-db01-256f-c0df" type="profile">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                                
-                                <infoLink id="14fe-fdfe-6e80-983e" name="Compressor Torus - H2H" hidden="false" targetId="04ce-712e-6e8c-b950" type="profile">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                              
-                            </infoLinks>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3d76-eb71-4835-2d77" type="min"/>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0043-76f5-3286-669a" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups>
-                                                
-                                <selectionEntryGroup id="3e69-6b7f-954b-bc30" name="Tsan Leader Options" hidden="false" collective="false">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                      
-                                    <selectionEntries/>
-                                                      
-                                    <selectionEntryGroups/>
-                                                      
-                                    <entryLinks>
-                                                            
-                                        <entryLink id="7c61-dc41-46b4-8eee" name="" hidden="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry">
-                                                                  
-                                            <profiles/>
-                                                                  
-                                            <rules/>
-                                                                  
-                                            <infoLinks/>
-                                                                  
-                                            <modifiers/>
-                                                                  
-                                            <constraints/>
-                                                                  
-                                            <categoryLinks/>
-                                                                
-                                        </entryLink>
-                                                          
-                                    </entryLinks>
-                                                    
-                                </selectionEntryGroup>
-                                              
-                            </selectionEntryGroups>
-                                          
-                            <entryLinks>
-                                                
-                                <entryLink id="e2e6-2799-e774-fc44" name="Phase Armour (E)" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                    
-                                </entryLink>
-                                                
-                                <entryLink id="4762-5a4b-eeca-0f1b" name="X-Sling (E)" hidden="false" targetId="6c13-252f-55b8-4de9" type="selectionEntry">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                    
-                                </entryLink>
-                                              
-                            </entryLinks>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="39.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                  
-                    </selectionEntries>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks/>
-                            
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="ac32-2821-b001-99e0" name="Leader" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d678-4504-c4fa-5237" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fa8a-16eb-2e61-d7d1" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="e992-1d75-438e-b2eb" name="Tsan Leader" hidden="false" collective="false" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3d76-eb71-4835-2d77" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0043-76f5-3286-669a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="4cfb-0681-bab3-f934" name="Tsan Leader" hidden="false" targetId="e480-7c4e-fa39-3a68" type="profile"/>
+                <infoLink id="15b6-6802-6c73-ee4e" name="Compressor Torus" hidden="false" targetId="7f76-db01-256f-c0df" type="profile"/>
+                <infoLink id="14fe-fdfe-6e80-983e" name="Compressor Torus - H2H" hidden="false" targetId="04ce-712e-6e8c-b950" type="profile"/>
+              </infoLinks>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="3e69-6b7f-954b-bc30" name="Tsan Leader Options" hidden="false" collective="false">
+                  <entryLinks>
+                    <entryLink id="7c61-dc41-46b4-8eee" name="" hidden="false" collective="false" targetId="cd4f-0ce9-a6a4-b34a" type="selectionEntry"/>
+                  </entryLinks>
                 </selectionEntryGroup>
-                        
-                <selectionEntryGroup id="a2f6-c5f6-7151-4cdc" name="Unit Options" hidden="false" collective="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="ad9b-a9fe-e000-c409" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="7f7d-32f1-606b-1daf" hidden="false" targetId="9f16-5a27-44b5-7471" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers>
-                                                
-                                <modifier type="increment" field="points" value="2">
-                                                      
-                                    <repeats/>
-                                                      
-                                    <conditions>
-                                                            
-                                        <condition field="selections" scope="a915-b4eb-2c22-6df8" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1f40-fa7f-66ab-c6bf" type="atLeast"/>
-                                                          
-                                    </conditions>
-                                                      
-                                    <conditionGroups/>
-                                                    
-                                </modifier>
-                                                
-                                <modifier type="increment" field="points" value="2">
-                                                      
-                                    <repeats/>
-                                                      
-                                    <conditions>
-                                                            
-                                        <condition field="selections" scope="a915-b4eb-2c22-6df8" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1f40-fa7f-66ab-c6bf" type="atLeast"/>
-                                                          
-                                    </conditions>
-                                                      
-                                    <conditionGroups/>
-                                                    
-                                </modifier>
-                                                
-                                <modifier type="increment" field="points" value="2.0">
-                                                      
-                                    <repeats/>
-                                                      
-                                    <conditions>
-                                                            
-                                        <condition field="selections" scope="a915-b4eb-2c22-6df8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e992-1d75-438e-b2eb" type="equalTo"/>
-                                                          
-                                    </conditions>
-                                                      
-                                    <conditionGroups/>
-                                                    
-                                </modifier>
-                                                
-                                <modifier type="increment" field="points" value="2.0">
-                                                      
-                                    <repeats/>
-                                                      
-                                    <conditions>
-                                                            
-                                        <condition field="selections" scope="a915-b4eb-2c22-6df8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1f40-fa7f-66ab-c6bf" type="atLeast"/>
-                                                          
-                                    </conditions>
-                                                      
-                                    <conditionGroups/>
-                                                    
-                                </modifier>
-                                                
-                                <modifier type="increment" field="points" value="2">
-                                                      
-                                    <repeats/>
-                                                      
-                                    <conditions>
-                                                            
-                                        <condition field="selections" scope="a915-b4eb-2c22-6df8" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1f40-fa7f-66ab-c6bf" type="atLeast"/>
-                                                          
-                                    </conditions>
-                                                      
-                                    <conditionGroups/>
-                                                    
-                                </modifier>
-                                              
-                            </modifiers>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="7816-0aec-4ce0-a95a" hidden="false" targetId="651f-9469-74a5-505a" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                            
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="e2e6-2799-e774-fc44" name="Phase Armour (E)" hidden="false" collective="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry"/>
+                <entryLink id="4762-5a4b-eeca-0f1b" name="X-Sling (E)" hidden="false" collective="false" targetId="6c13-252f-55b8-4de9" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="39.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="a2f6-c5f6-7151-4cdc" name="Unit Options" hidden="false" collective="false">
+          <entryLinks>
+            <entryLink id="ad9b-a9fe-e000-c409" hidden="false" collective="false" targetId="001a-9f15-b25b-b784" type="selectionEntry"/>
+            <entryLink id="7f7d-32f1-606b-1daf" hidden="false" collective="false" targetId="9f16-5a27-44b5-7471" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="2">
+                  <conditions>
+                    <condition field="selections" scope="a915-b4eb-2c22-6df8" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1f40-fa7f-66ab-c6bf" type="atLeast"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="points" value="2">
+                  <conditions>
+                    <condition field="selections" scope="a915-b4eb-2c22-6df8" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1f40-fa7f-66ab-c6bf" type="atLeast"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <conditions>
+                    <condition field="selections" scope="a915-b4eb-2c22-6df8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="e992-1d75-438e-b2eb" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <conditions>
+                    <condition field="selections" scope="a915-b4eb-2c22-6df8" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1f40-fa7f-66ab-c6bf" type="atLeast"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="points" value="2">
+                  <conditions>
+                    <condition field="selections" scope="a915-b4eb-2c22-6df8" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="1f40-fa7f-66ab-c6bf" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="7816-0aec-4ce0-a95a" hidden="false" collective="false" targetId="651f-9469-74a5-505a" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="-2.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8e9f-ea64-c891-9c37" name="Tsan Ra Command Squad" hidden="false" collective="false" type="unit">
+      <profiles>
+        <profile id="c969-c881-6247-992f" name="Compressor Torus" hidden="false" typeId="ecae-8ac8-2c13-0dd3" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Effective" typeId="c2de-17f1-10e2-2c0a">10</characteristic>
+            <characteristic name="Long" typeId="995e-b5e6-4c63-0baa">20</characteristic>
+            <characteristic name="Extreme" typeId="bf58-0ad5-c7ee-3fd9">30</characteristic>
+            <characteristic name="Strike Value" typeId="897c-d3c4-3983-896a">3/2/0</characteristic>
+            <characteristic name="Special Rules" typeId="7e87-2586-653f-d6ec">Compressor, No Cover</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink id="1425-06bb-8d81-85ca" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="05a7-d024-589e-3557" name="Tsan Trooper" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="317f-4c90-4e55-d40d" type="min"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7241-2379-be76-cf47" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="4212-eee6-06b3-acee" name="Tsan Trooper" hidden="false" targetId="2315-d39b-832f-4292" type="profile"/>
+          </infoLinks>
+          <entryLinks>
+            <entryLink id="c8b8-8c88-0aee-9f25" name="Phase Armour (E)" hidden="false" collective="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry"/>
+            <entryLink id="5013-6f88-75e9-26ea" name="Plasma Duocarb" hidden="false" collective="false" targetId="86a3-8659-018c-f8a1" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="29.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="abcc-c0e7-d24f-927f" name="Unit Options" hidden="false" collective="false">
+          <entryLinks>
+            <entryLink id="bd1c-5b05-8f8f-35fc" hidden="false" collective="false" targetId="001a-9f15-b25b-b784" type="selectionEntry"/>
+            <entryLink id="ad03-b4ec-b8df-4deb" hidden="false" collective="false" targetId="9f16-5a27-44b5-7471" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="2.0">
+                  <conditions>
+                    <condition field="selections" scope="8e9f-ea64-c891-9c37" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="05a7-d024-589e-3557" type="atLeast"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <conditions>
+                    <condition field="selections" scope="8e9f-ea64-c891-9c37" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="59e9-4536-6110-b5e1" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="points" value="2">
+                  <conditions>
+                    <condition field="selections" scope="8e9f-ea64-c891-9c37" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="05a7-d024-589e-3557" type="atLeast"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <conditions>
+                    <condition field="selections" scope="8e9f-ea64-c891-9c37" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="05a7-d024-589e-3557" type="atLeast"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="points" value="2.0">
+                  <conditions>
+                    <condition field="selections" scope="8e9f-ea64-c891-9c37" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="05a7-d024-589e-3557" type="atLeast"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink id="af51-fe15-8fa0-5a14" hidden="false" collective="false" targetId="651f-9469-74a5-505a" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="423f-a060-7724-325f" name="Commander" hidden="false" collective="false">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d2f7-bce4-08de-d529" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9480-f313-7fde-3780" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="59e9-4536-6110-b5e1" name="Tsan Commander" hidden="false" collective="false" type="model">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="630c-86d6-fbd1-b1dd" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a6e9-ff0d-a2a1-210f" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="0bf2-098f-3725-5272" name="Tsan Commander" hidden="false" targetId="0c5f-4f79-d01b-67c8" type="profile"/>
+              </infoLinks>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="37b7-3e90-b458-2437" name="Tsan Leader Options" hidden="false" collective="false">
+                  <selectionEntries>
+                    <selectionEntry id="9911-4da7-5497-f586" name="Sling net ammo" hidden="false" collective="false" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d313-447a-4efa-bd8e" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="points" value="5.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <entryLinks>
+                    <entryLink id="cb91-a753-a941-beef" name="Leader 3" hidden="false" collective="false" targetId="9e56-0965-ea32-7ff4" type="selectionEntry"/>
+                  </entryLinks>
                 </selectionEntryGroup>
-                      
-            </selectionEntryGroups>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="-2.0"/>
-                      
-            </costs>
-                
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink id="e5b4-4fc0-137f-f651" hidden="false" collective="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry"/>
+                <entryLink id="0f1c-d56d-49d1-c245" hidden="false" collective="false" targetId="86a3-8659-018c-f8a1" type="selectionEntry"/>
+                <entryLink id="cdea-4b35-11a2-ff33" name="X-Sling (E)" hidden="false" collective="false" targetId="6c13-252f-55b8-4de9" type="selectionEntry"/>
+              </entryLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="73.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fba5-2f44-c843-7c00" name="Isorian Drone Commander" publicationId="c339-677a-pubN76607" page="" hidden="false" collective="false" type="unit">
+      <categoryLinks>
+        <categoryLink id="248b-fda4-5e10-87db" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="36f7-932e-c8e4-205d" name="Weapon Drone" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0114-ec11-a440-a95c" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="c79a-b8a4-bebb-6b18" hidden="false" targetId="18f2-0352-9cf8-66a5" type="profile"/>
+          </infoLinks>
+          <entryLinks>
+            <entryLink id="fcc7-9b0c-5d28-e840" name="Plasma Light Support Gun" hidden="false" collective="false" targetId="62c2-106a-28aa-6cf5" type="selectionEntry"/>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="59.0"/>
+          </costs>
         </selectionEntry>
-            
-        <selectionEntry id="8e9f-ea64-c891-9c37" name="Tsan Ra Command Squad" hidden="false" collective="false" type="unit">
-                  
-            <profiles>
-                        
-                <profile typeId="ecae-8ac8-2c13-0dd3" typeName="Weapon" id="c969-c881-6247-992f" name="Compressor Torus" hidden="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <characteristics>
-                                    
-                        <characteristic typeId="c2de-17f1-10e2-2c0a" name="Effective">10</characteristic>
-                                    
-                        <characteristic typeId="995e-b5e6-4c63-0baa" name="Long">20</characteristic>
-                                    
-                        <characteristic typeId="bf58-0ad5-c7ee-3fd9" name="Extreme">30</characteristic>
-                                    
-                        <characteristic typeId="897c-d3c4-3983-896a" name="Strike Value">3/2/0</characteristic>
-                                    
-                        <characteristic typeId="7e87-2586-653f-d6ec" name="Special Rules">Compressor, No Cover</characteristic>
-                                  
-                    </characteristics>
-                            
-                </profile>
-                      
-            </profiles>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints/>
-                  
-            <categoryLinks>
-                        
-                <categoryLink id="1425-06bb-8d81-85ca" hidden="false" targetId="481abf13-c03e-0dd0-d520-9f9837253cbe" primary="true">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                            
-                </categoryLink>
-                      
-            </categoryLinks>
-                  
-            <selectionEntries>
-                        
-                <selectionEntry id="05a7-d024-589e-3557" name="Tsan Trooper" hidden="false" collective="false" type="model">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks>
-                                    
-                        <infoLink id="4212-eee6-06b3-acee" name="Tsan Trooper" hidden="false" targetId="2315-d39b-832f-4292" type="profile">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                        
-                        </infoLink>
-                                  
-                    </infoLinks>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="317f-4c90-4e55-d40d" type="min"/>
-                                    
-                        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7241-2379-be76-cf47" type="max"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="c8b8-8c88-0aee-9f25" name="Phase Armour (E)" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="5013-6f88-75e9-26ea" name="Plasma Duocarb" hidden="false" targetId="86a3-8659-018c-f8a1" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                              
-                    <costs>
-                                    
-                        <cost typeId="points" name="pts" value="29.0"/>
-                                  
-                    </costs>
-                            
-                </selectionEntry>
-                      
-            </selectionEntries>
-                  
-            <selectionEntryGroups>
-                        
-                <selectionEntryGroup id="abcc-c0e7-d24f-927f" name="Unit Options" hidden="false" collective="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries/>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks>
-                                    
-                        <entryLink id="bd1c-5b05-8f8f-35fc" hidden="false" targetId="001a-9f15-b25b-b784" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="ad03-b4ec-b8df-4deb" hidden="false" targetId="9f16-5a27-44b5-7471" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers>
-                                                
-                                <modifier type="increment" field="points" value="2.0">
-                                                      
-                                    <repeats/>
-                                                      
-                                    <conditions>
-                                                            
-                                        <condition field="selections" scope="8e9f-ea64-c891-9c37" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="05a7-d024-589e-3557" type="atLeast"/>
-                                                          
-                                    </conditions>
-                                                      
-                                    <conditionGroups/>
-                                                    
-                                </modifier>
-                                                
-                                <modifier type="increment" field="points" value="2.0">
-                                                      
-                                    <repeats/>
-                                                      
-                                    <conditions>
-                                                            
-                                        <condition field="selections" scope="8e9f-ea64-c891-9c37" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="59e9-4536-6110-b5e1" type="equalTo"/>
-                                                          
-                                    </conditions>
-                                                      
-                                    <conditionGroups/>
-                                                    
-                                </modifier>
-                                                
-                                <modifier type="increment" field="points" value="2">
-                                                      
-                                    <repeats/>
-                                                      
-                                    <conditions>
-                                                            
-                                        <condition field="selections" scope="8e9f-ea64-c891-9c37" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="05a7-d024-589e-3557" type="atLeast"/>
-                                                          
-                                    </conditions>
-                                                      
-                                    <conditionGroups/>
-                                                    
-                                </modifier>
-                                                
-                                <modifier type="increment" field="points" value="2.0">
-                                                      
-                                    <repeats/>
-                                                      
-                                    <conditions>
-                                                            
-                                        <condition field="selections" scope="8e9f-ea64-c891-9c37" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="05a7-d024-589e-3557" type="atLeast"/>
-                                                          
-                                    </conditions>
-                                                      
-                                    <conditionGroups/>
-                                                    
-                                </modifier>
-                                                
-                                <modifier type="increment" field="points" value="2.0">
-                                                      
-                                    <repeats/>
-                                                      
-                                    <conditions>
-                                                            
-                                        <condition field="selections" scope="8e9f-ea64-c891-9c37" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="05a7-d024-589e-3557" type="atLeast"/>
-                                                          
-                                    </conditions>
-                                                      
-                                    <conditionGroups/>
-                                                    
-                                </modifier>
-                                              
-                            </modifiers>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                    
-                        <entryLink id="af51-fe15-8fa0-5a14" hidden="false" targetId="651f-9469-74a5-505a" type="selectionEntry">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints/>
-                                          
-                            <categoryLinks/>
-                                        
-                        </entryLink>
-                                  
-                    </entryLinks>
-                            
-                </selectionEntryGroup>
-                        
-                <selectionEntryGroup id="423f-a060-7724-325f" name="Commander" hidden="false" collective="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d2f7-bce4-08de-d529" type="min"/>
-                                    
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9480-f313-7fde-3780" type="max"/>
-                                  
-                    </constraints>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries>
-                                    
-                        <selectionEntry id="59e9-4536-6110-b5e1" name="Tsan Commander" hidden="false" collective="false" type="model">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks>
-                                                
-                                <infoLink id="0bf2-098f-3725-5272" name="Tsan Commander" hidden="false" targetId="0c5f-4f79-d01b-67c8" type="profile">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                              
-                            </infoLinks>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="630c-86d6-fbd1-b1dd" type="min"/>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a6e9-ff0d-a2a1-210f" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups>
-                                                
-                                <selectionEntryGroup id="37b7-3e90-b458-2437" name="Tsan Leader Options" hidden="false" collective="false">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                      
-                                    <selectionEntries>
-                                                            
-                                        <selectionEntry id="9911-4da7-5497-f586" name="Sling net ammo" hidden="false" collective="false" type="upgrade">
-                                                                  
-                                            <profiles/>
-                                                                  
-                                            <rules/>
-                                                                  
-                                            <infoLinks/>
-                                                                  
-                                            <modifiers/>
-                                                                  
-                                            <constraints>
-                                                                        
-                                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d313-447a-4efa-bd8e" type="max"/>
-                                                                      
-                                            </constraints>
-                                                                  
-                                            <categoryLinks/>
-                                                                  
-                                            <selectionEntries/>
-                                                                  
-                                            <selectionEntryGroups/>
-                                                                  
-                                            <entryLinks/>
-                                                                  
-                                            <costs>
-                                                                        
-                                                <cost typeId="points" name="pts" value="5.0"/>
-                                                                      
-                                            </costs>
-                                                                
-                                        </selectionEntry>
-                                                          
-                                    </selectionEntries>
-                                                      
-                                    <selectionEntryGroups/>
-                                                      
-                                    <entryLinks>
-                                                            
-                                        <entryLink id="cb91-a753-a941-beef" name="Leader 3" hidden="false" targetId="9e56-0965-ea32-7ff4" type="selectionEntry">
-                                                                  
-                                            <profiles/>
-                                                                  
-                                            <rules/>
-                                                                  
-                                            <infoLinks/>
-                                                                  
-                                            <modifiers/>
-                                                                  
-                                            <constraints/>
-                                                                  
-                                            <categoryLinks/>
-                                                                
-                                        </entryLink>
-                                                          
-                                    </entryLinks>
-                                                    
-                                </selectionEntryGroup>
-                                              
-                            </selectionEntryGroups>
-                                          
-                            <entryLinks>
-                                                
-                                <entryLink id="e5b4-4fc0-137f-f651" hidden="false" targetId="bf65-f7cb-1b50-d144" type="selectionEntry">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                    
-                                </entryLink>
-                                                
-                                <entryLink id="0f1c-d56d-49d1-c245" hidden="false" targetId="86a3-8659-018c-f8a1" type="selectionEntry">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                    
-                                </entryLink>
-                                                
-                                <entryLink id="cdea-4b35-11a2-ff33" name="X-Sling (E)" hidden="false" targetId="6c13-252f-55b8-4de9" type="selectionEntry">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                      
-                                    <constraints/>
-                                                      
-                                    <categoryLinks/>
-                                                    
-                                </entryLink>
-                                              
-                            </entryLinks>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="73.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                  
-                    </selectionEntries>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks/>
-                            
-                </selectionEntryGroup>
-                      
-            </selectionEntryGroups>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
+        <selectionEntry id="1e4e-0af9-742e-a4ae" name="Drone Commander" hidden="false" collective="false" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5a49-2cb6-93ad-1034" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a6a5-4956-adc5-8b46" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a0c1-fa57-86f7-0475" name="Drone Commander" hidden="false" typeId="1650-77b3-10d1-6406" typeName="">
+              <characteristics>
+                <characteristic name="Ag" typeId="cf30-f234-691c-47bd">7</characteristic>
+                <characteristic name="Acc" typeId="017a-9b43-b7b3-030d">6</characteristic>
+                <characteristic name="Str" typeId="8294-36f1-6431-2145">1</characteristic>
+                <characteristic name="Res" typeId="f214-abe8-c922-c51b">8</characteristic>
+                <characteristic name="Init" typeId="08b9-e038-7ba6-488e">8</characteristic>
+                <characteristic name="Co" typeId="3993-27b0-c3d9-de20">9</characteristic>
+                <characteristic name="Special" typeId="3baa-9cfd-f273-822d">Command, Follow, Leader</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="51.0"/>
+          </costs>
         </selectionEntry>
-          
-    </selectionEntries>
-      
-    <entryLinks>
-            
-        <entryLink id="c042-2f1c-a169-12cb" name="New EntryLink" hidden="false" targetId="529a-3e2a-4bd5-5e5f" type="selectionEntry">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints/>
-                  
-            <categoryLinks>
-                        
-                <categoryLink id="c042-2f1c-a169-12cb-50ba-cf77-3941-189c" hidden="false" targetId="50ba-cf77-3941-189c" primary="true">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                            
-                </categoryLink>
-                      
-            </categoryLinks>
-                
-        </entryLink>
-          
-    </entryLinks>
-      
-    <sharedSelectionEntries>
-            
-        <selectionEntry id="e745-6ace-c0d4-6e35" name="AG Chute (E)" hidden="false" collective="true" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="7507-91ab-53d3-82d4" name="Options" hidden="false" collective="false">
+          <entryLinks>
+            <entryLink id="b645-86f1-40e9-9d3b" hidden="false" collective="false" targetId="001a-9f15-b25b-b784" type="selectionEntry"/>
+            <entryLink id="b785-0e38-3b3b-b804" hidden="false" collective="false" targetId="3ac2-e4a6-9011-4985" type="selectionEntry"/>
+            <entryLink id="a55e-ac1e-d1a6-70df" hidden="false" collective="false" targetId="5ed8-6bd4-d0f7-d7f0" type="selectionEntry"/>
+            <entryLink id="954a-d19f-7f7e-f607" hidden="false" collective="false" targetId="651f-9469-74a5-505a" type="selectionEntry"/>
+            <entryLink id="22eb-2c83-df1e-606d" name="Self Repair" hidden="false" collective="false" targetId="8c55-0529-22ab-3fa6" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="10">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="149e-51c9-fee3-7aad" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="8e01-936f-dd23-fa8e" name="Phaseshift Shield" hidden="false" collective="false" targetId="9801-e697-4e03-1582" type="selectionEntry">
+              <modifiers>
+                <modifier type="increment" field="points" value="10">
+                  <repeats>
+                    <repeat field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="83fc-603c-d18f-41f2" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+  </selectionEntries>
+  <entryLinks>
+    <entryLink id="c042-2f1c-a169-12cb" name="New EntryLink" hidden="false" collective="false" targetId="529a-3e2a-4bd5-5e5f" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="c042-2f1c-a169-12cb-50ba-cf77-3941-189c" hidden="false" targetId="50ba-cf77-3941-189c" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+  </entryLinks>
+  <sharedSelectionEntries>
+    <selectionEntry id="e745-6ace-c0d4-6e35" name="AG Chute (E)" hidden="false" collective="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3ac2-e4a6-9011-4985" name="Batter Drone" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2750-e65f-4c66-8235" name="Batter Drone (2)" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="b63d-0e1c-d14a-c3e4" name="Camo Drone " hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c87f-f5b0-1134-8ad9" name="Compactor Drone" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="d776-f344-44a4-c41b" name="Compactor Drone with Compacted Plasma Cannon" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="b2e8-9d64-9d68-23e5" hidden="false" targetId="ffe9-0b4e-fc35-d442" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c521-ffae-2a9d-88f9" name="Compression Bombard" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="a79e-c4ad-b89d-ac26" hidden="false" targetId="a854-0768-aa9e-8d94" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6ded-5798-dd23-8e6f" name="Compression Cannon" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="80bf-613e-52b4-f160" name="Compression Cannon" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f482-b1f7-5e3a-1960" name="Fractal Bombard" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="9156-5e49-d0a8-7993" hidden="false" targetId="cfed-0e3a-38c7-9618" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="25.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="90ca-6c03-a803-a140" name="Fractal Cannon" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="bc22-c5b0-170a-0ca8" hidden="false" targetId="e262-8ce4-a7d5-4d81" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="69d9-b84f-3c40-15fb" name="Fractal Cannon" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="4a79-2c10-c161-2234" hidden="false" targetId="e262-8ce4-a7d5-4d81" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5343-3c10-ccc3-0233" name="Gun Drone (2)" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="14.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c7a8-840b-096e-e2b8" name="IMTeL Stave (E)" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="41bd-5499-889a-ab16" name="Leader" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="cd4f-0ce9-a6a4-b34a" name="Leader 2" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a90a-fea5-107f-a019" name="Leader 3" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9e56-0965-ea32-7ff4" name="Leader 3" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eb71-6245-efd5-67c9" name="Mag Mortar" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="9df9-40f7-3d08-b560" hidden="false" targetId="5ba2-ac85-01a5-31be" type="profile"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="0e6a-0256-18e1-20af" name="&lt; Munition &gt;" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="a356-4661-a11e-41b8" name="Scrambler" hidden="false" collective="false" type="upgrade">
+              <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="3ac2-e4a6-9011-4985" name="Batter Drone" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a24b-a381-fb00-eb9f" name="Arc" hidden="false" collective="false" type="upgrade">
+              <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="20.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="2750-e65f-4c66-8235" name="Batter Drone (2)" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="20.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="b63d-0e1c-d14a-c3e4" name="Camo Drone " hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="3925-0866-3aea-e356" name="Blur" hidden="false" collective="false" type="upgrade">
+              <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="10.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="c87f-f5b0-1134-8ad9" name="Compactor Drone" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0afe-04ff-398b-3496" name="Scoot" hidden="false" collective="false" type="upgrade">
+              <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="5.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="d776-f344-44a4-c41b" name="Compactor Drone with Compacted Plasma Cannon" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks>
-                        
-                <infoLink id="b2e8-9d64-9d68-23e5" hidden="false" targetId="ffe9-0b4e-fc35-d442" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                      
-            </infoLinks>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5271-6bc1-1ad7-e9ba" name="Net " hidden="false" collective="false" type="upgrade">
+              <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="25.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="c521-ffae-2a9d-88f9" name="Compression Bombard" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks>
-                        
-                <infoLink id="a79e-c4ad-b89d-ac26" hidden="false" targetId="a854-0768-aa9e-8d94" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                      
-            </infoLinks>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1cd3-e444-8b62-dc9b" name="All" hidden="false" collective="false" type="upgrade">
+              <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="25.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="6ded-5798-dd23-8e6f" name="Compression Cannon" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4d2c-7d84-fe17-0c8f" name="Grip" hidden="false" collective="false" type="upgrade">
+              <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="10.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="80bf-613e-52b4-f160" name="Compression Cannon" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="057e-2e8a-1952-9de0" name="Medi-Drone" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a2e9-2b00-2191-a410" name="Nano Drone (E)" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bf65-f7cb-1b50-d144" name="Phase Armour (E)" hidden="false" collective="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="12f1-610b-0dc9-4732" name="Phase Armour Boost (E)" hidden="false" collective="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9443-effe-72e1-2f51" name="Phase Rifle" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="a32c-5b2d-c145-c471" name="Phase Rifle (E)" hidden="false" typeId="ecae-8ac8-2c13-0dd3" typeName="">
+          <characteristics>
+            <characteristic name="Effective" typeId="c2de-17f1-10e2-2c0a">20</characteristic>
+            <characteristic name="Long" typeId="995e-b5e6-4c63-0baa">30</characteristic>
+            <characteristic name="Extreme" typeId="bf58-0ad5-c7ee-3fd9">100</characteristic>
+            <characteristic name="Strike Value" typeId="897c-d3c4-3983-896a">2</characteristic>
+            <characteristic name="Special Rules" typeId="7e87-2586-653f-d6ec">No Cover, RF D6 Fire Only, Concentrated Fire </characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="4813-1c77-dd1e-605e" name="Phase Sniper" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="bd27-bc1d-7b09-21f8" name="Phase Sniper" hidden="false" typeId="1650-77b3-10d1-6406" typeName="">
+          <characteristics>
+            <characteristic name="Ag" typeId="cf30-f234-691c-47bd">5</characteristic>
+            <characteristic name="Acc" typeId="017a-9b43-b7b3-030d">8</characteristic>
+            <characteristic name="Str" typeId="8294-36f1-6431-2145">5</characteristic>
+            <characteristic name="Res" typeId="f214-abe8-c922-c51b">5 (7)</characteristic>
+            <characteristic name="Init" typeId="08b9-e038-7ba6-488e">7</characteristic>
+            <characteristic name="Co" typeId="3993-27b0-c3d9-de20">8</characteristic>
+            <characteristic name="Special" typeId="3baa-9cfd-f273-822d"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name="pts" typeId="points" value="52.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="a8d9-6fae-a541-9f4f" name="Phaseshift Shield" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1bc9-ce44-fdbe-ef90" name="Plasma Bombard (E)" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="c3b5-10fe-6527-f82f" hidden="false" targetId="581f-ff61-2525-a4b4" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="10e6-b49c-4401-a1cd" name="Plasma Cannon" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="d5c2-2c99-c6f0-8b8e" hidden="false" targetId="ffe9-0b4e-fc35-d442" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="35.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5a7d-3845-90ba-32eb" name="Plasma Cannon" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="96a4-2cce-4307-8f7b" hidden="false" targetId="ffe9-0b4e-fc35-d442" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="5.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3dfc-49e9-adcb-ae48" name="Plasma Cannon" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="95ff-37b4-8a0c-72d9" hidden="false" targetId="ffe9-0b4e-fc35-d442" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="eafe-a83e-6cfd-0559" name="Plasma Carbine (E)" hidden="false" collective="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="a184-65ab-58d9-e876" hidden="false" targetId="4c0f-9a37-2cd9-3f28" type="profile"/>
+        <infoLink id="fb83-6166-8d22-f6e2" hidden="false" targetId="acdc-a95e-a973-0c70" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="86a3-8659-018c-f8a1" name="Plasma Duocarb" hidden="false" collective="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="dfdc-086a-a087-8104" hidden="false" targetId="2c41-c23c-7075-40ca" type="profile"/>
+        <infoLink id="10de-9889-c5f1-0997" hidden="false" targetId="d34f-8025-31e7-54b8" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9f16-5a27-44b5-7471" name="Plasma Grenades" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="ae6b-5d5f-8311-739e" hidden="false" targetId="9c65-fbf8-41f5-47be" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3dd4-3b5c-6873-e8f2" name="Plasma Lance" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="7122-7702-547f-efa1" hidden="false" targetId="3376-2497-6739-ec52" type="profile"/>
+        <infoLink id="cc9d-d4f8-59db-be3c" hidden="false" targetId="db92-0aca-cde3-4d2d" type="profile"/>
+        <infoLink id="6d1e-8151-bd04-c247" hidden="false" targetId="19f6-390a-0d7c-8acb" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="3.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7dac-aa85-fc80-51d5" name="Plasma Lance (Bike)" hidden="false" collective="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="95fd-068f-3527-ff41" hidden="false" targetId="3376-2497-6739-ec52" type="profile"/>
+        <infoLink id="3303-cedc-7f35-8d8c" hidden="false" targetId="db92-0aca-cde3-4d2d" type="profile"/>
+        <infoLink id="8d2b-05f1-d035-fca6" hidden="false" targetId="19f6-390a-0d7c-8acb" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="21a7-132d-6703-9ff6" name="Plasma Lance (E)" hidden="false" collective="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="eae9-4fdc-d5ae-f150" hidden="false" targetId="3376-2497-6739-ec52" type="profile"/>
+        <infoLink id="44f0-8649-d04a-801b" hidden="false" targetId="db92-0aca-cde3-4d2d" type="profile"/>
+        <infoLink id="e52e-5001-8214-66e6" hidden="false" targetId="19f6-390a-0d7c-8acb" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="62c2-106a-28aa-6cf5" name="Plasma Light Support Gun" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="7d58-9532-baa3-0f50" name="Plasma Light Support Gun" hidden="false" targetId="2940-5bc4-f1ca-b78c" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c74e-2993-3474-7869" name="Plasma Light Support Gun (E)" hidden="false" collective="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="f652-56d4-3777-5ff0" hidden="false" targetId="2940-5bc4-f1ca-b78c" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2f22-37fa-4076-d255" name="Plasma Pistol (E)" hidden="false" collective="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="f9da-9df8-37a5-92ff" hidden="false" targetId="23fa-052e-36db-13a3" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="658c-b2dd-98f4-dafb" name="Pulse Bike with Twin Plasma Carbines" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="8c55-0529-22ab-3fa6" name="Self Repair" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5ed8-6bd4-d0f7-d7f0" name="Shield Drone" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="de46-fbd5-d8f5-7454" name="Shield Drone " hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f095-7ba3-b868-32de" name="Spotter Drone" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="001a-9f15-b25b-b784" name="Spotter Drone " hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="10.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e16f-acd1-265c-07f9" name="Spotter Drone (E)" hidden="false" collective="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="76e8-05d6-ff37-7205" name="Subverter Matrix" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="651f-9469-74a5-505a" name="Synchroniser Drone" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="20.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="e2b4-a034-c8ce-e376" name="X-Howitzer (E)" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="a4a1-491f-e195-4e0d" hidden="false" targetId="d0b6-5e2a-243d-b6ea" type="profile"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="4b18-33b8-84e0-5c2e" name="&lt; Munitions &gt;" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="c518-dc83-0b3b-d5d0" name="Scrambler" hidden="false" collective="false" type="upgrade">
+              <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="5.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="f482-b1f7-5e3a-1960" name="Fractal Bombard" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks>
-                        
-                <infoLink id="9156-5e49-d0a8-7993" hidden="false" targetId="cfed-0e3a-38c7-9618" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                      
-            </infoLinks>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
+              </constraints>
+              <infoLinks>
+                <infoLink id="4f17-4153-49e1-f6dc" hidden="false" targetId="0a09-eb21-a6c6-ad31" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="16ea-fdb9-4f62-644a" name="Arc" hidden="false" collective="false" type="upgrade">
+              <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="25.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="90ca-6c03-a803-a140" name="Fractal Cannon" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks>
-                        
-                <infoLink id="bc22-c5b0-170a-0ca8" hidden="false" targetId="e262-8ce4-a7d5-4d81" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                      
-            </infoLinks>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
+              </constraints>
+              <infoLinks>
+                <infoLink id="a50f-9b72-3685-ce99" hidden="false" targetId="4052-0eb4-88d7-cab0" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d695-e1d4-70ad-ab44" name="Blur" hidden="false" collective="false" type="upgrade">
+              <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="10.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="69d9-b84f-3c40-15fb" name="Fractal Cannon" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks>
-                        
-                <infoLink id="4a79-2c10-c161-2234" hidden="false" targetId="e262-8ce4-a7d5-4d81" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                      
-            </infoLinks>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
+              </constraints>
+              <infoLinks>
+                <infoLink id="e23c-a9f0-0a42-b621" hidden="false" targetId="1373-7755-bef3-50d6" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8a3f-6c9d-84ab-7ff7" name="Scoot" hidden="false" collective="false" type="upgrade">
+              <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="5.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="5343-3c10-ccc3-0233" name="Gun Drone (2)" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="14.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="c7a8-840b-096e-e2b8" name="IMTeL Stave (E)" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        
+              </constraints>
+              <infoLinks>
+                <infoLink id="5e49-ad1b-3c02-c442" hidden="false" targetId="f2cb-33fd-610a-eda3" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f919-51c2-e1f0-fa33" name="Net" hidden="false" collective="false" type="upgrade">
+              <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="41bd-5499-889a-ab16" name="Leader" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
+              </constraints>
+              <infoLinks>
+                <infoLink id="5eb1-95d1-6117-e8d2" hidden="false" targetId="b81d-9f77-4c39-3887" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6967-929f-0dac-4c2e" name="Grip" hidden="false" collective="false" type="upgrade">
+              <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="10.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="cd4f-0ce9-a6a4-b34a" name="Leader 2" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
+              </constraints>
+              <infoLinks>
+                <infoLink id="a1ce-1d22-c641-6d9d" hidden="false" targetId="053b-a389-59c4-0e00" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f58f-7571-0bda-13b5" name="All" hidden="false" collective="false" type="upgrade">
+              <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="10.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="a90a-fea5-107f-a019" name="Leader 3" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
+              </constraints>
+              <infoLinks>
+                <infoLink id="c003-c2b5-f035-4444" hidden="false" targetId="4052-0eb4-88d7-cab0" type="rule"/>
+                <infoLink id="2b2f-ad1c-6533-e2d7" hidden="false" targetId="1373-7755-bef3-50d6" type="rule"/>
+                <infoLink id="7cae-5b3f-2e71-6e33" hidden="false" targetId="053b-a389-59c4-0e00" type="rule"/>
+                <infoLink id="be82-4f21-bf38-ae68" hidden="false" targetId="b81d-9f77-4c39-3887" type="rule"/>
+                <infoLink id="ebcd-e2be-4841-8020" hidden="false" targetId="f2cb-33fd-610a-eda3" type="rule"/>
+                <infoLink id="5bab-a371-53ed-88d2" hidden="false" targetId="0a09-eb21-a6c6-ad31" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="85bd-3565-8ecd-a94f" name="X-Howitzer (E)" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="9d54-86cf-f28d-a5ef" hidden="false" targetId="d0b6-5e2a-243d-b6ea" type="profile"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="4473-5846-9144-3ed7" name="&lt; Munitions &gt;" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="869a-d024-f01b-902a" name="Scrambler" hidden="false" collective="false" type="upgrade">
+              <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="10.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="9e56-0965-ea32-7ff4" name="Leader 3" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
+              </constraints>
+              <infoLinks>
+                <infoLink id="538e-8399-5fd9-972e" hidden="false" targetId="0a09-eb21-a6c6-ad31" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="09ad-e164-6041-3e77" name="Arc" hidden="false" collective="false" type="upgrade">
+              <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="20.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="eb71-6245-efd5-67c9" name="Mag Mortar" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks>
-                        
-                <infoLink id="9df9-40f7-3d08-b560" hidden="false" targetId="5ba2-ac85-01a5-31be" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                      
-            </infoLinks>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
+              </constraints>
+              <infoLinks>
+                <infoLink id="c58d-a6d9-f53f-bf5d" hidden="false" targetId="4052-0eb4-88d7-cab0" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="aa49-b3f4-5d76-5b99" name="Blur" hidden="false" collective="false" type="upgrade">
+              <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups>
-                        
-                <selectionEntryGroup id="0e6a-0256-18e1-20af" name="&lt; Munition &gt;" hidden="false" collective="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries>
-                                    
-                        <selectionEntry id="a356-4661-a11e-41b8" name="Scrambler" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="5.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                    
-                        <selectionEntry id="a24b-a381-fb00-eb9f" name="Arc" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="5.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                    
-                        <selectionEntry id="3925-0866-3aea-e356" name="Blur" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="5.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                    
-                        <selectionEntry id="0afe-04ff-398b-3496" name="Scoot" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="5.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                    
-                        <selectionEntry id="5271-6bc1-1ad7-e9ba" name="Net " hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="5.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                    
-                        <selectionEntry id="1cd3-e444-8b62-dc9b" name="All" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="15.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                    
-                        <selectionEntry id="4d2c-7d84-fe17-0c8f" name="Grip" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks/>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="0.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                  
-                    </selectionEntries>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks/>
-                            
-                </selectionEntryGroup>
-                      
-            </selectionEntryGroups>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="057e-2e8a-1952-9de0" name="Medi-Drone" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
+              </constraints>
+              <infoLinks>
+                <infoLink id="e8ea-4904-644f-2434" hidden="false" targetId="1373-7755-bef3-50d6" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b9f0-d72f-1cf6-a855" name="Scoot" hidden="false" collective="false" type="upgrade">
+              <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="20.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="a2e9-2b00-2191-a410" name="Nano Drone (E)" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        
+              </constraints>
+              <infoLinks>
+                <infoLink id="1eac-780b-e921-e0cf" hidden="false" targetId="f2cb-33fd-610a-eda3" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a1b1-9170-9e10-fa54" name="Net" hidden="false" collective="false" type="upgrade">
+              <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="bf65-f7cb-1b50-d144" name="Phase Armour (E)" hidden="false" collective="true" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        
+              </constraints>
+              <infoLinks>
+                <infoLink id="e95f-1bbe-70fb-e3cd" hidden="false" targetId="b81d-9f77-4c39-3887" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b4ec-d02c-b3b1-e937" name="Grip" hidden="false" collective="false" type="upgrade">
+              <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="12f1-610b-0dc9-4732" name="Phase Armour Boost (E)" hidden="false" collective="true" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        
+              </constraints>
+              <infoLinks>
+                <infoLink id="6e15-34d7-c75e-912d" hidden="false" targetId="053b-a389-59c4-0e00" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6fb5-f33d-8fcc-5d00" name="All" hidden="false" collective="false" type="upgrade">
+              <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="9443-effe-72e1-2f51" name="Phase Rifle" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles>
-                        
-                <profile typeId="ecae-8ac8-2c13-0dd3" typeName="" id="a32c-5b2d-c145-c471" name="Phase Rifle (E)" hidden="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <characteristics>
-                                    
-                        <characteristic typeId="c2de-17f1-10e2-2c0a" name="Effective">20</characteristic>
-                                    
-                        <characteristic typeId="995e-b5e6-4c63-0baa" name="Long">30</characteristic>
-                                    
-                        <characteristic typeId="bf58-0ad5-c7ee-3fd9" name="Extreme">100</characteristic>
-                                    
-                        <characteristic typeId="897c-d3c4-3983-896a" name="Strike Value">2</characteristic>
-                                    
-                        <characteristic typeId="7e87-2586-653f-d6ec" name="Special Rules">No Cover, RF D6 Fire Only, Concentrated Fire </characteristic>
-                                  
-                    </characteristics>
-                            
-                </profile>
-                      
-            </profiles>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        
+              </constraints>
+              <infoLinks>
+                <infoLink id="4674-2dd7-fa1b-a44b" hidden="false" targetId="4052-0eb4-88d7-cab0" type="rule"/>
+                <infoLink id="c46e-1126-4846-466d" hidden="false" targetId="1373-7755-bef3-50d6" type="rule"/>
+                <infoLink id="b5e5-b58a-0bab-51af" hidden="false" targetId="053b-a389-59c4-0e00" type="rule"/>
+                <infoLink id="4349-8848-6641-8a17" hidden="false" targetId="b81d-9f77-4c39-3887" type="rule"/>
+                <infoLink id="af57-f563-f84f-2c9a" hidden="false" targetId="f2cb-33fd-610a-eda3" type="rule"/>
+                <infoLink id="b5da-6f53-11d9-af5a" hidden="false" targetId="0a09-eb21-a6c6-ad31" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="afc8-4f62-e1e2-1e4c" name="X-Launcher (E)" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="d588-2e56-e502-10ec" hidden="false" targetId="b984-90ae-a8e5-83c8" type="profile"/>
+      </infoLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c249-3049-66be-c18b" name="&lt; Munitions &gt;" hidden="false" collective="false">
+          <selectionEntries>
+            <selectionEntry id="855b-3877-638b-99e8" name="Scrambler" hidden="false" collective="false" type="upgrade">
+              <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="4813-1c77-dd1e-605e" name="Phase Sniper" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles>
-                        
-                <profile typeId="1650-77b3-10d1-6406" typeName="" id="bd27-bc1d-7b09-21f8" name="Phase Sniper" hidden="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <characteristics>
-                                    
-                        <characteristic typeId="cf30-f234-691c-47bd" name="Ag">5</characteristic>
-                                    
-                        <characteristic typeId="017a-9b43-b7b3-030d" name="Acc">8</characteristic>
-                                    
-                        <characteristic typeId="8294-36f1-6431-2145" name="Str">5</characteristic>
-                                    
-                        <characteristic typeId="f214-abe8-c922-c51b" name="Res">5 (7)</characteristic>
-                                    
-                        <characteristic typeId="08b9-e038-7ba6-488e" name="Init">7</characteristic>
-                                    
-                        <characteristic typeId="3993-27b0-c3d9-de20" name="Co">8</characteristic>
-                                    
-                        <characteristic typeId="3baa-9cfd-f273-822d" name="Special"/>
-                                  
-                    </characteristics>
-                            
-                </profile>
-                      
-            </profiles>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        
+              </constraints>
+              <infoLinks>
+                <infoLink id="594f-82ff-5ad7-c68d" hidden="false" targetId="0a09-eb21-a6c6-ad31" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="cf1c-5cab-dced-a300" name="Arc" hidden="false" collective="false" type="upgrade">
+              <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="52.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="a8d9-6fae-a541-9f4f" name="Phaseshift Shield" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
+              </constraints>
+              <infoLinks>
+                <infoLink id="8bce-b783-3ffc-92aa" hidden="false" targetId="4052-0eb4-88d7-cab0" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="bed3-8a4c-71e0-9a86" name="Blur" hidden="false" collective="false" type="upgrade">
+              <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="10.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="1bc9-ce44-fdbe-ef90" name="Plasma Bombard (E)" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks>
-                        
-                <infoLink id="c3b5-10fe-6527-f82f" hidden="false" targetId="581f-ff61-2525-a4b4" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                      
-            </infoLinks>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
+              </constraints>
+              <infoLinks>
+                <infoLink id="9be8-c879-a109-2f53" hidden="false" targetId="1373-7755-bef3-50d6" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7207-1027-8e26-6930" name="Scoot" hidden="false" collective="false" type="upgrade">
+              <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="10e6-b49c-4401-a1cd" name="Plasma Cannon" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks>
-                        
-                <infoLink id="d5c2-2c99-c6f0-8b8e" hidden="false" targetId="ffe9-0b4e-fc35-d442" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                      
-            </infoLinks>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
+              </constraints>
+              <infoLinks>
+                <infoLink id="9bd6-49f8-24e5-7631" hidden="false" targetId="f2cb-33fd-610a-eda3" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9b37-d7f7-9bb7-6061" name="Net" hidden="false" collective="false" type="upgrade">
+              <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="35.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="5a7d-3845-90ba-32eb" name="Plasma Cannon" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks>
-                        
-                <infoLink id="96a4-2cce-4307-8f7b" hidden="false" targetId="ffe9-0b4e-fc35-d442" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                      
-            </infoLinks>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
+              </constraints>
+              <infoLinks>
+                <infoLink id="d053-1be2-c8f4-3f6c" hidden="false" targetId="b81d-9f77-4c39-3887" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f569-f291-bc3a-fa3a" name="Grip" hidden="false" collective="false" type="upgrade">
+              <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="5.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="3dfc-49e9-adcb-ae48" name="Plasma Cannon" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks>
-                        
-                <infoLink id="95ff-37b4-8a0c-72d9" hidden="false" targetId="ffe9-0b4e-fc35-d442" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                      
-            </infoLinks>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
+              </constraints>
+              <infoLinks>
+                <infoLink id="3be2-c872-ad5c-35f7" hidden="false" targetId="053b-a389-59c4-0e00" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a6d2-1391-22e8-008b" name="All" hidden="false" collective="false" type="upgrade">
+              <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="eafe-a83e-6cfd-0559" name="Plasma Carbine (E)" hidden="false" collective="true" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks>
-                        
-                <infoLink id="a184-65ab-58d9-e876" hidden="false" targetId="4c0f-9a37-2cd9-3f28" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                        
-                <infoLink id="fb83-6166-8d22-f6e2" hidden="false" targetId="acdc-a95e-a973-0c70" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                      
-            </infoLinks>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="86a3-8659-018c-f8a1" name="Plasma Duocarb" hidden="false" collective="true" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks>
-                        
-                <infoLink id="dfdc-086a-a087-8104" hidden="false" targetId="2c41-c23c-7075-40ca" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                        
-                <infoLink id="10de-9889-c5f1-0997" hidden="false" targetId="d34f-8025-31e7-54b8" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                      
-            </infoLinks>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="9f16-5a27-44b5-7471" name="Plasma Grenades" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks>
-                        
-                <infoLink id="ae6b-5d5f-8311-739e" hidden="false" targetId="9c65-fbf8-41f5-47be" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                      
-            </infoLinks>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="3dd4-3b5c-6873-e8f2" name="Plasma Lance" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks>
-                        
-                <infoLink id="7122-7702-547f-efa1" hidden="false" targetId="3376-2497-6739-ec52" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                        
-                <infoLink id="cc9d-d4f8-59db-be3c" hidden="false" targetId="db92-0aca-cde3-4d2d" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                        
-                <infoLink id="6d1e-8151-bd04-c247" hidden="false" targetId="19f6-390a-0d7c-8acb" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                      
-            </infoLinks>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="3.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="7dac-aa85-fc80-51d5" name="Plasma Lance (Bike)" hidden="false" collective="true" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks>
-                        
-                <infoLink id="95fd-068f-3527-ff41" hidden="false" targetId="3376-2497-6739-ec52" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                        
-                <infoLink id="3303-cedc-7f35-8d8c" hidden="false" targetId="db92-0aca-cde3-4d2d" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                        
-                <infoLink id="8d2b-05f1-d035-fca6" hidden="false" targetId="19f6-390a-0d7c-8acb" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                      
-            </infoLinks>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs/>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="21a7-132d-6703-9ff6" name="Plasma Lance (E)" hidden="false" collective="true" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks>
-                        
-                <infoLink id="eae9-4fdc-d5ae-f150" hidden="false" targetId="3376-2497-6739-ec52" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                        
-                <infoLink id="44f0-8649-d04a-801b" hidden="false" targetId="db92-0aca-cde3-4d2d" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                        
-                <infoLink id="e52e-5001-8214-66e6" hidden="false" targetId="19f6-390a-0d7c-8acb" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                      
-            </infoLinks>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="62c2-106a-28aa-6cf5" name="Plasma Light Support Gun" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks>
-                        
-                <infoLink id="7d58-9532-baa3-0f50" hidden="false" targetId="2940-5bc4-f1ca-b78c" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                      
-            </infoLinks>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="c74e-2993-3474-7869" name="Plasma Light Support Gun (E)" hidden="false" collective="true" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks>
-                        
-                <infoLink id="f652-56d4-3777-5ff0" hidden="false" targetId="2940-5bc4-f1ca-b78c" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                      
-            </infoLinks>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="2f22-37fa-4076-d255" name="Plasma Pistol (E)" hidden="false" collective="true" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks>
-                        
-                <infoLink id="f9da-9df8-37a5-92ff" hidden="false" targetId="23fa-052e-36db-13a3" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                      
-            </infoLinks>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="658c-b2dd-98f4-dafb" name="Pulse Bike with Twin Plasma Carbines" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="8c55-0529-22ab-3fa6" name="Self Repair" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="5ed8-6bd4-d0f7-d7f0" name="Shield Drone" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="10.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="de46-fbd5-d8f5-7454" name="Shield Drone " hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="10.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="f095-7ba3-b868-32de" name="Spotter Drone" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="10.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="001a-9f15-b25b-b784" name="Spotter Drone " hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="10.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="e16f-acd1-265c-07f9" name="Spotter Drone (E)" hidden="false" collective="true" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="76e8-05d6-ff37-7205" name="Subverter Matrix" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="20.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="651f-9469-74a5-505a" name="Synchroniser Drone" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="20.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="e2b4-a034-c8ce-e376" name="X-Howitzer (E)" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks>
-                        
-                <infoLink id="a4a1-491f-e195-4e0d" hidden="false" targetId="d0b6-5e2a-243d-b6ea" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                      
-            </infoLinks>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups>
-                        
-                <selectionEntryGroup id="4b18-33b8-84e0-5c2e" name="&lt; Munitions &gt;" hidden="false" collective="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries>
-                                    
-                        <selectionEntry id="c518-dc83-0b3b-d5d0" name="Scrambler" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks>
-                                                
-                                <infoLink id="4f17-4153-49e1-f6dc" hidden="false" targetId="0a09-eb21-a6c6-ad31" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                              
-                            </infoLinks>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="5.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                    
-                        <selectionEntry id="16ea-fdb9-4f62-644a" name="Arc" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks>
-                                                
-                                <infoLink id="a50f-9b72-3685-ce99" hidden="false" targetId="4052-0eb4-88d7-cab0" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                              
-                            </infoLinks>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="5.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                    
-                        <selectionEntry id="d695-e1d4-70ad-ab44" name="Blur" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks>
-                                                
-                                <infoLink id="e23c-a9f0-0a42-b621" hidden="false" targetId="1373-7755-bef3-50d6" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                              
-                            </infoLinks>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="5.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                    
-                        <selectionEntry id="8a3f-6c9d-84ab-7ff7" name="Scoot" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks>
-                                                
-                                <infoLink id="5e49-ad1b-3c02-c442" hidden="false" targetId="f2cb-33fd-610a-eda3" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                              
-                            </infoLinks>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="5.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                    
-                        <selectionEntry id="f919-51c2-e1f0-fa33" name="Net" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks>
-                                                
-                                <infoLink id="5eb1-95d1-6117-e8d2" hidden="false" targetId="b81d-9f77-4c39-3887" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                              
-                            </infoLinks>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="5.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                    
-                        <selectionEntry id="6967-929f-0dac-4c2e" name="Grip" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks>
-                                                
-                                <infoLink id="a1ce-1d22-c641-6d9d" hidden="false" targetId="053b-a389-59c4-0e00" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                              
-                            </infoLinks>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="5.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                    
-                        <selectionEntry id="f58f-7571-0bda-13b5" name="All" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks>
-                                                
-                                <infoLink id="c003-c2b5-f035-4444" hidden="false" targetId="4052-0eb4-88d7-cab0" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                                
-                                <infoLink id="2b2f-ad1c-6533-e2d7" hidden="false" targetId="1373-7755-bef3-50d6" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                                
-                                <infoLink id="7cae-5b3f-2e71-6e33" hidden="false" targetId="053b-a389-59c4-0e00" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                                
-                                <infoLink id="be82-4f21-bf38-ae68" hidden="false" targetId="b81d-9f77-4c39-3887" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                                
-                                <infoLink id="ebcd-e2be-4841-8020" hidden="false" targetId="f2cb-33fd-610a-eda3" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                                
-                                <infoLink id="5bab-a371-53ed-88d2" hidden="false" targetId="0a09-eb21-a6c6-ad31" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                              
-                            </infoLinks>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="15.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                  
-                    </selectionEntries>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks/>
-                            
-                </selectionEntryGroup>
-                      
-            </selectionEntryGroups>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="85bd-3565-8ecd-a94f" name="X-Howitzer (E)" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks>
-                        
-                <infoLink id="9d54-86cf-f28d-a5ef" hidden="false" targetId="d0b6-5e2a-243d-b6ea" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                      
-            </infoLinks>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups>
-                        
-                <selectionEntryGroup id="4473-5846-9144-3ed7" name="&lt; Munitions &gt;" hidden="false" collective="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries>
-                                    
-                        <selectionEntry id="869a-d024-f01b-902a" name="Scrambler" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks>
-                                                
-                                <infoLink id="538e-8399-5fd9-972e" hidden="false" targetId="0a09-eb21-a6c6-ad31" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                              
-                            </infoLinks>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="5.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                    
-                        <selectionEntry id="09ad-e164-6041-3e77" name="Arc" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks>
-                                                
-                                <infoLink id="c58d-a6d9-f53f-bf5d" hidden="false" targetId="4052-0eb4-88d7-cab0" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                              
-                            </infoLinks>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="5.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                    
-                        <selectionEntry id="aa49-b3f4-5d76-5b99" name="Blur" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks>
-                                                
-                                <infoLink id="e8ea-4904-644f-2434" hidden="false" targetId="1373-7755-bef3-50d6" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                              
-                            </infoLinks>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="5.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                    
-                        <selectionEntry id="b9f0-d72f-1cf6-a855" name="Scoot" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks>
-                                                
-                                <infoLink id="1eac-780b-e921-e0cf" hidden="false" targetId="f2cb-33fd-610a-eda3" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                              
-                            </infoLinks>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="5.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                    
-                        <selectionEntry id="a1b1-9170-9e10-fa54" name="Net" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks>
-                                                
-                                <infoLink id="e95f-1bbe-70fb-e3cd" hidden="false" targetId="b81d-9f77-4c39-3887" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                              
-                            </infoLinks>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="5.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                    
-                        <selectionEntry id="b4ec-d02c-b3b1-e937" name="Grip" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks>
-                                                
-                                <infoLink id="6e15-34d7-c75e-912d" hidden="false" targetId="053b-a389-59c4-0e00" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                              
-                            </infoLinks>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="5.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                    
-                        <selectionEntry id="6fb5-f33d-8fcc-5d00" name="All" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks>
-                                                
-                                <infoLink id="4674-2dd7-fa1b-a44b" hidden="false" targetId="4052-0eb4-88d7-cab0" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                                
-                                <infoLink id="c46e-1126-4846-466d" hidden="false" targetId="1373-7755-bef3-50d6" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                                
-                                <infoLink id="b5e5-b58a-0bab-51af" hidden="false" targetId="053b-a389-59c4-0e00" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                                
-                                <infoLink id="4349-8848-6641-8a17" hidden="false" targetId="b81d-9f77-4c39-3887" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                                
-                                <infoLink id="af57-f563-f84f-2c9a" hidden="false" targetId="f2cb-33fd-610a-eda3" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                                
-                                <infoLink id="b5da-6f53-11d9-af5a" hidden="false" targetId="0a09-eb21-a6c6-ad31" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                              
-                            </infoLinks>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="15.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                  
-                    </selectionEntries>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks/>
-                            
-                </selectionEntryGroup>
-                      
-            </selectionEntryGroups>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="afc8-4f62-e1e2-1e4c" name="X-Launcher (E)" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks>
-                        
-                <infoLink id="d588-2e56-e502-10ec" hidden="false" targetId="b984-90ae-a8e5-83c8" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                      
-            </infoLinks>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups>
-                        
-                <selectionEntryGroup id="c249-3049-66be-c18b" name="&lt; Munitions &gt;" hidden="false" collective="false">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                              
-                    <constraints/>
-                              
-                    <categoryLinks/>
-                              
-                    <selectionEntries>
-                                    
-                        <selectionEntry id="855b-3877-638b-99e8" name="Scrambler" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks>
-                                                
-                                <infoLink id="594f-82ff-5ad7-c68d" hidden="false" targetId="0a09-eb21-a6c6-ad31" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                              
-                            </infoLinks>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="5.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                    
-                        <selectionEntry id="cf1c-5cab-dced-a300" name="Arc" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks>
-                                                
-                                <infoLink id="8bce-b783-3ffc-92aa" hidden="false" targetId="4052-0eb4-88d7-cab0" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                              
-                            </infoLinks>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="5.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                    
-                        <selectionEntry id="bed3-8a4c-71e0-9a86" name="Blur" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks>
-                                                
-                                <infoLink id="9be8-c879-a109-2f53" hidden="false" targetId="1373-7755-bef3-50d6" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                              
-                            </infoLinks>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="5.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                    
-                        <selectionEntry id="7207-1027-8e26-6930" name="Scoot" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks>
-                                                
-                                <infoLink id="9bd6-49f8-24e5-7631" hidden="false" targetId="f2cb-33fd-610a-eda3" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                              
-                            </infoLinks>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="5.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                    
-                        <selectionEntry id="9b37-d7f7-9bb7-6061" name="Net" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks>
-                                                
-                                <infoLink id="d053-1be2-c8f4-3f6c" hidden="false" targetId="b81d-9f77-4c39-3887" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                              
-                            </infoLinks>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="5.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                    
-                        <selectionEntry id="f569-f291-bc3a-fa3a" name="Grip" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks>
-                                                
-                                <infoLink id="3be2-c872-ad5c-35f7" hidden="false" targetId="053b-a389-59c4-0e00" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                              
-                            </infoLinks>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="5.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                    
-                        <selectionEntry id="a6d2-1391-22e8-008b" name="All" hidden="false" collective="false" type="upgrade">
-                                          
-                            <profiles/>
-                                          
-                            <rules/>
-                                          
-                            <infoLinks>
-                                                
-                                <infoLink id="1741-ddc1-2f5f-3ff2" hidden="false" targetId="4052-0eb4-88d7-cab0" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                                
-                                <infoLink id="b229-c301-4b0d-2ccd" hidden="false" targetId="1373-7755-bef3-50d6" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                                
-                                <infoLink id="c3df-d0d2-6144-d3f9" hidden="false" targetId="053b-a389-59c4-0e00" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                                
-                                <infoLink id="ed17-cff8-54c6-cf4d" hidden="false" targetId="b81d-9f77-4c39-3887" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                                
-                                <infoLink id="ff70-9ddf-025e-0a2d" hidden="false" targetId="f2cb-33fd-610a-eda3" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                                
-                                <infoLink id="3125-0cd8-92ea-7904" hidden="false" targetId="0a09-eb21-a6c6-ad31" type="rule">
-                                                      
-                                    <profiles/>
-                                                      
-                                    <rules/>
-                                                      
-                                    <infoLinks/>
-                                                      
-                                    <modifiers/>
-                                                    
-                                </infoLink>
-                                              
-                            </infoLinks>
-                                          
-                            <modifiers/>
-                                          
-                            <constraints>
-                                                
-                                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                                              
-                            </constraints>
-                                          
-                            <categoryLinks/>
-                                          
-                            <selectionEntries/>
-                                          
-                            <selectionEntryGroups/>
-                                          
-                            <entryLinks/>
-                                          
-                            <costs>
-                                                
-                                <cost typeId="points" name="pts" value="15.0"/>
-                                              
-                            </costs>
-                                        
-                        </selectionEntry>
-                                  
-                    </selectionEntries>
-                              
-                    <selectionEntryGroups/>
-                              
-                    <entryLinks/>
-                            
-                </selectionEntryGroup>
-                      
-            </selectionEntryGroups>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="6c13-252f-55b8-4de9" name="X-Sling (E)" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks>
-                        
-                <infoLink id="2d1d-7464-b34a-31f5" hidden="false" targetId="7c13-1aa1-5557-6103" type="profile">
-                              
-                    <profiles/>
-                              
-                    <rules/>
-                              
-                    <infoLinks/>
-                              
-                    <modifiers/>
-                            
-                </infoLink>
-                      
-            </infoLinks>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-            
-        <selectionEntry id="9801-e697-4e03-1582" name="Phaseshift Shield" publicationId="eaf6-3f46-pubN79807" hidden="false" collective="false" type="upgrade">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <constraints>
-                        
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fbf-40b5-f6d4-23b9" type="max"/>
-                      
-            </constraints>
-                  
-            <categoryLinks/>
-                  
-            <selectionEntries/>
-                  
-            <selectionEntryGroups/>
-                  
-            <entryLinks/>
-                  
-            <costs>
-                        
-                <cost typeId="points" name="pts" value="0.0"/>
-                      
-            </costs>
-                
-        </selectionEntry>
-          
-    </sharedSelectionEntries>
-      
-    <sharedSelectionEntryGroups/>
-      
-    <sharedRules>
-            
-        <rule id="7680-b7ff-1ca0-9855" name="AG Chute" publicationId="eaf6-3f46-pubN79859" page="120" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <description>May make 2M move and shoot when given advance order. +1 Ag. Treat difficult ground as suspensored vehicle. </description>
-                
-        </rule>
-            
-        <rule id="4052-0eb4-88d7-cab0" name="Arc" publicationId="eaf6-3f46-pubN79859" page="88" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <description>Creates 3" sink area. Affects any shooter attemping to draw LOS and shoot through the arc. Roll a D10 if LOS goes through - 1-5 the shot is normal, 6-10 the shot automatically misses. Make test before rolling Acc to hit. 
+              </constraints>
+              <infoLinks>
+                <infoLink id="1741-ddc1-2f5f-3ff2" hidden="false" targetId="4052-0eb4-88d7-cab0" type="rule"/>
+                <infoLink id="b229-c301-4b0d-2ccd" hidden="false" targetId="1373-7755-bef3-50d6" type="rule"/>
+                <infoLink id="c3df-d0d2-6144-d3f9" hidden="false" targetId="053b-a389-59c4-0e00" type="rule"/>
+                <infoLink id="ed17-cff8-54c6-cf4d" hidden="false" targetId="b81d-9f77-4c39-3887" type="rule"/>
+                <infoLink id="ff70-9ddf-025e-0a2d" hidden="false" targetId="f2cb-33fd-610a-eda3" type="rule"/>
+                <infoLink id="3125-0cd8-92ea-7904" hidden="false" targetId="0a09-eb21-a6c6-ad31" type="rule"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6c13-252f-55b8-4de9" name="X-Sling (E)" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="minSelections" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="maxSelections" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="2d1d-7464-b34a-31f5" hidden="false" targetId="7c13-1aa1-5557-6103" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="9801-e697-4e03-1582" name="Phaseshift Shield" publicationId="eaf6-3f46-pubN79807" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fbf-40b5-f6d4-23b9" type="max"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1201-b017-518c-6bf2" name="Phase-Shift Projector" publicationId="c339-677a-pubN108522" page="76" hidden="false" collective="false" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5510-47a0-e59c-4cec" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="983a-2570-790c-8e45" name="Phase-Shift Projector" hidden="false" typeId="ecae-8ac8-2c13-0dd3" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Effective" typeId="c2de-17f1-10e2-2c0a">20</characteristic>
+            <characteristic name="Long" typeId="995e-b5e6-4c63-0baa">30</characteristic>
+            <characteristic name="Extreme" typeId="bf58-0ad5-c7ee-3fd9">50</characteristic>
+            <characteristic name="Strike Value" typeId="897c-d3c4-3983-896a">2</characteristic>
+            <characteristic name="Special Rules" typeId="7e87-2586-653f-d6ec">RF2, Phased Synchronisation</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="de13-9201-eb18-4a45" name="Phased Synchronisation" hidden="false" targetId="ab64-a840-fffc-9109" type="rule"/>
+      </infoLinks>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedRules>
+    <rule id="7680-b7ff-1ca0-9855" name="AG Chute" publicationId="eaf6-3f46-pubN79859" page="120" hidden="false">
+      <description>May make 2M move and shoot when given advance order. +1 Ag. Treat difficult ground as suspensored vehicle. </description>
+    </rule>
+    <rule id="4052-0eb4-88d7-cab0" name="Arc" publicationId="eaf6-3f46-pubN79859" page="88" hidden="false">
+      <description>Creates 3&quot; sink area. Affects any shooter attemping to draw LOS and shoot through the arc. Roll a D10 if LOS goes through - 1-5 the shot is normal, 6-10 the shot automatically misses. Make test before rolling Acc to hit. 
 
-OH shots are affected if the target is within 3" of the marker. </description>
-                
-        </rule>
-            
-        <rule id="178b-d746-0f1a-74ec" name="Batter Drone" publicationId="eaf6-3f46-pubN79859" page="110" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <description>Projects curved shield as template - must be positioned with outer side facing away from drone, no part of template more than 5" from drone base. Template may be repositioned any time unit receives an order die.
+OH shots are affected if the target is within 3&quot; of the marker. </description>
+    </rule>
+    <rule id="178b-d746-0f1a-74ec" name="Batter Drone" publicationId="eaf6-3f46-pubN79859" page="110" hidden="false">
+      <description>Projects curved shield as template - must be positioned with outer side facing away from drone, no part of template more than 5&quot; from drone base. Template may be repositioned any time unit receives an order die.
 
 Enemy units shooting through shield suffer -2 ACC. Models positioned inside the shield do not receive the -2 ACC protection. Troops shooting from the inside convex side of the shield do not suffer the ACC penalty. 
 
 No protection is offered for OH shots.</description>
-                
-        </rule>
-            
-        <rule id="1cb7-4402-2f6c-b3cf" name="Blast D10" publicationId="eaf6-3f46-pubN79859" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <description>Inflicts D10 hits on a successful shooting attack.</description>
-                
-        </rule>
-            
-        <rule id="82bc-e8ec-5e5a-56d2" name="Blast D3" publicationId="eaf6-3f46-pubN79859" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <description>Inflicts D3 hits on a successful shooting attack.</description>
-                
-        </rule>
-            
-        <rule id="27db-c218-b60e-869b" name="Blast D4" publicationId="eaf6-3f46-pubN79859" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <description>Inflicts D4 hits on a successful shooting attack.</description>
-                
-        </rule>
-            
-        <rule id="3934-2688-e509-dbc5" name="Blast D5" publicationId="eaf6-3f46-pubN79859" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <description>Inflicts D5 hits on a successful shooting attack.</description>
-                
-        </rule>
-            
-        <rule id="1373-7755-bef3-50d6" name="Blur" publicationId="eaf6-3f46-pubN79859" page="89" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <description>Any unit within 3" reduces Acc by D3 each time it shoots. If within two or more blur markers, roll a D3 for each and take highest.</description>
-                
-        </rule>
-            
-        <rule id="5c9b-1bde-ee01-04a4" name="Command" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                
-        </rule>
-            
-        <rule id="b0ca-8e7d-d03f-f027" name="Fast" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                
-        </rule>
-            
-        <rule id="7bc9-5e98-2914-5abd" name="Follow" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                
-        </rule>
-            
-        <rule id="053b-a389-59c4-0e00" name="Grip" publicationId="eaf6-3f46-pubN79859" page="87" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <description>Unit beginning its move within 3" must take and pass an Ag test. If failed it may not move, if passed it can move half rate, failed on a 10 it takes a pin and cannot move.
+    </rule>
+    <rule id="1cb7-4402-2f6c-b3cf" name="Blast D10" publicationId="eaf6-3f46-pubN79859" hidden="false">
+      <description>Inflicts D10 hits on a successful shooting attack.</description>
+    </rule>
+    <rule id="82bc-e8ec-5e5a-56d2" name="Blast D3" publicationId="eaf6-3f46-pubN79859" hidden="false">
+      <description>Inflicts D3 hits on a successful shooting attack.</description>
+    </rule>
+    <rule id="27db-c218-b60e-869b" name="Blast D4" publicationId="eaf6-3f46-pubN79859" hidden="false">
+      <description>Inflicts D4 hits on a successful shooting attack.</description>
+    </rule>
+    <rule id="3934-2688-e509-dbc5" name="Blast D5" publicationId="eaf6-3f46-pubN79859" hidden="false">
+      <description>Inflicts D5 hits on a successful shooting attack.</description>
+    </rule>
+    <rule id="1373-7755-bef3-50d6" name="Blur" publicationId="eaf6-3f46-pubN79859" page="89" hidden="false">
+      <description>Any unit within 3&quot; reduces Acc by D3 each time it shoots. If within two or more blur markers, roll a D3 for each and take highest.</description>
+    </rule>
+    <rule id="5c9b-1bde-ee01-04a4" name="Command" hidden="false"/>
+    <rule id="b0ca-8e7d-d03f-f027" name="Fast" hidden="false"/>
+    <rule id="7bc9-5e98-2914-5abd" name="Follow" hidden="false"/>
+    <rule id="053b-a389-59c4-0e00" name="Grip" publicationId="eaf6-3f46-pubN79859" page="87" hidden="false">
+      <description>Unit beginning its move within 3&quot; must take and pass an Ag test. If failed it may not move, if passed it can move half rate, failed on a 10 it takes a pin and cannot move.
 
-If a unit moves within 3" it must take the Ag test as above. </description>
-                
-        </rule>
-            
-        <rule id="3c64-6022-a5f1-9c04" name="Hero" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                
-        </rule>
-            
-        <rule id="9d5f-b605-0d92-695d" name="HL Armor" publicationId="eaf6-3f46-pubN79859" page="93" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <description>Ranges of 10" or less, +1 to Res. Ranges of greater than 10" +2 Res. Against any Blast hits, +3 Res. </description>
-                
-        </rule>
-            
-        <rule id="f62d-5e99-81f7-07dd" name="Inaccurate" publicationId="eaf6-3f46-pubN79859" page="70" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <description>Additional -1 Acc penalty.</description>
-                
-        </rule>
-            
-        <rule id="a221-d53c-b4bd-b52c" name="Large" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                
-        </rule>
-            
-        <rule id="e441-c3a6-7d61-2c63" name="Leader" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                
-        </rule>
-            
-        <rule id="7850-89e7-bab8-86e9" name="Leader 2" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                
-        </rule>
-            
-        <rule id="05bb-4d34-70cd-25d2" name="Leader 3" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                
-        </rule>
-            
-        <rule id="d8dc-cf25-ef95-c94b" name="Limited Choice" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                
-        </rule>
-            
-        <rule id="2ff2-534c-34fe-b56b" name="Medi-Drone" publicationId="eaf6-3f46-pubN79859" page="113" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <description>Can only attend humans - not machines or Skarks. Any friendly unit within 5" may re-roll one failed Res test each time it is shot at, fights H2H, or otherwise suffers damage. Units within 5" of more than one medi-drone may re-roll one failed Res test for each medi-drone. </description>
-                
-        </rule>
-            
-        <rule id="5565-ce10-1c78-1ee7" name="MOD2" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                
-        </rule>
-            
-        <rule id="8151-2e24-94ee-0477" name="MOD3" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                
-        </rule>
-            
-        <rule id="b81d-9f77-4c39-3887" name="Net" publicationId="eaf6-3f46-pubN79859" page="88" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <description>Roll to hit as normal for a blast weapon. Target does not suffer blast damage, rather suffers pins:
+If a unit moves within 3&quot; it must take the Ag test as above. </description>
+    </rule>
+    <rule id="3c64-6022-a5f1-9c04" name="Hero" hidden="false"/>
+    <rule id="9d5f-b605-0d92-695d" name="HL Armor" publicationId="eaf6-3f46-pubN79859" page="93" hidden="false">
+      <description>Ranges of 10&quot; or less, +1 to Res. Ranges of greater than 10&quot; +2 Res. Against any Blast hits, +3 Res. </description>
+    </rule>
+    <rule id="f62d-5e99-81f7-07dd" name="Inaccurate" publicationId="eaf6-3f46-pubN79859" page="70" hidden="false">
+      <description>Additional -1 Acc penalty.</description>
+    </rule>
+    <rule id="a221-d53c-b4bd-b52c" name="Large" hidden="false"/>
+    <rule id="e441-c3a6-7d61-2c63" name="Leader" hidden="false"/>
+    <rule id="7850-89e7-bab8-86e9" name="Leader 2" hidden="false"/>
+    <rule id="05bb-4d34-70cd-25d2" name="Leader 3" hidden="false"/>
+    <rule id="d8dc-cf25-ef95-c94b" name="Limited Choice" hidden="false"/>
+    <rule id="2ff2-534c-34fe-b56b" name="Medi-Drone" publicationId="eaf6-3f46-pubN79859" page="113" hidden="false">
+      <description>Can only attend humans - not machines or Skarks. Any friendly unit within 5&quot; may re-roll one failed Res test each time it is shot at, fights H2H, or otherwise suffers damage. Units within 5&quot; of more than one medi-drone may re-roll one failed Res test for each medi-drone. </description>
+    </rule>
+    <rule id="5565-ce10-1c78-1ee7" name="MOD2" hidden="false"/>
+    <rule id="8151-2e24-94ee-0477" name="MOD3" hidden="false"/>
+    <rule id="b81d-9f77-4c39-3887" name="Net" publicationId="eaf6-3f46-pubN79859" page="88" hidden="false">
+      <description>Roll to hit as normal for a blast weapon. Target does not suffer blast damage, rather suffers pins:
 
 X-Launcher: D3+1 pin
 X-Howitzer: D5+1 pin
 Mag Mortar: D10+1 pin
 
 Targets that would normally force an Acc re-roll suffer half the number of pins rounded down. Divide pins equally between two or more units as normal.</description>
-                
-        </rule>
-            
-        <rule id="4abc-52df-bbed-7b28" name="New Rule" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                
-        </rule>
-            
-        <rule id="fbb8-f81a-2985-1273" name="Plasma Fade" publicationId="eaf6-3f46-pubN79859" page="76" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <description>On the Acc roll of a 10 to hit the shot is a miss and the unit goes down.</description>
-                
-        </rule>
-            
-        <rule id="f2cb-33fd-610a-eda3" name="Scoot" publicationId="eaf6-3f46-pubN79859" page="88" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <description>Only affects infantry, mounted, weapon team, beast, and humongous beast, command, and bike mounted units with living crew. Affects scramble proof units. Any affected unit within 3" canno tbe given any order except run or down. Cannot make any reaction apart from go down.</description>
-                
-        </rule>
-            
-        <rule id="0a09-eb21-a6c6-ad31" name="Scrambler" publicationId="eaf6-3f46-pubN79859" page="88" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <description>Enemy units within 3" that are not scramble proof it loses Reflex Armor, Hyperlight Armor, and Phase Armor along with any bonuses. Units in Phase Armor cannot use their armor to go down.
+    </rule>
+    <rule id="fbb8-f81a-2985-1273" name="Plasma Fade" publicationId="eaf6-3f46-pubN79859" page="76" hidden="false">
+      <description>On the Acc roll of a 10 to hit the shot is a miss and the unit goes down.</description>
+    </rule>
+    <rule id="f2cb-33fd-610a-eda3" name="Scoot" publicationId="eaf6-3f46-pubN79859" page="88" hidden="false">
+      <description>Only affects infantry, mounted, weapon team, beast, and humongous beast, command, and bike mounted units with living crew. Affects scramble proof units. Any affected unit within 3&quot; canno tbe given any order except run or down. Cannot make any reaction apart from go down.</description>
+    </rule>
+    <rule id="0a09-eb21-a6c6-ad31" name="Scrambler" publicationId="eaf6-3f46-pubN79859" page="88" hidden="false">
+      <description>Enemy units within 3&quot; that are not scramble proof it loses Reflex Armor, Hyperlight Armor, and Phase Armor along with any bonuses. Units in Phase Armor cannot use their armor to go down.
 
-Weapon Drone and vehicles have Res reduced by 2 within 3". Buddy drones cease to function if the unit is within 3". Probes can do nothing at all while marker is within 3". Penalties are not cumulative.</description>
-                
-        </rule>
-            
-        <rule id="3377-9408-33bb-6a02" name="Self Repair" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                
-        </rule>
-            
-        <rule id="1c4c-aaaf-0a08-e69e" name="Self Repair" publicationId="eaf6-3f46-pubN79859" page="137" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <description>Give unit rally order. If no pins exist after order, may attempt one repair on  immobilisation or weapon. 1-5 = success, 6-10 failure. Success = that function is working again.</description>
-                
-        </rule>
-            
-        <rule id="1b89-5e18-0f71-7dc5" name="Slingnet Ammo" publicationId="eaf6-3f46-pubN79859" page="112" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <description>Fired direct unless from Micro X Launcher. Targets hit suffer no damage but take +1 additional pin. Cannot affect units that cannot be pinned when hit.</description>
-                
-        </rule>
-            
-        <rule id="7c88-64d4-50ad-2313" name="Slow" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                
-        </rule>
-            
-        <rule id="19d8-5c9a-2e1f-4d8e" name="Spotter Drone" publicationId="eaf6-3f46-pubN79859" page="114" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <description>Unit may re-roll one miss each time it shoots as long as drone has LOS to target. Units may fire OH using drone as spotter as long as it has LOS to target. 
+Weapon Drone and vehicles have Res reduced by 2 within 3&quot;. Buddy drones cease to function if the unit is within 3&quot;. Probes can do nothing at all while marker is within 3&quot;. Penalties are not cumulative.</description>
+    </rule>
+    <rule id="3377-9408-33bb-6a02" name="Self Repair" hidden="false"/>
+    <rule id="1c4c-aaaf-0a08-e69e" name="Self Repair" publicationId="eaf6-3f46-pubN79859" page="137" hidden="false">
+      <description>Give unit rally order. If no pins exist after order, may attempt one repair on  immobilisation or weapon. 1-5 = success, 6-10 failure. Success = that function is working again.</description>
+    </rule>
+    <rule id="1b89-5e18-0f71-7dc5" name="Slingnet Ammo" publicationId="eaf6-3f46-pubN79859" page="112" hidden="false">
+      <description>Fired direct unless from Micro X Launcher. Targets hit suffer no damage but take +1 additional pin. Cannot affect units that cannot be pinned when hit.</description>
+    </rule>
+    <rule id="7c88-64d4-50ad-2313" name="Slow" hidden="false"/>
+    <rule id="19d8-5c9a-2e1f-4d8e" name="Spotter Drone" publicationId="eaf6-3f46-pubN79859" page="114" hidden="false">
+      <description>Unit may re-roll one miss each time it shoots as long as drone has LOS to target. Units may fire OH using drone as spotter as long as it has LOS to target. 
 
-Spotter drones may spot through another spotter drone (within 20") with LOS to the target. Unit does not receive spotter re-roll as their spotter does not have LOS to target.</description>
-                
-        </rule>
-            
-        <rule id="ab37-33d8-41f3-7532" name="Transport 10" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                
-        </rule>
-            
-        <rule id="3f71-546f-6b34-b449" name="Weapon Drone" publicationId="eaf6-3f46-pubN79859" page="115" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <description>Always measure to model, not base. Not allowed to assault. Never take a break test, however auto-break if suffer pins equal to their Co stat. If drone fails a Res test, roll on Weapon Drone Damage Chart.
+Spotter drones may spot through another spotter drone (within 20&quot;) with LOS to the target. Unit does not receive spotter re-roll as their spotter does not have LOS to target.</description>
+    </rule>
+    <rule id="ab37-33d8-41f3-7532" name="Transport 10" hidden="false"/>
+    <rule id="3f71-546f-6b34-b449" name="Weapon Drone" publicationId="eaf6-3f46-pubN79859" page="115" hidden="false">
+      <description>Always measure to model, not base. Not allowed to assault. Never take a break test, however auto-break if suffer pins equal to their Co stat. If drone fails a Res test, roll on Weapon Drone Damage Chart.
 
 D10 Result:
 1: Take one additional pin and go down.
@@ -11180,1403 +2470,511 @@ D10 Result:
 4: Take D3 additional pins and go down. Weapon malfunction.
 5: Take D6 additional pins and take a break test - destroyed if failed, go down if passed.
 6-10: Destroyed</description>
-                
-        </rule>
-          
-    </sharedRules>
-      
-    <sharedProfiles>
-            
-        <profile typeId="ecae-8ac8-2c13-0dd3" typeName="" id="a854-0768-aa9e-8d94" name="Compression Bombard" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="c2de-17f1-10e2-2c0a" name="Effective">10-50</characteristic>
-                        
-                <characteristic typeId="995e-b5e6-4c63-0baa" name="Long">100</characteristic>
-                        
-                <characteristic typeId="bf58-0ad5-c7ee-3fd9" name="Extreme">150</characteristic>
-                        
-                <characteristic typeId="897c-d3c4-3983-896a" name="Strike Value">9/7/5</characteristic>
-                        
-                <characteristic typeId="7e87-2586-653f-d6ec" name="Special Rules">Compressor, No Cover, Cycle</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="ecae-8ac8-2c13-0dd3" typeName="" id="fb4a-7317-0e7a-7278" name="Compression Cannon" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="c2de-17f1-10e2-2c0a" name="Effective">10-30</characteristic>
-                        
-                <characteristic typeId="995e-b5e6-4c63-0baa" name="Long">40</characteristic>
-                        
-                <characteristic typeId="bf58-0ad5-c7ee-3fd9" name="Extreme">80</characteristic>
-                        
-                <characteristic typeId="897c-d3c4-3983-896a" name="Strike Value">7/4/2</characteristic>
-                        
-                <characteristic typeId="7e87-2586-653f-d6ec" name="Special Rules">Compressor, No Cover, Cycle</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="1650-77b3-10d1-6406" typeName="" id="bed7-2549-f395-f271" name="Drone Commander" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="cf30-f234-691c-47bd" name="Ag">7</characteristic>
-                        
-                <characteristic typeId="017a-9b43-b7b3-030d" name="Acc">6</characteristic>
-                        
-                <characteristic typeId="8294-36f1-6431-2145" name="Str">1</characteristic>
-                        
-                <characteristic typeId="f214-abe8-c922-c51b" name="Res">8</characteristic>
-                        
-                <characteristic typeId="08b9-e038-7ba6-488e" name="Init">8</characteristic>
-                        
-                <characteristic typeId="3993-27b0-c3d9-de20" name="Co">9</characteristic>
-                        
-                <characteristic typeId="3baa-9cfd-f273-822d" name="Special">Command, Follow, Leader 2</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="ecae-8ac8-2c13-0dd3" typeName="" id="cfed-0e3a-38c7-9618" name="Fractal Bombard" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="c2de-17f1-10e2-2c0a" name="Effective">50</characteristic>
-                        
-                <characteristic typeId="995e-b5e6-4c63-0baa" name="Long">100</characteristic>
-                        
-                <characteristic typeId="bf58-0ad5-c7ee-3fd9" name="Extreme">200</characteristic>
-                        
-                <characteristic typeId="897c-d3c4-3983-896a" name="Strike Value">3 +2 max 10</characteristic>
-                        
-                <characteristic typeId="7e87-2586-653f-d6ec" name="Special Rules">Fractal Lock</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="ecae-8ac8-2c13-0dd3" typeName="" id="e262-8ce4-a7d5-4d81" name="Fractal Cannon" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="c2de-17f1-10e2-2c0a" name="Effective">30</characteristic>
-                        
-                <characteristic typeId="995e-b5e6-4c63-0baa" name="Long">40</characteristic>
-                        
-                <characteristic typeId="bf58-0ad5-c7ee-3fd9" name="Extreme">80</characteristic>
-                        
-                <characteristic typeId="897c-d3c4-3983-896a" name="Strike Value">2 +1 max 10</characteristic>
-                        
-                <characteristic typeId="7e87-2586-653f-d6ec" name="Special Rules">Fractal Lock</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="1650-77b3-10d1-6406" typeName="" id="be8e-2c8f-8288-e92a" name="Isorian Andhak SC2 Medium Support Drone" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="cf30-f234-691c-47bd" name="Ag">7</characteristic>
-                        
-                <characteristic typeId="017a-9b43-b7b3-030d" name="Acc">6</characteristic>
-                        
-                <characteristic typeId="8294-36f1-6431-2145" name="Str">1</characteristic>
-                        
-                <characteristic typeId="f214-abe8-c922-c51b" name="Res">10</characteristic>
-                        
-                <characteristic typeId="08b9-e038-7ba6-488e" name="Init">8</characteristic>
-                        
-                <characteristic typeId="3993-27b0-c3d9-de20" name="Co">8</characteristic>
-                        
-                <characteristic typeId="3baa-9cfd-f273-822d" name="Special">-</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="1650-77b3-10d1-6406" typeName="" id="18f2-0352-9cf8-66a5" name="Isorian Nhamak NC Light Support Drone" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="cf30-f234-691c-47bd" name="Ag">7</characteristic>
-                        
-                <characteristic typeId="017a-9b43-b7b3-030d" name="Acc">6</characteristic>
-                        
-                <characteristic typeId="8294-36f1-6431-2145" name="Str">1</characteristic>
-                        
-                <characteristic typeId="f214-abe8-c922-c51b" name="Res">8</characteristic>
-                        
-                <characteristic typeId="08b9-e038-7ba6-488e" name="Init">8</characteristic>
-                        
-                <characteristic typeId="3993-27b0-c3d9-de20" name="Co">8</characteristic>
-                        
-                <characteristic typeId="3baa-9cfd-f273-822d" name="Special">-</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="1650-77b3-10d1-6406" typeName="" id="1c7c-b76a-8d9f-4405" name="Kahloc KV Heavy Battle Drone" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="cf30-f234-691c-47bd" name="Ag">5</characteristic>
-                        
-                <characteristic typeId="017a-9b43-b7b3-030d" name="Acc">6</characteristic>
-                        
-                <characteristic typeId="8294-36f1-6431-2145" name="Str">1</characteristic>
-                        
-                <characteristic typeId="f214-abe8-c922-c51b" name="Res">15</characteristic>
-                        
-                <characteristic typeId="08b9-e038-7ba6-488e" name="Init">8</characteristic>
-                        
-                <characteristic typeId="3993-27b0-c3d9-de20" name="Co">8</characteristic>
-                        
-                <characteristic typeId="3baa-9cfd-f273-822d" name="Special">MOD3, Slow, Large</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="ecae-8ac8-2c13-0dd3" typeName="" id="5ba2-ac85-01a5-31be" name="Mag Mortar" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="c2de-17f1-10e2-2c0a" name="Effective">10-30</characteristic>
-                        
-                <characteristic typeId="995e-b5e6-4c63-0baa" name="Long">40</characteristic>
-                        
-                <characteristic typeId="bf58-0ad5-c7ee-3fd9" name="Extreme">50</characteristic>
-                        
-                <characteristic typeId="897c-d3c4-3983-896a" name="Strike Value">3</characteristic>
-                        
-                <characteristic typeId="7e87-2586-653f-d6ec" name="Special Rules">OHx2, Blast D10, No Cover</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="1650-77b3-10d1-6406" typeName="" id="eda1-434f-1771-a790" name="Mahran Vesh MV5 Combat Drone" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="cf30-f234-691c-47bd" name="Ag">5</characteristic>
-                        
-                <characteristic typeId="017a-9b43-b7b3-030d" name="Acc">6</characteristic>
-                        
-                <characteristic typeId="8294-36f1-6431-2145" name="Str">1</characteristic>
-                        
-                <characteristic typeId="f214-abe8-c922-c51b" name="Res">13</characteristic>
-                        
-                <characteristic typeId="08b9-e038-7ba6-488e" name="Init">8</characteristic>
-                        
-                <characteristic typeId="3993-27b0-c3d9-de20" name="Co">8</characteristic>
-                        
-                <characteristic typeId="3baa-9cfd-f273-822d" name="Special">MOD2, Large</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="1650-77b3-10d1-6406" typeName="" id="078e-4753-3545-ba51" name="Medi-Probe" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="cf30-f234-691c-47bd" name="Ag">-</characteristic>
-                        
-                <characteristic typeId="017a-9b43-b7b3-030d" name="Acc">-</characteristic>
-                        
-                <characteristic typeId="8294-36f1-6431-2145" name="Str">-</characteristic>
-                        
-                <characteristic typeId="f214-abe8-c922-c51b" name="Res">5</characteristic>
-                        
-                <characteristic typeId="08b9-e038-7ba6-488e" name="Init">-</characteristic>
-                        
-                <characteristic typeId="3993-27b0-c3d9-de20" name="Co">-</characteristic>
-                        
-                <characteristic typeId="3baa-9cfd-f273-822d" name="Special">Shard</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="1650-77b3-10d1-6406" typeName="" id="16bf-fee9-f1bf-8600" name="Nano Probe" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="cf30-f234-691c-47bd" name="Ag">-</characteristic>
-                        
-                <characteristic typeId="017a-9b43-b7b3-030d" name="Acc">-</characteristic>
-                        
-                <characteristic typeId="8294-36f1-6431-2145" name="Str">-</characteristic>
-                        
-                <characteristic typeId="f214-abe8-c922-c51b" name="Res">5</characteristic>
-                        
-                <characteristic typeId="08b9-e038-7ba6-488e" name="Init">-</characteristic>
-                        
-                <characteristic typeId="3993-27b0-c3d9-de20" name="Co">-</characteristic>
-                        
-                <characteristic typeId="3baa-9cfd-f273-822d" name="Special"/>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="1650-77b3-10d1-6406" typeName="" id="41d1-a002-0258-c407" name="NuHu Senatexis" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="cf30-f234-691c-47bd" name="Ag">5</characteristic>
-                        
-                <characteristic typeId="017a-9b43-b7b3-030d" name="Acc">6</characteristic>
-                        
-                <characteristic typeId="8294-36f1-6431-2145" name="Str">4</characteristic>
-                        
-                <characteristic typeId="f214-abe8-c922-c51b" name="Res">4(7)</characteristic>
-                        
-                <characteristic typeId="08b9-e038-7ba6-488e" name="Init">9</characteristic>
-                        
-                <characteristic typeId="3993-27b0-c3d9-de20" name="Co">9</characteristic>
-                        
-                <characteristic typeId="3baa-9cfd-f273-822d" name="Special">Command, Hero, Follow, Leader 3</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="1650-77b3-10d1-6406" typeName="" id="af6e-dcdb-77a5-b67e" name="Phase Leader" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers>
-                        
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2">
-                              
-                    <repeats/>
-                              
-                    <conditions>
-                                    
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cd4f-0ce9-a6a4-b34a" type="equalTo"/>
-                                  
-                    </conditions>
-                              
-                    <conditionGroups/>
-                            
-                </modifier>
-                      
-            </modifiers>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="cf30-f234-691c-47bd" name="Ag">5</characteristic>
-                        
-                <characteristic typeId="017a-9b43-b7b3-030d" name="Acc">5</characteristic>
-                        
-                <characteristic typeId="8294-36f1-6431-2145" name="Str">5</characteristic>
-                        
-                <characteristic typeId="f214-abe8-c922-c51b" name="Res">5(7)</characteristic>
-                        
-                <characteristic typeId="08b9-e038-7ba6-488e" name="Init">7</characteristic>
-                        
-                <characteristic typeId="3993-27b0-c3d9-de20" name="Co">8</characteristic>
-                        
-                <characteristic typeId="3baa-9cfd-f273-822d" name="Special">Leader</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="ecae-8ac8-2c13-0dd3" typeName="" id="42f9-6fbf-5a4c-76c2" name="Phase Rifle" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="c2de-17f1-10e2-2c0a" name="Effective">20</characteristic>
-                        
-                <characteristic typeId="995e-b5e6-4c63-0baa" name="Long">30</characteristic>
-                        
-                <characteristic typeId="bf58-0ad5-c7ee-3fd9" name="Extreme">100</characteristic>
-                        
-                <characteristic typeId="897c-d3c4-3983-896a" name="Strike Value">2</characteristic>
-                        
-                <characteristic typeId="7e87-2586-653f-d6ec" name="Special Rules">No Cover, RF D6 Fire Only, Concentrated Fire </characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="1650-77b3-10d1-6406" typeName="" id="6688-b331-6578-fb30" name="Phase Trooper" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="cf30-f234-691c-47bd" name="Ag">5</characteristic>
-                        
-                <characteristic typeId="017a-9b43-b7b3-030d" name="Acc">5</characteristic>
-                        
-                <characteristic typeId="8294-36f1-6431-2145" name="Str">5</characteristic>
-                        
-                <characteristic typeId="f214-abe8-c922-c51b" name="Res">5(7)</characteristic>
-                        
-                <characteristic typeId="08b9-e038-7ba6-488e" name="Init">7</characteristic>
-                        
-                <characteristic typeId="3993-27b0-c3d9-de20" name="Co">8</characteristic>
-                        
-                <characteristic typeId="3baa-9cfd-f273-822d" name="Special">-</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="ecae-8ac8-2c13-0dd3" typeName="" id="581f-ff61-2525-a4b4" name="Plasma Bombard" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="c2de-17f1-10e2-2c0a" name="Effective">50</characteristic>
-                        
-                <characteristic typeId="995e-b5e6-4c63-0baa" name="Long">100</characteristic>
-                        
-                <characteristic typeId="bf58-0ad5-c7ee-3fd9" name="Extreme">200</characteristic>
-                        
-                <characteristic typeId="897c-d3c4-3983-896a" name="Strike Value">7</characteristic>
-                        
-                <characteristic typeId="7e87-2586-653f-d6ec" name="Special Rules">Plasma Fade</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="ecae-8ac8-2c13-0dd3" typeName="" id="ffe9-0b4e-fc35-d442" name="Plasma Cannon" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="c2de-17f1-10e2-2c0a" name="Effective">30</characteristic>
-                        
-                <characteristic typeId="995e-b5e6-4c63-0baa" name="Long">40</characteristic>
-                        
-                <characteristic typeId="bf58-0ad5-c7ee-3fd9" name="Extreme">80</characteristic>
-                        
-                <characteristic typeId="897c-d3c4-3983-896a" name="Strike Value">6</characteristic>
-                        
-                <characteristic typeId="7e87-2586-653f-d6ec" name="Special Rules">Plasma Fade</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="ecae-8ac8-2c13-0dd3" typeName="" id="4c0f-9a37-2cd9-3f28" name="Plasma Carbine - Scatter" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="c2de-17f1-10e2-2c0a" name="Effective">20</characteristic>
-                        
-                <characteristic typeId="995e-b5e6-4c63-0baa" name="Long">30</characteristic>
-                        
-                <characteristic typeId="bf58-0ad5-c7ee-3fd9" name="Extreme">None</characteristic>
-                        
-                <characteristic typeId="897c-d3c4-3983-896a" name="Strike Value">0</characteristic>
-                        
-                <characteristic typeId="7e87-2586-653f-d6ec" name="Special Rules">RF2</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="ecae-8ac8-2c13-0dd3" typeName="" id="acdc-a95e-a973-0c70" name="Plasma Carbine - Single Shot" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="c2de-17f1-10e2-2c0a" name="Effective">20</characteristic>
-                        
-                <characteristic typeId="995e-b5e6-4c63-0baa" name="Long">30</characteristic>
-                        
-                <characteristic typeId="bf58-0ad5-c7ee-3fd9" name="Extreme">50</characteristic>
-                        
-                <characteristic typeId="897c-d3c4-3983-896a" name="Strike Value">2</characteristic>
-                        
-                <characteristic typeId="7e87-2586-653f-d6ec" name="Special Rules">-</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="ecae-8ac8-2c13-0dd3" typeName="" id="2c41-c23c-7075-40ca" name="Plasma Duocarb - Scatter" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="c2de-17f1-10e2-2c0a" name="Effective">20</characteristic>
-                        
-                <characteristic typeId="995e-b5e6-4c63-0baa" name="Long">30</characteristic>
-                        
-                <characteristic typeId="bf58-0ad5-c7ee-3fd9" name="Extreme">None</characteristic>
-                        
-                <characteristic typeId="897c-d3c4-3983-896a" name="Strike Value">0</characteristic>
-                        
-                <characteristic typeId="7e87-2586-653f-d6ec" name="Special Rules">RF3</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="ecae-8ac8-2c13-0dd3" typeName="" id="d34f-8025-31e7-54b8" name="Plasma Duocarb - Single Shot" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="c2de-17f1-10e2-2c0a" name="Effective">20</characteristic>
-                        
-                <characteristic typeId="995e-b5e6-4c63-0baa" name="Long">30</characteristic>
-                        
-                <characteristic typeId="bf58-0ad5-c7ee-3fd9" name="Extreme">50</characteristic>
-                        
-                <characteristic typeId="897c-d3c4-3983-896a" name="Strike Value">3</characteristic>
-                        
-                <characteristic typeId="7e87-2586-653f-d6ec" name="Special Rules"/>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="ecae-8ac8-2c13-0dd3" typeName="" id="9c65-fbf8-41f5-47be" name="Plasma Grenade" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="c2de-17f1-10e2-2c0a" name="Effective">5</characteristic>
-                        
-                <characteristic typeId="995e-b5e6-4c63-0baa" name="Long">None</characteristic>
-                        
-                <characteristic typeId="bf58-0ad5-c7ee-3fd9" name="Extreme">None</characteristic>
-                        
-                <characteristic typeId="897c-d3c4-3983-896a" name="Strike Value">1</characteristic>
-                        
-                <characteristic typeId="7e87-2586-653f-d6ec" name="Special Rules">-</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="ecae-8ac8-2c13-0dd3" typeName="" id="92a3-aaae-bc24-0d2d" name="Plasma Grenade Bandolier" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="c2de-17f1-10e2-2c0a" name="Effective">5</characteristic>
-                        
-                <characteristic typeId="995e-b5e6-4c63-0baa" name="Long">-</characteristic>
-                        
-                <characteristic typeId="bf58-0ad5-c7ee-3fd9" name="Extreme">-</characteristic>
-                        
-                <characteristic typeId="897c-d3c4-3983-896a" name="Strike Value">2</characteristic>
-                        
-                <characteristic typeId="7e87-2586-653f-d6ec" name="Special Rules">Blast D4, Hazardous H2H</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="ecae-8ac8-2c13-0dd3" typeName="" id="3376-2497-6739-ec52" name="Plasma Lance - Lance" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="c2de-17f1-10e2-2c0a" name="Effective">20</characteristic>
-                        
-                <characteristic typeId="995e-b5e6-4c63-0baa" name="Long">30</characteristic>
-                        
-                <characteristic typeId="bf58-0ad5-c7ee-3fd9" name="Extreme">None</characteristic>
-                        
-                <characteristic typeId="897c-d3c4-3983-896a" name="Strike Value">4</characteristic>
-                        
-                <characteristic typeId="7e87-2586-653f-d6ec" name="Special Rules">Choose Target, Inaccurate</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="ecae-8ac8-2c13-0dd3" typeName="" id="19f6-390a-0d7c-8acb" name="Plasma Lance - Scatter" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="c2de-17f1-10e2-2c0a" name="Effective">20</characteristic>
-                        
-                <characteristic typeId="995e-b5e6-4c63-0baa" name="Long">30</characteristic>
-                        
-                <characteristic typeId="bf58-0ad5-c7ee-3fd9" name="Extreme">None</characteristic>
-                        
-                <characteristic typeId="897c-d3c4-3983-896a" name="Strike Value">0</characteristic>
-                        
-                <characteristic typeId="7e87-2586-653f-d6ec" name="Special Rules">RF2</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="ecae-8ac8-2c13-0dd3" typeName="" id="db92-0aca-cde3-4d2d" name="Plasma Lance - Single Shot" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="c2de-17f1-10e2-2c0a" name="Effective">20</characteristic>
-                        
-                <characteristic typeId="995e-b5e6-4c63-0baa" name="Long">30</characteristic>
-                        
-                <characteristic typeId="bf58-0ad5-c7ee-3fd9" name="Extreme">50</characteristic>
-                        
-                <characteristic typeId="897c-d3c4-3983-896a" name="Strike Value">2</characteristic>
-                        
-                <characteristic typeId="7e87-2586-653f-d6ec" name="Special Rules">-</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="ecae-8ac8-2c13-0dd3" typeName="" id="2940-5bc4-f1ca-b78c" name="Plasma Light Support Gun" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="c2de-17f1-10e2-2c0a" name="Effective">30</characteristic>
-                        
-                <characteristic typeId="995e-b5e6-4c63-0baa" name="Long">40</characteristic>
-                        
-                <characteristic typeId="bf58-0ad5-c7ee-3fd9" name="Extreme">80</characteristic>
-                        
-                <characteristic typeId="897c-d3c4-3983-896a" name="Strike Value">3</characteristic>
-                        
-                <characteristic typeId="7e87-2586-653f-d6ec" name="Special Rules">RF3</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="ecae-8ac8-2c13-0dd3" typeName="" id="23fa-052e-36db-13a3" name="Plasma Pistol" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="c2de-17f1-10e2-2c0a" name="Effective">10</characteristic>
-                        
-                <characteristic typeId="995e-b5e6-4c63-0baa" name="Long">20</characteristic>
-                        
-                <characteristic typeId="bf58-0ad5-c7ee-3fd9" name="Extreme">30</characteristic>
-                        
-                <characteristic typeId="897c-d3c4-3983-896a" name="Strike Value">2</characteristic>
-                        
-                <characteristic typeId="7e87-2586-653f-d6ec" name="Special Rules">-</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="1650-77b3-10d1-6406" typeName="" id="9286-cbf7-0641-5ce1" name="Pulse Bike Commander" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers>
-                        
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command, Follow, Fast, Large, Leader 3">
-                              
-                    <repeats/>
-                              
-                    <conditions>
-                                    
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bd12-7ad6-eb09-08ba" type="equalTo"/>
-                                  
-                    </conditions>
-                              
-                    <conditionGroups/>
-                            
-                </modifier>
-                      
-            </modifiers>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="cf30-f234-691c-47bd" name="Ag">5</characteristic>
-                        
-                <characteristic typeId="017a-9b43-b7b3-030d" name="Acc">5</characteristic>
-                        
-                <characteristic typeId="8294-36f1-6431-2145" name="Str">5</characteristic>
-                        
-                <characteristic typeId="f214-abe8-c922-c51b" name="Res">5(8)</characteristic>
-                        
-                <characteristic typeId="08b9-e038-7ba6-488e" name="Init">7</characteristic>
-                        
-                <characteristic typeId="3993-27b0-c3d9-de20" name="Co">9</characteristic>
-                        
-                <characteristic typeId="3baa-9cfd-f273-822d" name="Special">Command, Follow, Fast, Large, Leader 2</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="1650-77b3-10d1-6406" typeName="" id="9ed6-e3f2-8847-d7a2" name="Pulse Bike Leader" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers>
-                        
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Fast, Large, Leader 2">
-                              
-                    <repeats/>
-                              
-                    <conditions>
-                                    
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="27d8-164a-139b-f635" type="equalTo"/>
-                                  
-                    </conditions>
-                              
-                    <conditionGroups/>
-                            
-                </modifier>
-                      
-            </modifiers>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="cf30-f234-691c-47bd" name="Ag">5</characteristic>
-                        
-                <characteristic typeId="017a-9b43-b7b3-030d" name="Acc">5</characteristic>
-                        
-                <characteristic typeId="8294-36f1-6431-2145" name="Str">5</characteristic>
-                        
-                <characteristic typeId="f214-abe8-c922-c51b" name="Res">5(8)</characteristic>
-                        
-                <characteristic typeId="08b9-e038-7ba6-488e" name="Init">7</characteristic>
-                        
-                <characteristic typeId="3993-27b0-c3d9-de20" name="Co">8</characteristic>
-                        
-                <characteristic typeId="3baa-9cfd-f273-822d" name="Special">Fast, Large, Leader</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="1650-77b3-10d1-6406" typeName="" id="34f9-12c5-7e7b-114c" name="Pulse Bike Trooper" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="cf30-f234-691c-47bd" name="Ag">5</characteristic>
-                        
-                <characteristic typeId="017a-9b43-b7b3-030d" name="Acc">5</characteristic>
-                        
-                <characteristic typeId="8294-36f1-6431-2145" name="Str">5</characteristic>
-                        
-                <characteristic typeId="f214-abe8-c922-c51b" name="Res">5 (8)</characteristic>
-                        
-                <characteristic typeId="08b9-e038-7ba6-488e" name="Init">7</characteristic>
-                        
-                <characteristic typeId="3993-27b0-c3d9-de20" name="Co">8</characteristic>
-                        
-                <characteristic typeId="3baa-9cfd-f273-822d" name="Special">Fast, Large</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="1650-77b3-10d1-6406" typeName="" id="56b9-5224-e0df-8218" name="Scout Probe" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="cf30-f234-691c-47bd" name="Ag">-</characteristic>
-                        
-                <characteristic typeId="017a-9b43-b7b3-030d" name="Acc">-</characteristic>
-                        
-                <characteristic typeId="8294-36f1-6431-2145" name="Str">-</characteristic>
-                        
-                <characteristic typeId="f214-abe8-c922-c51b" name="Res">5</characteristic>
-                        
-                <characteristic typeId="08b9-e038-7ba6-488e" name="Init">-</characteristic>
-                        
-                <characteristic typeId="3993-27b0-c3d9-de20" name="Co">-</characteristic>
-                        
-                <characteristic typeId="3baa-9cfd-f273-822d" name="Special">Shard</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="1650-77b3-10d1-6406" typeName="" id="9686-36fa-7ae7-f4dc" name="Senatex Commander" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers>
-                        
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Command, Follow, Leader 3">
-                              
-                    <repeats/>
-                              
-                    <conditions>
-                                    
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a90a-fea5-107f-a019" type="equalTo"/>
-                                  
-                    </conditions>
-                              
-                    <conditionGroups/>
-                            
-                </modifier>
-                      
-            </modifiers>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="cf30-f234-691c-47bd" name="Ag">5</characteristic>
-                        
-                <characteristic typeId="017a-9b43-b7b3-030d" name="Acc">6</characteristic>
-                        
-                <characteristic typeId="8294-36f1-6431-2145" name="Str">5</characteristic>
-                        
-                <characteristic typeId="f214-abe8-c922-c51b" name="Res">5(7)</characteristic>
-                        
-                <characteristic typeId="08b9-e038-7ba6-488e" name="Init">7</characteristic>
-                        
-                <characteristic typeId="3993-27b0-c3d9-de20" name="Co">9</characteristic>
-                        
-                <characteristic typeId="3baa-9cfd-f273-822d" name="Special">Command, Follow, Leader 2</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="1650-77b3-10d1-6406" typeName="" id="9ce3-1277-65a2-7ab0" name="Targeter Probe" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="cf30-f234-691c-47bd" name="Ag">-</characteristic>
-                        
-                <characteristic typeId="017a-9b43-b7b3-030d" name="Acc">-</characteristic>
-                        
-                <characteristic typeId="8294-36f1-6431-2145" name="Str">-</characteristic>
-                        
-                <characteristic typeId="f214-abe8-c922-c51b" name="Res">5</characteristic>
-                        
-                <characteristic typeId="08b9-e038-7ba6-488e" name="Init">-</characteristic>
-                        
-                <characteristic typeId="3993-27b0-c3d9-de20" name="Co">-</characteristic>
-                        
-                <characteristic typeId="3baa-9cfd-f273-822d" name="Special">Shard</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="1650-77b3-10d1-6406" typeName="" id="1aa8-c7f2-fa2d-324a" name="Tograh MV2 Transporter Drone " hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="cf30-f234-691c-47bd" name="Ag">5</characteristic>
-                        
-                <characteristic typeId="017a-9b43-b7b3-030d" name="Acc">6</characteristic>
-                        
-                <characteristic typeId="8294-36f1-6431-2145" name="Str">1</characteristic>
-                        
-                <characteristic typeId="f214-abe8-c922-c51b" name="Res">13</characteristic>
-                        
-                <characteristic typeId="08b9-e038-7ba6-488e" name="Init">8</characteristic>
-                        
-                <characteristic typeId="3993-27b0-c3d9-de20" name="Co">8</characteristic>
-                        
-                <characteristic typeId="3baa-9cfd-f273-822d" name="Special">MOD2, Transport 10, Large</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="1650-77b3-10d1-6406" typeName="" id="e480-7c4e-fa39-3a68" name="Tsan Leader" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="cf30-f234-691c-47bd" name="Ag">5</characteristic>
-                        
-                <characteristic typeId="017a-9b43-b7b3-030d" name="Acc">5</characteristic>
-                        
-                <characteristic typeId="8294-36f1-6431-2145" name="Str">7</characteristic>
-                        
-                <characteristic typeId="f214-abe8-c922-c51b" name="Res">6 (8)</characteristic>
-                        
-                <characteristic typeId="08b9-e038-7ba6-488e" name="Init">7</characteristic>
-                        
-                <characteristic typeId="3993-27b0-c3d9-de20" name="Co">8</characteristic>
-                        
-                <characteristic typeId="3baa-9cfd-f273-822d" name="Special">Leader, Large</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="ecae-8ac8-2c13-0dd3" typeName="" id="d0b6-5e2a-243d-b6ea" name="X-Howitzer" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="c2de-17f1-10e2-2c0a" name="Effective">10-50</characteristic>
-                        
-                <characteristic typeId="995e-b5e6-4c63-0baa" name="Long">100</characteristic>
-                        
-                <characteristic typeId="bf58-0ad5-c7ee-3fd9" name="Extreme">250</characteristic>
-                        
-                <characteristic typeId="897c-d3c4-3983-896a" name="Strike Value">2</characteristic>
-                        
-                <characteristic typeId="7e87-2586-653f-d6ec" name="Special Rules">OH, Blast D10, No Cover</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="ecae-8ac8-2c13-0dd3" typeName="" id="b984-90ae-a8e5-83c8" name="X-Launcher" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="c2de-17f1-10e2-2c0a" name="Effective">10-30</characteristic>
-                        
-                <characteristic typeId="995e-b5e6-4c63-0baa" name="Long">60</characteristic>
-                        
-                <characteristic typeId="bf58-0ad5-c7ee-3fd9" name="Extreme">120</characteristic>
-                        
-                <characteristic typeId="897c-d3c4-3983-896a" name="Strike Value">1</characteristic>
-                        
-                <characteristic typeId="7e87-2586-653f-d6ec" name="Special Rules">OH, Blast D5, No Cover</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="ecae-8ac8-2c13-0dd3" typeName="" id="7c13-1aa1-5557-6103" name="X-Sling" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="c2de-17f1-10e2-2c0a" name="Effective">10</characteristic>
-                        
-                <characteristic typeId="995e-b5e6-4c63-0baa" name="Long">20</characteristic>
-                        
-                <characteristic typeId="bf58-0ad5-c7ee-3fd9" name="Extreme">None</characteristic>
-                        
-                <characteristic typeId="897c-d3c4-3983-896a" name="Strike Value">0</characteristic>
-                        
-                <characteristic typeId="7e87-2586-653f-d6ec" name="Special Rules">Blast D3</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="1650-77b3-10d1-6406" typeName="" id="2966-969b-3981-06ed" name="Phase Trooper" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="cf30-f234-691c-47bd" name="Ag">5</characteristic>
-                        
-                <characteristic typeId="017a-9b43-b7b3-030d" name="Acc">6</characteristic>
-                        
-                <characteristic typeId="8294-36f1-6431-2145" name="Str">5</characteristic>
-                        
-                <characteristic typeId="f214-abe8-c922-c51b" name="Res">5(7)</characteristic>
-                        
-                <characteristic typeId="08b9-e038-7ba6-488e" name="Init">7</characteristic>
-                        
-                <characteristic typeId="3993-27b0-c3d9-de20" name="Co">8</characteristic>
-                        
-                <characteristic typeId="3baa-9cfd-f273-822d" name="Special">-</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="1650-77b3-10d1-6406" typeName="" id="01b3-4a09-3a38-9c8c" name="Phase Trooper" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers>
-                        
-                <modifier type="set" field="3baa-9cfd-f273-822d" value="Large, Slow">
-                              
-                    <repeats/>
-                              
-                    <conditions/>
-                              
-                    <conditionGroups/>
-                            
-                </modifier>
-                      
-            </modifiers>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="cf30-f234-691c-47bd" name="Ag">5</characteristic>
-                        
-                <characteristic typeId="017a-9b43-b7b3-030d" name="Acc">5</characteristic>
-                        
-                <characteristic typeId="8294-36f1-6431-2145" name="Str">5</characteristic>
-                        
-                <characteristic typeId="f214-abe8-c922-c51b" name="Res">5(7)</characteristic>
-                        
-                <characteristic typeId="08b9-e038-7ba6-488e" name="Init">7</characteristic>
-                        
-                <characteristic typeId="3993-27b0-c3d9-de20" name="Co">8</characteristic>
-                        
-                <characteristic typeId="3baa-9cfd-f273-822d" name="Special">-</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="1650-77b3-10d1-6406" typeName="" id="c626-1591-8fa9-bdf0" name="Tsan Trooper" publicationId="eaf6-3f46-pubN65565" page="82" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="cf30-f234-691c-47bd" name="Ag">5</characteristic>
-                        
-                <characteristic typeId="017a-9b43-b7b3-030d" name="Acc">5</characteristic>
-                        
-                <characteristic typeId="8294-36f1-6431-2145" name="Str">7</characteristic>
-                        
-                <characteristic typeId="f214-abe8-c922-c51b" name="Res">6 (8)</characteristic>
-                        
-                <characteristic typeId="08b9-e038-7ba6-488e" name="Init">7</characteristic>
-                        
-                <characteristic typeId="3993-27b0-c3d9-de20" name="Co">8</characteristic>
-                        
-                <characteristic typeId="3baa-9cfd-f273-822d" name="Special">Large</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="ecae-8ac8-2c13-0dd3" typeName="Weapon" id="7f76-db01-256f-c0df" name="Compressor Torus - Ranged" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="c2de-17f1-10e2-2c0a" name="Effective">10</characteristic>
-                        
-                <characteristic typeId="995e-b5e6-4c63-0baa" name="Long">20</characteristic>
-                        
-                <characteristic typeId="bf58-0ad5-c7ee-3fd9" name="Extreme">30</characteristic>
-                        
-                <characteristic typeId="897c-d3c4-3983-896a" name="Strike Value">3/2/0</characteristic>
-                        
-                <characteristic typeId="7e87-2586-653f-d6ec" name="Special Rules">Compressor, No Cover</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="ecae-8ac8-2c13-0dd3" typeName="Weapon" id="04ce-712e-6e8c-b950" name="Compressor Torus - H2H" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="c2de-17f1-10e2-2c0a" name="Effective">H2H Only</characteristic>
-                        
-                <characteristic typeId="995e-b5e6-4c63-0baa" name="Long">-</characteristic>
-                        
-                <characteristic typeId="bf58-0ad5-c7ee-3fd9" name="Extreme">-</characteristic>
-                        
-                <characteristic typeId="897c-d3c4-3983-896a" name="Strike Value">3</characteristic>
-                        
-                <characteristic typeId="7e87-2586-653f-d6ec" name="Special Rules">Shock Wave (3 Attacks)</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="1650-77b3-10d1-6406" typeName="Model" id="2315-d39b-832f-4292" name="Tsan Trooper" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="cf30-f234-691c-47bd" name="Ag">5</characteristic>
-                        
-                <characteristic typeId="017a-9b43-b7b3-030d" name="Acc">6</characteristic>
-                        
-                <characteristic typeId="8294-36f1-6431-2145" name="Str">7</characteristic>
-                        
-                <characteristic typeId="f214-abe8-c922-c51b" name="Res">6(8)</characteristic>
-                        
-                <characteristic typeId="08b9-e038-7ba6-488e" name="Init">7</characteristic>
-                        
-                <characteristic typeId="3993-27b0-c3d9-de20" name="Co">8</characteristic>
-                        
-                <characteristic typeId="3baa-9cfd-f273-822d" name="Special">Large</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-            
-        <profile typeId="1650-77b3-10d1-6406" typeName="Model" id="0c5f-4f79-d01b-67c8" name="Tsan Commander" hidden="false">
-                  
-            <profiles/>
-                  
-            <rules/>
-                  
-            <infoLinks/>
-                  
-            <modifiers/>
-                  
-            <characteristics>
-                        
-                <characteristic typeId="cf30-f234-691c-47bd" name="Ag">5</characteristic>
-                        
-                <characteristic typeId="017a-9b43-b7b3-030d" name="Acc">6</characteristic>
-                        
-                <characteristic typeId="8294-36f1-6431-2145" name="Str">7</characteristic>
-                        
-                <characteristic typeId="f214-abe8-c922-c51b" name="Res">6(8)</characteristic>
-                        
-                <characteristic typeId="08b9-e038-7ba6-488e" name="Init">7</characteristic>
-                        
-                <characteristic typeId="3993-27b0-c3d9-de20" name="Co">9</characteristic>
-                        
-                <characteristic typeId="3baa-9cfd-f273-822d" name="Special">Command, Follow, Leader 2, Large</characteristic>
-                      
-            </characteristics>
-                
-        </profile>
-          
-    </sharedProfiles>
-    
+    </rule>
+    <rule id="ab64-a840-fffc-9109" name="Phased Synchronisation" publicationId="c339-677a-pubN108522" page="76" hidden="false">
+      <description>When weapon hits obstacle up to 2&quot; thick, not only does the target inside take damage but a friendly unit within 10&quot; that has Phase-Armour can make an immediate, sychronised Advance or Run action to move straight through the obstacle. Models take pins if ending move in obstacle, destroyed at end of action</description>
+    </rule>
+  </sharedRules>
+  <sharedProfiles>
+    <profile id="a854-0768-aa9e-8d94" name="Compression Bombard" hidden="false" typeId="ecae-8ac8-2c13-0dd3" typeName="">
+      <characteristics>
+        <characteristic name="Effective" typeId="c2de-17f1-10e2-2c0a">10-50</characteristic>
+        <characteristic name="Long" typeId="995e-b5e6-4c63-0baa">100</characteristic>
+        <characteristic name="Extreme" typeId="bf58-0ad5-c7ee-3fd9">150</characteristic>
+        <characteristic name="Strike Value" typeId="897c-d3c4-3983-896a">9/7/5</characteristic>
+        <characteristic name="Special Rules" typeId="7e87-2586-653f-d6ec">Compressor, No Cover, Cycle</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="fb4a-7317-0e7a-7278" name="Compression Cannon" hidden="false" typeId="ecae-8ac8-2c13-0dd3" typeName="">
+      <characteristics>
+        <characteristic name="Effective" typeId="c2de-17f1-10e2-2c0a">10-30</characteristic>
+        <characteristic name="Long" typeId="995e-b5e6-4c63-0baa">40</characteristic>
+        <characteristic name="Extreme" typeId="bf58-0ad5-c7ee-3fd9">80</characteristic>
+        <characteristic name="Strike Value" typeId="897c-d3c4-3983-896a">7/4/2</characteristic>
+        <characteristic name="Special Rules" typeId="7e87-2586-653f-d6ec">Compressor, No Cover, Cycle</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="bed7-2549-f395-f271" name="Drone Commander" hidden="false" typeId="1650-77b3-10d1-6406" typeName="">
+      <characteristics>
+        <characteristic name="Ag" typeId="cf30-f234-691c-47bd">7</characteristic>
+        <characteristic name="Acc" typeId="017a-9b43-b7b3-030d">6</characteristic>
+        <characteristic name="Str" typeId="8294-36f1-6431-2145">1</characteristic>
+        <characteristic name="Res" typeId="f214-abe8-c922-c51b">8</characteristic>
+        <characteristic name="Init" typeId="08b9-e038-7ba6-488e">8</characteristic>
+        <characteristic name="Co" typeId="3993-27b0-c3d9-de20">9</characteristic>
+        <characteristic name="Special" typeId="3baa-9cfd-f273-822d">Command, Follow, Leader 2</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="cfed-0e3a-38c7-9618" name="Fractal Bombard" hidden="false" typeId="ecae-8ac8-2c13-0dd3" typeName="">
+      <characteristics>
+        <characteristic name="Effective" typeId="c2de-17f1-10e2-2c0a">50</characteristic>
+        <characteristic name="Long" typeId="995e-b5e6-4c63-0baa">100</characteristic>
+        <characteristic name="Extreme" typeId="bf58-0ad5-c7ee-3fd9">200</characteristic>
+        <characteristic name="Strike Value" typeId="897c-d3c4-3983-896a">3 +2 max 10</characteristic>
+        <characteristic name="Special Rules" typeId="7e87-2586-653f-d6ec">Fractal Lock</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="e262-8ce4-a7d5-4d81" name="Fractal Cannon" hidden="false" typeId="ecae-8ac8-2c13-0dd3" typeName="">
+      <characteristics>
+        <characteristic name="Effective" typeId="c2de-17f1-10e2-2c0a">30</characteristic>
+        <characteristic name="Long" typeId="995e-b5e6-4c63-0baa">40</characteristic>
+        <characteristic name="Extreme" typeId="bf58-0ad5-c7ee-3fd9">80</characteristic>
+        <characteristic name="Strike Value" typeId="897c-d3c4-3983-896a">2 +1 max 10</characteristic>
+        <characteristic name="Special Rules" typeId="7e87-2586-653f-d6ec">Fractal Lock</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="be8e-2c8f-8288-e92a" name="Andhak SC2 Medium Support Drone" hidden="false" typeId="1650-77b3-10d1-6406" typeName="">
+      <characteristics>
+        <characteristic name="Ag" typeId="cf30-f234-691c-47bd">7</characteristic>
+        <characteristic name="Acc" typeId="017a-9b43-b7b3-030d">6</characteristic>
+        <characteristic name="Str" typeId="8294-36f1-6431-2145">1</characteristic>
+        <characteristic name="Res" typeId="f214-abe8-c922-c51b">10</characteristic>
+        <characteristic name="Init" typeId="08b9-e038-7ba6-488e">8</characteristic>
+        <characteristic name="Co" typeId="3993-27b0-c3d9-de20">8</characteristic>
+        <characteristic name="Special" typeId="3baa-9cfd-f273-822d">-</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="18f2-0352-9cf8-66a5" name="Isorian Nhamak NC Light Support Drone" hidden="false" typeId="1650-77b3-10d1-6406" typeName="">
+      <characteristics>
+        <characteristic name="Ag" typeId="cf30-f234-691c-47bd">7</characteristic>
+        <characteristic name="Acc" typeId="017a-9b43-b7b3-030d">6</characteristic>
+        <characteristic name="Str" typeId="8294-36f1-6431-2145">1</characteristic>
+        <characteristic name="Res" typeId="f214-abe8-c922-c51b">8</characteristic>
+        <characteristic name="Init" typeId="08b9-e038-7ba6-488e">8</characteristic>
+        <characteristic name="Co" typeId="3993-27b0-c3d9-de20">8</characteristic>
+        <characteristic name="Special" typeId="3baa-9cfd-f273-822d">-</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="1c7c-b76a-8d9f-4405" name="Kahloc KV Heavy Battle Drone" hidden="false" typeId="1650-77b3-10d1-6406" typeName="">
+      <characteristics>
+        <characteristic name="Ag" typeId="cf30-f234-691c-47bd">5</characteristic>
+        <characteristic name="Acc" typeId="017a-9b43-b7b3-030d">6</characteristic>
+        <characteristic name="Str" typeId="8294-36f1-6431-2145">1</characteristic>
+        <characteristic name="Res" typeId="f214-abe8-c922-c51b">15</characteristic>
+        <characteristic name="Init" typeId="08b9-e038-7ba6-488e">8</characteristic>
+        <characteristic name="Co" typeId="3993-27b0-c3d9-de20">8</characteristic>
+        <characteristic name="Special" typeId="3baa-9cfd-f273-822d">MOD3, Slow, Large</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="5ba2-ac85-01a5-31be" name="Mag Mortar" hidden="false" typeId="ecae-8ac8-2c13-0dd3" typeName="">
+      <characteristics>
+        <characteristic name="Effective" typeId="c2de-17f1-10e2-2c0a">10-30</characteristic>
+        <characteristic name="Long" typeId="995e-b5e6-4c63-0baa">40</characteristic>
+        <characteristic name="Extreme" typeId="bf58-0ad5-c7ee-3fd9">50</characteristic>
+        <characteristic name="Strike Value" typeId="897c-d3c4-3983-896a">3</characteristic>
+        <characteristic name="Special Rules" typeId="7e87-2586-653f-d6ec">OHx2, Blast D10, No Cover</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="eda1-434f-1771-a790" name="Mahran Vesh MV5 Combat Drone" hidden="false" typeId="1650-77b3-10d1-6406" typeName="">
+      <characteristics>
+        <characteristic name="Ag" typeId="cf30-f234-691c-47bd">5</characteristic>
+        <characteristic name="Acc" typeId="017a-9b43-b7b3-030d">6</characteristic>
+        <characteristic name="Str" typeId="8294-36f1-6431-2145">1</characteristic>
+        <characteristic name="Res" typeId="f214-abe8-c922-c51b">13</characteristic>
+        <characteristic name="Init" typeId="08b9-e038-7ba6-488e">8</characteristic>
+        <characteristic name="Co" typeId="3993-27b0-c3d9-de20">8</characteristic>
+        <characteristic name="Special" typeId="3baa-9cfd-f273-822d">MOD2, Large</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="078e-4753-3545-ba51" name="Medi-Probe" hidden="false" typeId="1650-77b3-10d1-6406" typeName="">
+      <characteristics>
+        <characteristic name="Ag" typeId="cf30-f234-691c-47bd">-</characteristic>
+        <characteristic name="Acc" typeId="017a-9b43-b7b3-030d">-</characteristic>
+        <characteristic name="Str" typeId="8294-36f1-6431-2145">-</characteristic>
+        <characteristic name="Res" typeId="f214-abe8-c922-c51b">5</characteristic>
+        <characteristic name="Init" typeId="08b9-e038-7ba6-488e">-</characteristic>
+        <characteristic name="Co" typeId="3993-27b0-c3d9-de20">-</characteristic>
+        <characteristic name="Special" typeId="3baa-9cfd-f273-822d">Shard</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="16bf-fee9-f1bf-8600" name="Nano Probe" hidden="false" typeId="1650-77b3-10d1-6406" typeName="">
+      <characteristics>
+        <characteristic name="Ag" typeId="cf30-f234-691c-47bd">-</characteristic>
+        <characteristic name="Acc" typeId="017a-9b43-b7b3-030d">-</characteristic>
+        <characteristic name="Str" typeId="8294-36f1-6431-2145">-</characteristic>
+        <characteristic name="Res" typeId="f214-abe8-c922-c51b">5</characteristic>
+        <characteristic name="Init" typeId="08b9-e038-7ba6-488e">-</characteristic>
+        <characteristic name="Co" typeId="3993-27b0-c3d9-de20">-</characteristic>
+        <characteristic name="Special" typeId="3baa-9cfd-f273-822d"/>
+      </characteristics>
+    </profile>
+    <profile id="41d1-a002-0258-c407" name="NuHu Senatexis" hidden="false" typeId="1650-77b3-10d1-6406" typeName="">
+      <characteristics>
+        <characteristic name="Ag" typeId="cf30-f234-691c-47bd">5</characteristic>
+        <characteristic name="Acc" typeId="017a-9b43-b7b3-030d">6</characteristic>
+        <characteristic name="Str" typeId="8294-36f1-6431-2145">4</characteristic>
+        <characteristic name="Res" typeId="f214-abe8-c922-c51b">4(7)</characteristic>
+        <characteristic name="Init" typeId="08b9-e038-7ba6-488e">9</characteristic>
+        <characteristic name="Co" typeId="3993-27b0-c3d9-de20">9</characteristic>
+        <characteristic name="Special" typeId="3baa-9cfd-f273-822d">Command, Hero, Follow, Leader 3</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="af6e-dcdb-77a5-b67e" name="Phase Leader" hidden="false" typeId="1650-77b3-10d1-6406" typeName="">
+      <modifiers>
+        <modifier type="set" field="3baa-9cfd-f273-822d" value="Leader 2">
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="cd4f-0ce9-a6a4-b34a" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <characteristics>
+        <characteristic name="Ag" typeId="cf30-f234-691c-47bd">5</characteristic>
+        <characteristic name="Acc" typeId="017a-9b43-b7b3-030d">5</characteristic>
+        <characteristic name="Str" typeId="8294-36f1-6431-2145">5</characteristic>
+        <characteristic name="Res" typeId="f214-abe8-c922-c51b">5(7)</characteristic>
+        <characteristic name="Init" typeId="08b9-e038-7ba6-488e">7</characteristic>
+        <characteristic name="Co" typeId="3993-27b0-c3d9-de20">8</characteristic>
+        <characteristic name="Special" typeId="3baa-9cfd-f273-822d">Leader</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="42f9-6fbf-5a4c-76c2" name="Phase Rifle" hidden="false" typeId="ecae-8ac8-2c13-0dd3" typeName="">
+      <characteristics>
+        <characteristic name="Effective" typeId="c2de-17f1-10e2-2c0a">20</characteristic>
+        <characteristic name="Long" typeId="995e-b5e6-4c63-0baa">30</characteristic>
+        <characteristic name="Extreme" typeId="bf58-0ad5-c7ee-3fd9">100</characteristic>
+        <characteristic name="Strike Value" typeId="897c-d3c4-3983-896a">2</characteristic>
+        <characteristic name="Special Rules" typeId="7e87-2586-653f-d6ec">No Cover, RF D6 Fire Only, Concentrated Fire </characteristic>
+      </characteristics>
+    </profile>
+    <profile id="6688-b331-6578-fb30" name="Phase Trooper" hidden="false" typeId="1650-77b3-10d1-6406" typeName="">
+      <characteristics>
+        <characteristic name="Ag" typeId="cf30-f234-691c-47bd">5</characteristic>
+        <characteristic name="Acc" typeId="017a-9b43-b7b3-030d">5</characteristic>
+        <characteristic name="Str" typeId="8294-36f1-6431-2145">5</characteristic>
+        <characteristic name="Res" typeId="f214-abe8-c922-c51b">5(7)</characteristic>
+        <characteristic name="Init" typeId="08b9-e038-7ba6-488e">7</characteristic>
+        <characteristic name="Co" typeId="3993-27b0-c3d9-de20">8</characteristic>
+        <characteristic name="Special" typeId="3baa-9cfd-f273-822d">-</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="581f-ff61-2525-a4b4" name="Plasma Bombard" hidden="false" typeId="ecae-8ac8-2c13-0dd3" typeName="">
+      <characteristics>
+        <characteristic name="Effective" typeId="c2de-17f1-10e2-2c0a">50</characteristic>
+        <characteristic name="Long" typeId="995e-b5e6-4c63-0baa">100</characteristic>
+        <characteristic name="Extreme" typeId="bf58-0ad5-c7ee-3fd9">200</characteristic>
+        <characteristic name="Strike Value" typeId="897c-d3c4-3983-896a">7</characteristic>
+        <characteristic name="Special Rules" typeId="7e87-2586-653f-d6ec">Plasma Fade</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="ffe9-0b4e-fc35-d442" name="Plasma Cannon" hidden="false" typeId="ecae-8ac8-2c13-0dd3" typeName="">
+      <characteristics>
+        <characteristic name="Effective" typeId="c2de-17f1-10e2-2c0a">30</characteristic>
+        <characteristic name="Long" typeId="995e-b5e6-4c63-0baa">40</characteristic>
+        <characteristic name="Extreme" typeId="bf58-0ad5-c7ee-3fd9">80</characteristic>
+        <characteristic name="Strike Value" typeId="897c-d3c4-3983-896a">6</characteristic>
+        <characteristic name="Special Rules" typeId="7e87-2586-653f-d6ec">Plasma Fade</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="4c0f-9a37-2cd9-3f28" name="Plasma Carbine - Scatter" hidden="false" typeId="ecae-8ac8-2c13-0dd3" typeName="">
+      <characteristics>
+        <characteristic name="Effective" typeId="c2de-17f1-10e2-2c0a">20</characteristic>
+        <characteristic name="Long" typeId="995e-b5e6-4c63-0baa">30</characteristic>
+        <characteristic name="Extreme" typeId="bf58-0ad5-c7ee-3fd9">None</characteristic>
+        <characteristic name="Strike Value" typeId="897c-d3c4-3983-896a">0</characteristic>
+        <characteristic name="Special Rules" typeId="7e87-2586-653f-d6ec">RF2</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="acdc-a95e-a973-0c70" name="Plasma Carbine - Single Shot" hidden="false" typeId="ecae-8ac8-2c13-0dd3" typeName="">
+      <characteristics>
+        <characteristic name="Effective" typeId="c2de-17f1-10e2-2c0a">20</characteristic>
+        <characteristic name="Long" typeId="995e-b5e6-4c63-0baa">30</characteristic>
+        <characteristic name="Extreme" typeId="bf58-0ad5-c7ee-3fd9">50</characteristic>
+        <characteristic name="Strike Value" typeId="897c-d3c4-3983-896a">2</characteristic>
+        <characteristic name="Special Rules" typeId="7e87-2586-653f-d6ec">-</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="2c41-c23c-7075-40ca" name="Plasma Duocarb - Scatter" hidden="false" typeId="ecae-8ac8-2c13-0dd3" typeName="">
+      <characteristics>
+        <characteristic name="Effective" typeId="c2de-17f1-10e2-2c0a">20</characteristic>
+        <characteristic name="Long" typeId="995e-b5e6-4c63-0baa">30</characteristic>
+        <characteristic name="Extreme" typeId="bf58-0ad5-c7ee-3fd9">None</characteristic>
+        <characteristic name="Strike Value" typeId="897c-d3c4-3983-896a">0</characteristic>
+        <characteristic name="Special Rules" typeId="7e87-2586-653f-d6ec">RF3</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="d34f-8025-31e7-54b8" name="Plasma Duocarb - Single Shot" hidden="false" typeId="ecae-8ac8-2c13-0dd3" typeName="">
+      <characteristics>
+        <characteristic name="Effective" typeId="c2de-17f1-10e2-2c0a">20</characteristic>
+        <characteristic name="Long" typeId="995e-b5e6-4c63-0baa">30</characteristic>
+        <characteristic name="Extreme" typeId="bf58-0ad5-c7ee-3fd9">50</characteristic>
+        <characteristic name="Strike Value" typeId="897c-d3c4-3983-896a">3</characteristic>
+        <characteristic name="Special Rules" typeId="7e87-2586-653f-d6ec"/>
+      </characteristics>
+    </profile>
+    <profile id="9c65-fbf8-41f5-47be" name="Plasma Grenade" hidden="false" typeId="ecae-8ac8-2c13-0dd3" typeName="">
+      <characteristics>
+        <characteristic name="Effective" typeId="c2de-17f1-10e2-2c0a">5</characteristic>
+        <characteristic name="Long" typeId="995e-b5e6-4c63-0baa">None</characteristic>
+        <characteristic name="Extreme" typeId="bf58-0ad5-c7ee-3fd9">None</characteristic>
+        <characteristic name="Strike Value" typeId="897c-d3c4-3983-896a">1</characteristic>
+        <characteristic name="Special Rules" typeId="7e87-2586-653f-d6ec">-</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="92a3-aaae-bc24-0d2d" name="Plasma Grenade Bandolier" hidden="false" typeId="ecae-8ac8-2c13-0dd3" typeName="">
+      <characteristics>
+        <characteristic name="Effective" typeId="c2de-17f1-10e2-2c0a">5</characteristic>
+        <characteristic name="Long" typeId="995e-b5e6-4c63-0baa">-</characteristic>
+        <characteristic name="Extreme" typeId="bf58-0ad5-c7ee-3fd9">-</characteristic>
+        <characteristic name="Strike Value" typeId="897c-d3c4-3983-896a">2</characteristic>
+        <characteristic name="Special Rules" typeId="7e87-2586-653f-d6ec">Blast D4, Hazardous H2H</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="3376-2497-6739-ec52" name="Plasma Lance - Lance" hidden="false" typeId="ecae-8ac8-2c13-0dd3" typeName="">
+      <characteristics>
+        <characteristic name="Effective" typeId="c2de-17f1-10e2-2c0a">20</characteristic>
+        <characteristic name="Long" typeId="995e-b5e6-4c63-0baa">30</characteristic>
+        <characteristic name="Extreme" typeId="bf58-0ad5-c7ee-3fd9">None</characteristic>
+        <characteristic name="Strike Value" typeId="897c-d3c4-3983-896a">4</characteristic>
+        <characteristic name="Special Rules" typeId="7e87-2586-653f-d6ec">Choose Target, Inaccurate</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="19f6-390a-0d7c-8acb" name="Plasma Lance - Scatter" hidden="false" typeId="ecae-8ac8-2c13-0dd3" typeName="">
+      <characteristics>
+        <characteristic name="Effective" typeId="c2de-17f1-10e2-2c0a">20</characteristic>
+        <characteristic name="Long" typeId="995e-b5e6-4c63-0baa">30</characteristic>
+        <characteristic name="Extreme" typeId="bf58-0ad5-c7ee-3fd9">None</characteristic>
+        <characteristic name="Strike Value" typeId="897c-d3c4-3983-896a">0</characteristic>
+        <characteristic name="Special Rules" typeId="7e87-2586-653f-d6ec">RF2</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="db92-0aca-cde3-4d2d" name="Plasma Lance - Single Shot" hidden="false" typeId="ecae-8ac8-2c13-0dd3" typeName="">
+      <characteristics>
+        <characteristic name="Effective" typeId="c2de-17f1-10e2-2c0a">20</characteristic>
+        <characteristic name="Long" typeId="995e-b5e6-4c63-0baa">30</characteristic>
+        <characteristic name="Extreme" typeId="bf58-0ad5-c7ee-3fd9">50</characteristic>
+        <characteristic name="Strike Value" typeId="897c-d3c4-3983-896a">2</characteristic>
+        <characteristic name="Special Rules" typeId="7e87-2586-653f-d6ec">-</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="2940-5bc4-f1ca-b78c" name="Plasma Light Support Gun" hidden="false" typeId="ecae-8ac8-2c13-0dd3" typeName="">
+      <characteristics>
+        <characteristic name="Effective" typeId="c2de-17f1-10e2-2c0a">30</characteristic>
+        <characteristic name="Long" typeId="995e-b5e6-4c63-0baa">40</characteristic>
+        <characteristic name="Extreme" typeId="bf58-0ad5-c7ee-3fd9">80</characteristic>
+        <characteristic name="Strike Value" typeId="897c-d3c4-3983-896a">3</characteristic>
+        <characteristic name="Special Rules" typeId="7e87-2586-653f-d6ec">RF3</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="23fa-052e-36db-13a3" name="Plasma Pistol" hidden="false" typeId="ecae-8ac8-2c13-0dd3" typeName="">
+      <characteristics>
+        <characteristic name="Effective" typeId="c2de-17f1-10e2-2c0a">10</characteristic>
+        <characteristic name="Long" typeId="995e-b5e6-4c63-0baa">20</characteristic>
+        <characteristic name="Extreme" typeId="bf58-0ad5-c7ee-3fd9">30</characteristic>
+        <characteristic name="Strike Value" typeId="897c-d3c4-3983-896a">2</characteristic>
+        <characteristic name="Special Rules" typeId="7e87-2586-653f-d6ec">-</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="9286-cbf7-0641-5ce1" name="Pulse Bike Commander" hidden="false" typeId="1650-77b3-10d1-6406" typeName="">
+      <modifiers>
+        <modifier type="set" field="3baa-9cfd-f273-822d" value="Command, Follow, Fast, Large, Leader 3">
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="bd12-7ad6-eb09-08ba" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <characteristics>
+        <characteristic name="Ag" typeId="cf30-f234-691c-47bd">5</characteristic>
+        <characteristic name="Acc" typeId="017a-9b43-b7b3-030d">5</characteristic>
+        <characteristic name="Str" typeId="8294-36f1-6431-2145">5</characteristic>
+        <characteristic name="Res" typeId="f214-abe8-c922-c51b">5(8)</characteristic>
+        <characteristic name="Init" typeId="08b9-e038-7ba6-488e">7</characteristic>
+        <characteristic name="Co" typeId="3993-27b0-c3d9-de20">9</characteristic>
+        <characteristic name="Special" typeId="3baa-9cfd-f273-822d">Command, Follow, Fast, Large, Leader 2</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="9ed6-e3f2-8847-d7a2" name="Pulse Bike Leader" hidden="false" typeId="1650-77b3-10d1-6406" typeName="">
+      <modifiers>
+        <modifier type="set" field="3baa-9cfd-f273-822d" value="Fast, Large, Leader 2">
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="27d8-164a-139b-f635" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <characteristics>
+        <characteristic name="Ag" typeId="cf30-f234-691c-47bd">5</characteristic>
+        <characteristic name="Acc" typeId="017a-9b43-b7b3-030d">5</characteristic>
+        <characteristic name="Str" typeId="8294-36f1-6431-2145">5</characteristic>
+        <characteristic name="Res" typeId="f214-abe8-c922-c51b">5(8)</characteristic>
+        <characteristic name="Init" typeId="08b9-e038-7ba6-488e">7</characteristic>
+        <characteristic name="Co" typeId="3993-27b0-c3d9-de20">8</characteristic>
+        <characteristic name="Special" typeId="3baa-9cfd-f273-822d">Fast, Large, Leader</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="34f9-12c5-7e7b-114c" name="Pulse Bike Trooper" hidden="false" typeId="1650-77b3-10d1-6406" typeName="">
+      <characteristics>
+        <characteristic name="Ag" typeId="cf30-f234-691c-47bd">5</characteristic>
+        <characteristic name="Acc" typeId="017a-9b43-b7b3-030d">5</characteristic>
+        <characteristic name="Str" typeId="8294-36f1-6431-2145">5</characteristic>
+        <characteristic name="Res" typeId="f214-abe8-c922-c51b">5 (8)</characteristic>
+        <characteristic name="Init" typeId="08b9-e038-7ba6-488e">7</characteristic>
+        <characteristic name="Co" typeId="3993-27b0-c3d9-de20">8</characteristic>
+        <characteristic name="Special" typeId="3baa-9cfd-f273-822d">Fast, Large</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="56b9-5224-e0df-8218" name="Scout Probe" hidden="false" typeId="1650-77b3-10d1-6406" typeName="">
+      <characteristics>
+        <characteristic name="Ag" typeId="cf30-f234-691c-47bd">-</characteristic>
+        <characteristic name="Acc" typeId="017a-9b43-b7b3-030d">-</characteristic>
+        <characteristic name="Str" typeId="8294-36f1-6431-2145">-</characteristic>
+        <characteristic name="Res" typeId="f214-abe8-c922-c51b">5</characteristic>
+        <characteristic name="Init" typeId="08b9-e038-7ba6-488e">-</characteristic>
+        <characteristic name="Co" typeId="3993-27b0-c3d9-de20">-</characteristic>
+        <characteristic name="Special" typeId="3baa-9cfd-f273-822d">Shard</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="9686-36fa-7ae7-f4dc" name="Senatex Commander" hidden="false" typeId="1650-77b3-10d1-6406" typeName="">
+      <modifiers>
+        <modifier type="set" field="3baa-9cfd-f273-822d" value="Command, Follow, Leader 3">
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a90a-fea5-107f-a019" type="equalTo"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <characteristics>
+        <characteristic name="Ag" typeId="cf30-f234-691c-47bd">5</characteristic>
+        <characteristic name="Acc" typeId="017a-9b43-b7b3-030d">6</characteristic>
+        <characteristic name="Str" typeId="8294-36f1-6431-2145">5</characteristic>
+        <characteristic name="Res" typeId="f214-abe8-c922-c51b">5(7)</characteristic>
+        <characteristic name="Init" typeId="08b9-e038-7ba6-488e">7</characteristic>
+        <characteristic name="Co" typeId="3993-27b0-c3d9-de20">9</characteristic>
+        <characteristic name="Special" typeId="3baa-9cfd-f273-822d">Command, Follow, Leader 2</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="9ce3-1277-65a2-7ab0" name="Targeter Probe" hidden="false" typeId="1650-77b3-10d1-6406" typeName="">
+      <characteristics>
+        <characteristic name="Ag" typeId="cf30-f234-691c-47bd">-</characteristic>
+        <characteristic name="Acc" typeId="017a-9b43-b7b3-030d">-</characteristic>
+        <characteristic name="Str" typeId="8294-36f1-6431-2145">-</characteristic>
+        <characteristic name="Res" typeId="f214-abe8-c922-c51b">5</characteristic>
+        <characteristic name="Init" typeId="08b9-e038-7ba6-488e">-</characteristic>
+        <characteristic name="Co" typeId="3993-27b0-c3d9-de20">-</characteristic>
+        <characteristic name="Special" typeId="3baa-9cfd-f273-822d">Shard</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="1aa8-c7f2-fa2d-324a" name="Tograh MV2 Transporter Drone " hidden="false" typeId="1650-77b3-10d1-6406" typeName="">
+      <characteristics>
+        <characteristic name="Ag" typeId="cf30-f234-691c-47bd">5</characteristic>
+        <characteristic name="Acc" typeId="017a-9b43-b7b3-030d">6</characteristic>
+        <characteristic name="Str" typeId="8294-36f1-6431-2145">1</characteristic>
+        <characteristic name="Res" typeId="f214-abe8-c922-c51b">13</characteristic>
+        <characteristic name="Init" typeId="08b9-e038-7ba6-488e">8</characteristic>
+        <characteristic name="Co" typeId="3993-27b0-c3d9-de20">8</characteristic>
+        <characteristic name="Special" typeId="3baa-9cfd-f273-822d">MOD2, Transport 10, Large</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="e480-7c4e-fa39-3a68" name="Tsan Leader" hidden="false" typeId="1650-77b3-10d1-6406" typeName="">
+      <characteristics>
+        <characteristic name="Ag" typeId="cf30-f234-691c-47bd">5</characteristic>
+        <characteristic name="Acc" typeId="017a-9b43-b7b3-030d">5</characteristic>
+        <characteristic name="Str" typeId="8294-36f1-6431-2145">7</characteristic>
+        <characteristic name="Res" typeId="f214-abe8-c922-c51b">6 (8)</characteristic>
+        <characteristic name="Init" typeId="08b9-e038-7ba6-488e">7</characteristic>
+        <characteristic name="Co" typeId="3993-27b0-c3d9-de20">8</characteristic>
+        <characteristic name="Special" typeId="3baa-9cfd-f273-822d">Leader, Large</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="d0b6-5e2a-243d-b6ea" name="X-Howitzer" hidden="false" typeId="ecae-8ac8-2c13-0dd3" typeName="">
+      <characteristics>
+        <characteristic name="Effective" typeId="c2de-17f1-10e2-2c0a">10-50</characteristic>
+        <characteristic name="Long" typeId="995e-b5e6-4c63-0baa">100</characteristic>
+        <characteristic name="Extreme" typeId="bf58-0ad5-c7ee-3fd9">250</characteristic>
+        <characteristic name="Strike Value" typeId="897c-d3c4-3983-896a">2</characteristic>
+        <characteristic name="Special Rules" typeId="7e87-2586-653f-d6ec">OH, Blast D10, No Cover</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="b984-90ae-a8e5-83c8" name="X-Launcher" hidden="false" typeId="ecae-8ac8-2c13-0dd3" typeName="">
+      <characteristics>
+        <characteristic name="Effective" typeId="c2de-17f1-10e2-2c0a">10-30</characteristic>
+        <characteristic name="Long" typeId="995e-b5e6-4c63-0baa">60</characteristic>
+        <characteristic name="Extreme" typeId="bf58-0ad5-c7ee-3fd9">120</characteristic>
+        <characteristic name="Strike Value" typeId="897c-d3c4-3983-896a">1</characteristic>
+        <characteristic name="Special Rules" typeId="7e87-2586-653f-d6ec">OH, Blast D5, No Cover</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="7c13-1aa1-5557-6103" name="X-Sling" hidden="false" typeId="ecae-8ac8-2c13-0dd3" typeName="">
+      <characteristics>
+        <characteristic name="Effective" typeId="c2de-17f1-10e2-2c0a">10</characteristic>
+        <characteristic name="Long" typeId="995e-b5e6-4c63-0baa">20</characteristic>
+        <characteristic name="Extreme" typeId="bf58-0ad5-c7ee-3fd9">None</characteristic>
+        <characteristic name="Strike Value" typeId="897c-d3c4-3983-896a">0</characteristic>
+        <characteristic name="Special Rules" typeId="7e87-2586-653f-d6ec">Blast D3</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="2966-969b-3981-06ed" name="Phase Trooper" hidden="false" typeId="1650-77b3-10d1-6406" typeName="">
+      <characteristics>
+        <characteristic name="Ag" typeId="cf30-f234-691c-47bd">5</characteristic>
+        <characteristic name="Acc" typeId="017a-9b43-b7b3-030d">6</characteristic>
+        <characteristic name="Str" typeId="8294-36f1-6431-2145">5</characteristic>
+        <characteristic name="Res" typeId="f214-abe8-c922-c51b">5(7)</characteristic>
+        <characteristic name="Init" typeId="08b9-e038-7ba6-488e">7</characteristic>
+        <characteristic name="Co" typeId="3993-27b0-c3d9-de20">8</characteristic>
+        <characteristic name="Special" typeId="3baa-9cfd-f273-822d">-</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="01b3-4a09-3a38-9c8c" name="Phase Trooper" hidden="false" typeId="1650-77b3-10d1-6406" typeName="">
+      <modifiers>
+        <modifier type="set" field="3baa-9cfd-f273-822d" value="Large, Slow"/>
+      </modifiers>
+      <characteristics>
+        <characteristic name="Ag" typeId="cf30-f234-691c-47bd">5</characteristic>
+        <characteristic name="Acc" typeId="017a-9b43-b7b3-030d">5</characteristic>
+        <characteristic name="Str" typeId="8294-36f1-6431-2145">5</characteristic>
+        <characteristic name="Res" typeId="f214-abe8-c922-c51b">5(7)</characteristic>
+        <characteristic name="Init" typeId="08b9-e038-7ba6-488e">7</characteristic>
+        <characteristic name="Co" typeId="3993-27b0-c3d9-de20">8</characteristic>
+        <characteristic name="Special" typeId="3baa-9cfd-f273-822d">-</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="c626-1591-8fa9-bdf0" name="Tsan Trooper" publicationId="eaf6-3f46-pubN65565" page="82" hidden="false" typeId="1650-77b3-10d1-6406" typeName="">
+      <characteristics>
+        <characteristic name="Ag" typeId="cf30-f234-691c-47bd">5</characteristic>
+        <characteristic name="Acc" typeId="017a-9b43-b7b3-030d">5</characteristic>
+        <characteristic name="Str" typeId="8294-36f1-6431-2145">7</characteristic>
+        <characteristic name="Res" typeId="f214-abe8-c922-c51b">6 (8)</characteristic>
+        <characteristic name="Init" typeId="08b9-e038-7ba6-488e">7</characteristic>
+        <characteristic name="Co" typeId="3993-27b0-c3d9-de20">8</characteristic>
+        <characteristic name="Special" typeId="3baa-9cfd-f273-822d">Large</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="7f76-db01-256f-c0df" name="Compressor Torus - Ranged" hidden="false" typeId="ecae-8ac8-2c13-0dd3" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Effective" typeId="c2de-17f1-10e2-2c0a">10</characteristic>
+        <characteristic name="Long" typeId="995e-b5e6-4c63-0baa">20</characteristic>
+        <characteristic name="Extreme" typeId="bf58-0ad5-c7ee-3fd9">30</characteristic>
+        <characteristic name="Strike Value" typeId="897c-d3c4-3983-896a">3/2/0</characteristic>
+        <characteristic name="Special Rules" typeId="7e87-2586-653f-d6ec">Compressor, No Cover</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="04ce-712e-6e8c-b950" name="Compressor Torus - H2H" hidden="false" typeId="ecae-8ac8-2c13-0dd3" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Effective" typeId="c2de-17f1-10e2-2c0a">H2H Only</characteristic>
+        <characteristic name="Long" typeId="995e-b5e6-4c63-0baa">-</characteristic>
+        <characteristic name="Extreme" typeId="bf58-0ad5-c7ee-3fd9">-</characteristic>
+        <characteristic name="Strike Value" typeId="897c-d3c4-3983-896a">3</characteristic>
+        <characteristic name="Special Rules" typeId="7e87-2586-653f-d6ec">Shock Wave (3 Attacks)</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="2315-d39b-832f-4292" name="Tsan Trooper" hidden="false" typeId="1650-77b3-10d1-6406" typeName="Model">
+      <characteristics>
+        <characteristic name="Ag" typeId="cf30-f234-691c-47bd">5</characteristic>
+        <characteristic name="Acc" typeId="017a-9b43-b7b3-030d">6</characteristic>
+        <characteristic name="Str" typeId="8294-36f1-6431-2145">7</characteristic>
+        <characteristic name="Res" typeId="f214-abe8-c922-c51b">6(8)</characteristic>
+        <characteristic name="Init" typeId="08b9-e038-7ba6-488e">7</characteristic>
+        <characteristic name="Co" typeId="3993-27b0-c3d9-de20">8</characteristic>
+        <characteristic name="Special" typeId="3baa-9cfd-f273-822d">Large</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="0c5f-4f79-d01b-67c8" name="Tsan Commander" hidden="false" typeId="1650-77b3-10d1-6406" typeName="Model">
+      <characteristics>
+        <characteristic name="Ag" typeId="cf30-f234-691c-47bd">5</characteristic>
+        <characteristic name="Acc" typeId="017a-9b43-b7b3-030d">6</characteristic>
+        <characteristic name="Str" typeId="8294-36f1-6431-2145">7</characteristic>
+        <characteristic name="Res" typeId="f214-abe8-c922-c51b">6(8)</characteristic>
+        <characteristic name="Init" typeId="08b9-e038-7ba6-488e">7</characteristic>
+        <characteristic name="Co" typeId="3993-27b0-c3d9-de20">9</characteristic>
+        <characteristic name="Special" typeId="3baa-9cfd-f273-822d">Command, Follow, Leader 2, Large</characteristic>
+      </characteristics>
+    </profile>
+  </sharedProfiles>
 </catalogue>


### PR DESCRIPTION
No option for generic Drone Commander

No option for nano probe net (also note that the army must take a drone commander to take one, and it ts a tactical entry)

Pulse bike squad should not have option for synchroniser drone

Heavy Support Team is only listed as “Support Team” under Strategic

Base weapon is listed as an X Launcher, it should be an X Howitzer

Andhak Medium Support Drone needs Phase-Shift Projector added to weapon options (free)

Enhanced Machine Intelligence upgrade for the Tograh Transport Drone should be 10 points and not free

Cleaned up some unnecessary brackets

Closes #172